### PR TITLE
[Backport 7.71.x] dyninst/irgen: fix panic due to cycles involving nested slices (#41060)

### DIFF
--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -1036,18 +1036,20 @@ func completeGoMapType(tc *typeCatalog, t *ir.GoMapType) error {
 	}
 }
 
-func field(st *ir.StructureType, name string) (*ir.Field, error) {
+func field(tc *typeCatalog, st *ir.StructureType, name string) (*ir.Field, error) {
 	offset := slices.IndexFunc(st.RawFields, func(f ir.Field) bool {
 		return f.Name == name
 	})
 	if offset == -1 {
 		return nil, fmt.Errorf("type %q has no %s field", st.Name, name)
 	}
+	f := &st.RawFields[offset]
+	f.Type = tc.typesByID[f.Type.GetID()]
 	return &st.RawFields[offset], nil
 }
 
-func fieldType[T ir.Type](st *ir.StructureType, name string) (T, error) {
-	f, err := field(st, name)
+func fieldType[T ir.Type](tc *typeCatalog, st *ir.StructureType, name string) (T, error) {
+	f, err := field(tc, st, name)
 	if err != nil {
 		return *new(T), err
 	}
@@ -1068,6 +1070,7 @@ func resolvePointeeType[T ir.Type](tc *typeCatalog, t ir.Type) (T, error) {
 	if !ok {
 		return *new(T), fmt.Errorf("type %q is not a pointer type, got %T", t.GetName(), t)
 	}
+	ptrType.Pointee = tc.typesByID[ptrType.Pointee.GetID()]
 	if ppt, ok := ptrType.Pointee.(*pointeePlaceholderType); ok {
 		pointee, err := tc.addType(ppt.offset)
 		if err != nil {
@@ -1090,7 +1093,7 @@ func completeSwissMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {
 	var groupReferenceType *ir.StructureType
 	var groupType *ir.StructureType
 	{
-		dirPtrType, err := fieldType[*ir.PointerType](st, "dirPtr")
+		dirPtrType, err := fieldType[*ir.PointerType](tc, st, "dirPtr")
 		if err != nil {
 			return err
 		}
@@ -1102,11 +1105,11 @@ func completeSwissMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {
 		if err != nil {
 			return err
 		}
-		groupReferenceType, err = fieldType[*ir.StructureType](tableType, "groups")
+		groupReferenceType, err = fieldType[*ir.StructureType](tc, tableType, "groups")
 		if err != nil {
 			return err
 		}
-		groupPtrType, err := fieldType[*ir.PointerType](groupReferenceType, "data")
+		groupPtrType, err := fieldType[*ir.PointerType](tc, groupReferenceType, "data")
 		if err != nil {
 			return err
 		}
@@ -1153,7 +1156,7 @@ func completeSwissMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {
 }
 
 func completeHMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {
-	bucketsField, err := field(st, "buckets")
+	bucketsField, err := field(tc, st, "buckets")
 	if err != nil {
 		return err
 	}
@@ -1161,12 +1164,12 @@ func completeHMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {
 	if err != nil {
 		return err
 	}
-	keysArrayType, err := fieldType[*ir.ArrayType](bucketsStructType, "keys")
+	keysArrayType, err := fieldType[*ir.ArrayType](tc, bucketsStructType, "keys")
 	if err != nil {
 		return err
 	}
 	keyType := keysArrayType.Element
-	valuesArrayType, err := fieldType[*ir.ArrayType](bucketsStructType, "values")
+	valuesArrayType, err := fieldType[*ir.ArrayType](tc, bucketsStructType, "values")
 	if err != nil {
 		return err
 	}
@@ -1196,7 +1199,7 @@ func completeHMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {
 }
 
 func completeGoStringType(tc *typeCatalog, st *ir.StructureType) error {
-	strField, err := field(st, "str")
+	strField, err := field(tc, st, "str")
 	if err != nil {
 		return err
 	}
@@ -1227,7 +1230,7 @@ func completeGoStringType(tc *typeCatalog, st *ir.StructureType) error {
 }
 
 func completeGoSliceType(tc *typeCatalog, st *ir.StructureType) error {
-	arrayField, err := field(st, "array")
+	arrayField, err := field(tc, st, "array")
 	if err != nil {
 		return err
 	}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 1054 EventRootType Probe[main.stackC]
+          Type: 1124 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd07bca", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 1009 EventRootType Probe[main.testAny]
+          Type: 1079 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04b4a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 1011 EventRootType Probe[main.testAnyPtr]
+          Type: 1081 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04bea", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 971 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1041 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 973 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1043 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 1019 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1089 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd05340", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 972 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1042 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 991 EventRootType Probe[main.testBigStruct]
+          Type: 1061 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03700", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 960 EventRootType Probe[main.testBoolArray]
+          Type: 1030 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 957 EventRootType Probe[main.testByteArray]
+          Type: 1027 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02de0", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 1035 EventRootType Probe[main.testChannel]
+          Type: 1105 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd06e80", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 1033 EventRootType Probe[main.testCombinedByte]
+          Type: 1103 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd06aa0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 1043 EventRootType Probe[main.testCycle]
+          Type: 1113 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd07240", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 996 EventRootType Probe[main.testDeepMap1]
+          Type: 1066 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03ae0", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 997 EventRootType Probe[main.testDeepMap7]
+          Type: 1067 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b00", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 992 EventRootType Probe[main.testDeepPtr1]
+          Type: 1062 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd037c0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 993 EventRootType Probe[main.testDeepPtr7]
+          Type: 1063 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd037e0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 994 EventRootType Probe[main.testDeepSlice1]
+          Type: 1064 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd03960", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 995 EventRootType Probe[main.testDeepSlice7]
+          Type: 1065 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd03980", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 1045 EventRootType Probe[main.testEmptySlice]
+          Type: 1115 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd07780", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 1048 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1118 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 1062 EventRootType Probe[main.testEmptyString]
+          Type: 1132 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd07d00", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 108
-          Type: 1064 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd08100", Frameless: true}]
+        - ID: 110
+          Type: 1136 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd08140", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 109
-          Type: 1065 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xd08120", Frameless: true}]
+        - ID: 111
+          Type: 1137 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xd08160", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 1010 EventRootType Probe[main.testError]
+          Type: 1080 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04bc0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 1001 EventRootType Probe[main.testEsotericHeap]
+          Type: 1071 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd040ca", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 1000 EventRootType Probe[main.testEsotericStack]
+          Type: 1070 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd03fae", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 1006 EventRootType Probe[main.testFrameless]
+          Type: 1076 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 1007 EventRootType Probe[main.testFramelessArray]
+          Type: 1077 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04844", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 1002 EventRootType Probe[main.testInlinedBA]
+          Type: 1072 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd0450a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 1003 EventRootType Probe[main.testInlinedBB]
+          Type: 1073 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd045ae", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 1004 EventRootType Probe[main.testInlinedBBA]
+          Type: 1074 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd0468a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 111
-          Type: 1067 EventRootType Probe[main.testInlinedBBB]
+        - ID: 113
+          Type: 1139 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd04606", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 1005 EventRootType Probe[main.testInlinedBC]
+          Type: 1075 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd0470e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 112
-          Type: 1068 EventRootType Probe[main.testInlinedBCA]
+        - ID: 114
+          Type: 1140 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd04713", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 113
-          Type: 1069 EventRootType Probe[main.testInlinedBCB]
+        - ID: 115
+          Type: 1141 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd047c6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 110
-          Type: 1066 EventRootType Probe[main.testInlinedPrint]
+        - ID: 112
+          Type: 1138 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0436a"
               Frameless: false
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 114
-          Type: 1070 EventRootType Probe[main.testInlinedSq]
+        - ID: 116
+          Type: 1142 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04821", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 115
-          Type: 1071 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 117
+          Type: 1143 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04865"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 963 EventRootType Probe[main.testInt16Array]
+          Type: 1033 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 964 EventRootType Probe[main.testInt32Array]
+          Type: 1034 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 965 EventRootType Probe[main.testInt64Array]
+          Type: 1035 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 962 EventRootType Probe[main.testInt8Array]
+          Type: 1032 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 961 EventRootType Probe[main.testIntArray]
+          Type: 1031 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 1008 EventRootType Probe[main.testInterface]
+          Type: 1078 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04b20", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 1037 EventRootType Probe[main.testLinkedList]
+          Type: 1107 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd07060", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 1017 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1087 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd05300", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 1023 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1093 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd053c0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 1021 EventRootType Probe[main.testMapIntToInt]
+          Type: 1091 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd05380", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 1032 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1102 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd054e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 1031 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1101 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd054c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 1022 EventRootType Probe[main.testMapMassive]
+          Type: 1092 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd053a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 1030 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1100 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd054a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 1029 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1099 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd05480", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 1015 EventRootType Probe[main.testMapStringToInt]
+          Type: 1085 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd052c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 1016 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1086 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd052e0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 1014 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1084 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd052a0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 1024 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1094 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd053e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 1027 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1097 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd05440", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 1028 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1098 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd05460", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 1025 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1095 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd05400", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 1026 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1096 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd05420", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 1060 EventRootType Probe[main.testMassiveString]
+          Type: 1130 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd07cc0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 1034 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1104 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd06c60", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 1042 EventRootType Probe[main.testNilPointer]
+          Type: 1112 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd07200", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 1052 EventRootType Probe[main.testNilSlice]
+          Type: 1122 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd07860", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 1049 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1119 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd07800", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 1051 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1121 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd07840", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 1059 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1129 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd07ca0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 1038 EventRootType Probe[main.testPointerLoop]
+          Type: 1108 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07080", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 1020 EventRootType Probe[main.testPointerToMap]
+          Type: 1090 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd05360", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 1036 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1106 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd07040", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 958 EventRootType Probe[main.testRuneArray]
+          Type: 1028 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 977 EventRootType Probe[main.testSingleBool]
+          Type: 1047 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 975 EventRootType Probe[main.testSingleByte]
+          Type: 1045 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd033c0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 988 EventRootType Probe[main.testSingleFloat32]
+          Type: 1058 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 989 EventRootType Probe[main.testSingleFloat64]
+          Type: 1059 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 978 EventRootType Probe[main.testSingleInt]
+          Type: 1048 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 980 EventRootType Probe[main.testSingleInt16]
+          Type: 1050 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 981 EventRootType Probe[main.testSingleInt32]
+          Type: 1051 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 982 EventRootType Probe[main.testSingleInt64]
+          Type: 1052 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 979 EventRootType Probe[main.testSingleInt8]
+          Type: 1049 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 976 EventRootType Probe[main.testSingleRune]
+          Type: 1046 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd033e0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 1055 EventRootType Probe[main.testSingleString]
+          Type: 1125 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd07c20", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 983 EventRootType Probe[main.testSingleUint]
+          Type: 1053 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 985 EventRootType Probe[main.testSingleUint16]
+          Type: 1055 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 986 EventRootType Probe[main.testSingleUint32]
+          Type: 1056 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 987 EventRootType Probe[main.testSingleUint64]
+          Type: 1057 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 984 EventRootType Probe[main.testSingleUint8]
+          Type: 1054 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 1046 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1116 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd077a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 1018 EventRootType Probe[main.testSmallMap]
+          Type: 1088 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd05320", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 959 EventRootType Probe[main.testStringArray]
+          Type: 1029 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 1041 EventRootType Probe[main.testStringPointer]
+          Type: 1111 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd071c0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 1050 EventRootType Probe[main.testStringSlice]
+          Type: 1120 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd07820", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 998 EventRootType Probe[main.testStringType1]
+          Type: 1068 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 999 EventRootType Probe[main.testStringType2]
+          Type: 1069 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 107
-          Type: 1063 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd07f80", Frameless: true}]
+        - ID: 109
+          Type: 1135 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd07fc0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 1047 EventRootType Probe[main.testStructSlice]
+          Type: 1117 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,8 +1425,34 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 1012 EventRootType Probe[main.testStructWithAny]
+          Type: 1082 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xd04c40", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicMaps}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 108
+          Type: 1134 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xd07e80", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicSlices
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicSlices}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 107
+          Type: 1133 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xd07e60", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1439,7 +1465,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 1013 EventRootType Probe[main.testStructWithMap]
+          Type: 1083 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05280", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1479,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 1056 EventRootType Probe[main.testThreeStrings]
+          Type: 1126 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd07c40", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1493,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 1057 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1127 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd07c60", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1507,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 1058 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1128 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd07c80", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1521,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 990 EventRootType Probe[main.testTypeAlias]
+          Type: 1060 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1535,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 968 EventRootType Probe[main.testUint16Array]
+          Type: 1038 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1549,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 969 EventRootType Probe[main.testUint32Array]
+          Type: 1039 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1563,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 970 EventRootType Probe[main.testUint64Array]
+          Type: 1040 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1577,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 967 EventRootType Probe[main.testUint8Array]
+          Type: 1037 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1591,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 966 EventRootType Probe[main.testUintArray]
+          Type: 1036 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1605,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 1040 EventRootType Probe[main.testUintPointer]
+          Type: 1110 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd070e0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1619,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 1044 EventRootType Probe[main.testUintSlice]
+          Type: 1114 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd07760", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1633,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 1061 EventRootType Probe[main.testUnitializedString]
+          Type: 1131 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd07ce0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1647,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 1039 EventRootType Probe[main.testUnsafePointer]
+          Type: 1109 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd070a0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1661,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 974 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1044 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1675,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 1053 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1123 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd07880", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3279,14 +3305,50 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 107
+      Name: main.testStructWithCyclicSlices
+      OutOfLinePCRanges: [0xd07e60..0xd07e61]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 175 StructureType main.structWithCyclicSlices
+          Locations:
+            - Range: 0xd07e60..0xd07e61
+              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 108
+      Name: main.testStructWithCyclicMaps
+      OutOfLinePCRanges: [0xd07e80..0xd07e9f]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 188 StructureType main.structWithCyclicMaps
+          Locations:
+            - Range: 0xd07e80..0xd07e9f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd07f80..0xd07fa3]
+      OutOfLinePCRanges: [0xd07fc0..0xd07fe3]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 175 StructureType main.aStruct
+          Type: 219 StructureType main.aStruct
           Locations:
-            - Range: 0xd07f80..0xd07fa3
+            - Range: 0xd07fc0..0xd07fe3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3304,29 +3366,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd08100..0xd08101]
+      OutOfLinePCRanges: [0xd08140..0xd08141]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 177 StructureType main.emptyStruct
-          Locations: [{Range: 0xd08100..0xd08101, Pieces: []}]
+          Type: 221 StructureType main.emptyStruct
+          Locations: [{Range: 0xd08140..0xd08141, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd08120..0xd08121]
+      OutOfLinePCRanges: [0xd08160..0xd08161]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 178 PointerType *main.emptyStruct
+          Type: 222 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd08120..0xd08121
+            - Range: 0xd08160..0xd08161
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 112
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd04360..0xd043c2]
       InlinePCRanges:
@@ -3356,28 +3418,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 113
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04606..0xd0463e]
           RootRanges: [0xd045a0..0xd04665]
       Variables: []
-    - ID: 112
+    - ID: 114
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04713..0xd04751]
           RootRanges: [0xd04700..0xd0480e]
       Variables: []
-    - ID: 113
+    - ID: 115
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd047c6..0xd047fe]
           RootRanges: [0xd04700..0xd0480e]
       Variables: []
-    - ID: 114
+    - ID: 116
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3391,7 +3453,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 117
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3416,20 +3478,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 897
+      ID: 967
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 898 PointerType *main.deepSlice3
+      Pointee: 968 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 918
+      ID: 988
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 919 PointerType *main.deepSlice8
+      Pointee: 989 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 924
+      ID: 994
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 925 PointerType *main.deepSlice9
+      Pointee: 995 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3437,7 +3499,7 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 893
+      ID: 963
       Name: '**main.t'
       ByteSize: 8
       Pointee: 160 PointerType *main.t
@@ -3449,146 +3511,201 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 185
+      ID: 229
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 228 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 901
+      ID: 971
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 900 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 970 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 922
+      ID: 992
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 921 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 991 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 928
+      ID: 998
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 927 GoSliceDataType []*main.deepSlice9.array
-    - __kind: PointerType
-      ID: 182
-      Name: '*[]*string.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType []*string.array
-    - __kind: PointerType
-      ID: 224
-      Name: '*[][]uint.array'
-      ByteSize: 8
-      Pointee: 223 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 230
-      Name: '*[]bool.array'
-      ByteSize: 8
-      Pointee: 229 GoSliceDataType []bool.array
-    - __kind: PointerType
-      ID: 684
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 683 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 931
-      Name: '*[]interface {}.array'
-      ByteSize: 8
-      Pointee: 930 GoSliceDataType []interface {}.array
-    - __kind: PointerType
-      ID: 912
-      Name: '*[]main.structWithMap.array'
-      ByteSize: 8
-      Pointee: 911 GoSliceDataType []main.structWithMap.array
+      Pointee: 997 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 226
+      Name: '*[]*string.array'
+      ByteSize: 8
+      Pointee: 225 GoSliceDataType []*string.array
+    - __kind: PointerType
+      ID: 288
+      Name: '*[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 287 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 187
+      Name: '*[][][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 184 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 286
+      Name: '*[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 285 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 182 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 284
+      Name: '*[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 283 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 180 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 282
+      Name: '*[][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 281 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 178 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 280
+      Name: '*[][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 279 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 268
+      Name: '*[][]uint.array'
+      ByteSize: 8
+      Pointee: 267 GoSliceDataType [][]uint.array
+    - __kind: PointerType
+      ID: 274
+      Name: '*[]bool.array'
+      ByteSize: 8
+      Pointee: 273 GoSliceDataType []bool.array
+    - __kind: PointerType
+      ID: 754
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 753 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 1001
+      Name: '*[]interface {}.array'
+      ByteSize: 8
+      Pointee: 1000 GoSliceDataType []interface {}.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 176 GoSliceHeaderType []main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 278
+      Name: '*[]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 277 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 982
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 981 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 270
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 269 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 228
+      ID: 272
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []string.array
+      Pointee: 271 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 164
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 162 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 222
+      ID: 266
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType []uint.array
+      Pointee: 265 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 232
+      ID: 276
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType []uint16.array
+      Pointee: 275 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 682
+      ID: 752
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 681 GoSliceDataType []uint8.array
+      Pointee: 751 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 809
+      ID: 879
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.848384e+06
       GoKind: 22
-      Pointee: 810 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 880 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 458
+      ID: 528
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858336
       GoKind: 22
-      Pointee: 459 GoSliceHeaderType archive/tar.headerError
+      Pointee: 529 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 461
+      ID: 531
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 460 GoSliceDataType archive/tar.headerError.array
+      Pointee: 530 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 749
+      ID: 819
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.252928e+06
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 820 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 697
+      ID: 767
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858528
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 768 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 699
+      ID: 769
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858624
       GoKind: 22
-      Pointee: 700 StructureType archive/zip.dirWriter
+      Pointee: 770 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 796
+      ID: 866
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.772672e+06
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 867 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 725
+      ID: 795
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.016448e+06
       GoKind: 22
-      Pointee: 726 StructureType archive/zip.nopCloser
+      Pointee: 796 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 727
+      ID: 797
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.016704e+06
       GoKind: 22
-      Pointee: 728 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 798 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3622,30 +3739,30 @@ Types:
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 905
+      ID: 975
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 906 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 976 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 935
+      ID: 1005
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 936 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1006 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 944
+      ID: 1014
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 945 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1015 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 96
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 97 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 953
+      ID: 1023
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 954 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1024 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 133
       Name: '*bucket<int,uint8>'
@@ -3662,10 +3779,10 @@ Types:
       ByteSize: 8
       Pointee: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 650
+      ID: 720
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 106
       Name: '*bucket<string,int>'
@@ -3677,6 +3794,36 @@ Types:
       ByteSize: 8
       Pointee: 102 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
+      ID: 192
+      Name: '*bucket<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 193 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 197
+      Name: '*bucket<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 198 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 202
+      Name: '*bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 203 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 207
+      Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 208 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 212
+      Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 213 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 217
+      Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 218 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
       ID: 143
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
@@ -3687,393 +3834,393 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 773
+      ID: 843
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.028864e+06
       GoKind: 22
-      Pointee: 774 UnresolvedPointeeType bufio.Reader
+      Pointee: 844 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 798
+      ID: 868
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.814112e+06
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType bufio.Writer
+      Pointee: 869 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 845
+      ID: 915
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.121824e+06
       GoKind: 22
-      Pointee: 846 UnresolvedPointeeType bytes.Buffer
+      Pointee: 916 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 371
+      ID: 441
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 840960
       GoKind: 22
-      Pointee: 266 BaseType compress/flate.CorruptInputError
+      Pointee: 336 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 372
+      ID: 442
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 267 GoStringHeaderType compress/flate.InternalError
+      Pointee: 337 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 269
+      ID: 339
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType compress/flate.InternalError.str
+      Pointee: 338 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 747
+      ID: 817
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.243168e+06
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 818 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 693
+      ID: 763
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 764 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 769
+      ID: 839
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.599296e+06
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 840 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 602
+      ID: 672
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.1176e+06
       GoKind: 22
-      Pointee: 603 StructureType context.deadlineExceededError
+      Pointee: 673 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 451
+      ID: 521
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853248
       GoKind: 22
-      Pointee: 280 BaseType crypto/aes.KeySizeError
+      Pointee: 350 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 452
+      ID: 522
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853440
       GoKind: 22
-      Pointee: 281 BaseType crypto/des.KeySizeError
+      Pointee: 351 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 759
+      ID: 829
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.37344e+06
       GoKind: 22
-      Pointee: 760 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 830 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 784
+      ID: 854
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.678304e+06
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 855 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 453
+      ID: 523
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 282 BaseType crypto/rc4.KeySizeError
+      Pointee: 352 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 792
+      ID: 862
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.769856e+06
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 863 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 786
+      ID: 856
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.678752e+06
       GoKind: 22
-      Pointee: 787 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 857 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 788
+      ID: 858
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.6792e+06
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 859 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 377
+      ID: 447
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842592
       GoKind: 22
-      Pointee: 270 BaseType crypto/tls.AlertError
+      Pointee: 340 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 542
+      ID: 612
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.004288e+06
       GoKind: 22
-      Pointee: 543 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 613 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 871
+      ID: 941
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.230944e+06
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 942 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 375
+      ID: 445
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842400
       GoKind: 22
-      Pointee: 376 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 446 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 373
+      ID: 443
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842304
       GoKind: 22
-      Pointee: 374 StructureType crypto/tls.RecordHeaderError
+      Pointee: 444 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 541
+      ID: 611
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.002624e+06
       GoKind: 22
-      Pointee: 498 BaseType crypto/tls.alert
+      Pointee: 568 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 757
+      ID: 827
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.37056e+06
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 828 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 764
+      ID: 834
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.449632e+06
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 835 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 637
+      ID: 707
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.243488e+06
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 708 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 652
+      ID: 722
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.905536e+06
       GoKind: 22
-      Pointee: 653 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 723 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 447
+      ID: 517
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 448 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 518 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 441
+      ID: 511
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851712
       GoKind: 22
-      Pointee: 442 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 512 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 443
+      ID: 513
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 851808
       GoKind: 22
-      Pointee: 444 StructureType crypto/x509.HostnameError
+      Pointee: 514 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 440
+      ID: 510
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851616
       GoKind: 22
-      Pointee: 279 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 349 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 547
+      ID: 617
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010176e+06
       GoKind: 22
-      Pointee: 548 StructureType crypto/x509.SystemRootsError
+      Pointee: 618 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 449
+      ID: 519
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852288
       GoKind: 22
-      Pointee: 450 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 520 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 445
+      ID: 515
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852096
       GoKind: 22
-      Pointee: 446 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 516 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 462
+      ID: 532
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 858816
       GoKind: 22
-      Pointee: 463 StructureType encoding/asn1.StructuralError
+      Pointee: 533 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 466
+      ID: 536
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859008
       GoKind: 22
-      Pointee: 467 StructureType encoding/asn1.SyntaxError
+      Pointee: 537 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 464
+      ID: 534
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 858912
       GoKind: 22
-      Pointee: 465 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 535 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 363
+      ID: 433
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839232
       GoKind: 22
-      Pointee: 264 BaseType encoding/base64.CorruptInputError
+      Pointee: 334 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 715
+      ID: 785
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 999424
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 786 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 366
+      ID: 436
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840096
       GoKind: 22
-      Pointee: 265 BaseType encoding/hex.InvalidByteError
+      Pointee: 335 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 334
+      ID: 404
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 833952
       GoKind: 22
-      Pointee: 335 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 405 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 533
+      ID: 603
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995072
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 604 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 326
+      ID: 396
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833568
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 397 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 332
+      ID: 402
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 333 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 403 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 330
+      ID: 400
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 833760
       GoKind: 22
-      Pointee: 331 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 401 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 328
+      ID: 398
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833664
       GoKind: 22
-      Pointee: 329 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 399 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 851
+      ID: 921
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.147392e+06
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 922 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 336
+      ID: 406
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834336
       GoKind: 22
-      Pointee: 337 StructureType encoding/json.jsonError
+      Pointee: 407 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 723
+      ID: 793
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.012992e+06
       GoKind: 22
-      Pointee: 724 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 794 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 435
+      ID: 505
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 22
-      Pointee: 436 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 506 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 433
+      ID: 503
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850560
       GoKind: 22
-      Pointee: 434 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 504 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 437
+      ID: 507
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 276 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 346 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 278
+      ID: 348
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 347 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 438
+      ID: 508
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 439 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 509 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 829
+      ID: 899
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.017344e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 900 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4082,19 +4229,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 304
+      ID: 374
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824256
       GoKind: 22
-      Pointee: 305 UnresolvedPointeeType errors.errorString
+      Pointee: 375 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 500
+      ID: 570
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 979712
       GoKind: 22
-      Pointee: 501 UnresolvedPointeeType errors.joinError
+      Pointee: 571 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4110,806 +4257,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 839
+      ID: 909
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.11312e+06
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType fmt.pp
+      Pointee: 910 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 502
+      ID: 572
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 981504
       GoKind: 22
-      Pointee: 503 UnresolvedPointeeType fmt.wrapError
+      Pointee: 573 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 504
+      ID: 574
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 981632
       GoKind: 22
-      Pointee: 505 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 575 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 364
+      ID: 434
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839616
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 435 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 345
+      ID: 415
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 346 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 416 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 347
+      ID: 417
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 22
-      Pointee: 348 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 418 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 665
+      ID: 735
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836544
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 736 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 351
+      ID: 421
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 352 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 422 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 667
+      ID: 737
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 349
+      ID: 419
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 22
-      Pointee: 258 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 260
+      ID: 330
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 259 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 344
+      ID: 414
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836448
       GoKind: 22
-      Pointee: 255 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 325 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 257
+      ID: 327
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 256 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 326 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 350
+      ID: 420
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 22
-      Pointee: 261 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 263
+      ID: 333
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 737
+      ID: 807
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.12336e+06
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 808 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 817
+      ID: 887
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.920544e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 888 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 456
+      ID: 526
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857280
       GoKind: 22
-      Pointee: 457 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 527 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 611
+      ID: 681
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.126688e+06
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 682 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 847
+      ID: 917
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.12336e+06
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 918 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 384
+      ID: 454
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846144
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 455 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 391
+      ID: 461
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847200
       GoKind: 22
-      Pointee: 392 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 462 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 386
+      ID: 456
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 846912
       GoKind: 22
-      Pointee: 275 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 345 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 389
+      ID: 459
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 22
-      Pointee: 390 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 387
+      ID: 457
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 22
-      Pointee: 388 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 458 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 407
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849120
       GoKind: 22
-      Pointee: 408 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 411
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849312
       GoKind: 22
-      Pointee: 412 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 409
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849216
       GoKind: 22
-      Pointee: 410 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 405
+      ID: 475
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849024
       GoKind: 22
-      Pointee: 406 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 476 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 686
+      ID: 756
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 685 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 755 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 419
+      ID: 489
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 22
-      Pointee: 420 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 413
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849408
       GoKind: 22
-      Pointee: 414 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 417
+      ID: 487
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849600
       GoKind: 22
-      Pointee: 418 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 415
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 22
-      Pointee: 416 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 421
+      ID: 491
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 849792
       GoKind: 22
-      Pointee: 422 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 427
+      ID: 497
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850080
       GoKind: 22
-      Pointee: 428 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 429
+      ID: 499
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850176
       GoKind: 22
-      Pointee: 430 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 425
+      ID: 495
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 849984
       GoKind: 22
-      Pointee: 426 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 423
+      ID: 493
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 849888
       GoKind: 22
-      Pointee: 424 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 431
+      ID: 501
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850368
       GoKind: 22
-      Pointee: 432 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 353
+      ID: 423
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838272
       GoKind: 22
-      Pointee: 354 StructureType github.com/cihub/seelog.baseError
+      Pointee: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 776
+      ID: 846
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.675392e+06
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 847 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 355
+      ID: 425
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838368
       GoKind: 22
-      Pointee: 356 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 426 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 755
+      ID: 825
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.36944e+06
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 826 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 711
+      ID: 781
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 998400
       GoKind: 22
-      Pointee: 712 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 782 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 745
+      ID: 815
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.241248e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 359
+      ID: 429
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838560
       GoKind: 22
-      Pointee: 360 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 430 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 807
+      ID: 877
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.838592e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 878 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 822
+      ID: 892
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.992e+06
       GoKind: 22
-      Pointee: 819 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 889 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 821
+      ID: 891
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.991616e+06
       GoKind: 22
-      Pointee: 820 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 890 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 713
+      ID: 783
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 998528
       GoKind: 22
-      Pointee: 714 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 357
+      ID: 427
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838464
       GoKind: 22
-      Pointee: 358 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 428 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 361
+      ID: 431
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838656
       GoKind: 22
-      Pointee: 362 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 780
+      ID: 850
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.67696e+06
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 851 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 813
+      ID: 883
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.874464e+06
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 884 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 815
+      ID: 885
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.905216e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 886 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 642
+      ID: 712
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.255328e+06
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 713 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 555
+      ID: 625
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.024384e+06
       GoKind: 22
-      Pointee: 556 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 626 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 553
+      ID: 623
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024256e+06
       GoKind: 22
-      Pointee: 554 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 624 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 557
+      ID: 627
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.028352e+06
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 628 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 559
+      ID: 629
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.02848e+06
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 630 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 766
+      ID: 836
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.47728e+06
       GoKind: 22
-      Pointee: 767 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 837 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 549
+      ID: 619
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.010944e+06
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 620 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 367
+      ID: 437
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840288
       GoKind: 22
-      Pointee: 368 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 438 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 863
+      ID: 933
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.210048e+06
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 934 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 613
+      ID: 683
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.13488e+06
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 684 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 586
+      ID: 656
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.11376e+06
       GoKind: 22
-      Pointee: 587 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 580
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.113376e+06
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 651 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 519
+      ID: 589
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 988928
       GoKind: 22
-      Pointee: 520 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 592
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114144e+06
       GoKind: 22
-      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 518
+      ID: 588
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 988800
       GoKind: 22
-      Pointee: 497 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 567 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 584
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.113632e+06
       GoKind: 22
-      Pointee: 585 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 582
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.113504e+06
       GoKind: 22
-      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 590
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114016e+06
       GoKind: 22
-      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 588
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.113888e+06
       GoKind: 22
-      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 867
+      ID: 937
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.221088e+06
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 938 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 596
+      ID: 666
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.114528e+06
       GoKind: 22
-      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 523
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989184
       GoKind: 22
-      Pointee: 524 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 521
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989056
       GoKind: 22
-      Pointee: 522 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 594
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 478
+      ID: 548
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 870912
       GoKind: 22
-      Pointee: 287 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 357 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 289
+      ID: 359
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 358 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 655
+      ID: 725
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.475744e+06
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 726 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 563
+      ID: 633
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.043328e+06
       GoKind: 22
-      Pointee: 564 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 634 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 743
+      ID: 813
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.173792e+06
       GoKind: 22
-      Pointee: 744 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 814 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 827
+      ID: 897
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.006976e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 898 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 729
+      ID: 799
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.045632e+06
       GoKind: 22
-      Pointee: 730 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 800 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 479
+      ID: 549
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872160
       GoKind: 22
-      Pointee: 290 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 360 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 621
+      ID: 691
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.175456e+06
       GoKind: 22
-      Pointee: 622 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 692 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 482
+      ID: 552
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872448
       GoKind: 22
-      Pointee: 483 StructureType golang.org/x/net/http2.connError
+      Pointee: 553 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 481
+      ID: 551
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872352
       GoKind: 22
-      Pointee: 294 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 364 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 296
+      ID: 366
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 295 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 365 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 485
+      ID: 555
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872640
       GoKind: 22
-      Pointee: 300 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 370 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 302
+      ID: 372
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 301 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 371 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 484
+      ID: 554
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872544
       GoKind: 22
-      Pointee: 297 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 367 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 299
+      ID: 369
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 368 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 480
+      ID: 550
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872256
       GoKind: 22
-      Pointee: 291 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 361 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 293
+      ID: 363
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 292 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 362 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 825
+      ID: 895
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.005056e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 896 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 486
+      ID: 556
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872736
       GoKind: 22
-      Pointee: 487 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 557 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 488
+      ID: 558
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 872832
       GoKind: 22
-      Pointee: 303 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 373 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 474
+      ID: 544
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866304
       GoKind: 22
-      Pointee: 475 StructureType google.golang.org/grpc.dropError
+      Pointee: 545 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 619
+      ID: 689
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.172384e+06
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 690 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 644
+      ID: 714
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.262688e+06
       GoKind: 22
-      Pointee: 645 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 715 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 476
+      ID: 546
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869184
       GoKind: 22
-      Pointee: 477 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 547 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 790
+      ID: 860
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.68368e+06
       GoKind: 22
-      Pointee: 791 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 861 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 741
+      ID: 811
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.168928e+06
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 812 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 561
+      ID: 631
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.037568e+06
       GoKind: 22
-      Pointee: 562 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 632 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 701
+      ID: 771
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869280
       GoKind: 22
-      Pointee: 702 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 772 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 454
+      ID: 524
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855168
       GoKind: 22
-      Pointee: 455 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 525 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 551
+      ID: 621
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.0144e+06
       GoKind: 22
-      Pointee: 552 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 622 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 617
+      ID: 687
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.14064e+06
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 688 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 615
+      ID: 685
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.140384e+06
       GoKind: 22
-      Pointee: 616 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 686 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 468
+      ID: 538
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 859872
       GoKind: 22
-      Pointee: 469 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 539 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 470
+      ID: 540
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 22
-      Pointee: 471 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 541 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 399
+      ID: 469
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 470 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 778
+      ID: 848
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.676064e+06
       GoKind: 22
-      Pointee: 779 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 849 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 151
       Name: '*hash<[4]int,[4]int>'
@@ -4936,30 +5083,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 903
+      ID: 973
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 904 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 974 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 933
+      ID: 1003
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 934 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1004 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 942
+      ID: 1012
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 943 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1013 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 95 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 951
+      ID: 1021
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 952 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1022 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '*hash<int,uint8>'
@@ -4976,10 +5123,10 @@ Types:
       ByteSize: 8
       Pointee: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 648
+      ID: 718
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 649 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 719 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '*hash<string,int>'
@@ -4991,6 +5138,36 @@ Types:
       ByteSize: 8
       Pointee: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
+      ID: 190
+      Name: '*hash<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 191 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 195
+      Name: '*hash<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 196 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 200
+      Name: '*hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 201 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 205
+      Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 206 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 210
+      Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 211 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 215
+      Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 216 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
       ID: 141
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
@@ -5001,12 +5178,12 @@ Types:
       ByteSize: 8
       Pointee: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 489
+      ID: 559
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873600
       GoKind: 22
-      Pointee: 490 UnresolvedPointeeType html/template.Error
+      Pointee: 560 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -5050,96 +5227,96 @@ Types:
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 369
+      ID: 439
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840672
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 440 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 687
+      ID: 757
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 828864
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 758 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 578
+      ID: 648
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.112608e+06
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 649 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 869
+      ID: 939
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.22576e+06
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType internal/poll.FD
+      Pointee: 940 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 576
+      ID: 646
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.11248e+06
       GoKind: 22
-      Pointee: 577 StructureType internal/poll.errNetClosing
+      Pointee: 647 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 306
+      ID: 376
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828000
       GoKind: 22
-      Pointee: 307 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 377 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 733
+      ID: 803
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.103648e+06
       GoKind: 22
-      Pointee: 734 UnresolvedPointeeType io.PipeWriter
+      Pointee: 804 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 731
+      ID: 801
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.103264e+06
       GoKind: 22
-      Pointee: 732 StructureType io.discard
+      Pointee: 802 StructureType io.discard
     - __kind: PointerType
-      ID: 705
+      ID: 775
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 979968
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType io.multiWriter
+      Pointee: 776 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 574
+      ID: 644
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112224e+06
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType io/fs.PathError
+      Pointee: 645 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 782
+      ID: 852
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.677184e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 853 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 189
+      ID: 233
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 356288
       GoKind: 22
-      Pointee: 190 StructureType main.deepMap2
+      Pointee: 234 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 908
+      ID: 978
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType main.deepMap3
+      Pointee: 979 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -5148,19 +5325,19 @@ Types:
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 938
+      ID: 1008
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 355904
       GoKind: 22
-      Pointee: 939 StructureType main.deepMap8
+      Pointee: 1009 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 947
+      ID: 1017
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355840
       GoKind: 22
-      Pointee: 948 StructureType main.deepMap9
+      Pointee: 1018 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -5169,12 +5346,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 873
+      ID: 943
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 874 UnresolvedPointeeType main.deepPtr3
+      Pointee: 944 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5183,33 +5360,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 913
+      ID: 983
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356480
       GoKind: 22
-      Pointee: 914 StructureType main.deepPtr8
+      Pointee: 984 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 915
+      ID: 985
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356416
       GoKind: 22
-      Pointee: 916 StructureType main.deepPtr9
+      Pointee: 986 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 357440
       GoKind: 22
-      Pointee: 183 StructureType main.deepSlice2
+      Pointee: 227 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 898
+      ID: 968
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357376
       GoKind: 22
-      Pointee: 899 UnresolvedPointeeType main.deepSlice3
+      Pointee: 969 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5218,25 +5395,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 919
+      ID: 989
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357056
       GoKind: 22
-      Pointee: 920 StructureType main.deepSlice8
+      Pointee: 990 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 925
+      ID: 995
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 356992
       GoKind: 22
-      Pointee: 926 StructureType main.deepSlice9
+      Pointee: 996 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 178
+      ID: 222
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 177 StructureType main.emptyStruct
+      Pointee: 221 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 86
       Name: '*main.esotericHeap'
@@ -5245,12 +5422,12 @@ Types:
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 889
+      ID: 959
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 823968
       GoKind: 22
-      Pointee: 890 StructureType main.firstBehavior
+      Pointee: 960 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 159
       Name: '*main.node'
@@ -5265,19 +5442,19 @@ Types:
       GoKind: 22
       Pointee: 174 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 891
+      ID: 961
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824064
       GoKind: 22
-      Pointee: 892 StructureType main.secondBehavior
+      Pointee: 962 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 878
+      ID: 948
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824160
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType main.somethingImpl
+      Pointee: 949 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
@@ -5285,18 +5462,23 @@ Types:
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 876
+      ID: 946
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 875 GoStringDataType main.stringType1.str
+      Pointee: 945 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType main.stringType2
+      Pointee: 947 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 206
+      ID: 177
+      Name: '*main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 175 StructureType main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 250
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 355776
@@ -5320,10 +5502,10 @@ Types:
       GoKind: 22
       Pointee: 161 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 895
+      ID: 965
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 894 GoSliceDataType main.t.array
+      Pointee: 964 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 172
       Name: '*main.threeStringStruct'
@@ -5337,580 +5519,580 @@ Types:
       GoKind: 22
       Pointee: 103 GoMapType map[string]int
     - __kind: PointerType
-      ID: 403
+      ID: 473
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848448
       GoKind: 22
-      Pointee: 404 StructureType math/big.ErrNaN
+      Pointee: 474 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 695
+      ID: 765
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843072
       GoKind: 22
-      Pointee: 696 StructureType mime/multipart.writerOnly·1
+      Pointee: 766 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 605
+      ID: 675
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.120928e+06
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType net.AddrError
+      Pointee: 676 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 631
+      ID: 701
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.239488e+06
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType net.DNSError
+      Pointee: 702 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 833
+      ID: 903
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.085792e+06
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType net.IPConn
+      Pointee: 904 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 629
+      ID: 699
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.239168e+06
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType net.OpError
+      Pointee: 700 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 607
+      ID: 677
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121056e+06
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType net.ParseError
+      Pointee: 678 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 843
+      ID: 913
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.115168e+06
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType net.TCPConn
+      Pointee: 914 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 853
+      ID: 923
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.160128e+06
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType net.UDPConn
+      Pointee: 924 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 841
+      ID: 911
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.114656e+06
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType net.UnixConn
+      Pointee: 912 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 604
+      ID: 674
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.12016e+06
       GoKind: 22
-      Pointee: 567 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 637 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 569
+      ID: 639
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 568 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 638 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 535
+      ID: 605
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 995840
       GoKind: 22
-      Pointee: 536 StructureType net.canceledError
+      Pointee: 606 StructureType net.canceledError
     - __kind: PointerType
-      ID: 811
+      ID: 881
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.87216e+06
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType net.conn
+      Pointee: 882 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 674
+      ID: 744
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.716384e+06
       GoKind: 22
-      Pointee: 675 StructureType net.dialResult·1
+      Pointee: 745 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 855
+      ID: 925
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.164384e+06
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType net.netFD
+      Pointee: 926 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 338
+      ID: 408
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835296
       GoKind: 22
-      Pointee: 339 UnresolvedPointeeType net.notFoundError
+      Pointee: 409 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 340
+      ID: 410
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 835968
       GoKind: 22
-      Pointee: 341 StructureType net.result·2
+      Pointee: 411 StructureType net.result·2
     - __kind: PointerType
-      ID: 837
+      ID: 907
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.09968e+06
       GoKind: 22
-      Pointee: 838 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 908 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 835
+      ID: 905
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.0992e+06
       GoKind: 22
-      Pointee: 836 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 906 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 609
+      ID: 679
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.121696e+06
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType net.temporaryError
+      Pointee: 680 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 633
+      ID: 703
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.239648e+06
       GoKind: 22
-      Pointee: 634 UnresolvedPointeeType net.timeoutError
+      Pointee: 704 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 525
+      ID: 595
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 991616
       GoKind: 22
-      Pointee: 526 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 596 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 689
+      ID: 759
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831168
       GoKind: 22
-      Pointee: 690 StructureType net/http.bufioFlushWriter
+      Pointee: 760 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 315
+      ID: 385
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 831840
       GoKind: 22
-      Pointee: 236 BaseType net/http.http2ConnectionError
+      Pointee: 306 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 316
+      ID: 386
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 831936
       GoKind: 22
-      Pointee: 317 StructureType net/http.http2GoAwayError
+      Pointee: 387 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 625
+      ID: 695
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.235328e+06
       GoKind: 22
-      Pointee: 626 StructureType net/http.http2StreamError
+      Pointee: 696 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 320
+      ID: 390
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832416
       GoKind: 22
-      Pointee: 321 StructureType net/http.http2connError
+      Pointee: 391 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 751
+      ID: 821
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.36608e+06
       GoKind: 22
-      Pointee: 752 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 822 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 319
+      ID: 389
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832320
       GoKind: 22
-      Pointee: 240 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 310 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 242
+      ID: 312
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 241 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 311 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 323
+      ID: 393
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832608
       GoKind: 22
-      Pointee: 246 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 316 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 248
+      ID: 318
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 247 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 317 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 322
+      ID: 392
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832512
       GoKind: 22
-      Pointee: 243 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 313 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 245
+      ID: 315
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 244 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 314 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 600
+      ID: 670
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.116704e+06
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 671 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 531
+      ID: 601
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992256
       GoKind: 22
-      Pointee: 532 StructureType net/http.http2noCachedConnError
+      Pointee: 602 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 802
+      ID: 872
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.81616e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 873 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 318
+      ID: 388
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832224
       GoKind: 22
-      Pointee: 237 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 307 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 239
+      ID: 309
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 238 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 308 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 691
+      ID: 761
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832704
       GoKind: 22
-      Pointee: 692 StructureType net/http.http2stickyErrWriter
+      Pointee: 762 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 527
+      ID: 597
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 991872
       GoKind: 22
-      Pointee: 528 StructureType net/http.nothingWrittenError
+      Pointee: 598 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 753
+      ID: 823
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.030112e+06
       GoKind: 22
-      Pointee: 754 UnresolvedPointeeType net/http.persistConn
+      Pointee: 824 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 709
+      ID: 779
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 991744
       GoKind: 22
-      Pointee: 710 StructureType net/http.persistConnWriter
+      Pointee: 780 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 735
+      ID: 805
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.11568e+06
       GoKind: 22
-      Pointee: 736 StructureType net/http.readWriteCloserBody
+      Pointee: 806 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 324
+      ID: 394
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 832800
       GoKind: 22
-      Pointee: 325 StructureType net/http.requestBodyReadError
+      Pointee: 395 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 627
+      ID: 697
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.236448e+06
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 698 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 598
+      ID: 668
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.116576e+06
       GoKind: 22
-      Pointee: 599 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 669 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 529
+      ID: 599
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992000
       GoKind: 22
-      Pointee: 530 StructureType net/http.transportReadFromServerError
+      Pointee: 600 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 313
+      ID: 383
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831072
       GoKind: 22
-      Pointee: 314 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 384 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 804
+      ID: 874
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.817696e+06
       GoKind: 22
-      Pointee: 805 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 875 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 719
+      ID: 789
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.005312e+06
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 790 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 395
+      ID: 465
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847392
       GoKind: 22
-      Pointee: 396 StructureType net/netip.parseAddrError
+      Pointee: 466 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 393
+      ID: 463
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847296
       GoKind: 22
-      Pointee: 394 StructureType net/netip.parsePrefixError
+      Pointee: 464 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 761
+      ID: 831
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.979776e+06
       GoKind: 22
-      Pointee: 762 UnresolvedPointeeType net/smtp.Client
+      Pointee: 832 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 721
+      ID: 791
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.010432e+06
       GoKind: 22
-      Pointee: 722 StructureType net/smtp.dataCloser
+      Pointee: 792 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 379
+      ID: 449
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843264
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType net/textproto.Error
+      Pointee: 450 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 378
+      ID: 448
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843168
       GoKind: 22
-      Pointee: 271 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 341 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 273
+      ID: 343
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 342 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 717
+      ID: 787
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.004672e+06
       GoKind: 22
-      Pointee: 718 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 788 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 635
+      ID: 705
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.239968e+06
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType net/url.Error
+      Pointee: 706 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 342
+      ID: 412
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836064
       GoKind: 22
-      Pointee: 249 GoStringHeaderType net/url.EscapeError
+      Pointee: 319 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 251
+      ID: 321
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 250 GoStringDataType net/url.EscapeError.str
+      Pointee: 320 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 343
+      ID: 413
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836160
       GoKind: 22
-      Pointee: 252 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 322 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 254
+      ID: 324
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 253 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 323 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 861
+      ID: 931
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.201632e+06
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType os.File
+      Pointee: 932 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 506
+      ID: 576
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 982784
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType os.LinkError
+      Pointee: 577 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 570
+      ID: 640
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105184e+06
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType os.SyscallError
+      Pointee: 641 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 859
+      ID: 929
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.198688e+06
       GoKind: 22
-      Pointee: 860 StructureType os.fileWithoutReadFrom
+      Pointee: 930 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 857
+      ID: 927
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.197952e+06
       GoKind: 22
-      Pointee: 858 StructureType os.fileWithoutWriteTo
+      Pointee: 928 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 537
+      ID: 607
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001344e+06
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType os/exec.Error
+      Pointee: 608 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 677
+      ID: 747
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.951744e+06
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 748 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 739
+      ID: 809
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.127712e+06
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 810 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 539
+      ID: 609
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.001472e+06
       GoKind: 22
-      Pointee: 540 StructureType os/exec.wrappedError
+      Pointee: 610 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 473
+      ID: 543
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864384
       GoKind: 22
-      Pointee: 284 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 354 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 286
+      ID: 356
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 355 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 472
+      ID: 542
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864288
       GoKind: 22
-      Pointee: 283 BaseType os/user.UnknownUserIdError
+      Pointee: 353 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 308
+      ID: 378
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 828768
       GoKind: 22
-      Pointee: 309 UnresolvedPointeeType reflect.ValueError
+      Pointee: 379 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 401
+      ID: 471
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848064
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 472 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 509
+      ID: 579
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984320
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 580 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 514
+      ID: 584
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986240
       GoKind: 22
-      Pointee: 515 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 585 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 511
+      ID: 581
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 984448
       GoKind: 22
-      Pointee: 512 StructureType runtime.boundsError
+      Pointee: 582 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 572
+      ID: 642
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.11056e+06
       GoKind: 22
-      Pointee: 573 StructureType runtime.errorAddressString
+      Pointee: 643 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 508
+      ID: 578
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984064
       GoKind: 22
-      Pointee: 491 GoStringHeaderType runtime.errorString
+      Pointee: 561 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 493
+      ID: 563
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 492 GoStringDataType runtime.errorString.str
+      Pointee: 562 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
@@ -5919,24 +6101,24 @@ Types:
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 513
+      ID: 583
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 985984
       GoKind: 22
-      Pointee: 494 GoStringHeaderType runtime.plainError
+      Pointee: 564 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 496
+      ID: 566
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 495 GoStringDataType runtime.plainError.str
+      Pointee: 565 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 516
+      ID: 586
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 986496
       GoKind: 22
-      Pointee: 517 UnresolvedPointeeType strconv.NumError
+      Pointee: 587 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -5945,78 +6127,78 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 180
+      ID: 224
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 179 GoStringDataType string.str
+      Pointee: 223 GoStringDataType string.str
     - __kind: PointerType
-      ID: 800
+      ID: 870
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.81488e+06
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType strings.Builder
+      Pointee: 871 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 707
+      ID: 777
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 986624
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 778 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 703
+      ID: 773
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 704 StructureType struct { io.Writer }
+      Pointee: 774 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 624
+      ID: 694
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.234688e+06
       GoKind: 22
-      Pointee: 623 BaseType syscall.Errno
+      Pointee: 693 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 831
+      ID: 901
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.017728e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 902 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 565
+      ID: 635
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.047168e+06
       GoKind: 22
-      Pointee: 566 StructureType text/template.ExecError
+      Pointee: 636 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 640
+      ID: 710
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.4312e+06
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType time.Location
+      Pointee: 711 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 311
+      ID: 381
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829632
       GoKind: 22
-      Pointee: 312 UnresolvedPointeeType time.ParseError
+      Pointee: 382 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 310
+      ID: 380
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829536
       GoKind: 22
-      Pointee: 233 GoStringHeaderType time.fileSizeError
+      Pointee: 303 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 235
+      ID: 305
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 234 GoStringDataType time.fileSizeError.str
+      Pointee: 304 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6060,59 +6242,59 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 794
+      ID: 864
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.771136e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 865 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 397
+      ID: 467
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847488
       GoKind: 22
-      Pointee: 398 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 468 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 823
+      ID: 893
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.994304e+06
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 894 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 381
+      ID: 451
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843648
       GoKind: 22
-      Pointee: 382 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 452 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 383
+      ID: 453
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 843744
       GoKind: 22
-      Pointee: 274 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 344 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 544
+      ID: 614
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005056e+06
       GoKind: 22
-      Pointee: 545 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 615 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 546
+      ID: 616
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005184e+06
       GoKind: 22
-      Pointee: 499 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 569 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1054
+      ID: 1124
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1011
+      ID: 1081
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6127,7 +6309,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1009
+      ID: 1079
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6142,7 +6324,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 973
+      ID: 1043
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6157,7 +6339,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 971
+      ID: 1041
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6172,7 +6354,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1019
+      ID: 1089
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6187,7 +6369,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 972
+      ID: 1042
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6202,7 +6384,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 991
+      ID: 1061
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6217,7 +6399,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 960
+      ID: 1030
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6232,7 +6414,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 957
+      ID: 1027
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6247,7 +6429,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1035
+      ID: 1105
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6262,7 +6444,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1033
+      ID: 1103
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6295,7 +6477,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1043
+      ID: 1113
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6310,7 +6492,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 996
+      ID: 1066
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6325,7 +6507,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 997
+      ID: 1067
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6340,7 +6522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 992
+      ID: 1062
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6355,7 +6537,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 993
+      ID: 1063
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6370,7 +6552,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 994
+      ID: 1064
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6385,7 +6567,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 995
+      ID: 1065
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6400,7 +6582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1048
+      ID: 1118
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6424,7 +6606,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1045
+      ID: 1115
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6439,7 +6621,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1062
+      ID: 1132
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6454,7 +6636,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1065
+      ID: 1137
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6462,14 +6644,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 178 PointerType *main.emptyStruct
+            Type: 222 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: e}
+                  Variable: {subprogram: 111, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1064
+      ID: 1136
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6477,14 +6659,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 177 StructureType main.emptyStruct
+            Type: 221 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 110, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1010
+      ID: 1080
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6499,7 +6681,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1001
+      ID: 1071
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6514,7 +6696,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1000
+      ID: 1070
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6529,7 +6711,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1007
+      ID: 1077
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6544,7 +6726,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1006
+      ID: 1076
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6559,7 +6741,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1002
+      ID: 1072
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6574,7 +6756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1004
+      ID: 1074
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6589,10 +6771,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1067
+      ID: 1139
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1003
+      ID: 1073
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6616,16 +6798,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1068
+      ID: 1140
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1069
+      ID: 1141
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1005
+      ID: 1075
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1066
+      ID: 1138
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6636,11 +6818,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 112, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1070
+      ID: 1142
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6651,11 +6833,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1071
+      ID: 1143
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6666,11 +6848,11 @@ Types:
             Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: a}
+                  Variable: {subprogram: 117, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 963
+      ID: 1033
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6685,7 +6867,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 964
+      ID: 1034
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6700,7 +6882,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 965
+      ID: 1035
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6715,7 +6897,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 962
+      ID: 1032
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6730,7 +6912,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 961
+      ID: 1031
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6745,7 +6927,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1008
+      ID: 1078
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6760,7 +6942,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1037
+      ID: 1107
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6775,7 +6957,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1017
+      ID: 1087
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6790,7 +6972,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1023
+      ID: 1093
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6805,7 +6987,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1021
+      ID: 1091
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6820,7 +7002,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1032
+      ID: 1102
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6835,7 +7017,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1031
+      ID: 1101
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6850,7 +7032,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1022
+      ID: 1092
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6865,7 +7047,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1030
+      ID: 1100
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6880,7 +7062,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1029
+      ID: 1099
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6895,7 +7077,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1015
+      ID: 1085
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6910,7 +7092,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1016
+      ID: 1086
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6925,7 +7107,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1014
+      ID: 1084
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6940,7 +7122,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1024
+      ID: 1094
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6955,7 +7137,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1028
+      ID: 1098
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6970,7 +7152,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1027
+      ID: 1097
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6985,7 +7167,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1026
+      ID: 1096
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7000,7 +7182,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1025
+      ID: 1095
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7015,7 +7197,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1060
+      ID: 1130
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7030,7 +7212,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1034
+      ID: 1104
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7081,7 +7263,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1042
+      ID: 1112
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7105,7 +7287,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1049
+      ID: 1119
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7129,7 +7311,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1051
+      ID: 1121
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7162,7 +7344,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1052
+      ID: 1122
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7177,7 +7359,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1059
+      ID: 1129
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7192,7 +7374,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1038
+      ID: 1108
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7207,7 +7389,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1020
+      ID: 1090
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7222,7 +7404,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1036
+      ID: 1106
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7237,7 +7419,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 958
+      ID: 1028
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7252,7 +7434,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 977
+      ID: 1047
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7267,7 +7449,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 975
+      ID: 1045
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7282,7 +7464,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 988
+      ID: 1058
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7297,7 +7479,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 989
+      ID: 1059
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7312,7 +7494,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 980
+      ID: 1050
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7327,7 +7509,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 981
+      ID: 1051
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7342,7 +7524,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 982
+      ID: 1052
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7357,7 +7539,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 979
+      ID: 1049
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7372,7 +7554,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 978
+      ID: 1048
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7387,7 +7569,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 976
+      ID: 1046
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7402,7 +7584,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1055
+      ID: 1125
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7417,7 +7599,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 985
+      ID: 1055
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7432,7 +7614,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 986
+      ID: 1056
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7447,7 +7629,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 987
+      ID: 1057
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7462,7 +7644,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 984
+      ID: 1054
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7477,7 +7659,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 983
+      ID: 1053
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7492,7 +7674,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1046
+      ID: 1116
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7507,7 +7689,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1018
+      ID: 1088
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7522,7 +7704,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 959
+      ID: 1029
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7537,7 +7719,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1041
+      ID: 1111
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7552,7 +7734,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1050
+      ID: 1120
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7567,7 +7749,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 998
+      ID: 1068
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7582,7 +7764,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 999
+      ID: 1069
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7597,7 +7779,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1047
+      ID: 1117
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7621,7 +7803,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1012
+      ID: 1082
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7636,7 +7818,37 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1013
+      ID: 1134
+      Name: Probe[main.testStructWithCyclicMaps]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 188 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 1133
+      Name: Probe[main.testStructWithCyclicSlices]
+      ByteSize: 145
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 175 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
+    - __kind: EventRootType
+      ID: 1083
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7651,7 +7863,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1063
+      ID: 1135
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7659,14 +7871,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 175 StructureType main.aStruct
+            Type: 219 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1058
+      ID: 1128
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7681,7 +7893,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1057
+      ID: 1127
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7696,7 +7908,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1056
+      ID: 1126
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7729,7 +7941,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 990
+      ID: 1060
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7744,7 +7956,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 968
+      ID: 1038
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7759,7 +7971,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 969
+      ID: 1039
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7774,7 +7986,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 970
+      ID: 1040
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7789,7 +8001,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 967
+      ID: 1037
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7804,7 +8016,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 966
+      ID: 1036
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7819,7 +8031,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1040
+      ID: 1110
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7834,7 +8046,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1044
+      ID: 1114
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7849,7 +8061,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1061
+      ID: 1131
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7864,7 +8076,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1039
+      ID: 1109
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7879,7 +8091,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 974
+      ID: 1044
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -7894,7 +8106,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1053
+      ID: 1123
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7961,7 +8173,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 624096
+      GoRuntimeType: 624192
       GoKind: 17
       Count: 2
       HasCount: true
@@ -7994,7 +8206,7 @@ Types:
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 624192
+      GoRuntimeType: 624288
       GoKind: 17
       Count: 2
       HasCount: true
@@ -8027,7 +8239,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 624288
+      GoRuntimeType: 624384
       GoKind: 17
       Count: 2
       HasCount: true
@@ -8036,13 +8248,13 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 624000
+      GoRuntimeType: 624096
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 216
+      ID: 260
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 622560
@@ -8051,7 +8263,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 201
+      ID: 245
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 622848
@@ -8068,16 +8280,16 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 669
+      ID: 739
       Name: '[5]uint8'
       ByteSize: 5
-      GoRuntimeType: 623904
+      GoRuntimeType: 624000
       GoKind: 17
       Count: 5
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 186
+      ID: 230
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 619872
@@ -8101,14 +8313,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []*main.deepSlice2.array
+      Data: 228 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 228
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 896
+      ID: 966
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446848
@@ -8116,21 +8328,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 897 PointerType **main.deepSlice3
+          Type: 967 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 900 GoSliceDataType []*main.deepSlice3.array
+      Data: 970 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 900
+      ID: 970
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 898 PointerType *main.deepSlice3
+      Element: 968 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 917
+      ID: 987
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446528
@@ -8138,21 +8350,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 918 PointerType **main.deepSlice8
+          Type: 988 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 921 GoSliceDataType []*main.deepSlice8.array
+      Data: 991 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 921
+      ID: 991
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 919 PointerType *main.deepSlice8
+      Element: 989 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 923
+      ID: 993
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446464
@@ -8160,19 +8372,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 924 PointerType **main.deepSlice9
+          Type: 994 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 927 GoSliceDataType []*main.deepSlice9.array
+      Data: 997 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 927
+      ID: 997
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 925 PointerType *main.deepSlice9
+      Element: 995 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -8189,12 +8401,117 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 181 GoSliceDataType []*string.array
+      Data: 225 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 225
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
+    - __kind: GoSliceHeaderType
+      ID: 186
+      Name: '[][][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 187 PointerType *[][][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 287 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 287
+      Name: '[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 184 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 184
+      Name: '[][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 185 PointerType *[][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 285 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 285
+      Name: '[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 182 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 182
+      Name: '[][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 183 PointerType *[][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 283 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 283
+      Name: '[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 180 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 180
+      Name: '[][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 181 PointerType *[][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 281 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 281
+      Name: '[][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 178 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 178
+      Name: '[][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 179 PointerType *[]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 279 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 279
+      Name: '[][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 176 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
       ID: 163
       Name: '[][]uint'
@@ -8210,9 +8527,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 223 GoSliceDataType [][]uint.array
+      Data: 267 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 267
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 162 GoSliceHeaderType []uint
@@ -8232,104 +8549,134 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []bool.array
+      Data: 273 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 273
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 264
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
       Element: 154 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 263
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
       Element: 149 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 247
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
       Element: 117 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 254
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
       Element: 129 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 235
       Name: '[]bucket<int,*main.deepMap2>.array'
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 910
+      ID: 980
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 906 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 976 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 940
+      ID: 1010
       Name: '[]bucket<int,*main.deepMap8>.array'
       ByteSize: 2048
-      Element: 936 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1006 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 949
+      ID: 1019
       Name: '[]bucket<int,*main.deepMap9>.array'
       ByteSize: 2048
-      Element: 945 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1015 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 237
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 97 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 956
+      ID: 1026
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
-      Element: 954 GoHMapBucketType bucket<int,interface {}>
+      Element: 1024 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 256
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
       Element: 134 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 251
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 243
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 680
+      ID: 750
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 2048
-      Element: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 241
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 107 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 240
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
       Element: 102 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 292
+      Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 193 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 294
+      Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 198 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 296
+      Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 203 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 298
+      Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 208 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 300
+      Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 213 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 302
+      Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 218 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 261
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
       Element: 144 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 258
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
       Element: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 664
+      ID: 734
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454080
@@ -8344,14 +8691,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 683 GoSliceDataType []float64.array
+      Data: 753 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 753
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 929
+      ID: 999
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454528
@@ -8366,56 +8713,83 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 930 GoSliceDataType []interface {}.array
+      Data: 1000 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 930
+      ID: 1000
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 218
+      ID: 262
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 216 ArrayType [4]int
+      Element: 260 ArrayType [4]int
     - __kind: ArrayType
-      ID: 200
+      ID: 244
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 201 ArrayType [4]string
+      Element: 245 ArrayType [4]string
     - __kind: ArrayType
-      ID: 208
+      ID: 252
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 187
+      ID: 231
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 194
+      ID: 238
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 213
+      ID: 289
+      Name: '[]key<struct {}>'
+      Count: 8
+      HasCount: true
+      Element: 290 StructureType struct {}
+    - __kind: ArrayType
+      ID: 257
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 205
+      ID: 176
+      Name: '[]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 177 PointerType *main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 277 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 277
+      Name: '[]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 175 StructureType main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 249
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 447168
@@ -8423,16 +8797,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 206 PointerType *main.structWithMap
+          Type: 250 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 911 GoSliceDataType []main.structWithMap.array
+      Data: 981 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 911
+      ID: 981
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 92 StructureType main.structWithMap
@@ -8451,9 +8825,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 225 GoSliceDataType []main.structWithNoStrings.array
+      Data: 269 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 269
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 167 StructureType main.structWithNoStrings
@@ -8473,9 +8847,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 227 GoSliceDataType []string.array
+      Data: 271 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 271
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
@@ -8495,9 +8869,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 221 GoSliceDataType []uint.array
+      Data: 265 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 265
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 15 BaseType uint
@@ -8517,14 +8891,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 231 GoSliceDataType []uint16.array
+      Data: 275 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 275
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 658
+      ID: 728
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 453056
@@ -8539,116 +8913,158 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 681 GoSliceDataType []uint8.array
+      Data: 751 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 681
+      ID: 751
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 188
+      ID: 232
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 189 PointerType *main.deepMap2
+      Element: 233 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 907
+      ID: 977
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 908 PointerType *main.deepMap3
+      Element: 978 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 937
+      ID: 1007
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 938 PointerType *main.deepMap8
+      Element: 1008 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 946
+      ID: 1016
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 947 PointerType *main.deepMap9
+      Element: 1017 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 202
+      ID: 246
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 215
+      ID: 259
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 216 ArrayType [4]int
+      Element: 260 ArrayType [4]int
     - __kind: ArrayType
-      ID: 204
+      ID: 248
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 205 GoSliceHeaderType []main.structWithMap
+      Element: 249 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 198
+      ID: 242
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 168 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 679
+      ID: 749
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 192
+      ID: 236
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 955
+      ID: 1025
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 195
+      ID: 239
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 176 StructureType main.nestedStruct
+      Element: 220 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 209
+      ID: 253
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 158 StructureType main.node
     - __kind: ArrayType
-      ID: 211
+      ID: 291
+      Name: '[]val<main.structWithCyclicMaps>'
+      ByteSize: 384
+      Count: 8
+      HasCount: true
+      Element: 188 StructureType main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 293
+      Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 189 GoMapType map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 295
+      Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 194 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 297
+      Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 199 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 299
+      Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 204 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 301
+      Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 209 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 255
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 810
+      ID: 880
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 459
+      ID: 529
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858432
@@ -8663,32 +9079,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 460 GoSliceDataType archive/tar.headerError.array
+      Data: 530 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 530
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 820
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 768
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 700
+      ID: 770
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.078272e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 867
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 726
+      ID: 796
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.37616e+06
@@ -8698,7 +9114,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 728
+      ID: 798
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -8714,18 +9130,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 218 ArrayType []key<[4]int>
+          Type: 262 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 215 ArrayType []val<[4]int>
+          Type: 259 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 153 PointerType *bucket<[4]int,[4]int>
-      KeyType: 216 ArrayType [4]int
-      ValueType: 216 ArrayType [4]int
+      KeyType: 260 ArrayType [4]int
+      ValueType: 260 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 149
       Name: bucket<[4]int,uint8>
@@ -8733,17 +9149,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 218 ArrayType []key<[4]int>
+          Type: 262 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 211 ArrayType []val<uint8>
+          Type: 255 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 148 PointerType *bucket<[4]int,uint8>
-      KeyType: 216 ArrayType [4]int
+      KeyType: 260 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 117
@@ -8752,17 +9168,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 200 ArrayType []key<[4]string>
+          Type: 244 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 202 ArrayType []val<[2]int>
+          Type: 246 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 116 PointerType *bucket<[4]string,[2]int>
-      KeyType: 201 ArrayType [4]string
+      KeyType: 245 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 129
@@ -8771,13 +9187,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 208 ArrayType []key<bool>
+          Type: 252 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 209 ArrayType []val<main.node>
+          Type: 253 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 128 PointerType *bucket<bool,main.node>
@@ -8790,75 +9206,75 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 188 ArrayType []val<*main.deepMap2>
+          Type: 232 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 71 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 189 PointerType *main.deepMap2
+      ValueType: 233 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 906
+      ID: 976
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 907 ArrayType []val<*main.deepMap3>
+          Type: 977 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 905 PointerType *bucket<int,*main.deepMap3>
+          Type: 975 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 908 PointerType *main.deepMap3
+      ValueType: 978 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 936
+      ID: 1006
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 937 ArrayType []val<*main.deepMap8>
+          Type: 1007 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 935 PointerType *bucket<int,*main.deepMap8>
+          Type: 1005 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 938 PointerType *main.deepMap8
+      ValueType: 1008 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 945
+      ID: 1015
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 946 ArrayType []val<*main.deepMap9>
+          Type: 1016 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 944 PointerType *bucket<int,*main.deepMap9>
+          Type: 1014 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 947 PointerType *main.deepMap9
+      ValueType: 1017 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 97
       Name: bucket<int,int>
@@ -8866,35 +9282,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 192 ArrayType []val<int>
+          Type: 236 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 96 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 954
+      ID: 1024
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 955 ArrayType []val<interface {}>
+          Type: 1025 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 953 PointerType *bucket<int,interface {}>
+          Type: 1023 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -8904,13 +9320,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 211 ArrayType []val<uint8>
+          Type: 255 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 133 PointerType *bucket<int,uint8>
@@ -8923,18 +9339,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 204 ArrayType []val<[]main.structWithMap>
+          Type: 248 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 123 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 205 GoSliceHeaderType []main.structWithMap
+      ValueType: 249 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 112
       Name: bucket<string,[]string>
@@ -8942,37 +9358,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 198 ArrayType []val<[]string>
+          Type: 242 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 111 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 168 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 651
+      ID: 721
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 679 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 749 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 107
       Name: bucket<string,int>
@@ -8980,13 +9396,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 192 ArrayType []val<int>
+          Type: 236 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 106 PointerType *bucket<string,int>
@@ -8999,18 +9415,132 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 195 ArrayType []val<main.nestedStruct>
+          Type: 239 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 101 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 176 StructureType main.nestedStruct
+      ValueType: 220 StructureType main.nestedStruct
+    - __kind: GoHMapBucketType
+      ID: 193
+      Name: bucket<struct {},main.structWithCyclicMaps>
+      ByteSize: 400
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 291 ArrayType []val<main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 392
+          Type: 192 PointerType *bucket<struct {},main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 188 StructureType main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 198
+      Name: bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 293 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 197 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 189 GoMapType map[struct {}]main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 203
+      Name: bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 295 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 202 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 194 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 208
+      Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 297 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 207 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 199 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 213
+      Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 299 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 212 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 204 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 218
+      Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 301 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 217 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 209 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
       ID: 144
       Name: bucket<uint8,[4]int>
@@ -9018,18 +9548,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 213 ArrayType []key<uint8>
+          Type: 257 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 215 ArrayType []val<[4]int>
+          Type: 259 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 143 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 216 ArrayType [4]int
+      ValueType: 260 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 139
       Name: bucket<uint8,uint8>
@@ -9037,28 +9567,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 213 ArrayType []key<uint8>
+          Type: 257 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 211 ArrayType []val<uint8>
+          Type: 255 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 138 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 774
+      ID: 844
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 869
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 846
+      ID: 916
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9084,13 +9614,13 @@ Types:
       GoRuntimeType: 532064
       GoKind: 15
     - __kind: BaseType
-      ID: 266
+      ID: 336
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764544
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 337
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764640
@@ -9098,91 +9628,91 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *compress/flate.InternalError.str
+          Type: 339 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType compress/flate.InternalError.str
+      Data: 338 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 338
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 818
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 764
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 840
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 603
+      ID: 673
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296096e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 280
+      ID: 350
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767136
       GoKind: 2
     - __kind: BaseType
-      ID: 281
+      ID: 351
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767232
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 760
+      ID: 830
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 855
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 282
+      ID: 352
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767328
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 863
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 787
+      ID: 857
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 859
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 270
+      ID: 340
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765120
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 543
+      ID: 613
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 942
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 376
+      ID: 446
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 374
+      ID: 444
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.60448e+06
@@ -9193,34 +9723,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 669 ArrayType [5]uint8
+          Type: 739 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 670 GoInterfaceType net.Conn
+          Type: 740 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 498
+      ID: 568
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951296
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 828
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 835
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 708
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 653
+      ID: 723
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 448
+      ID: 518
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.607552e+06
@@ -9228,21 +9758,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 652 PointerType *crypto/x509.Certificate
+          Type: 722 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 672 BaseType crypto/x509.InvalidReason
+          Type: 742 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 442
+      ID: 512
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.075584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 444
+      ID: 514
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.408512e+06
@@ -9250,24 +9780,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 652 PointerType *crypto/x509.Certificate
+          Type: 722 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 279
+      ID: 349
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 766752
       GoKind: 2
     - __kind: BaseType
-      ID: 672
+      ID: 742
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537568
       GoKind: 2
     - __kind: StructureType
-      ID: 548
+      ID: 618
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.37248e+06
@@ -9277,13 +9807,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 450
+      ID: 520
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.07584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 446
+      ID: 516
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.60736e+06
@@ -9291,15 +9821,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 652 PointerType *crypto/x509.Certificate
+          Type: 722 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 652 PointerType *crypto/x509.Certificate
+          Type: 722 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 463
+      ID: 533
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.253568e+06
@@ -9309,7 +9839,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 467
+      ID: 537
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.253728e+06
@@ -9319,55 +9849,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 465
+      ID: 535
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 264
+      ID: 334
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764160
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 786
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 265
+      ID: 335
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764352
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 335
+      ID: 405
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 604
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 397
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 333
+      ID: 403
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 331
+      ID: 401
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 329
+      ID: 399
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 922
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 337
+      ID: 407
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.238208e+06
@@ -9377,19 +9907,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 724
+      ID: 794
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 436
+      ID: 506
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 434
+      ID: 504
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 346
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766656
@@ -9397,21 +9927,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *encoding/xml.UnmarshalError.str
+          Type: 348 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 347 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 347
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 439
+      ID: 509
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 900
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9428,11 +9958,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 305
+      ID: 375
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 501
+      ID: 571
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9448,15 +9978,15 @@ Types:
       GoRuntimeType: 532256
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 910
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 503
+      ID: 573
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 505
+      ID: 575
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9466,11 +9996,11 @@ Types:
       GoRuntimeType: 445248
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 435
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 346
+      ID: 416
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.602752e+06
@@ -9478,7 +10008,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 662 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 732 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -9486,25 +10016,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 348
+      ID: 418
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 736
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 352
+      ID: 422
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 738
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 258
+      ID: 328
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763584
@@ -9512,17 +10042,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 260 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 259 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 259
+      ID: 329
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 662
+      ID: 732
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.073568e+06
@@ -9530,7 +10060,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 663 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 733 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -9545,7 +10075,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 664 GoSliceHeaderType []float64
+          Type: 734 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -9554,10 +10084,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 665 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 667 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 737 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 168 GoSliceHeaderType []string
@@ -9571,13 +10101,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 663
+      ID: 733
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534112
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 255
+      ID: 325
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763488
@@ -9585,17 +10115,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 257 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 327 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 256 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 326 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 256
+      ID: 326
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 331
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763680
@@ -9603,59 +10133,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 262 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 332
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 808
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 888
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 457
+      ID: 527
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 682
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 918
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 455
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 392
+      ID: 462
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.074816e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 275
+      ID: 345
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 765792
       GoKind: 2
     - __kind: StructureType
-      ID: 390
+      ID: 460
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.074688e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 388
+      ID: 458
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.406592e+06
@@ -9668,7 +10198,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 408
+      ID: 478
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.407392e+06
@@ -9681,7 +10211,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 412
+      ID: 482
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.606784e+06
@@ -9697,7 +10227,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 410
+      ID: 480
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.247968e+06
@@ -9707,7 +10237,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 406
+      ID: 476
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.247648e+06
@@ -9717,14 +10247,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 647
+      ID: 717
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135136e+06
       GoKind: 21
-      HeaderType: 649 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 719 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 671
+      ID: 741
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.008768e+06
@@ -9739,14 +10269,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 685 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 755 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 685
+      ID: 755
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 420
+      ID: 490
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.407712e+06
@@ -9754,12 +10284,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 647 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 717 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 647 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 717 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 414
+      ID: 484
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.248128e+06
@@ -9769,7 +10299,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 418
+      ID: 488
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.606976e+06
@@ -9780,12 +10310,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 416
+      ID: 486
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.407552e+06
@@ -9798,7 +10328,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 422
+      ID: 492
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.248288e+06
@@ -9806,9 +10336,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 639 StructureType time.Time
+          Type: 709 StructureType time.Time
     - __kind: StructureType
-      ID: 428
+      ID: 498
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.408032e+06
@@ -9821,7 +10351,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 430
+      ID: 500
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.248608e+06
@@ -9831,7 +10361,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 426
+      ID: 496
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.407872e+06
@@ -9844,7 +10374,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 424
+      ID: 494
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.248448e+06
@@ -9854,7 +10384,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 432
+      ID: 502
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.408192e+06
@@ -9867,7 +10397,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 354
+      ID: 424
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.240448e+06
@@ -9877,11 +10407,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 847
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 356
+      ID: 426
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.240608e+06
@@ -9889,21 +10419,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 354 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 826
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 712
+      ID: 782
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 816
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 360
+      ID: 430
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.240928e+06
@@ -9911,13 +10441,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 354 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 878
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 819
+      ID: 889
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.96784e+06
@@ -9925,12 +10455,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 807 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 877 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 820
+      ID: 890
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.991232e+06
@@ -9938,7 +10468,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 807 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 877 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -9946,11 +10476,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 714
+      ID: 784
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 358
+      ID: 428
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.240768e+06
@@ -9958,9 +10488,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 354 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 362
+      ID: 432
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.241088e+06
@@ -9968,64 +10498,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 354 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 851
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 884
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 886
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 713
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 556
+      ID: 626
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 554
+      ID: 624
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 628
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 630
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 767
+      ID: 837
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 620
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 368
+      ID: 438
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.242048e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 934
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 684
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 587
+      ID: 657
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.711456e+06
@@ -10041,11 +10571,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 520
+      ID: 590
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.509248e+06
@@ -10058,7 +10588,7 @@ Types:
           Offset: 1
           Type: 14 BaseType int8
     - __kind: StructureType
-      ID: 593
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.711904e+06
@@ -10074,13 +10604,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 497
+      ID: 567
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 948704
       GoKind: 8
     - __kind: StructureType
-      ID: 585
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.711232e+06
@@ -10096,13 +10626,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 673
+      ID: 743
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 761760
       GoKind: 8
     - __kind: StructureType
-      ID: 583
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.711008e+06
@@ -10110,15 +10640,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 673 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 743 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 673 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 743 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 591
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.6296e+06
@@ -10131,7 +10661,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 589
+      ID: 659
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.71168e+06
@@ -10147,11 +10677,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 938
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 597
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.43216e+06
@@ -10161,19 +10691,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 524
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.194976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 522
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.194848e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 595
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.629792e+06
@@ -10186,7 +10716,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 357
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769152
@@ -10194,21 +10724,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 359 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 288 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 358 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 358
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 726
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 564
+      ID: 634
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.265408e+06
@@ -10218,7 +10748,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 744
+      ID: 814
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.486112e+06
@@ -10226,13 +10756,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 768 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 838 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 898
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 768
+      ID: 838
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.085696e+06
@@ -10245,7 +10775,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 730
+      ID: 800
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.38096e+06
@@ -10255,19 +10785,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 290
+      ID: 360
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769728
       GoKind: 10
     - __kind: BaseType
-      ID: 654
+      ID: 724
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 961952
       GoKind: 10
     - __kind: StructureType
-      ID: 622
+      ID: 692
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.749984e+06
@@ -10278,12 +10808,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 654 BaseType golang.org/x/net/http2.ErrCode
+          Type: 724 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 483
+      ID: 553
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.415392e+06
@@ -10291,12 +10821,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 654 BaseType golang.org/x/net/http2.ErrCode
+          Type: 724 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 294
+      ID: 364
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769920
@@ -10304,17 +10834,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 296 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 366 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 295 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 365 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 295
+      ID: 365
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 300
+      ID: 370
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770112
@@ -10322,17 +10852,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 302 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 372 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 301 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 371 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 301
+      ID: 371
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 367
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770016
@@ -10340,17 +10870,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 369 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 368 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 368
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 291
+      ID: 361
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769824
@@ -10358,21 +10888,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 293 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 363 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 292 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 362 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 292
+      ID: 362
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 896
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 487
+      ID: 557
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.266048e+06
@@ -10382,13 +10912,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 303
+      ID: 373
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770208
       GoKind: 2
     - __kind: StructureType
-      ID: 475
+      ID: 545
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.261088e+06
@@ -10398,11 +10928,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 690
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 715
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.775744e+06
@@ -10418,7 +10948,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 477
+      ID: 547
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.414912e+06
@@ -10431,7 +10961,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 791
+      ID: 861
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.829216e+06
@@ -10439,16 +10969,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 670 GoInterfaceType net.Conn
+          Type: 740 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 806 GoInterfaceType io.Reader
+          Type: 876 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 812
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 562
+      ID: 632
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.37856e+06
@@ -10458,29 +10988,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 702
+      ID: 772
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 455
+      ID: 525
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 552
+      ID: 622
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 688
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 616
+      ID: 686
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.325696e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 469
+      ID: 539
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.254368e+06
@@ -10490,7 +11020,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 471
+      ID: 541
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.254528e+06
@@ -10500,11 +11030,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 470
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 779
+      ID: 849
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -10540,7 +11070,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 154 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 220 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 264 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 147
       Name: hash<[4]int,uint8>
@@ -10574,7 +11104,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 149 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 219 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 263 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 115
       Name: hash<[4]string,[2]int>
@@ -10608,7 +11138,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 117 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 203 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 247 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 127
       Name: hash<bool,main.node>
@@ -10642,7 +11172,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 129 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 210 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 254 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 70
       Name: hash<int,*main.deepMap2>
@@ -10676,9 +11206,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 191 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 235 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 904
+      ID: 974
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -10699,20 +11229,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 905 PointerType *bucket<int,*main.deepMap3>
+          Type: 975 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 905 PointerType *bucket<int,*main.deepMap3>
+          Type: 975 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 906 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 910 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 976 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 980 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 934
+      ID: 1004
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -10733,20 +11263,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 935 PointerType *bucket<int,*main.deepMap8>
+          Type: 1005 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 935 PointerType *bucket<int,*main.deepMap8>
+          Type: 1005 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 936 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 940 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1006 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1010 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 943
+      ID: 1013
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -10767,18 +11297,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 944 PointerType *bucket<int,*main.deepMap9>
+          Type: 1014 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 944 PointerType *bucket<int,*main.deepMap9>
+          Type: 1014 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 945 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 949 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1015 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1019 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 95
       Name: hash<int,int>
@@ -10812,9 +11342,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 97 GoHMapBucketType bucket<int,int>
-      BucketsType: 193 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 237 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 952
+      ID: 1022
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -10835,18 +11365,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 953 PointerType *bucket<int,interface {}>
+          Type: 1023 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 953 PointerType *bucket<int,interface {}>
+          Type: 1023 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 954 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 956 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1024 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1026 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 132
       Name: hash<int,uint8>
@@ -10880,7 +11410,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 134 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 212 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 256 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 122
       Name: hash<string,[]main.structWithMap>
@@ -10914,7 +11444,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 207 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 251 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 110
       Name: hash<string,[]string>
@@ -10948,9 +11478,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 112 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 199 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 243 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 649
+      ID: 719
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -10971,18 +11501,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 680 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 750 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 105
       Name: hash<string,int>
@@ -11016,7 +11546,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 107 GoHMapBucketType bucket<string,int>
-      BucketsType: 197 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 241 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 100
       Name: hash<string,main.nestedStruct>
@@ -11050,7 +11580,211 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 102 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 196 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 240 GoSliceDataType []bucket<string,main.nestedStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 191
+      Name: hash<struct {},main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 192 PointerType *bucket<struct {},main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 192 PointerType *bucket<struct {},main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 193 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+      BucketsType: 292 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 196
+      Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 197 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 197 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 198 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 294 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 201
+      Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 202 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 202 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 203 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 296 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 206
+      Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 207 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 207 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 208 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 298 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 211
+      Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 212 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 212 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 213 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 300 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 216
+      Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 217 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 217 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 218 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 302 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 142
       Name: hash<uint8,[4]int>
@@ -11084,7 +11818,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 144 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 217 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 261 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 137
       Name: hash<uint8,uint8>
@@ -11118,9 +11852,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 139 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 214 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 258 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 490
+      ID: 560
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11167,37 +11901,37 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 440
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 758
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 649
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 940
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 577
+      ID: 647
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293056e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 307
+      ID: 377
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 734
+      ID: 804
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 775
+      ID: 845
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.103392e+06
@@ -11210,7 +11944,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 806
+      ID: 876
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 980096
@@ -11223,7 +11957,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 763
+      ID: 833
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.068416e+06
@@ -11249,25 +11983,25 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 732
+      ID: 802
       Name: io.discard
       GoRuntimeType: 1.280416e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 776
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 645
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 853
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 175
+      ID: 219
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -11283,7 +12017,7 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 176 StructureType main.nestedStruct
+          Type: 220 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 89
       Name: main.behavior
@@ -11323,7 +12057,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 190
+      ID: 234
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.099936e+06
@@ -11331,9 +12065,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 902 GoMapType map[int]*main.deepMap3
+          Type: 972 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 979
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11345,9 +12079,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 932 GoMapType map[int]*main.deepMap8
+          Type: 1002 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 939
+      ID: 1009
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.099168e+06
@@ -11355,9 +12089,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 941 GoMapType map[int]*main.deepMap9
+          Type: 1011 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 948
+      ID: 1018
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.09904e+06
@@ -11365,7 +12099,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 950 GoMapType map[int]interface {}
+          Type: 1020 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -11385,9 +12119,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 873 PointerType *main.deepPtr3
+          Type: 943 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 874
+      ID: 944
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11399,9 +12133,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 913 PointerType *main.deepPtr8
+          Type: 983 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 914
+      ID: 984
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.10032e+06
@@ -11409,9 +12143,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 915 PointerType *main.deepPtr9
+          Type: 985 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 916
+      ID: 986
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.100192e+06
@@ -11431,7 +12165,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 183
+      ID: 227
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.10224e+06
@@ -11439,9 +12173,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 896 GoSliceHeaderType []*main.deepSlice3
+          Type: 966 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 899
+      ID: 969
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11453,9 +12187,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 917 GoSliceHeaderType []*main.deepSlice8
+          Type: 987 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 920
+      ID: 990
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.101472e+06
@@ -11463,9 +12197,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 923 GoSliceHeaderType []*main.deepSlice9
+          Type: 993 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 926
+      ID: 996
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101344e+06
@@ -11473,9 +12207,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 929 GoSliceHeaderType []interface {}
+          Type: 999 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 177
+      ID: 221
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -11491,16 +12225,16 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 880 StructureType sync.Mutex
+          Type: 950 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 881 StructureType sync.Once
+          Type: 951 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 884 StructureType sync.WaitGroup
+          Type: 954 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 888 StructureType sync/atomic.Int32
+          Type: 958 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
@@ -11530,7 +12264,7 @@ Types:
           Offset: 56
           Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 890
+      ID: 960
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.231488e+06
@@ -11540,7 +12274,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 176
+      ID: 220
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.279936e+06
@@ -11575,7 +12309,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 892
+      ID: 962
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.231648e+06
@@ -11595,7 +12329,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 949
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11606,17 +12340,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 876 PointerType *main.stringType1.str
+          Type: 946 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 875 GoStringDataType main.stringType1.str
+      Data: 945 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 875
+      ID: 945
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 947
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11629,6 +12363,54 @@ Types:
         - Name: a
           Offset: 0
           Type: 83 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 188
+      Name: main.structWithCyclicMaps
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: m1
+          Offset: 0
+          Type: 189 GoMapType map[struct {}]main.structWithCyclicMaps
+        - Name: m2
+          Offset: 8
+          Type: 194 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m3
+          Offset: 16
+          Type: 199 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m4
+          Offset: 24
+          Type: 204 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m5
+          Offset: 32
+          Type: 209 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m6
+          Offset: 40
+          Type: 214 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 175
+      Name: main.structWithCyclicSlices
+      ByteSize: 144
+      GoKind: 25
+      RawFields:
+        - Name: s1
+          Offset: 0
+          Type: 176 GoSliceHeaderType []main.structWithCyclicSlices
+        - Name: s2
+          Offset: 24
+          Type: 178 GoSliceHeaderType [][]main.structWithCyclicSlices
+        - Name: s3
+          Offset: 48
+          Type: 180 GoSliceHeaderType [][][]main.structWithCyclicSlices
+        - Name: s4
+          Offset: 72
+          Type: 182 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+        - Name: s5
+          Offset: 96
+          Type: 184 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+        - Name: s6
+          Offset: 120
+          Type: 186 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 92
       Name: main.structWithMap
@@ -11671,16 +12453,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 893 PointerType **main.t
+          Type: 963 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 894 GoSliceDataType main.t.array
+      Data: 964 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 894
+      ID: 964
       Name: main.t.array
       ByteSize: 2048
       Element: 160 PointerType *main.t
@@ -11740,26 +12522,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 902
+      ID: 972
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879744
       GoKind: 21
-      HeaderType: 904 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 974 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 932
+      ID: 1002
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879264
       GoKind: 21
-      HeaderType: 934 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1004 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 941
+      ID: 1011
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879168
       GoKind: 21
-      HeaderType: 943 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1013 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 93
       Name: map[int]int
@@ -11768,12 +12550,12 @@ Types:
       GoKind: 21
       HeaderType: 95 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 950
+      ID: 1020
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879072
       GoKind: 21
-      HeaderType: 952 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1022 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 130
       Name: map[int]uint8
@@ -11810,6 +12592,42 @@ Types:
       GoKind: 21
       HeaderType: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
+      ID: 189
+      Name: map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 191 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 194
+      Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 196 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 199
+      Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 201 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 204
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 206 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 209
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 211 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 214
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 216 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
       ID: 140
       Name: map[uint8][4]int
       ByteSize: 8
@@ -11824,7 +12642,7 @@ Types:
       GoKind: 21
       HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 404
+      ID: 474
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.247328e+06
@@ -11834,7 +12652,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 696
+      ID: 766
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.244128e+06
@@ -11844,11 +12662,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 676
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 670
+      ID: 740
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.405312e+06
@@ -11861,35 +12679,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 702
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 904
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 700
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 678
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 914
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 924
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 912
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 567
+      ID: 637
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.071616e+06
@@ -11897,27 +12715,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 569 PointerType *net.UnknownNetworkError.str
+          Type: 639 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 568 GoStringDataType net.UnknownNetworkError.str
+      Data: 638 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 568
+      ID: 638
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 536
+      ID: 606
       Name: net.canceledError
       GoRuntimeType: 1.195872e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 882
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 675
+      ID: 745
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.967136e+06
@@ -11925,7 +12743,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 670 GoInterfaceType net.Conn
+          Type: 740 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -11936,27 +12754,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 926
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 920
       Name: net.noReadFrom
       GoRuntimeType: 1.071872e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 849
+      ID: 919
       Name: net.noWriteTo
       GoRuntimeType: 1.071744e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 339
+      ID: 409
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 341
+      ID: 411
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.60256e+06
@@ -11964,7 +12782,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 657 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 727 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -11972,7 +12790,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 838
+      ID: 908
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.143456e+06
@@ -11980,12 +12798,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 850 StructureType net.noReadFrom
+          Type: 920 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 843 PointerType *net.TCPConn
+          Type: 913 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 836
+      ID: 906
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.142912e+06
@@ -11993,24 +12811,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 849 StructureType net.noWriteTo
+          Type: 919 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 843 PointerType *net.TCPConn
+          Type: 913 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 680
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 634
+      ID: 704
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 526
+      ID: 596
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 690
+      ID: 760
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.235648e+06
@@ -12020,19 +12838,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 236
+      ID: 306
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762240
       GoKind: 10
     - __kind: BaseType
-      ID: 646
+      ID: 716
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 948800
       GoKind: 10
     - __kind: StructureType
-      ID: 317
+      ID: 387
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.60064e+06
@@ -12043,12 +12861,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 646 BaseType net/http.http2ErrCode
+          Type: 716 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 626
+      ID: 696
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.766016e+06
@@ -12059,12 +12877,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 646 BaseType net/http.http2ErrCode
+          Type: 716 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 321
+      ID: 391
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.404832e+06
@@ -12072,16 +12890,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 646 BaseType net/http.http2ErrCode
+          Type: 716 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 752
+      ID: 822
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 240
+      ID: 310
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762432
@@ -12089,17 +12907,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 242 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 312 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 241 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 311 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 241
+      ID: 311
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 246
+      ID: 316
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762624
@@ -12107,17 +12925,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 248 PointerType *net/http.http2headerFieldNameError.str
+          Type: 318 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 247 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 317 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 247
+      ID: 317
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 243
+      ID: 313
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762528
@@ -12125,31 +12943,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 245 PointerType *net/http.http2headerFieldValueError.str
+          Type: 315 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 244 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 314 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 244
+      ID: 314
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 671
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 532
+      ID: 602
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.195232e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 873
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 237
+      ID: 307
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762336
@@ -12157,17 +12975,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 239 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 309 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 238 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 308 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 238
+      ID: 308
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 692
+      ID: 762
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.601408e+06
@@ -12175,22 +12993,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 670 GoInterfaceType net.Conn
+          Type: 740 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 771 BaseType time.Duration
+          Type: 841 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 33 PointerType *error
     - __kind: ArrayType
-      ID: 772
+      ID: 842
       Name: net/http.incomparable
       GoRuntimeType: 830880
       GoKind: 17
       HasCount: true
       Element: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 528
+      ID: 598
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.36672e+06
@@ -12200,11 +13018,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 754
+      ID: 824
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 710
+      ID: 780
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.36656e+06
@@ -12212,9 +13030,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 753 PointerType *net/http.persistConn
+          Type: 823 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 736
+      ID: 806
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.672704e+06
@@ -12222,15 +13040,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 772 ArrayType net/http.incomparable
+          Type: 842 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 773 PointerType *bufio.Reader
+          Type: 843 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 775 GoInterfaceType io.ReadWriteCloser
+          Type: 845 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 325
+      ID: 395
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.236608e+06
@@ -12240,17 +13058,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 698
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 599
+      ID: 669
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.295776e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 530
+      ID: 600
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.36688e+06
@@ -12260,11 +13078,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 314
+      ID: 384
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 805
+      ID: 875
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.904256e+06
@@ -12272,13 +13090,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 798 PointerType *bufio.Writer
+          Type: 868 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 790
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 396
+      ID: 466
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.6064e+06
@@ -12294,7 +13112,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 394
+      ID: 464
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.406752e+06
@@ -12307,11 +13125,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 762
+      ID: 832
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 792
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.408672e+06
@@ -12319,16 +13137,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 761 PointerType *net/smtp.Client
+          Type: 831 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 763 GoInterfaceType io.WriteCloser
+          Type: 833 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 450
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 341
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765216
@@ -12336,25 +13154,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *net/textproto.ProtocolError.str
+          Type: 343 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 272 GoStringDataType net/textproto.ProtocolError.str
+      Data: 342 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 342
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 718
+      ID: 788
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 706
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 249
+      ID: 319
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763200
@@ -12362,17 +13180,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 251 PointerType *net/url.EscapeError.str
+          Type: 321 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 250 GoStringDataType net/url.EscapeError.str
+      Data: 320 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 250
+      ID: 320
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 252
+      ID: 322
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763296
@@ -12380,29 +13198,29 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 254 PointerType *net/url.InvalidHostError.str
+          Type: 324 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 253 GoStringDataType net/url.InvalidHostError.str
+      Data: 323 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 253
+      ID: 323
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 932
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 577
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 641
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 860
+      ID: 930
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.211648e+06
@@ -12410,12 +13228,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 866 StructureType os.noReadFrom
+          Type: 936 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 861 PointerType *os.File
+          Type: 931 PointerType *os.File
     - __kind: StructureType
-      ID: 858
+      ID: 928
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.210848e+06
@@ -12423,36 +13241,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 865 StructureType os.noWriteTo
+          Type: 935 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 861 PointerType *os.File
+          Type: 931 PointerType *os.File
     - __kind: StructureType
-      ID: 866
+      ID: 936
       Name: os.noReadFrom
       GoRuntimeType: 1.069312e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 865
+      ID: 935
       Name: os.noWriteTo
       GoRuntimeType: 1.069184e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 608
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 748
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 810
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 540
+      ID: 610
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.509824e+06
@@ -12465,7 +13283,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 354
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768384
@@ -12473,39 +13291,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *os/user.UnknownGroupIdError.str
+          Type: 356 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 285 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 355 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 355
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 283
+      ID: 353
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768288
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 309
+      ID: 379
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 472
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 580
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 515
+      ID: 585
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 512
+      ID: 582
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.755584e+06
@@ -12522,15 +13340,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 676 BaseType runtime.boundsErrorCode
+          Type: 746 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 676
+      ID: 746
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532448
       GoKind: 8
     - __kind: StructureType
-      ID: 573
+      ID: 643
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.626528e+06
@@ -12543,7 +13361,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 491
+      ID: 561
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 947648
@@ -12551,13 +13369,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 493 PointerType *runtime.errorString.str
+          Type: 563 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 492 GoStringDataType runtime.errorString.str
+      Data: 562 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 492
+      ID: 562
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
@@ -12565,7 +13383,7 @@ Types:
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 494
+      ID: 564
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948224
@@ -12573,17 +13391,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 496 PointerType *runtime.plainError.str
+          Type: 566 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 495 GoStringDataType runtime.plainError.str
+      Data: 565 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 495
+      ID: 565
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 517
+      ID: 587
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12595,25 +13413,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 180 PointerType *string.str
+          Type: 224 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 179 GoStringDataType string.str
+      Data: 223 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 179
+      ID: 223
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 871
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 778
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 704
+      ID: 774
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.272576e+06
@@ -12623,7 +13441,13 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 880
+      ID: 290
+      Name: struct {}
+      GoRuntimeType: 772032
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 950
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281216e+06
@@ -12636,7 +13460,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 881
+      ID: 951
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282336e+06
@@ -12644,12 +13468,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 882 StructureType sync/atomic.Uint32
+          Type: 952 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 880 StructureType sync.Mutex
+          Type: 950 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 884
+      ID: 954
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421024e+06
@@ -12657,21 +13481,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 885 StructureType sync.noCopy
+          Type: 955 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 886 StructureType sync/atomic.Uint64
+          Type: 956 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 885
+      ID: 955
       Name: sync.noCopy
       GoRuntimeType: 946592
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 888
+      ID: 958
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282656e+06
@@ -12679,12 +13503,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 883 StructureType sync/atomic.noCopy
+          Type: 953 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 882
+      ID: 952
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.282816e+06
@@ -12692,12 +13516,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 883 StructureType sync/atomic.noCopy
+          Type: 953 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 886
+      ID: 956
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.421408e+06
@@ -12705,37 +13529,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 883 StructureType sync/atomic.noCopy
+          Type: 953 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 887 StructureType sync/atomic.align64
+          Type: 957 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 887
+      ID: 957
       Name: sync/atomic.align64
       GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 883
+      ID: 953
       Name: sync/atomic.noCopy
       GoRuntimeType: 946688
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 623
+      ID: 693
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.194464e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 902
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 566
+      ID: 636
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.51424e+06
@@ -12748,21 +13572,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 771
+      ID: 841
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.781856e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 711
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 312
+      ID: 382
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 639
+      ID: 709
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.223872e+06
@@ -12776,9 +13600,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 640 PointerType *time.Location
+          Type: 710 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 233
+      ID: 303
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761376
@@ -12786,13 +13610,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 235 PointerType *time.fileSizeError.str
+          Type: 305 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 234 GoStringDataType time.fileSizeError.str
+      Data: 304 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 234
+      ID: 304
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -12838,11 +13662,11 @@ Types:
       GoRuntimeType: 532384
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 865
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 727
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.925984e+06
@@ -12850,13 +13674,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 658 GoSliceHeaderType []uint8
+          Type: 728 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 659 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 729 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 660 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 730 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -12871,18 +13695,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 661 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 731 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 661
+      ID: 731
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 952928
       GoKind: 9
     - __kind: StructureType
-      ID: 659
+      ID: 729
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.792352e+06
@@ -12907,21 +13731,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 398
+      ID: 468
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 660
+      ID: 730
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536032
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 894
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 382
+      ID: 452
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.244448e+06
@@ -12931,13 +13755,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 274
+      ID: 344
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765312
       GoKind: 2
     - __kind: StructureType
-      ID: 545
+      ID: 615
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510016e+06
@@ -12950,11 +13774,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 499
+      ID: 569
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 951776
       GoKind: 5
-MaxTypeID: 1071
+MaxTypeID: 1143
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x1755760", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1757760", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 1169 EventRootType Probe[main.stackC]
+          Type: 1274 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcd906a", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 1124 EventRootType Probe[main.testAny]
+          Type: 1229 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd5e6a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 1126 EventRootType Probe[main.testAnyPtr]
+          Type: 1231 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd5f0a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 1086 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1191 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 1088 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1193 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 1134 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1239 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd6660", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 1087 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1192 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 1106 EventRootType Probe[main.testBigStruct]
+          Type: 1211 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a20", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 1075 EventRootType Probe[main.testBoolArray]
+          Type: 1180 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 1072 EventRootType Probe[main.testByteArray]
+          Type: 1177 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4100", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 1150 EventRootType Probe[main.testChannel]
+          Type: 1255 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd8320", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 1148 EventRootType Probe[main.testCombinedByte]
+          Type: 1253 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd7f40", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 1158 EventRootType Probe[main.testCycle]
+          Type: 1263 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd86e0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 1111 EventRootType Probe[main.testDeepMap1]
+          Type: 1216 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e00", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 1112 EventRootType Probe[main.testDeepMap7]
+          Type: 1217 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e20", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 1107 EventRootType Probe[main.testDeepPtr1]
+          Type: 1212 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4ae0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 1108 EventRootType Probe[main.testDeepPtr7]
+          Type: 1213 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b00", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 1109 EventRootType Probe[main.testDeepSlice1]
+          Type: 1214 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4c80", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 1110 EventRootType Probe[main.testDeepSlice7]
+          Type: 1215 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ca0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 1160 EventRootType Probe[main.testEmptySlice]
+          Type: 1265 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 1163 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1268 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcd8c80", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 1177 EventRootType Probe[main.testEmptyString]
+          Type: 1282 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 108
-          Type: 1179 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
+        - ID: 110
+          Type: 1286 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcd95e0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 109
-          Type: 1180 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
+        - ID: 111
+          Type: 1287 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcd9600", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 1125 EventRootType Probe[main.testError]
+          Type: 1230 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd5ee0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 1116 EventRootType Probe[main.testEsotericHeap]
+          Type: 1221 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd53ea", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 1115 EventRootType Probe[main.testEsotericStack]
+          Type: 1220 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd52ce", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 1121 EventRootType Probe[main.testFrameless]
+          Type: 1226 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 1122 EventRootType Probe[main.testFramelessArray]
+          Type: 1227 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5b64", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 1117 EventRootType Probe[main.testInlinedBA]
+          Type: 1222 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd582a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 1118 EventRootType Probe[main.testInlinedBB]
+          Type: 1223 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd58ce", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 1119 EventRootType Probe[main.testInlinedBBA]
+          Type: 1224 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd59aa", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 111
-          Type: 1182 EventRootType Probe[main.testInlinedBBB]
+        - ID: 113
+          Type: 1289 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5926", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 1120 EventRootType Probe[main.testInlinedBC]
+          Type: 1225 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5a2e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 112
-          Type: 1183 EventRootType Probe[main.testInlinedBCA]
+        - ID: 114
+          Type: 1290 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5a33", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 113
-          Type: 1184 EventRootType Probe[main.testInlinedBCB]
+        - ID: 115
+          Type: 1291 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5ae6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 110
-          Type: 1181 EventRootType Probe[main.testInlinedPrint]
+        - ID: 112
+          Type: 1288 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd568a"
               Frameless: false
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 114
-          Type: 1185 EventRootType Probe[main.testInlinedSq]
+        - ID: 116
+          Type: 1292 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5b41", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 115
-          Type: 1186 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 117
+          Type: 1293 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5b85"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 1078 EventRootType Probe[main.testInt16Array]
+          Type: 1183 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 1079 EventRootType Probe[main.testInt32Array]
+          Type: 1184 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 1080 EventRootType Probe[main.testInt64Array]
+          Type: 1185 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 1077 EventRootType Probe[main.testInt8Array]
+          Type: 1182 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 1076 EventRootType Probe[main.testIntArray]
+          Type: 1181 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 1123 EventRootType Probe[main.testInterface]
+          Type: 1228 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd5e40", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 1152 EventRootType Probe[main.testLinkedList]
+          Type: 1257 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd8500", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 1132 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1237 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd6620", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 1138 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1243 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd66e0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 1136 EventRootType Probe[main.testMapIntToInt]
+          Type: 1241 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd66a0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 1147 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1252 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6800", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 1146 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1251 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd67e0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 1137 EventRootType Probe[main.testMapMassive]
+          Type: 1242 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd66c0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 1145 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1250 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd67c0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 1144 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1249 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd67a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 1130 EventRootType Probe[main.testMapStringToInt]
+          Type: 1235 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd65e0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 1131 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1236 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd6600", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 1129 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1234 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd65c0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 1139 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1244 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd6700", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 1142 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1247 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd6760", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 1143 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1248 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd6780", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 1140 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1245 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd6720", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 1141 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1246 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd6740", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 1175 EventRootType Probe[main.testMassiveString]
+          Type: 1280 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 1149 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1254 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd8100", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 1157 EventRootType Probe[main.testNilPointer]
+          Type: 1262 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd86a0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 1167 EventRootType Probe[main.testNilSlice]
+          Type: 1272 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcd8d00", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 1164 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1269 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 1166 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1271 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcd8ce0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 1174 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1279 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 1153 EventRootType Probe[main.testPointerLoop]
+          Type: 1258 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd8520", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 1135 EventRootType Probe[main.testPointerToMap]
+          Type: 1240 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd6680", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 1151 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1256 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 1073 EventRootType Probe[main.testRuneArray]
+          Type: 1178 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 1092 EventRootType Probe[main.testSingleBool]
+          Type: 1197 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 1090 EventRootType Probe[main.testSingleByte]
+          Type: 1195 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd46e0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 1103 EventRootType Probe[main.testSingleFloat32]
+          Type: 1208 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 1104 EventRootType Probe[main.testSingleFloat64]
+          Type: 1209 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 1093 EventRootType Probe[main.testSingleInt]
+          Type: 1198 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 1095 EventRootType Probe[main.testSingleInt16]
+          Type: 1200 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 1096 EventRootType Probe[main.testSingleInt32]
+          Type: 1201 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 1097 EventRootType Probe[main.testSingleInt64]
+          Type: 1202 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 1094 EventRootType Probe[main.testSingleInt8]
+          Type: 1199 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 1091 EventRootType Probe[main.testSingleRune]
+          Type: 1196 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4700", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 1170 EventRootType Probe[main.testSingleString]
+          Type: 1275 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 1098 EventRootType Probe[main.testSingleUint]
+          Type: 1203 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 1100 EventRootType Probe[main.testSingleUint16]
+          Type: 1205 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 1101 EventRootType Probe[main.testSingleUint32]
+          Type: 1206 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 1102 EventRootType Probe[main.testSingleUint64]
+          Type: 1207 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 1099 EventRootType Probe[main.testSingleUint8]
+          Type: 1204 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 1161 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1266 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 1133 EventRootType Probe[main.testSmallMap]
+          Type: 1238 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd6640", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 1074 EventRootType Probe[main.testStringArray]
+          Type: 1179 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 1156 EventRootType Probe[main.testStringPointer]
+          Type: 1261 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd8660", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 1165 EventRootType Probe[main.testStringSlice]
+          Type: 1270 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcd8cc0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 1113 EventRootType Probe[main.testStringType1]
+          Type: 1218 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 1114 EventRootType Probe[main.testStringType2]
+          Type: 1219 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 107
-          Type: 1178 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd9420", Frameless: true}]
+        - ID: 109
+          Type: 1285 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcd9460", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 1162 EventRootType Probe[main.testStructSlice]
+          Type: 1267 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,8 +1425,34 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 1127 EventRootType Probe[main.testStructWithAny]
+          Type: 1232 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcd5f60", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicMaps}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 108
+          Type: 1284 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicSlices
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicSlices}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 107
+          Type: 1283 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcd9300", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1439,7 +1465,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 1128 EventRootType Probe[main.testStructWithMap]
+          Type: 1233 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd65a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1479,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 1171 EventRootType Probe[main.testThreeStrings]
+          Type: 1276 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1493,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 1172 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1277 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1507,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 1173 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1278 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1521,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 1105 EventRootType Probe[main.testTypeAlias]
+          Type: 1210 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1535,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 1083 EventRootType Probe[main.testUint16Array]
+          Type: 1188 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1549,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 1084 EventRootType Probe[main.testUint32Array]
+          Type: 1189 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1563,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 1085 EventRootType Probe[main.testUint64Array]
+          Type: 1190 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1577,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 1082 EventRootType Probe[main.testUint8Array]
+          Type: 1187 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1591,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 1081 EventRootType Probe[main.testUintArray]
+          Type: 1186 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1605,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 1155 EventRootType Probe[main.testUintPointer]
+          Type: 1260 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8580", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1619,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 1159 EventRootType Probe[main.testUintSlice]
+          Type: 1264 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1633,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 1176 EventRootType Probe[main.testUnitializedString]
+          Type: 1281 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1647,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 1154 EventRootType Probe[main.testUnsafePointer]
+          Type: 1259 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd8540", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1661,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 1089 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1194 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1675,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 1168 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1273 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd8d20", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3279,14 +3305,50 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 107
+      Name: main.testStructWithCyclicSlices
+      OutOfLinePCRanges: [0xcd9300..0xcd9301]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 173 StructureType main.structWithCyclicSlices
+          Locations:
+            - Range: 0xcd9300..0xcd9301
+              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 108
+      Name: main.testStructWithCyclicMaps
+      OutOfLinePCRanges: [0xcd9320..0xcd933f]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 186 StructureType main.structWithCyclicMaps
+          Locations:
+            - Range: 0xcd9320..0xcd933f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcd9420..0xcd9443]
+      OutOfLinePCRanges: [0xcd9460..0xcd9483]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 173 StructureType main.aStruct
+          Type: 217 StructureType main.aStruct
           Locations:
-            - Range: 0xcd9420..0xcd9443
+            - Range: 0xcd9460..0xcd9483
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3304,29 +3366,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd95a0..0xcd95a1]
+      OutOfLinePCRanges: [0xcd95e0..0xcd95e1]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 175 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd95a0..0xcd95a1, Pieces: []}]
+          Type: 219 StructureType main.emptyStruct
+          Locations: [{Range: 0xcd95e0..0xcd95e1, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcd95c0..0xcd95c1]
+      OutOfLinePCRanges: [0xcd9600..0xcd9601]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 176 PointerType *main.emptyStruct
+          Type: 220 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcd95c0..0xcd95c1
+            - Range: 0xcd9600..0xcd9601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 112
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd5680..0xcd56e2]
       InlinePCRanges:
@@ -3356,28 +3418,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 113
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5926..0xcd595e]
           RootRanges: [0xcd58c0..0xcd5985]
       Variables: []
-    - ID: 112
+    - ID: 114
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5a33..0xcd5a71]
           RootRanges: [0xcd5a20..0xcd5b2e]
       Variables: []
-    - ID: 113
+    - ID: 115
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5ae6..0xcd5b1e]
           RootRanges: [0xcd5a20..0xcd5b2e]
       Variables: []
-    - ID: 114
+    - ID: 116
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3391,7 +3453,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 117
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3416,20 +3478,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 988
+      ID: 1093
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 989 PointerType *main.deepSlice3
+      Pointee: 1094 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1015
+      ID: 1120
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1016 PointerType *main.deepSlice8
+      Pointee: 1121 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1021
+      ID: 1126
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1022 PointerType *main.deepSlice9
+      Pointee: 1127 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3437,7 +3499,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 984
+      ID: 1089
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3474,30 +3536,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 996
+      ID: 1101
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 997 PointerType *table<int,*main.deepMap3>
+      Pointee: 1102 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1032
+      ID: 1137
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1033 PointerType *table<int,*main.deepMap8>
+      Pointee: 1138 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1047
+      ID: 1152
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1048 PointerType *table<int,*main.deepMap9>
+      Pointee: 1153 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1062
+      ID: 1167
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1063 PointerType *table<int,interface {}>
+      Pointee: 1168 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '**table<int,uint8>'
@@ -3514,10 +3576,10 @@ Types:
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 727
+      ID: 832
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 728 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 833 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3529,6 +3591,36 @@ Types:
       ByteSize: 8
       Pointee: 100 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
+      ID: 190
+      Name: '**table<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 191 PointerType *table<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 195
+      Name: '**table<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 196 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 200
+      Name: '**table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 201 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 205
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 206 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 210
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 211 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 215
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 216 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
       ID: 141
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
@@ -3539,146 +3631,201 @@ Types:
       ByteSize: 8
       Pointee: 137 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 183
+      ID: 227
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 992
+      ID: 1097
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 991 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1096 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1019
+      ID: 1124
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1018 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1123 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1025
+      ID: 1130
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1024 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1129 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 180
+      ID: 224
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*string.array
+      Pointee: 223 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 297
+      ID: 361
+      Name: '*[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 360 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[][][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 359
+      Name: '*[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 358 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 357
+      Name: '*[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 356 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 355
+      Name: '*[][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 354 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 353
+      Name: '*[][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 352 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 341
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType [][]uint.array
+      Pointee: 340 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 303
+      ID: 347
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []bool.array
+      Pointee: 346 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 767
+      ID: 872
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 766 GoSliceDataType []float64.array
+      Pointee: 871 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1028
+      ID: 1133
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1027 GoSliceDataType []interface {}.array
+      Pointee: 1132 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 1009
+      ID: 177
+      Name: '*[]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 174 GoSliceHeaderType []main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 351
+      Name: '*[]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 350 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 1114
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1008 GoSliceDataType []main.structWithMap.array
+      Pointee: 1113 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 299
+      ID: 343
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 342 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 301
+      ID: 345
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []string.array
+      Pointee: 344 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 162
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 295
+      ID: 339
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType []uint.array
+      Pointee: 338 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 305
+      ID: 349
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 304 GoSliceDataType []uint16.array
+      Pointee: 348 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 765
+      ID: 870
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 764 GoSliceDataType []uint8.array
+      Pointee: 869 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 897
+      ID: 1002
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.976896e+06
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1003 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 535
+      ID: 640
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 926624
       GoKind: 22
-      Pointee: 536 GoSliceHeaderType archive/tar.headerError
+      Pointee: 641 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 538
+      ID: 643
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 537 GoSliceDataType archive/tar.headerError.array
+      Pointee: 642 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 832
+      ID: 937
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.43072e+06
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 938 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 780
+      ID: 885
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 886 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 782
+      ID: 887
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 783 StructureType archive/zip.dirWriter
+      Pointee: 888 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 880
+      ID: 985
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.896576e+06
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 986 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 808
+      ID: 913
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.053248e+06
       GoKind: 22
-      Pointee: 809 StructureType archive/zip.nopCloser
+      Pointee: 914 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 810
+      ID: 915
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.053504e+06
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 916 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3687,421 +3834,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 855
+      ID: 960
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.165024e+06
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType bufio.Reader
+      Pointee: 961 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 884
+      ID: 989
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.941088e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType bufio.Writer
+      Pointee: 990 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 935
+      ID: 1040
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.262304e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1041 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 447
+      ID: 552
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 909152
       GoKind: 22
-      Pointee: 339 BaseType compress/flate.CorruptInputError
+      Pointee: 444 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 448
+      ID: 553
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 909248
       GoKind: 22
-      Pointee: 340 GoStringHeaderType compress/flate.InternalError
+      Pointee: 445 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 342
+      ID: 447
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 341 GoStringDataType compress/flate.InternalError.str
+      Pointee: 446 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 830
+      ID: 935
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.42016e+06
       GoKind: 22
-      Pointee: 831 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 936 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 776
+      ID: 881
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 909344
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 882 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 852
+      ID: 957
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.718336e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 958 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 679
+      ID: 784
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.199456e+06
       GoKind: 22
-      Pointee: 680 StructureType context.deadlineExceededError
+      Pointee: 785 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 527
+      ID: 632
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921248
       GoKind: 22
-      Pointee: 353 BaseType crypto/aes.KeySizeError
+      Pointee: 458 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 528
+      ID: 633
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921440
       GoKind: 22
-      Pointee: 354 BaseType crypto/des.KeySizeError
+      Pointee: 459 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 529
+      ID: 634
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921728
       GoKind: 22
-      Pointee: 355 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 460 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 842
+      ID: 947
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.56064e+06
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 948 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 876
+      ID: 981
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.855008e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 982 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 908
+      ID: 1013
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.112352e+06
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1014 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 882
+      ID: 987
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.897088e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 988 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 878
+      ID: 983
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.85568e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 984 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 874
+      ID: 979
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.84784e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 980 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 530
+      ID: 635
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922016
       GoKind: 22
-      Pointee: 356 BaseType crypto/rc4.KeySizeError
+      Pointee: 461 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 892
+      ID: 997
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.946464e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 998 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 864
+      ID: 969
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.801824e+06
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 970 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 453
+      ID: 558
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 910880
       GoKind: 22
-      Pointee: 343 BaseType crypto/tls.AlertError
+      Pointee: 448 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 619
+      ID: 724
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.041856e+06
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 725 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 961
+      ID: 1066
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.374176e+06
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1067 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 451
+      ID: 556
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 452 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 557 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 449
+      ID: 554
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 910592
       GoKind: 22
-      Pointee: 450 StructureType crypto/tls.RecordHeaderError
+      Pointee: 555 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 618
+      ID: 723
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.040192e+06
       GoKind: 22
-      Pointee: 575 BaseType crypto/tls.alert
+      Pointee: 680 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 840
+      ID: 945
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.5536e+06
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 946 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 847
+      ID: 952
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.636032e+06
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 953 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 714
+      ID: 819
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.42048e+06
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 820 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 729
+      ID: 834
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.034944e+06
       GoKind: 22
-      Pointee: 730 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 835 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 523
+      ID: 628
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 524 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 629 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 517
+      ID: 622
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 919808
       GoKind: 22
-      Pointee: 518 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 623 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 519
+      ID: 624
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 520 StructureType crypto/x509.HostnameError
+      Pointee: 625 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 516
+      ID: 621
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 352 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 457 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 624
+      ID: 729
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.047616e+06
       GoKind: 22
-      Pointee: 625 StructureType crypto/x509.SystemRootsError
+      Pointee: 730 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 525
+      ID: 630
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 526 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 631 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 521
+      ID: 626
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 920192
       GoKind: 22
-      Pointee: 522 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 627 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 539
+      ID: 644
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 927104
       GoKind: 22
-      Pointee: 540 StructureType encoding/asn1.StructuralError
+      Pointee: 645 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 543
+      ID: 648
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927296
       GoKind: 22
-      Pointee: 544 StructureType encoding/asn1.SyntaxError
+      Pointee: 649 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 541
+      ID: 646
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 542 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 647 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 437
+      ID: 542
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 907232
       GoKind: 22
-      Pointee: 337 BaseType encoding/base64.CorruptInputError
+      Pointee: 442 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 798
+      ID: 903
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.037376e+06
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 904 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 440
+      ID: 545
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 908096
       GoKind: 22
-      Pointee: 338 BaseType encoding/hex.InvalidByteError
+      Pointee: 443 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 408
+      ID: 513
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 901952
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 514 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 610
+      ID: 715
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.033664e+06
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 716 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 400
+      ID: 505
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 901568
       GoKind: 22
-      Pointee: 401 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 506 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 406
+      ID: 511
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 901856
       GoKind: 22
-      Pointee: 407 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 512 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 404
+      ID: 509
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 901760
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 510 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 402
+      ID: 507
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 901664
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 508 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 941
+      ID: 1046
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.287328e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1047 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 410
+      ID: 515
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 902336
       GoKind: 22
-      Pointee: 411 StructureType encoding/json.jsonError
+      Pointee: 516 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 806
+      ID: 911
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.050176e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 912 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 511
+      ID: 616
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 918752
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 617 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 509
+      ID: 614
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 918656
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 615 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 513
+      ID: 618
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 349 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 454 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 351
+      ID: 456
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 350 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 455 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 514
+      ID: 619
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918944
       GoKind: 22
-      Pointee: 515 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 620 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 919
+      ID: 1024
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.150784e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1025 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4110,19 +4257,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 378
+      ID: 483
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 892256
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType errors.errorString
+      Pointee: 484 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 577
+      ID: 682
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.01856e+06
       GoKind: 22
-      Pointee: 578 UnresolvedPointeeType errors.joinError
+      Pointee: 683 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4138,813 +4285,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 929
+      ID: 1034
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.254624e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType fmt.pp
+      Pointee: 1035 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 579
+      ID: 684
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.020352e+06
       GoKind: 22
-      Pointee: 580 UnresolvedPointeeType fmt.wrapError
+      Pointee: 685 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 581
+      ID: 686
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.02048e+06
       GoKind: 22
-      Pointee: 582 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 687 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 438
+      ID: 543
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 907616
       GoKind: 22
-      Pointee: 439 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 544 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 419
+      ID: 524
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 904736
       GoKind: 22
-      Pointee: 420 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 525 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 421
+      ID: 526
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 904832
       GoKind: 22
-      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 527 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 742
+      ID: 847
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 904544
       GoKind: 22
-      Pointee: 743 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 848 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 425
+      ID: 530
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 22
-      Pointee: 426 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 531 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 744
+      ID: 849
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 904640
       GoKind: 22
-      Pointee: 745 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 850 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 423
+      ID: 528
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 904928
       GoKind: 22
-      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 333
+      ID: 438
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 418
+      ID: 523
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 904448
       GoKind: 22
-      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 330
+      ID: 435
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 424
+      ID: 529
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 905024
       GoKind: 22
-      Pointee: 334 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 439 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 336
+      ID: 441
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 820
+      ID: 925
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.20496e+06
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 926 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 905
+      ID: 1010
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.049952e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1011 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 533
+      ID: 638
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 639 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 688
+      ID: 793
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.208544e+06
       GoKind: 22
-      Pointee: 689 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 794 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 937
+      ID: 1042
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.264352e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1043 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 460
+      ID: 565
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 914240
       GoKind: 22
-      Pointee: 461 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 566 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 467
+      ID: 572
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 915296
       GoKind: 22
-      Pointee: 468 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 573 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 462
+      ID: 567
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 348 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 453 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 465
+      ID: 570
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 915200
       GoKind: 22
-      Pointee: 466 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 571 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 463
+      ID: 568
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 915104
       GoKind: 22
-      Pointee: 464 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 569 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 483
+      ID: 588
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 484 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 589 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 487
+      ID: 592
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 917408
       GoKind: 22
-      Pointee: 488 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 593 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 485
+      ID: 590
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 917312
       GoKind: 22
-      Pointee: 486 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 591 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 481
+      ID: 586
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 917120
       GoKind: 22
-      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 587 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 769
+      ID: 874
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 768 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 873 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 495
+      ID: 600
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 917792
       GoKind: 22
-      Pointee: 496 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 601 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 489
+      ID: 594
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 595 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 493
+      ID: 598
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 917696
       GoKind: 22
-      Pointee: 494 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 599 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 491
+      ID: 596
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 492 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 597 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 497
+      ID: 602
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 917888
       GoKind: 22
-      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 603 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 503
+      ID: 608
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 504 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 609 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 505
+      ID: 610
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 506 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 501
+      ID: 606
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 607 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 499
+      ID: 604
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 917984
       GoKind: 22
-      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 605 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 507
+      ID: 612
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 918464
       GoKind: 22
-      Pointee: 508 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 427
+      ID: 532
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 906272
       GoKind: 22
-      Pointee: 428 StructureType github.com/cihub/seelog.baseError
+      Pointee: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 858
+      ID: 963
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.794432e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 964 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 429
+      ID: 534
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 906368
       GoKind: 22
-      Pointee: 430 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 535 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 838
+      ID: 943
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.55248e+06
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 944 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 794
+      ID: 899
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.036352e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 900 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 828
+      ID: 933
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.41824e+06
       GoKind: 22
-      Pointee: 829 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 934 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 433
+      ID: 538
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 906560
       GoKind: 22
-      Pointee: 434 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 539 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 895
+      ID: 1000
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.966816e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1001 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 912
+      ID: 1017
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.123936e+06
       GoKind: 22
-      Pointee: 907 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1012 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 911
+      ID: 1016
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.123552e+06
       GoKind: 22
-      Pointee: 910 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1015 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 796
+      ID: 901
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.03648e+06
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 431
+      ID: 536
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 906464
       GoKind: 22
-      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 537 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 435
+      ID: 540
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 906656
       GoKind: 22
-      Pointee: 436 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 541 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 860
+      ID: 965
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.796224e+06
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 966 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 901
+      ID: 1006
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.003552e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1007 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 903
+      ID: 1008
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.034624e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1009 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 719
+      ID: 824
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.43312e+06
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 825 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 632
+      ID: 737
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.061696e+06
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 738 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 630
+      ID: 735
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.061568e+06
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 736 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 634
+      ID: 739
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.065664e+06
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 740 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 636
+      ID: 741
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.065792e+06
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 742 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 849
+      ID: 954
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.663104e+06
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 955 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 626
+      ID: 731
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.048256e+06
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 732 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 441
+      ID: 546
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 908288
       GoKind: 22
-      Pointee: 442 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 547 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 953
+      ID: 1058
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.3504e+06
       GoKind: 22
-      Pointee: 954 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1059 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 690
+      ID: 795
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.216992e+06
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 796 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 663
+      ID: 768
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.195744e+06
       GoKind: 22
-      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 769 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 657
+      ID: 762
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.19536e+06
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 763 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 596
+      ID: 701
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.027648e+06
       GoKind: 22
-      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 702 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 669
+      ID: 774
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.196128e+06
       GoKind: 22
-      Pointee: 670 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 595
+      ID: 700
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.02752e+06
       GoKind: 22
-      Pointee: 574 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 679 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 661
+      ID: 766
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.195616e+06
       GoKind: 22
-      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 767 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 659
+      ID: 764
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.195488e+06
       GoKind: 22
-      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 765 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 667
+      ID: 772
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.196e+06
       GoKind: 22
-      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 773 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 665
+      ID: 770
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195872e+06
       GoKind: 22
-      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 771 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 957
+      ID: 1062
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.362208e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1063 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 673
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.196512e+06
       GoKind: 22
-      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 600
+      ID: 705
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.027904e+06
       GoKind: 22
-      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 706 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 598
+      ID: 703
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.027776e+06
       GoKind: 22
-      Pointee: 599 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 704 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 671
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.196384e+06
       GoKind: 22
-      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 555
+      ID: 660
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 940064
       GoKind: 22
-      Pointee: 361 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 466 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 363
+      ID: 468
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 362 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 467 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 732
+      ID: 837
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.661568e+06
       GoKind: 22
-      Pointee: 733 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 838 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 640
+      ID: 745
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.080512e+06
       GoKind: 22
-      Pointee: 641 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 746 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 826
+      ID: 931
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.256544e+06
       GoKind: 22
-      Pointee: 827 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 932 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 917
+      ID: 1022
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.138912e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1023 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 812
+      ID: 917
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.082816e+06
       GoKind: 22
-      Pointee: 813 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 918 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 556
+      ID: 661
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 941312
       GoKind: 22
-      Pointee: 364 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 469 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 698
+      ID: 803
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.258208e+06
       GoKind: 22
-      Pointee: 699 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 804 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 559
+      ID: 664
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 941600
       GoKind: 22
-      Pointee: 560 StructureType golang.org/x/net/http2.connError
+      Pointee: 665 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 558
+      ID: 663
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941504
       GoKind: 22
-      Pointee: 368 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 473 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 370
+      ID: 475
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 369 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 474 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 562
+      ID: 667
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 941792
       GoKind: 22
-      Pointee: 374 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 479 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 376
+      ID: 481
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 375 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 480 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 561
+      ID: 666
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 941696
       GoKind: 22
-      Pointee: 371 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 476 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 373
+      ID: 478
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 372 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 477 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 557
+      ID: 662
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941408
       GoKind: 22
-      Pointee: 365 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 470 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 367
+      ID: 472
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 366 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 471 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 915
+      ID: 1020
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.136992e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1021 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 563
+      ID: 668
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 941888
       GoKind: 22
-      Pointee: 564 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 669 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 565
+      ID: 670
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 377 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 482 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 551
+      ID: 656
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 935264
       GoKind: 22
-      Pointee: 552 StructureType google.golang.org/grpc.dropError
+      Pointee: 657 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 696
+      ID: 801
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.255264e+06
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 802 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 721
+      ID: 826
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.44048e+06
       GoKind: 22
-      Pointee: 722 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 827 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 553
+      ID: 658
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 554 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 659 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 866
+      ID: 971
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.802272e+06
       GoKind: 22
-      Pointee: 867 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 972 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 824
+      ID: 929
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.251808e+06
       GoKind: 22
-      Pointee: 825 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 930 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 638
+      ID: 743
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.074752e+06
       GoKind: 22
-      Pointee: 639 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 744 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 784
+      ID: 889
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 938432
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 890 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 531
+      ID: 636
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 637 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 628
+      ID: 733
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.051584e+06
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 734 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 694
+      ID: 799
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.223264e+06
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 800 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 692
+      ID: 797
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.223008e+06
       GoKind: 22
-      Pointee: 693 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 798 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 545
+      ID: 650
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 928160
       GoKind: 22
-      Pointee: 546 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 651 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 547
+      ID: 652
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 928256
       GoKind: 22
-      Pointee: 548 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 653 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 475
+      ID: 580
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 915680
       GoKind: 22
-      Pointee: 476 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 581 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 872
+      ID: 977
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.842912e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 978 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 566
+      ID: 671
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 942752
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType html/template.Error
+      Pointee: 672 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -4988,103 +5135,103 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 445
+      ID: 550
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 446 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 551 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 443
+      ID: 548
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 908768
       GoKind: 22
-      Pointee: 444 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 549 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 770
+      ID: 875
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 896768
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 876 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 655
+      ID: 760
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.194592e+06
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 761 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 959
+      ID: 1064
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.36784e+06
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1065 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 653
+      ID: 758
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.194464e+06
       GoKind: 22
-      Pointee: 654 StructureType internal/poll.errNetClosing
+      Pointee: 759 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 380
+      ID: 485
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 896000
       GoKind: 22
-      Pointee: 381 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 486 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 816
+      ID: 921
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.186016e+06
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType io.PipeWriter
+      Pointee: 922 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 814
+      ID: 919
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.185632e+06
       GoKind: 22
-      Pointee: 815 StructureType io.discard
+      Pointee: 920 StructureType io.discard
     - __kind: PointerType
-      ID: 788
+      ID: 893
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.018816e+06
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType io.multiWriter
+      Pointee: 894 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 651
+      ID: 756
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.194208e+06
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType io/fs.PathError
+      Pointee: 757 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 862
+      ID: 967
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.796448e+06
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 968 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 190
+      ID: 234
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 383232
       GoKind: 22
-      Pointee: 191 StructureType main.deepMap2
+      Pointee: 235 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1004
+      ID: 1109
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383168
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType main.deepMap3
+      Pointee: 1110 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -5093,19 +5240,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1040
+      ID: 1145
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 382848
       GoKind: 22
-      Pointee: 1041 StructureType main.deepMap8
+      Pointee: 1146 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1055
+      ID: 1160
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382784
       GoKind: 22
-      Pointee: 1056 StructureType main.deepMap9
+      Pointee: 1161 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -5114,12 +5261,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 963
+      ID: 1068
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1069 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5128,33 +5275,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1010
+      ID: 1115
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383424
       GoKind: 22
-      Pointee: 1011 StructureType main.deepPtr8
+      Pointee: 1116 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1012
+      ID: 1117
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383360
       GoKind: 22
-      Pointee: 1013 StructureType main.deepPtr9
+      Pointee: 1118 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 384384
       GoKind: 22
-      Pointee: 181 StructureType main.deepSlice2
+      Pointee: 225 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 989
+      ID: 1094
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384320
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1095 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5163,25 +5310,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1016
+      ID: 1121
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 384000
       GoKind: 22
-      Pointee: 1017 StructureType main.deepSlice8
+      Pointee: 1122 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1022
+      ID: 1127
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383936
       GoKind: 22
-      Pointee: 1023 StructureType main.deepSlice9
+      Pointee: 1128 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 176
+      ID: 220
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 175 StructureType main.emptyStruct
+      Pointee: 219 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
@@ -5190,12 +5337,12 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 980
+      ID: 1085
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 891968
       GoKind: 22
-      Pointee: 981 StructureType main.firstBehavior
+      Pointee: 1086 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
@@ -5210,19 +5357,19 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 982
+      ID: 1087
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 892064
       GoKind: 22
-      Pointee: 983 StructureType main.secondBehavior
+      Pointee: 1088 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 968
+      ID: 1073
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 892160
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1074 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -5230,18 +5377,23 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 966
+      ID: 1071
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 965 GoStringDataType main.stringType1.str
+      Pointee: 1070 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType main.stringType2
+      Pointee: 1072 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 242
+      ID: 175
+      Name: '*main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 173 StructureType main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 286
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382720
@@ -5265,10 +5417,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 986
+      ID: 1091
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 985 GoSliceDataType main.t.array
+      Pointee: 1090 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -5301,30 +5453,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 994
+      ID: 1099
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 995 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1100 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1030
+      ID: 1135
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1031 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1136 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1045
+      ID: 1150
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1046 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1151 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1060
+      ID: 1165
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1061 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1166 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 129
       Name: '*map<int,uint8>'
@@ -5341,10 +5493,10 @@ Types:
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 725
+      ID: 830
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 726 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 831 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -5355,6 +5507,36 @@ Types:
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 188
+      Name: '*map<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 189 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 193
+      Name: '*map<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 194 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 198
+      Name: '*map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 199 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 203
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 204 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 208
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 209 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 213
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 214 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 139
       Name: '*map<uint8,[4]int>'
@@ -5372,696 +5554,726 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 479
+      ID: 584
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 480 StructureType math/big.ErrNaN
+      Pointee: 585 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 778
+      ID: 883
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 911360
       GoKind: 22
-      Pointee: 779 StructureType mime/multipart.writerOnly·1
+      Pointee: 884 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 682
+      ID: 787
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.202784e+06
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType net.AddrError
+      Pointee: 788 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 708
+      ID: 813
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.41648e+06
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType net.DNSError
+      Pointee: 814 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 923
+      ID: 1028
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.22544e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net.IPConn
+      Pointee: 1029 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 706
+      ID: 811
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.41616e+06
       GoKind: 22
-      Pointee: 707 UnresolvedPointeeType net.OpError
+      Pointee: 812 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 684
+      ID: 789
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.202912e+06
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType net.ParseError
+      Pointee: 790 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 933
+      ID: 1038
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.255648e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net.TCPConn
+      Pointee: 1039 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 943
+      ID: 1048
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.30064e+06
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType net.UDPConn
+      Pointee: 1049 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 931
+      ID: 1036
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.255136e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType net.UnixConn
+      Pointee: 1037 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 681
+      ID: 786
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.202016e+06
       GoKind: 22
-      Pointee: 644 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 749 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 646
+      ID: 751
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 645 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 750 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 612
+      ID: 717
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.03456e+06
       GoKind: 22
-      Pointee: 613 StructureType net.canceledError
+      Pointee: 718 StructureType net.canceledError
     - __kind: PointerType
-      ID: 899
+      ID: 1004
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.000672e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType net.conn
+      Pointee: 1005 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 751
+      ID: 856
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.838208e+06
       GoKind: 22
-      Pointee: 752 StructureType net.dialResult·1
+      Pointee: 857 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 945
+      ID: 1050
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.304896e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType net.netFD
+      Pointee: 1051 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 412
+      ID: 517
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 903296
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType net.notFoundError
+      Pointee: 518 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 414
+      ID: 519
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 903968
       GoKind: 22
-      Pointee: 415 StructureType net.result·2
+      Pointee: 520 StructureType net.result·2
     - __kind: PointerType
-      ID: 927
+      ID: 1032
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.241664e+06
       GoKind: 22
-      Pointee: 928 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1033 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 925
+      ID: 1030
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.241184e+06
       GoKind: 22
-      Pointee: 926 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1031 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 686
+      ID: 791
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.203552e+06
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType net.temporaryError
+      Pointee: 792 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 710
+      ID: 815
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.41664e+06
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType net.timeoutError
+      Pointee: 816 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 602
+      ID: 707
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.030336e+06
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 708 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 772
+      ID: 877
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 899072
       GoKind: 22
-      Pointee: 773 StructureType net/http.bufioFlushWriter
+      Pointee: 878 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 389
+      ID: 494
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 899744
       GoKind: 22
-      Pointee: 309 BaseType net/http.http2ConnectionError
+      Pointee: 414 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 390
+      ID: 495
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 899840
       GoKind: 22
-      Pointee: 391 StructureType net/http.http2GoAwayError
+      Pointee: 496 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 702
+      ID: 807
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.41232e+06
       GoKind: 22
-      Pointee: 703 StructureType net/http.http2StreamError
+      Pointee: 808 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 394
+      ID: 499
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 900416
       GoKind: 22
-      Pointee: 395 StructureType net/http.http2connError
+      Pointee: 500 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 834
+      ID: 939
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.54896e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 940 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 393
+      ID: 498
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900320
       GoKind: 22
-      Pointee: 313 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 418 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 315
+      ID: 420
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 397
+      ID: 502
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 900608
       GoKind: 22
-      Pointee: 319 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 424 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 321
+      ID: 426
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 425 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 396
+      ID: 501
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 900512
       GoKind: 22
-      Pointee: 316 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 421 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 318
+      ID: 423
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 422 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 677
+      ID: 782
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.19856e+06
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 783 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 608
+      ID: 713
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.030976e+06
       GoKind: 22
-      Pointee: 609 StructureType net/http.http2noCachedConnError
+      Pointee: 714 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 888
+      ID: 993
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.943136e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 994 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 392
+      ID: 497
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900224
       GoKind: 22
-      Pointee: 310 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 415 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 312
+      ID: 417
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 416 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 774
+      ID: 879
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 900704
       GoKind: 22
-      Pointee: 775 StructureType net/http.http2stickyErrWriter
+      Pointee: 880 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 604
+      ID: 709
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.030592e+06
       GoKind: 22
-      Pointee: 605 StructureType net/http.nothingWrittenError
+      Pointee: 710 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 836
+      ID: 941
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.166272e+06
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType net/http.persistConn
+      Pointee: 942 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 792
+      ID: 897
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.030464e+06
       GoKind: 22
-      Pointee: 793 StructureType net/http.persistConnWriter
+      Pointee: 898 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 818
+      ID: 923
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.197664e+06
       GoKind: 22
-      Pointee: 819 StructureType net/http.readWriteCloserBody
+      Pointee: 924 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 398
+      ID: 503
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 900800
       GoKind: 22
-      Pointee: 399 StructureType net/http.requestBodyReadError
+      Pointee: 504 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 704
+      ID: 809
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.41344e+06
       GoKind: 22
-      Pointee: 705 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 810 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 675
+      ID: 780
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.198432e+06
       GoKind: 22
-      Pointee: 676 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 781 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 606
+      ID: 711
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.03072e+06
       GoKind: 22
-      Pointee: 607 StructureType net/http.transportReadFromServerError
+      Pointee: 712 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 870
+      ID: 975
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.834848e+06
       GoKind: 22
-      Pointee: 871 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 976 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 387
+      ID: 492
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 898976
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 493 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 890
+      ID: 995
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.944672e+06
       GoKind: 22
-      Pointee: 891 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 996 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 802
+      ID: 907
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.043008e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 908 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 471
+      ID: 576
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915488
       GoKind: 22
-      Pointee: 472 StructureType net/netip.parseAddrError
+      Pointee: 577 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 469
+      ID: 574
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915392
       GoKind: 22
-      Pointee: 470 StructureType net/netip.parsePrefixError
+      Pointee: 575 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 844
+      ID: 949
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.110944e+06
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType net/smtp.Client
+      Pointee: 950 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 804
+      ID: 909
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.047872e+06
       GoKind: 22
-      Pointee: 805 StructureType net/smtp.dataCloser
+      Pointee: 910 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 455
+      ID: 560
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 911552
       GoKind: 22
-      Pointee: 456 UnresolvedPointeeType net/textproto.Error
+      Pointee: 561 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 454
+      ID: 559
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 911456
       GoKind: 22
-      Pointee: 344 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 449 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 346
+      ID: 451
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 345 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 450 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 800
+      ID: 905
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.04224e+06
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 906 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 712
+      ID: 817
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.41696e+06
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType net/url.Error
+      Pointee: 818 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 416
+      ID: 521
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 904064
       GoKind: 22
-      Pointee: 322 GoStringHeaderType net/url.EscapeError
+      Pointee: 427 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 324
+      ID: 429
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType net/url.EscapeError.str
+      Pointee: 428 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 417
+      ID: 522
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 22
-      Pointee: 325 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 430 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 327
+      ID: 432
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 431 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 288
+      ID: 332
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 289 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 280
+      ID: 324
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 281 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 228
+      ID: 272
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 229 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 247
+      ID: 291
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 248 StructureType noalg.map.group[bool]main.node
+      Pointee: 292 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 186
+      ID: 230
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1000
+      ID: 1105
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1001 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1106 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1036
+      ID: 1141
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1037 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1142 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1051
+      ID: 1156
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1052 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1157 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 196
+      ID: 240
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[int]int
+      Pointee: 241 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1066
+      ID: 1171
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1067 StructureType noalg.map.group[int]interface {}
+      Pointee: 1172 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 255
+      ID: 299
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 256 StructureType noalg.map.group[int]uint8
+      Pointee: 300 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 237
+      ID: 281
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 238 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 220
+      ID: 264
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 221 StructureType noalg.map.group[string][]string
+      Pointee: 265 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 758
+      ID: 863
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 212
+      ID: 256
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 213 StructureType noalg.map.group[string]int
+      Pointee: 257 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 204
+      ID: 248
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 205 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 249 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 271
+      ID: 364
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 373
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 381
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 389
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 397
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 405
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 315
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 272 StructureType noalg.map.group[uint8][4]int
+      Pointee: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 263
+      ID: 307
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 264 StructureType noalg.map.group[uint8]uint8
+      Pointee: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 951
+      ID: 1056
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.343552e+06
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType os.File
+      Pointee: 1057 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 583
+      ID: 688
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.021632e+06
       GoKind: 22
-      Pointee: 584 UnresolvedPointeeType os.LinkError
+      Pointee: 689 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 647
+      ID: 752
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.187552e+06
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType os.SyscallError
+      Pointee: 753 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 949
+      ID: 1054
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.339872e+06
       GoKind: 22
-      Pointee: 950 StructureType os.fileWithoutReadFrom
+      Pointee: 1055 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 947
+      ID: 1052
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.339136e+06
       GoKind: 22
-      Pointee: 948 StructureType os.fileWithoutWriteTo
+      Pointee: 1053 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 614
+      ID: 719
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.038912e+06
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType os/exec.Error
+      Pointee: 720 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 754
+      ID: 859
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.0808e+06
       GoKind: 22
-      Pointee: 755 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 860 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 822
+      ID: 927
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.209824e+06
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 928 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 616
+      ID: 721
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.03904e+06
       GoKind: 22
-      Pointee: 617 StructureType os/exec.wrappedError
+      Pointee: 722 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 550
+      ID: 655
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 933344
       GoKind: 22
-      Pointee: 358 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 463 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 360
+      ID: 465
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 359 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 464 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 549
+      ID: 654
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 933248
       GoKind: 22
-      Pointee: 357 BaseType os/user.UnknownUserIdError
+      Pointee: 462 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 382
+      ID: 487
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 896672
       GoKind: 22
-      Pointee: 383 UnresolvedPointeeType reflect.ValueError
+      Pointee: 488 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 477
+      ID: 582
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 916160
       GoKind: 22
-      Pointee: 478 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 583 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 587
+      ID: 692
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.023168e+06
       GoKind: 22
-      Pointee: 588 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 693 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 591
+      ID: 696
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.02496e+06
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 697 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 589
+      ID: 694
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.023296e+06
       GoKind: 22
-      Pointee: 590 StructureType runtime.boundsError
+      Pointee: 695 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 649
+      ID: 754
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.192928e+06
       GoKind: 22
-      Pointee: 650 StructureType runtime.errorAddressString
+      Pointee: 755 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 585
+      ID: 690
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.022784e+06
       GoKind: 22
-      Pointee: 568 GoStringHeaderType runtime.errorString
+      Pointee: 673 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 570
+      ID: 675
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 569 GoStringDataType runtime.errorString.str
+      Pointee: 674 GoStringDataType runtime.errorString.str
     - __kind: PointerType
-      ID: 586
+      ID: 691
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.022912e+06
       GoKind: 22
-      Pointee: 571 GoStringHeaderType runtime.plainError
+      Pointee: 676 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 573
+      ID: 678
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 572 GoStringDataType runtime.plainError.str
+      Pointee: 677 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 593
+      ID: 698
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.025216e+06
       GoKind: 22
-      Pointee: 594 UnresolvedPointeeType strconv.NumError
+      Pointee: 699 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6070,168 +6282,198 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 178
+      ID: 222
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 177 GoStringDataType string.str
+      Pointee: 221 GoStringDataType string.str
     - __kind: PointerType
-      ID: 886
+      ID: 991
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.941856e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType strings.Builder
+      Pointee: 992 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 790
+      ID: 895
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.025344e+06
       GoKind: 22
-      Pointee: 791 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 896 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 786
+      ID: 891
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 966144
       GoKind: 22
-      Pointee: 787 StructureType struct { io.Writer }
+      Pointee: 892 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 701
+      ID: 806
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.41168e+06
       GoKind: 22
-      Pointee: 700 BaseType syscall.Errno
+      Pointee: 805 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 286 StructureType table<[4]int,[4]int>
+      Pointee: 330 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 147
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 278 StructureType table<[4]int,uint8>
+      Pointee: 322 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 115
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 226 StructureType table<[4]string,[2]int>
+      Pointee: 270 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 127
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 245 StructureType table<bool,main.node>
+      Pointee: 289 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 184 StructureType table<int,*main.deepMap2>
+      Pointee: 228 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 997
+      ID: 1102
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 998 StructureType table<int,*main.deepMap3>
+      Pointee: 1103 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1033
+      ID: 1138
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1034 StructureType table<int,*main.deepMap8>
+      Pointee: 1139 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1048
+      ID: 1153
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1049 StructureType table<int,*main.deepMap9>
+      Pointee: 1154 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 194 StructureType table<int,int>
+      Pointee: 238 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1063
+      ID: 1168
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1064 StructureType table<int,interface {}>
+      Pointee: 1169 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 253 StructureType table<int,uint8>
+      Pointee: 297 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 122
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 235 StructureType table<string,[]main.structWithMap>
+      Pointee: 279 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 110
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 218 StructureType table<string,[]string>
+      Pointee: 262 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 728
+      ID: 833
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 756 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 861 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 210 StructureType table<string,int>
+      Pointee: 254 StructureType table<string,int>
     - __kind: PointerType
       ID: 100
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 202 StructureType table<string,main.nestedStruct>
+      Pointee: 246 StructureType table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 191
+      Name: '*table<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 362 StructureType table<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 196
+      Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 371 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 201
+      Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 379 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 206
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 387 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 211
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 395 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 216
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 403 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 142
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 269 StructureType table<uint8,[4]int>
+      Pointee: 313 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 137
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 261 StructureType table<uint8,uint8>
+      Pointee: 305 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 921
+      ID: 1026
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.151168e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1027 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 642
+      ID: 747
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.084352e+06
       GoKind: 22
-      Pointee: 643 StructureType text/template.ExecError
+      Pointee: 748 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 717
+      ID: 822
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.617024e+06
       GoKind: 22
-      Pointee: 718 UnresolvedPointeeType time.Location
+      Pointee: 823 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 385
+      ID: 490
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 897536
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType time.ParseError
+      Pointee: 491 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 384
+      ID: 489
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 897440
       GoKind: 22
-      Pointee: 306 GoStringHeaderType time.fileSizeError
+      Pointee: 411 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 308
+      ID: 413
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType time.fileSizeError.str
+      Pointee: 412 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6275,52 +6517,52 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 473
+      ID: 578
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 915584
       GoKind: 22
-      Pointee: 474 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 579 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 913
+      ID: 1018
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.126624e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1019 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 457
+      ID: 562
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 458 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 563 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 459
+      ID: 564
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 911840
       GoKind: 22
-      Pointee: 347 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 452 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 621
+      ID: 726
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.042752e+06
       GoKind: 22
-      Pointee: 622 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 727 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 623
+      ID: 728
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.04288e+06
       GoKind: 22
-      Pointee: 576 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 681 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1169
+      ID: 1274
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1126
+      ID: 1231
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6335,7 +6577,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1124
+      ID: 1229
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6350,7 +6592,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1088
+      ID: 1193
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6365,7 +6607,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1086
+      ID: 1191
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6380,7 +6622,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1134
+      ID: 1239
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6395,7 +6637,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1087
+      ID: 1192
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6410,7 +6652,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1106
+      ID: 1211
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6425,7 +6667,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1075
+      ID: 1180
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6440,7 +6682,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1072
+      ID: 1177
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6455,7 +6697,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1150
+      ID: 1255
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6470,7 +6712,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1148
+      ID: 1253
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6503,7 +6745,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1158
+      ID: 1263
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6518,7 +6760,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1111
+      ID: 1216
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6533,7 +6775,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1112
+      ID: 1217
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6548,7 +6790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1107
+      ID: 1212
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6563,7 +6805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1108
+      ID: 1213
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6578,7 +6820,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1109
+      ID: 1214
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6593,7 +6835,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1110
+      ID: 1215
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6608,7 +6850,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1163
+      ID: 1268
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6632,7 +6874,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1160
+      ID: 1265
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6647,7 +6889,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1177
+      ID: 1282
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6662,7 +6904,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1180
+      ID: 1287
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6670,14 +6912,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 176 PointerType *main.emptyStruct
+            Type: 220 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: e}
+                  Variable: {subprogram: 111, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1179
+      ID: 1286
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6685,14 +6927,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 StructureType main.emptyStruct
+            Type: 219 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 110, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1125
+      ID: 1230
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6707,7 +6949,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1116
+      ID: 1221
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6722,7 +6964,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1115
+      ID: 1220
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6737,7 +6979,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1122
+      ID: 1227
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6752,7 +6994,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1121
+      ID: 1226
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6767,7 +7009,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1117
+      ID: 1222
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6782,7 +7024,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1119
+      ID: 1224
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6797,10 +7039,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1182
+      ID: 1289
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1118
+      ID: 1223
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6824,16 +7066,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1290
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1184
+      ID: 1291
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1120
+      ID: 1225
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1181
+      ID: 1288
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6844,11 +7086,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 112, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1185
+      ID: 1292
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6859,11 +7101,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1186
+      ID: 1293
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6874,11 +7116,11 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: a}
+                  Variable: {subprogram: 117, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1078
+      ID: 1183
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6893,7 +7135,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1079
+      ID: 1184
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6908,7 +7150,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1080
+      ID: 1185
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6923,7 +7165,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1077
+      ID: 1182
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6938,7 +7180,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1076
+      ID: 1181
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6953,7 +7195,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1123
+      ID: 1228
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6968,7 +7210,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1152
+      ID: 1257
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6983,7 +7225,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1132
+      ID: 1237
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6998,7 +7240,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1138
+      ID: 1243
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7013,7 +7255,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1136
+      ID: 1241
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7028,7 +7270,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1147
+      ID: 1252
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7043,7 +7285,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1146
+      ID: 1251
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7058,7 +7300,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1137
+      ID: 1242
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7073,7 +7315,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1145
+      ID: 1250
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7088,7 +7330,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1144
+      ID: 1249
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7103,7 +7345,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1130
+      ID: 1235
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7118,7 +7360,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1131
+      ID: 1236
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7133,7 +7375,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1129
+      ID: 1234
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7148,7 +7390,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1139
+      ID: 1244
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7163,7 +7405,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1143
+      ID: 1248
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7178,7 +7420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1142
+      ID: 1247
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7193,7 +7435,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1141
+      ID: 1246
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7208,7 +7450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1140
+      ID: 1245
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7223,7 +7465,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1175
+      ID: 1280
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7238,7 +7480,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1149
+      ID: 1254
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7289,7 +7531,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1157
+      ID: 1262
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7313,7 +7555,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1164
+      ID: 1269
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7337,7 +7579,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1166
+      ID: 1271
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7370,7 +7612,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1272
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7385,7 +7627,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1174
+      ID: 1279
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7400,7 +7642,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1153
+      ID: 1258
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7415,7 +7657,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1135
+      ID: 1240
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7430,7 +7672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1151
+      ID: 1256
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7445,7 +7687,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1073
+      ID: 1178
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7460,7 +7702,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1092
+      ID: 1197
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7475,7 +7717,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1090
+      ID: 1195
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7490,7 +7732,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1103
+      ID: 1208
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7505,7 +7747,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1104
+      ID: 1209
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7520,7 +7762,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1095
+      ID: 1200
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7535,7 +7777,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1096
+      ID: 1201
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7550,7 +7792,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1097
+      ID: 1202
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7565,7 +7807,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1094
+      ID: 1199
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7580,7 +7822,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1093
+      ID: 1198
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7595,7 +7837,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1091
+      ID: 1196
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7610,7 +7852,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1170
+      ID: 1275
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7625,7 +7867,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1100
+      ID: 1205
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7640,7 +7882,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1101
+      ID: 1206
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7655,7 +7897,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1102
+      ID: 1207
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7670,7 +7912,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1099
+      ID: 1204
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7685,7 +7927,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1098
+      ID: 1203
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7700,7 +7942,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1161
+      ID: 1266
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7715,7 +7957,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1133
+      ID: 1238
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7730,7 +7972,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1074
+      ID: 1179
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7745,7 +7987,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1156
+      ID: 1261
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7760,7 +8002,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1165
+      ID: 1270
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7775,7 +8017,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1113
+      ID: 1218
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7790,7 +8032,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1114
+      ID: 1219
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7805,7 +8047,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1162
+      ID: 1267
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7829,7 +8071,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1127
+      ID: 1232
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7844,7 +8086,37 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1128
+      ID: 1284
+      Name: Probe[main.testStructWithCyclicMaps]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 186 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 1283
+      Name: Probe[main.testStructWithCyclicSlices]
+      ByteSize: 145
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 173 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
+    - __kind: EventRootType
+      ID: 1233
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7859,7 +8131,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1178
+      ID: 1285
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7867,14 +8139,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 173 StructureType main.aStruct
+            Type: 217 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1173
+      ID: 1278
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7889,7 +8161,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1172
+      ID: 1277
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7904,7 +8176,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1171
+      ID: 1276
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7937,7 +8209,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1105
+      ID: 1210
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7952,7 +8224,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1083
+      ID: 1188
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7967,7 +8239,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1084
+      ID: 1189
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7982,7 +8254,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1085
+      ID: 1190
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7997,7 +8269,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1082
+      ID: 1187
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8012,7 +8284,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1081
+      ID: 1186
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8027,7 +8299,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1155
+      ID: 1260
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8042,7 +8314,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1159
+      ID: 1264
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8057,7 +8329,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1176
+      ID: 1281
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8072,7 +8344,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1154
+      ID: 1259
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8087,7 +8359,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1089
+      ID: 1194
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -8102,7 +8374,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1168
+      ID: 1273
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8250,7 +8522,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 275
+      ID: 319
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 679136
@@ -8259,7 +8531,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 232
+      ID: 276
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 679424
@@ -8276,7 +8548,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 746
+      ID: 851
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 680672
@@ -8300,14 +8572,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 182 GoSliceDataType []*main.deepSlice2.array
+      Data: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 226
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 987
+      ID: 1092
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474944
@@ -8315,21 +8587,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 988 PointerType **main.deepSlice3
+          Type: 1093 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 991 GoSliceDataType []*main.deepSlice3.array
+      Data: 1096 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 991
+      ID: 1096
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 989 PointerType *main.deepSlice3
+      Element: 1094 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1014
+      ID: 1119
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474624
@@ -8337,21 +8609,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1015 PointerType **main.deepSlice8
+          Type: 1120 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1018 GoSliceDataType []*main.deepSlice8.array
+      Data: 1123 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1018
+      ID: 1123
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 1016 PointerType *main.deepSlice8
+      Element: 1121 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1020
+      ID: 1125
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474560
@@ -8359,19 +8631,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1021 PointerType **main.deepSlice9
+          Type: 1126 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1024 GoSliceDataType []*main.deepSlice9.array
+      Data: 1129 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1024
+      ID: 1129
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 1022 PointerType *main.deepSlice9
+      Element: 1127 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -8388,102 +8660,237 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 179 GoSliceDataType []*string.array
+      Data: 223 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 223
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 336
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 152 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 328
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 147 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 277
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 115 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 295
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 236
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1006
+      ID: 1111
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 997 PointerType *table<int,*main.deepMap3>
+      Element: 1102 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1042
+      ID: 1147
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 1033 PointerType *table<int,*main.deepMap8>
+      Element: 1138 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1057
+      ID: 1162
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 1048 PointerType *table<int,*main.deepMap9>
+      Element: 1153 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 244
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1070
+      ID: 1175
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 1063 PointerType *table<int,interface {}>
+      Element: 1168 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 303
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 132 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 287
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 268
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 762
+      ID: 867
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 8192
-      Element: 728 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 833 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 260
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 252
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 100 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 369
+      Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 191 PointerType *table<struct {},main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 377
+      Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 196 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 385
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 201 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 393
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 206 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 401
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 211 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 409
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 216 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 320
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 142 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 311
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 137 PointerType *table<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 184
+      Name: '[][][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 185 PointerType *[][][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 360 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 360
+      Name: '[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 182
+      Name: '[][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 183 PointerType *[][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 358 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 358
+      Name: '[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 180
+      Name: '[][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 181 PointerType *[][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 356 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 356
+      Name: '[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 178
+      Name: '[][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 179 PointerType *[][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 354 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 354
+      Name: '[][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 176
+      Name: '[][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 177 PointerType *[]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 352 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 352
+      Name: '[][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 174 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
       ID: 161
       Name: '[][]uint'
@@ -8499,9 +8906,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 296 GoSliceDataType [][]uint.array
+      Data: 340 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 340
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 160 GoSliceHeaderType []uint
@@ -8521,14 +8928,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 302 GoSliceDataType []bool.array
+      Data: 346 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 346
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 741
+      ID: 846
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 483776
@@ -8543,14 +8950,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 766 GoSliceDataType []float64.array
+      Data: 871 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 766
+      ID: 871
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1026
+      ID: 1131
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484224
@@ -8565,14 +8972,35 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1027 GoSliceDataType []interface {}.array
+      Data: 1132 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1027
+      ID: 1132
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 241
+      ID: 174
+      Name: '[]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 175 PointerType *main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 350 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 350
+      Name: '[]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 173 StructureType main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 285
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 475264
@@ -8580,16 +9008,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 242 PointerType *main.structWithMap
+          Type: 286 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1008 GoSliceDataType []main.structWithMap.array
+      Data: 1113 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1008
+      ID: 1113
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -8608,102 +9036,132 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 298 GoSliceDataType []main.structWithNoStrings.array
+      Data: 342 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 342
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 337
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 289 StructureType noalg.map.group[[4]int][4]int
+      Element: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 329
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 281 StructureType noalg.map.group[[4]int]uint8
+      Element: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 278
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 229 StructureType noalg.map.group[[4]string][2]int
+      Element: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 296
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 248 StructureType noalg.map.group[bool]main.node
+      Element: 292 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 237
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 187 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1007
+      ID: 1112
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 1001 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1106 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1043
+      ID: 1148
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 1037 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1142 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1058
+      ID: 1163
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 1052 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1157 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 245
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[int]int
+      Element: 241 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1071
+      ID: 1176
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 1067 StructureType noalg.map.group[int]interface {}
+      Element: 1172 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 304
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 256 StructureType noalg.map.group[int]uint8
+      Element: 300 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 288
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 238 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 269
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 221 StructureType noalg.map.group[string][]string
+      Element: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 763
+      ID: 868
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 2048
-      Element: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 261
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 213 StructureType noalg.map.group[string]int
+      Element: 257 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 253
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 205 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 249 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 370
+      Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 378
+      Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 386
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 394
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 402
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 410
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 321
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 272 StructureType noalg.map.group[uint8][4]int
+      Element: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 312
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 264 StructureType noalg.map.group[uint8]uint8
+      Element: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 166
       Name: '[]string'
@@ -8720,9 +9178,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 300 GoSliceDataType []string.array
+      Data: 344 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 344
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -8742,9 +9200,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 294 GoSliceDataType []uint.array
+      Data: 338 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 338
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 16 BaseType uint
@@ -8764,14 +9222,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 304 GoSliceDataType []uint16.array
+      Data: 348 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 304
+      ID: 348
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 735
+      ID: 840
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 482752
@@ -8786,18 +9244,18 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 764 GoSliceDataType []uint8.array
+      Data: 869 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 764
+      ID: 869
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 1003
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 536
+      ID: 641
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 926720
@@ -8812,32 +9270,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 537 GoSliceDataType archive/tar.headerError.array
+      Data: 642 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 537
+      ID: 642
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 938
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 886
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 783
+      ID: 888
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.115488e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 986
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 914
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.55952e+06
@@ -8847,7 +9305,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 916
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -8857,15 +9315,15 @@ Types:
       GoRuntimeType: 581408
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 961
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 990
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 1041
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -8891,13 +9349,13 @@ Types:
       GoRuntimeType: 581152
       GoKind: 15
     - __kind: BaseType
-      ID: 339
+      ID: 444
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831136
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 340
+      ID: 445
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 831232
@@ -8905,109 +9363,109 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 342 PointerType *compress/flate.InternalError.str
+          Type: 447 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 341 GoStringDataType compress/flate.InternalError.str
+      Data: 446 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 341
+      ID: 446
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 831
+      ID: 936
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 882
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 958
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 680
+      ID: 785
       Name: context.deadlineExceededError
       GoRuntimeType: 1.47392e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 353
+      ID: 458
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833728
       GoKind: 2
     - __kind: BaseType
-      ID: 354
+      ID: 459
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833824
       GoKind: 2
     - __kind: BaseType
-      ID: 355
+      ID: 460
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833920
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 948
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 982
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 1014
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 988
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 984
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 980
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 356
+      ID: 461
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834016
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 998
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 970
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 343
+      ID: 448
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 831712
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 725
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 1067
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 452
+      ID: 557
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 450
+      ID: 555
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.722944e+06
@@ -9018,34 +9476,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 746 ArrayType [5]uint8
+          Type: 851 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 575
+      ID: 680
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 988960
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 946
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 953
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 820
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 730
+      ID: 835
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 524
+      ID: 629
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.725824e+06
@@ -9053,21 +9511,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 729 PointerType *crypto/x509.Certificate
+          Type: 834 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 749 BaseType crypto/x509.InvalidReason
+          Type: 854 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 518
+      ID: 623
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.113056e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 520
+      ID: 625
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.59424e+06
@@ -9075,24 +9533,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 729 PointerType *crypto/x509.Certificate
+          Type: 834 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 352
+      ID: 457
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 833344
       GoKind: 2
     - __kind: BaseType
-      ID: 749
+      ID: 854
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 586592
       GoKind: 2
     - __kind: StructureType
-      ID: 625
+      ID: 730
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.55552e+06
@@ -9102,13 +9560,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 526
+      ID: 631
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.113312e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 522
+      ID: 627
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.725632e+06
@@ -9116,15 +9574,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 729 PointerType *crypto/x509.Certificate
+          Type: 834 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 729 PointerType *crypto/x509.Certificate
+          Type: 834 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 540
+      ID: 645
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.43136e+06
@@ -9134,7 +9592,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 544
+      ID: 649
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.43152e+06
@@ -9144,55 +9602,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 542
+      ID: 647
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 337
+      ID: 442
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830752
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 904
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 338
+      ID: 443
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 830944
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 514
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 716
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 401
+      ID: 506
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 407
+      ID: 512
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 510
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 508
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 1047
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 411
+      ID: 516
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.4152e+06
@@ -9202,19 +9660,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 912
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 617
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 615
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 349
+      ID: 454
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 833248
@@ -9222,21 +9680,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 351 PointerType *encoding/xml.UnmarshalError.str
+          Type: 456 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 350 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 455 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 350
+      ID: 455
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 515
+      ID: 620
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 1025
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9253,11 +9711,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 484
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 578
+      ID: 683
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9273,15 +9731,15 @@ Types:
       GoRuntimeType: 581344
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 1035
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 580
+      ID: 685
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 582
+      ID: 687
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9291,11 +9749,11 @@ Types:
       GoRuntimeType: 473216
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 439
+      ID: 544
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 420
+      ID: 525
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.721792e+06
@@ -9303,7 +9761,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 739 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 844 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -9311,25 +9769,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 422
+      ID: 527
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 743
+      ID: 848
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 426
+      ID: 531
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.109344e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 745
+      ID: 850
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 830176
@@ -9337,17 +9795,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 437
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 739
+      ID: 844
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.210976e+06
@@ -9355,7 +9813,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 740 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 845 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9370,7 +9828,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 741 GoSliceHeaderType []float64
+          Type: 846 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -9379,10 +9837,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 742 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 847 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 744 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 849 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 166 GoSliceHeaderType []string
@@ -9396,13 +9854,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 740
+      ID: 845
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 583200
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 433
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 830080
@@ -9410,17 +9868,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 434
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 334
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 830272
@@ -9428,59 +9886,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 336 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 441 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 335
+      ID: 440
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 926
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 1011
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 639
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 689
+      ID: 794
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 1043
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 461
+      ID: 566
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 468
+      ID: 573
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.112288e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 348
+      ID: 453
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 832384
       GoKind: 2
     - __kind: StructureType
-      ID: 466
+      ID: 571
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.11216e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 464
+      ID: 569
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.59232e+06
@@ -9493,7 +9951,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 484
+      ID: 589
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.59312e+06
@@ -9506,7 +9964,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 488
+      ID: 593
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.725056e+06
@@ -9522,7 +9980,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 486
+      ID: 591
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.42496e+06
@@ -9532,7 +9990,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 482
+      ID: 587
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.42464e+06
@@ -9542,14 +10000,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 724
+      ID: 829
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.49488e+06
       GoKind: 21
-      HeaderType: 726 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 831 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 748
+      ID: 853
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.046336e+06
@@ -9564,14 +10022,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 768 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 873 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 768
+      ID: 873
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 496
+      ID: 601
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.59344e+06
@@ -9579,12 +10037,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 724 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 829 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 724 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 829 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 490
+      ID: 595
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.42512e+06
@@ -9594,7 +10052,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 494
+      ID: 599
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.725248e+06
@@ -9605,12 +10063,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 492
+      ID: 597
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.59328e+06
@@ -9623,7 +10081,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 498
+      ID: 603
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.42528e+06
@@ -9631,9 +10089,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 716 StructureType time.Time
+          Type: 821 StructureType time.Time
     - __kind: StructureType
-      ID: 504
+      ID: 609
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.59376e+06
@@ -9646,7 +10104,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 506
+      ID: 611
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.4256e+06
@@ -9656,7 +10114,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 502
+      ID: 607
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.5936e+06
@@ -9669,7 +10127,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 500
+      ID: 605
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.42544e+06
@@ -9679,7 +10137,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 508
+      ID: 613
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.59392e+06
@@ -9692,7 +10150,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 428
+      ID: 533
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.41744e+06
@@ -9702,11 +10160,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 964
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 430
+      ID: 535
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.4176e+06
@@ -9714,21 +10172,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 428 StructureType github.com/cihub/seelog.baseError
+          Type: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 944
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 900
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 829
+      ID: 934
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 434
+      ID: 539
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.41792e+06
@@ -9736,13 +10194,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 428 StructureType github.com/cihub/seelog.baseError
+          Type: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 1001
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 907
+      ID: 1012
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.09936e+06
@@ -9750,12 +10208,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 895 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1000 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 910
+      ID: 1015
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.123168e+06
@@ -9763,7 +10221,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 895 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1000 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9771,11 +10229,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 902
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 432
+      ID: 537
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.41776e+06
@@ -9783,9 +10241,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 428 StructureType github.com/cihub/seelog.baseError
+          Type: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 436
+      ID: 541
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.41808e+06
@@ -9793,64 +10251,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 428 StructureType github.com/cihub/seelog.baseError
+          Type: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 966
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 1007
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 1009
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 825
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 738
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 736
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 740
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 742
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 955
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 732
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 442
+      ID: 547
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.41904e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 954
+      ID: 1059
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 796
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 664
+      ID: 769
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.833056e+06
@@ -9866,11 +10324,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 763
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 597
+      ID: 702
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.69584e+06
@@ -9883,7 +10341,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 670
+      ID: 775
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.833504e+06
@@ -9899,13 +10357,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 574
+      ID: 679
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 986272
       GoKind: 8
     - __kind: StructureType
-      ID: 662
+      ID: 767
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.832832e+06
@@ -9921,13 +10379,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 750
+      ID: 855
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 828352
       GoKind: 8
     - __kind: StructureType
-      ID: 660
+      ID: 765
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.832608e+06
@@ -9935,15 +10393,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 750 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 855 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 750 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 855 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 668
+      ID: 773
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.747296e+06
@@ -9956,7 +10414,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 666
+      ID: 771
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.83328e+06
@@ -9972,11 +10430,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 1063
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 674
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.617984e+06
@@ -9986,19 +10444,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 601
+      ID: 706
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.278752e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 599
+      ID: 704
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.278624e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 672
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.747488e+06
@@ -10011,7 +10469,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 361
+      ID: 466
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835840
@@ -10019,21 +10477,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 363 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 468 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 362 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 467 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 362
+      ID: 467
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 733
+      ID: 838
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 641
+      ID: 746
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.4432e+06
@@ -10043,7 +10501,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 827
+      ID: 932
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.671936e+06
@@ -10051,13 +10509,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 851 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 956 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 1023
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 851
+      ID: 956
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.12304e+06
@@ -10070,7 +10528,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 813
+      ID: 918
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.56448e+06
@@ -10080,19 +10538,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 364
+      ID: 469
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 836416
       GoKind: 10
     - __kind: BaseType
-      ID: 731
+      ID: 836
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 999424
       GoKind: 10
     - __kind: StructureType
-      ID: 699
+      ID: 804
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.872256e+06
@@ -10103,12 +10561,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 731 BaseType golang.org/x/net/http2.ErrCode
+          Type: 836 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 560
+      ID: 665
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.60096e+06
@@ -10116,12 +10574,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 731 BaseType golang.org/x/net/http2.ErrCode
+          Type: 836 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 368
+      ID: 473
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836608
@@ -10129,17 +10587,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 370 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 475 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 369 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 474 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 369
+      ID: 474
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 374
+      ID: 479
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836800
@@ -10147,17 +10605,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 376 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 481 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 375 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 480 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 375
+      ID: 480
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 371
+      ID: 476
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836704
@@ -10165,17 +10623,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 373 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 478 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 372 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 477 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 372
+      ID: 477
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 365
+      ID: 470
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836512
@@ -10183,21 +10641,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 367 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 472 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 366 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 471 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 366
+      ID: 471
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 1021
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 564
+      ID: 669
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.44384e+06
@@ -10207,13 +10665,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 377
+      ID: 482
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 2
     - __kind: StructureType
-      ID: 552
+      ID: 657
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.43888e+06
@@ -10223,11 +10681,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 802
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 827
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.90016e+06
@@ -10243,7 +10701,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 554
+      ID: 659
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.60048e+06
@@ -10256,7 +10714,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 867
+      ID: 972
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.957728e+06
@@ -10264,16 +10722,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 894 GoInterfaceType io.Reader
+          Type: 999 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 825
+      ID: 930
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 639
+      ID: 744
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.56208e+06
@@ -10283,29 +10741,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 890
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 637
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 734
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 800
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 693
+      ID: 798
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.50544e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 546
+      ID: 651
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.43216e+06
@@ -10315,7 +10773,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 548
+      ID: 653
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.43232e+06
@@ -10325,267 +10783,351 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 476
+      ID: 581
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 287
+      ID: 331
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 288 PointerType *noalg.map.group[[4]int][4]int
+          Type: 332 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 293 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 333 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 337 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 279
+      ID: 323
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 280 PointerType *noalg.map.group[[4]int]uint8
+          Type: 324 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 285 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 325 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 329 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 227
+      ID: 271
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 228 PointerType *noalg.map.group[[4]string][2]int
+          Type: 272 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 234 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 273 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 278 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 246
+      ID: 290
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 247 PointerType *noalg.map.group[bool]main.node
+          Type: 291 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 248 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 252 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 292 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 296 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 185
+      ID: 229
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 186 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 230 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 999
+      ID: 1104
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1000 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1105 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1001 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1007 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1106 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1112 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1035
+      ID: 1140
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1036 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1141 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1037 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1043 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1142 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1148 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1050
+      ID: 1155
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1051 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1156 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1052 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1058 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1157 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1163 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 239
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[int]int
+          Type: 240 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[int]int
-      GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 241 StructureType noalg.map.group[int]int
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1065
+      ID: 1170
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1066 PointerType *noalg.map.group[int]interface {}
+          Type: 1171 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1067 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1071 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1172 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1176 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 254
+      ID: 298
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 255 PointerType *noalg.map.group[int]uint8
+          Type: 299 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 256 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 260 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 300 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 304 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 236
+      ID: 280
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 237 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 281 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 282 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 288 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 219
+      ID: 263
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 220 PointerType *noalg.map.group[string][]string
+          Type: 264 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 221 StructureType noalg.map.group[string][]string
-      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 265 StructureType noalg.map.group[string][]string
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 757
+      ID: 862
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 758 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 863 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 763 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 868 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 211
+      ID: 255
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 212 PointerType *noalg.map.group[string]int
+          Type: 256 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 213 StructureType noalg.map.group[string]int
-      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 257 StructureType noalg.map.group[string]int
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 203
+      ID: 247
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 204 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 248 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 249 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 270
+      ID: 363
+      Name: groupReference<struct {},main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 364 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 370 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 372
+      Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 373 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 380
+      Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 381 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 386 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 388
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 389 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 394 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 396
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 397 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 402 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 404
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 405 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 410 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 314
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 271 PointerType *noalg.map.group[uint8][4]int
+          Type: 315 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 272 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 277 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 316 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 321 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 262
+      ID: 306
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 263 PointerType *noalg.map.group[uint8]uint8
+          Type: 307 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 264 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 308 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 312 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 978
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 672
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -10632,37 +11174,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 446
+      ID: 551
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 444
+      ID: 549
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 876
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 761
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 1065
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 654
+      ID: 759
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.47072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 381
+      ID: 486
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 972
+      ID: 1077
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.46816e+06
@@ -10675,11 +11217,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 922
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 857
+      ID: 962
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.18576e+06
@@ -10692,7 +11234,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 894
+      ID: 999
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.018944e+06
@@ -10705,7 +11247,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 846
+      ID: 951
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.105632e+06
@@ -10731,25 +11273,25 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 815
+      ID: 920
       Name: io.discard
       GoRuntimeType: 1.45808e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 894
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 757
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 968
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 173
+      ID: 217
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -10765,7 +11307,7 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 174 StructureType main.nestedStruct
+          Type: 218 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
@@ -10805,7 +11347,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 191
+      ID: 235
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.182304e+06
@@ -10813,9 +11355,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 993 GoMapType map[int]*main.deepMap3
+          Type: 1098 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1110
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -10827,9 +11369,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1029 GoMapType map[int]*main.deepMap8
+          Type: 1134 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1041
+      ID: 1146
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.181536e+06
@@ -10837,9 +11379,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1044 GoMapType map[int]*main.deepMap9
+          Type: 1149 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1056
+      ID: 1161
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.181408e+06
@@ -10847,7 +11389,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1059 GoMapType map[int]interface {}
+          Type: 1164 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -10867,9 +11409,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 963 PointerType *main.deepPtr3
+          Type: 1068 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 1069
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -10881,9 +11423,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1010 PointerType *main.deepPtr8
+          Type: 1115 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1011
+      ID: 1116
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.182688e+06
@@ -10891,9 +11433,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1012 PointerType *main.deepPtr9
+          Type: 1117 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1013
+      ID: 1118
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18256e+06
@@ -10913,7 +11455,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 181
+      ID: 225
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.184608e+06
@@ -10921,9 +11463,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 987 GoSliceHeaderType []*main.deepSlice3
+          Type: 1092 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 1095
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -10935,9 +11477,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1014 GoSliceHeaderType []*main.deepSlice8
+          Type: 1119 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1017
+      ID: 1122
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.18384e+06
@@ -10945,9 +11487,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1020 GoSliceHeaderType []*main.deepSlice9
+          Type: 1125 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1023
+      ID: 1128
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.183712e+06
@@ -10955,9 +11497,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1026 GoSliceHeaderType []interface {}
+          Type: 1131 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 175
+      ID: 219
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -10973,16 +11515,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 970 StructureType sync.Mutex
+          Type: 1075 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 973 StructureType sync.Once
+          Type: 1078 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 976 StructureType sync.WaitGroup
+          Type: 1081 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 979 StructureType sync/atomic.Int32
+          Type: 1084 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -11012,7 +11554,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 981
+      ID: 1086
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.40832e+06
@@ -11022,7 +11564,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 174
+      ID: 218
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.4576e+06
@@ -11057,7 +11599,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 983
+      ID: 1088
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.40848e+06
@@ -11077,7 +11619,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 1074
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11088,17 +11630,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 966 PointerType *main.stringType1.str
+          Type: 1071 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 965 GoStringDataType main.stringType1.str
+      Data: 1070 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 965
+      ID: 1070
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 1072
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11111,6 +11653,54 @@ Types:
         - Name: a
           Offset: 0
           Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 186
+      Name: main.structWithCyclicMaps
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: m1
+          Offset: 0
+          Type: 187 GoMapType map[struct {}]main.structWithCyclicMaps
+        - Name: m2
+          Offset: 8
+          Type: 192 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m3
+          Offset: 16
+          Type: 197 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m4
+          Offset: 24
+          Type: 202 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m5
+          Offset: 32
+          Type: 207 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m6
+          Offset: 40
+          Type: 212 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 173
+      Name: main.structWithCyclicSlices
+      ByteSize: 144
+      GoKind: 25
+      RawFields:
+        - Name: s1
+          Offset: 0
+          Type: 174 GoSliceHeaderType []main.structWithCyclicSlices
+        - Name: s2
+          Offset: 24
+          Type: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+        - Name: s3
+          Offset: 48
+          Type: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+        - Name: s4
+          Offset: 72
+          Type: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+        - Name: s5
+          Offset: 96
+          Type: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+        - Name: s6
+          Offset: 120
+          Type: 184 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 90
       Name: main.structWithMap
@@ -11153,16 +11743,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 984 PointerType **main.t
+          Type: 1089 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 985 GoSliceDataType main.t.array
+      Data: 1090 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 985
+      ID: 1090
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -11216,8 +11806,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 292 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 336 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 145
       Name: map<[4]int,uint8>
@@ -11248,8 +11838,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 284 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 328 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 113
       Name: map<[4]string,[2]int>
@@ -11280,8 +11870,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 233 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 277 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 125
       Name: map<bool,main.node>
@@ -11312,8 +11902,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 251 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 248 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 295 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 292 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -11344,10 +11934,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 236 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 995
+      ID: 1100
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -11360,7 +11950,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 996 PointerType **table<int,*main.deepMap3>
+          Type: 1101 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11376,10 +11966,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1006 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1001 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1111 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1106 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1031
+      ID: 1136
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -11392,7 +11982,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1032 PointerType **table<int,*main.deepMap8>
+          Type: 1137 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11408,10 +11998,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1042 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1037 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1147 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1142 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1046
+      ID: 1151
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -11424,7 +12014,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1047 PointerType **table<int,*main.deepMap9>
+          Type: 1152 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11440,8 +12030,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1057 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1052 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1162 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1157 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 93
       Name: map<int,int>
@@ -11472,10 +12062,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
-      GroupType: 197 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 244 GoSliceDataType []*table<int,int>.array
+      GroupType: 241 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1061
+      ID: 1166
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -11488,7 +12078,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1062 PointerType **table<int,interface {}>
+          Type: 1167 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11504,8 +12094,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1070 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1067 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1175 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1172 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 130
       Name: map<int,uint8>
@@ -11536,8 +12126,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 259 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 256 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 303 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 300 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<string,[]main.structWithMap>
@@ -11568,8 +12158,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 287 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 108
       Name: map<string,[]string>
@@ -11600,10 +12190,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 221 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 268 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 726
+      ID: 831
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -11616,7 +12206,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 727 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 832 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11632,8 +12222,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 762 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 867 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -11664,8 +12254,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 216 GoSliceDataType []*table<string,int>.array
-      GroupType: 213 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 260 GoSliceDataType []*table<string,int>.array
+      GroupType: 257 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 98
       Name: map<string,main.nestedStruct>
@@ -11696,8 +12286,200 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 208 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 249 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 189
+      Name: map<struct {},main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 190 PointerType **table<struct {},main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 369 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 194
+      Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 195 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 377 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 199
+      Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 200 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 385 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 204
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 205 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 393 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 209
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 210 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 401 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 214
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 215 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 409 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 140
       Name: map<uint8,[4]int>
@@ -11728,8 +12510,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 276 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 272 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 320 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 135
       Name: map<uint8,uint8>
@@ -11760,8 +12542,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 267 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 264 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 311 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 148
       Name: map[[4]int][4]int
@@ -11798,26 +12580,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 993
+      ID: 1098
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124704e+06
       GoKind: 21
-      HeaderType: 995 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1100 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1029
+      ID: 1134
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.124064e+06
       GoKind: 21
-      HeaderType: 1031 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1136 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1044
+      ID: 1149
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.123936e+06
       GoKind: 21
-      HeaderType: 1046 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1151 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
@@ -11826,12 +12608,12 @@ Types:
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1059
+      ID: 1164
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.123808e+06
       GoKind: 21
-      HeaderType: 1061 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1166 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
@@ -11868,6 +12650,42 @@ Types:
       GoKind: 21
       HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
+      ID: 187
+      Name: map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 189 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 192
+      Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 194 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 197
+      Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 199 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 202
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 204 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 207
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 209 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 212
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 214 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
       ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
@@ -11882,7 +12700,7 @@ Types:
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 480
+      ID: 585
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.42432e+06
@@ -11892,7 +12710,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 779
+      ID: 884
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.42112e+06
@@ -11902,11 +12720,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 788
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 747
+      ID: 852
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.59104e+06
@@ -11919,35 +12737,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 814
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 1029
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 707
+      ID: 812
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 790
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 1039
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 1049
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 1037
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 644
+      ID: 749
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.10896e+06
@@ -11955,27 +12773,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 646 PointerType *net.UnknownNetworkError.str
+          Type: 751 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 645 GoStringDataType net.UnknownNetworkError.str
+      Data: 750 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 645
+      ID: 750
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 613
+      ID: 718
       Name: net.canceledError
       GoRuntimeType: 1.279776e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 1005
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 752
+      ID: 857
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.098656e+06
@@ -11983,7 +12801,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -11994,27 +12812,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 1051
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 940
+      ID: 1045
       Name: net.noReadFrom
       GoRuntimeType: 1.109216e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 939
+      ID: 1044
       Name: net.noWriteTo
       GoRuntimeType: 1.109088e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 518
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 415
+      ID: 520
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.7216e+06
@@ -12022,7 +12840,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 734 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 839 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -12030,7 +12848,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 928
+      ID: 1033
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.283392e+06
@@ -12038,12 +12856,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 940 StructureType net.noReadFrom
+          Type: 1045 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 933 PointerType *net.TCPConn
+          Type: 1038 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 926
+      ID: 1031
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.282848e+06
@@ -12051,24 +12869,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 939 StructureType net.noWriteTo
+          Type: 1044 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 933 PointerType *net.TCPConn
+          Type: 1038 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 792
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 816
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 708
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 773
+      ID: 878
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.41264e+06
@@ -12078,19 +12896,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 309
+      ID: 414
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 828832
       GoKind: 10
     - __kind: BaseType
-      ID: 723
+      ID: 828
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 986368
       GoKind: 10
     - __kind: StructureType
-      ID: 391
+      ID: 496
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.719872e+06
@@ -12101,12 +12919,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 723 BaseType net/http.http2ErrCode
+          Type: 828 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 703
+      ID: 808
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.891456e+06
@@ -12117,12 +12935,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 723 BaseType net/http.http2ErrCode
+          Type: 828 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 395
+      ID: 500
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.59056e+06
@@ -12130,16 +12948,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 723 BaseType net/http.http2ErrCode
+          Type: 828 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 940
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 418
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829024
@@ -12147,17 +12965,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 420 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 419
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 424
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 829216
@@ -12165,17 +12983,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *net/http.http2headerFieldNameError.str
+          Type: 426 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 320 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 425 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 425
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 421
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 829120
@@ -12183,31 +13001,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *net/http.http2headerFieldValueError.str
+          Type: 423 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 317 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 422 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 422
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 783
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 609
+      ID: 714
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.279008e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 994
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 415
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828928
@@ -12215,17 +13033,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 417 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 416 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 416
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 775
+      ID: 880
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.815744e+06
@@ -12233,18 +13051,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 868 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 973 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 869 BaseType time.Duration
+          Type: 974 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 33 PointerType *error
     - __kind: GoInterfaceType
-      ID: 868
+      ID: 973
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.412e+06
@@ -12257,14 +13075,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 854
+      ID: 959
       Name: net/http.incomparable
       GoRuntimeType: 898784
       GoKind: 17
       HasCount: true
       Element: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 605
+      ID: 710
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.5496e+06
@@ -12274,11 +13092,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 942
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 793
+      ID: 898
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.54944e+06
@@ -12286,9 +13104,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 836 PointerType *net/http.persistConn
+          Type: 941 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 819
+      ID: 924
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.791744e+06
@@ -12296,15 +13114,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 854 ArrayType net/http.incomparable
+          Type: 959 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 855 PointerType *bufio.Reader
+          Type: 960 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 857 GoInterfaceType io.ReadWriteCloser
+          Type: 962 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 399
+      ID: 504
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.4136e+06
@@ -12314,17 +13132,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 705
+      ID: 810
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 676
+      ID: 781
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.4736e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 607
+      ID: 712
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.54976e+06
@@ -12334,7 +13152,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 871
+      ID: 976
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.017632e+06
@@ -12342,16 +13160,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 493
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 891
+      ID: 996
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.033664e+06
@@ -12359,13 +13177,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 884 PointerType *bufio.Writer
+          Type: 989 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 908
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 472
+      ID: 577
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.724672e+06
@@ -12381,7 +13199,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 470
+      ID: 575
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.59248e+06
@@ -12394,11 +13212,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 950
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 805
+      ID: 910
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.5944e+06
@@ -12406,16 +13224,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 844 PointerType *net/smtp.Client
+          Type: 949 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 846 GoInterfaceType io.WriteCloser
+          Type: 951 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 456
+      ID: 561
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 344
+      ID: 449
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 831808
@@ -12423,25 +13241,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 346 PointerType *net/textproto.ProtocolError.str
+          Type: 451 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 345 GoStringDataType net/textproto.ProtocolError.str
+      Data: 450 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 345
+      ID: 450
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 906
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 818
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 427
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 829792
@@ -12449,17 +13267,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *net/url.EscapeError.str
+          Type: 429 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 323 GoStringDataType net/url.EscapeError.str
+      Data: 428 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 428
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 430
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 829888
@@ -12467,179 +13285,227 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *net/url.InvalidHostError.str
+          Type: 432 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 326 GoStringDataType net/url.InvalidHostError.str
+      Data: 431 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 431
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: ArrayType
-      ID: 290
+      ID: 334
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 679232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 291 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 335 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 282
+      ID: 326
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 679328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 283 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 327 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 230
+      ID: 274
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 679616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 231 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 275 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 249
+      ID: 293
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 679712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 250 StructureType noalg.struct { key bool; elem main.node }
+      Element: 294 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 188
+      ID: 232
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 678560
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 233 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1002
+      ID: 1107
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678464
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1003 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1108 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1038
+      ID: 1143
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 677984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1039 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1144 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1053
+      ID: 1158
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1054 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1159 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 198
+      ID: 242
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 676640
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 199 StructureType noalg.struct { key int; elem int }
+      Element: 243 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1068
+      ID: 1173
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1069 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1174 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 257
+      ID: 301
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 679808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 258 StructureType noalg.struct { key int; elem uint8 }
+      Element: 302 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 239
+      ID: 283
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 679904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 240 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 284 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 222
+      ID: 266
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 680000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 223 StructureType noalg.struct { key string; elem []string }
+      Element: 267 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 760
+      ID: 865
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 755104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 761 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 866 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 214
+      ID: 258
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 680096
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem int }
+      Element: 259 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 206
+      ID: 250
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 680192
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 207 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 251 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 273
+      ID: 366
+      Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+      ByteSize: 384
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 367 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 375
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 376 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 383
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 384 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 391
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 392 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 399
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 400 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 407
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 408 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 317
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 680288
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 274 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 318 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 265
+      ID: 309
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 680384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 266 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 310 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 289
+      ID: 333
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.290784e+06
@@ -12650,9 +13516,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 290 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 334 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 281
+      ID: 325
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.29104e+06
@@ -12663,9 +13529,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 282 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 326 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 229
+      ID: 273
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.291296e+06
@@ -12676,9 +13542,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 230 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 274 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 248
+      ID: 292
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.291552e+06
@@ -12689,9 +13555,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 249 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 293 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 187
+      ID: 231
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.290528e+06
@@ -12702,9 +13568,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 232 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1001
+      ID: 1106
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.290272e+06
@@ -12715,9 +13581,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1002 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1107 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1037
+      ID: 1142
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.288992e+06
@@ -12728,9 +13594,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1038 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1143 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1052
+      ID: 1157
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.288736e+06
@@ -12741,9 +13607,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1053 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1158 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 197
+      ID: 241
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.287712e+06
@@ -12754,9 +13620,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 198 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 242 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1067
+      ID: 1172
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.28848e+06
@@ -12767,9 +13633,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1068 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1173 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 256
+      ID: 300
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.291808e+06
@@ -12780,9 +13646,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 257 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 301 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 238
+      ID: 282
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.292064e+06
@@ -12793,9 +13659,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 239 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 283 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 221
+      ID: 265
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.29232e+06
@@ -12806,9 +13672,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 266 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 759
+      ID: 864
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.353504e+06
@@ -12819,9 +13685,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 760 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 865 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 213
+      ID: 257
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.292576e+06
@@ -12832,9 +13698,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 258 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 205
+      ID: 249
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.292832e+06
@@ -12845,9 +13711,81 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 206 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 250 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 272
+      ID: 365
+      Name: noalg.map.group[struct {}]main.structWithCyclicMaps
+      ByteSize: 392
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 366 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 374
+      Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 375 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 382
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 383 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 390
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 391 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 398
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 399 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 406
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 407 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 316
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.293088e+06
@@ -12858,9 +13796,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 273 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 317 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 264
+      ID: 308
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.293344e+06
@@ -12871,9 +13809,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 265 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 309 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 291
+      ID: 335
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.290656e+06
@@ -12881,12 +13819,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
     - __kind: StructureType
-      ID: 283
+      ID: 327
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.290912e+06
@@ -12894,12 +13832,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 231
+      ID: 275
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.291168e+06
@@ -12907,12 +13845,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 232 ArrayType [4]string
+          Type: 276 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 250
+      ID: 294
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.291424e+06
@@ -12925,7 +13863,7 @@ Types:
           Offset: 8
           Type: 156 StructureType main.node
     - __kind: StructureType
-      ID: 189
+      ID: 233
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.2904e+06
@@ -12936,9 +13874,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 190 PointerType *main.deepMap2
+          Type: 234 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1003
+      ID: 1108
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.290144e+06
@@ -12949,9 +13887,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1004 PointerType *main.deepMap3
+          Type: 1109 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1039
+      ID: 1144
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.288864e+06
@@ -12962,9 +13900,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1040 PointerType *main.deepMap8
+          Type: 1145 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1054
+      ID: 1159
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.288608e+06
@@ -12975,9 +13913,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1055 PointerType *main.deepMap9
+          Type: 1160 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 199
+      ID: 243
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.287584e+06
@@ -12990,7 +13928,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1069
+      ID: 1174
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.288352e+06
@@ -13003,7 +13941,7 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 258
+      ID: 302
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.29168e+06
@@ -13016,7 +13954,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 240
+      ID: 284
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.291936e+06
@@ -13027,9 +13965,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 241 GoSliceHeaderType []main.structWithMap
+          Type: 285 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 223
+      ID: 267
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.292192e+06
@@ -13042,7 +13980,7 @@ Types:
           Offset: 16
           Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 761
+      ID: 866
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.353376e+06
@@ -13053,9 +13991,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 215
+      ID: 259
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.292448e+06
@@ -13068,7 +14006,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 207
+      ID: 251
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.292704e+06
@@ -13079,9 +14017,81 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 174 StructureType main.nestedStruct
+          Type: 218 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 274
+      ID: 367
+      Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 186 StructureType main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 376
+      Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 187 GoMapType map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 384
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 192 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 392
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 197 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 400
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 202 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 408
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 207 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 318
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.29296e+06
@@ -13092,9 +14102,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
     - __kind: StructureType
-      ID: 266
+      ID: 310
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.293216e+06
@@ -13107,19 +14117,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 1057
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 584
+      ID: 689
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 753
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 950
+      ID: 1055
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.352e+06
@@ -13127,12 +14137,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 956 StructureType os.noReadFrom
+          Type: 1061 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 951 PointerType *os.File
+          Type: 1056 PointerType *os.File
     - __kind: StructureType
-      ID: 948
+      ID: 1053
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.3512e+06
@@ -13140,36 +14150,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 955 StructureType os.noWriteTo
+          Type: 1060 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 951 PointerType *os.File
+          Type: 1056 PointerType *os.File
     - __kind: StructureType
-      ID: 956
+      ID: 1061
       Name: os.noReadFrom
       GoRuntimeType: 1.106528e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 955
+      ID: 1060
       Name: os.noWriteTo
       GoRuntimeType: 1.1064e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 720
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 755
+      ID: 860
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 928
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 617
+      ID: 722
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.696416e+06
@@ -13182,7 +14192,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 358
+      ID: 463
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 835072
@@ -13190,39 +14200,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 360 PointerType *os/user.UnknownGroupIdError.str
+          Type: 465 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 359 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 464 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 359
+      ID: 464
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 357
+      ID: 462
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 834976
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 383
+      ID: 488
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 478
+      ID: 583
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 588
+      ID: 693
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 697
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 695
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.879872e+06
@@ -13239,15 +14249,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 753 BaseType runtime.boundsErrorCode
+          Type: 858 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 753
+      ID: 858
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 581536
       GoKind: 8
     - __kind: StructureType
-      ID: 650
+      ID: 755
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.744224e+06
@@ -13260,7 +14270,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 568
+      ID: 673
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 985024
@@ -13268,17 +14278,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 570 PointerType *runtime.errorString.str
+          Type: 675 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 569 GoStringDataType runtime.errorString.str
+      Data: 674 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 569
+      ID: 674
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 571
+      ID: 676
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 985120
@@ -13286,17 +14296,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 573 PointerType *runtime.plainError.str
+          Type: 678 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 572 GoStringDataType runtime.plainError.str
+      Data: 677 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 572
+      ID: 677
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 594
+      ID: 699
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -13308,25 +14318,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 178 PointerType *string.str
+          Type: 222 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 177 GoStringDataType string.str
+      Data: 221 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 177
+      ID: 221
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 992
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 791
+      ID: 896
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 787
+      ID: 892
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.4504e+06
@@ -13336,7 +14346,13 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 970
+      ID: 368
+      Name: struct {}
+      GoRuntimeType: 838720
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 1075
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.45888e+06
@@ -13344,12 +14360,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 971 StructureType sync.noCopy
+          Type: 1076 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 972 StructureType internal/sync.Mutex
+          Type: 1077 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 973
+      ID: 1078
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.607232e+06
@@ -13357,15 +14373,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 971 StructureType sync.noCopy
+          Type: 1076 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 974 StructureType sync/atomic.Uint32
+          Type: 1079 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 970 StructureType sync.Mutex
+          Type: 1075 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 976
+      ID: 1081
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.607424e+06
@@ -13373,21 +14389,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 971 StructureType sync.noCopy
+          Type: 1076 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 977 StructureType sync/atomic.Uint64
+          Type: 1082 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 971
+      ID: 1076
       Name: sync.noCopy
       GoRuntimeType: 983968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 979
+      ID: 1084
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.46016e+06
@@ -13395,12 +14411,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 975 StructureType sync/atomic.noCopy
+          Type: 1080 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 974
+      ID: 1079
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.46032e+06
@@ -13408,12 +14424,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 975 StructureType sync/atomic.noCopy
+          Type: 1080 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 977
+      ID: 1082
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607808e+06
@@ -13421,33 +14437,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 975 StructureType sync/atomic.noCopy
+          Type: 1080 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 978 StructureType sync/atomic.align64
+          Type: 1083 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 978
+      ID: 1083
       Name: sync/atomic.align64
       GoRuntimeType: 984160
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 975
+      ID: 1080
       Name: sync/atomic.noCopy
       GoRuntimeType: 984064
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 700
+      ID: 805
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.278368e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 286
+      ID: 330
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -13469,9 +14485,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 287 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 331 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 278
+      ID: 322
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13493,9 +14509,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 279 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 323 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 226
+      ID: 270
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -13517,9 +14533,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 227 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 271 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 245
+      ID: 289
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -13541,9 +14557,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 246 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 290 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 184
+      ID: 228
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -13565,9 +14581,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 229 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 998
+      ID: 1103
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -13589,9 +14605,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 999 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1104 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1034
+      ID: 1139
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -13613,9 +14629,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1035 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1140 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1049
+      ID: 1154
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -13637,9 +14653,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1050 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1155 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 194
+      ID: 238
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -13661,9 +14677,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<int,int>
+          Type: 239 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1064
+      ID: 1169
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -13685,9 +14701,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1065 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1170 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 253
+      ID: 297
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13709,9 +14725,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 254 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 298 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 235
+      ID: 279
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -13733,9 +14749,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 236 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 280 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 218
+      ID: 262
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -13757,9 +14773,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 263 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 756
+      ID: 861
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -13781,9 +14797,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 757 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 862 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 210
+      ID: 254
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -13805,9 +14821,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 211 GoSwissMapGroupsType groupReference<string,int>
+          Type: 255 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 202
+      ID: 246
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -13829,9 +14845,153 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 203 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 247 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 269
+      ID: 362
+      Name: table<struct {},main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 363 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 371
+      Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 372 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 379
+      Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 380 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 387
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 388 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 395
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 396 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 403
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 404 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 313
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -13853,9 +15013,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 270 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 314 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 261
+      ID: 305
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13877,13 +15037,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 306 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 1027
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 643
+      ID: 748
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.700832e+06
@@ -13896,21 +15056,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 869
+      ID: 974
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.906016e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 718
+      ID: 823
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 491
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 716
+      ID: 821
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.36688e+06
@@ -13924,9 +15084,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 717 PointerType *time.Location
+          Type: 822 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 411
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 827968
@@ -13934,13 +15094,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *time.fileSizeError.str
+          Type: 413 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 307 GoStringDataType time.fileSizeError.str
+      Data: 412 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 412
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -13986,7 +15146,7 @@ Types:
       GoRuntimeType: 581472
       GoKind: 26
     - __kind: StructureType
-      ID: 734
+      ID: 839
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.055072e+06
@@ -13994,13 +15154,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 735 GoSliceHeaderType []uint8
+          Type: 840 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 736 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 841 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 737 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 842 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -14015,18 +15175,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 738 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 843 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 738
+      ID: 843
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 990592
       GoKind: 9
     - __kind: StructureType
-      ID: 736
+      ID: 841
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.916768e+06
@@ -14051,21 +15211,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 474
+      ID: 579
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 737
+      ID: 842
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 585120
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 1019
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 458
+      ID: 563
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.42144e+06
@@ -14075,13 +15235,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 347
+      ID: 452
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 831904
       GoKind: 2
     - __kind: StructureType
-      ID: 622
+      ID: 727
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.696608e+06
@@ -14094,11 +15254,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 576
+      ID: 681
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 989440
       GoKind: 5
-MaxTypeID: 1186
+MaxTypeID: 1293
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x17fa3a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x17fb3a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 1185 EventRootType Probe[main.stackC]
+          Type: 1290 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcdd8ca", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 1140 EventRootType Probe[main.testAny]
+          Type: 1245 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda74a", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 1142 EventRootType Probe[main.testAnyPtr]
+          Type: 1247 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcda7ea", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 1102 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1207 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 1104 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1209 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 1150 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1255 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcdaee0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 1103 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1208 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 1122 EventRootType Probe[main.testBigStruct]
+          Type: 1227 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 1091 EventRootType Probe[main.testBoolArray]
+          Type: 1196 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 1088 EventRootType Probe[main.testByteArray]
+          Type: 1193 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 1166 EventRootType Probe[main.testChannel]
+          Type: 1271 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdcba0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 1164 EventRootType Probe[main.testCombinedByte]
+          Type: 1269 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcdc7c0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 1174 EventRootType Probe[main.testCycle]
+          Type: 1279 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdcf40", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 1127 EventRootType Probe[main.testDeepMap1]
+          Type: 1232 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9700", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 1128 EventRootType Probe[main.testDeepMap7]
+          Type: 1233 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9720", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 1123 EventRootType Probe[main.testDeepPtr1]
+          Type: 1228 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd93e0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 1124 EventRootType Probe[main.testDeepPtr7]
+          Type: 1229 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9400", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 1125 EventRootType Probe[main.testDeepSlice1]
+          Type: 1230 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd9580", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 1126 EventRootType Probe[main.testDeepSlice7]
+          Type: 1231 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 1176 EventRootType Probe[main.testEmptySlice]
+          Type: 1281 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdd480", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 1179 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1284 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdd4e0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 1193 EventRootType Probe[main.testEmptyString]
+          Type: 1298 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 108
-          Type: 1195 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcdde00", Frameless: true}]
+        - ID: 110
+          Type: 1302 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcdde40", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 109
-          Type: 1196 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcdde20", Frameless: true}]
+        - ID: 111
+          Type: 1303 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcdde60", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 1141 EventRootType Probe[main.testError]
+          Type: 1246 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcda7c0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 1132 EventRootType Probe[main.testEsotericHeap]
+          Type: 1237 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9cca", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 1131 EventRootType Probe[main.testEsotericStack]
+          Type: 1236 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 1137 EventRootType Probe[main.testFrameless]
+          Type: 1242 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda420", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 1138 EventRootType Probe[main.testFramelessArray]
+          Type: 1243 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda444", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 1133 EventRootType Probe[main.testInlinedBA]
+          Type: 1238 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda10a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 1134 EventRootType Probe[main.testInlinedBB]
+          Type: 1239 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda1ae", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 1135 EventRootType Probe[main.testInlinedBBA]
+          Type: 1240 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda28a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 111
-          Type: 1198 EventRootType Probe[main.testInlinedBBB]
+        - ID: 113
+          Type: 1305 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda206", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 1136 EventRootType Probe[main.testInlinedBC]
+          Type: 1241 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda30e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 112
-          Type: 1199 EventRootType Probe[main.testInlinedBCA]
+        - ID: 114
+          Type: 1306 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda313", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 113
-          Type: 1200 EventRootType Probe[main.testInlinedBCB]
+        - ID: 115
+          Type: 1307 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda3bb", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 110
-          Type: 1197 EventRootType Probe[main.testInlinedPrint]
+        - ID: 112
+          Type: 1304 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd9f6a"
               Frameless: false
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 114
-          Type: 1201 EventRootType Probe[main.testInlinedSq]
+        - ID: 116
+          Type: 1308 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda421", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 115
-          Type: 1202 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 117
+          Type: 1309 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda465"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 1094 EventRootType Probe[main.testInt16Array]
+          Type: 1199 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 1095 EventRootType Probe[main.testInt32Array]
+          Type: 1200 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 1096 EventRootType Probe[main.testInt64Array]
+          Type: 1201 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 1093 EventRootType Probe[main.testInt8Array]
+          Type: 1198 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 1092 EventRootType Probe[main.testIntArray]
+          Type: 1197 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 1139 EventRootType Probe[main.testInterface]
+          Type: 1244 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda720", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 1168 EventRootType Probe[main.testLinkedList]
+          Type: 1273 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdcd60", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 1148 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1253 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcdaea0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 1154 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1259 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcdaf60", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 1152 EventRootType Probe[main.testMapIntToInt]
+          Type: 1257 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcdaf20", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 1163 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1268 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb080", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 1162 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1267 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcdb060", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 1153 EventRootType Probe[main.testMapMassive]
+          Type: 1258 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdaf40", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 1161 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1266 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb040", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 1160 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1265 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcdb020", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 1146 EventRootType Probe[main.testMapStringToInt]
+          Type: 1251 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcdae60", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 1147 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1252 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcdae80", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 1145 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1250 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 1155 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1260 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcdaf80", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 1158 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1263 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcdafe0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 1159 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1264 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcdb000", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 1156 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1261 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcdafa0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 1157 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1262 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcdafc0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 1191 EventRootType Probe[main.testMassiveString]
+          Type: 1296 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 1165 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1270 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdc980", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 1173 EventRootType Probe[main.testNilPointer]
+          Type: 1278 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdcf00", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 1183 EventRootType Probe[main.testNilSlice]
+          Type: 1288 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdd560", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 1180 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1285 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdd500", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 1182 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1287 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdd540", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 1190 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1295 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdd9a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 1169 EventRootType Probe[main.testPointerLoop]
+          Type: 1274 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdcd80", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 1151 EventRootType Probe[main.testPointerToMap]
+          Type: 1256 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcdaf00", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 1167 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1272 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdcd40", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 1089 EventRootType Probe[main.testRuneArray]
+          Type: 1194 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 1108 EventRootType Probe[main.testSingleBool]
+          Type: 1213 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 1106 EventRootType Probe[main.testSingleByte]
+          Type: 1211 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd8fe0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 1119 EventRootType Probe[main.testSingleFloat32]
+          Type: 1224 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 1120 EventRootType Probe[main.testSingleFloat64]
+          Type: 1225 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 1109 EventRootType Probe[main.testSingleInt]
+          Type: 1214 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 1111 EventRootType Probe[main.testSingleInt16]
+          Type: 1216 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 1112 EventRootType Probe[main.testSingleInt32]
+          Type: 1217 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 1113 EventRootType Probe[main.testSingleInt64]
+          Type: 1218 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 1110 EventRootType Probe[main.testSingleInt8]
+          Type: 1215 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 1107 EventRootType Probe[main.testSingleRune]
+          Type: 1212 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9000", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 1186 EventRootType Probe[main.testSingleString]
+          Type: 1291 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 1114 EventRootType Probe[main.testSingleUint]
+          Type: 1219 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 1116 EventRootType Probe[main.testSingleUint16]
+          Type: 1221 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 1117 EventRootType Probe[main.testSingleUint32]
+          Type: 1222 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 1118 EventRootType Probe[main.testSingleUint64]
+          Type: 1223 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 1115 EventRootType Probe[main.testSingleUint8]
+          Type: 1220 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 1177 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1282 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdd4a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 1149 EventRootType Probe[main.testSmallMap]
+          Type: 1254 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcdaec0", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 1090 EventRootType Probe[main.testStringArray]
+          Type: 1195 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 1172 EventRootType Probe[main.testStringPointer]
+          Type: 1277 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdcec0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 1181 EventRootType Probe[main.testStringSlice]
+          Type: 1286 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdd520", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 1129 EventRootType Probe[main.testStringType1]
+          Type: 1234 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 1130 EventRootType Probe[main.testStringType2]
+          Type: 1235 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 107
-          Type: 1194 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcddc80", Frameless: true}]
+        - ID: 109
+          Type: 1301 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcddcc0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 1178 EventRootType Probe[main.testStructSlice]
+          Type: 1283 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdd4c0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,8 +1425,34 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 1143 EventRootType Probe[main.testStructWithAny]
+          Type: 1248 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcda840", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicMaps}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 108
+          Type: 1300 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcddb80", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicSlices
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicSlices}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 107
+          Type: 1299 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcddb60", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1439,7 +1465,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 1144 EventRootType Probe[main.testStructWithMap]
+          Type: 1249 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdae20", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1479,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 1187 EventRootType Probe[main.testThreeStrings]
+          Type: 1292 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1493,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 1188 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1293 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdd960", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1507,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 1189 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1294 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdd980", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1521,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 1121 EventRootType Probe[main.testTypeAlias]
+          Type: 1226 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1535,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 1099 EventRootType Probe[main.testUint16Array]
+          Type: 1204 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1549,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 1100 EventRootType Probe[main.testUint32Array]
+          Type: 1205 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1563,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 1101 EventRootType Probe[main.testUint64Array]
+          Type: 1206 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1577,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 1098 EventRootType Probe[main.testUint8Array]
+          Type: 1203 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1591,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 1097 EventRootType Probe[main.testUintArray]
+          Type: 1202 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1605,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 1171 EventRootType Probe[main.testUintPointer]
+          Type: 1276 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdcde0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1619,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 1175 EventRootType Probe[main.testUintSlice]
+          Type: 1280 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1633,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 1192 EventRootType Probe[main.testUnitializedString]
+          Type: 1297 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdd9e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1647,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 1170 EventRootType Probe[main.testUnsafePointer]
+          Type: 1275 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdcda0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1661,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 1105 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1210 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1675,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 1184 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1289 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3279,14 +3305,50 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 107
+      Name: main.testStructWithCyclicSlices
+      OutOfLinePCRanges: [0xcddb60..0xcddb61]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 173 StructureType main.structWithCyclicSlices
+          Locations:
+            - Range: 0xcddb60..0xcddb61
+              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 108
+      Name: main.testStructWithCyclicMaps
+      OutOfLinePCRanges: [0xcddb80..0xcddb9f]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 186 StructureType main.structWithCyclicMaps
+          Locations:
+            - Range: 0xcddb80..0xcddb9f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcddc80..0xcddca3]
+      OutOfLinePCRanges: [0xcddcc0..0xcddce3]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 173 StructureType main.aStruct
+          Type: 217 StructureType main.aStruct
           Locations:
-            - Range: 0xcddc80..0xcddca3
+            - Range: 0xcddcc0..0xcddce3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3304,29 +3366,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcdde00..0xcdde01]
+      OutOfLinePCRanges: [0xcdde40..0xcdde41]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 175 StructureType main.emptyStruct
-          Locations: [{Range: 0xcdde00..0xcdde01, Pieces: []}]
+          Type: 219 StructureType main.emptyStruct
+          Locations: [{Range: 0xcdde40..0xcdde41, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcdde20..0xcdde21]
+      OutOfLinePCRanges: [0xcdde60..0xcdde61]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 176 PointerType *main.emptyStruct
+          Type: 220 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcdde20..0xcdde21
+            - Range: 0xcdde60..0xcdde61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 112
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd9f60..0xcd9fc2]
       InlinePCRanges:
@@ -3356,28 +3418,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 113
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda206..0xcda23e]
           RootRanges: [0xcda1a0..0xcda265]
       Variables: []
-    - ID: 112
+    - ID: 114
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda313..0xcda351]
           RootRanges: [0xcda300..0xcda405]
       Variables: []
-    - ID: 113
+    - ID: 115
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda3bb..0xcda3f3]
           RootRanges: [0xcda300..0xcda405]
       Variables: []
-    - ID: 114
+    - ID: 116
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3391,7 +3453,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 117
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3416,20 +3478,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1004
+      ID: 1109
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1005 PointerType *main.deepSlice3
+      Pointee: 1110 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1031
+      ID: 1136
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1032 PointerType *main.deepSlice8
+      Pointee: 1137 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1037
+      ID: 1142
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1038 PointerType *main.deepSlice9
+      Pointee: 1143 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3437,7 +3499,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1000
+      ID: 1105
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3474,30 +3536,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1012
+      ID: 1117
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1013 PointerType *table<int,*main.deepMap3>
+      Pointee: 1118 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1048
+      ID: 1153
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1049 PointerType *table<int,*main.deepMap8>
+      Pointee: 1154 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1063
+      ID: 1168
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1064 PointerType *table<int,*main.deepMap9>
+      Pointee: 1169 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1078
+      ID: 1183
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1079 PointerType *table<int,interface {}>
+      Pointee: 1184 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '**table<int,uint8>'
@@ -3514,10 +3576,10 @@ Types:
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 743
+      ID: 848
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 744 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 849 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3529,6 +3591,36 @@ Types:
       ByteSize: 8
       Pointee: 100 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
+      ID: 190
+      Name: '**table<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 191 PointerType *table<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 195
+      Name: '**table<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 196 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 200
+      Name: '**table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 201 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 205
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 206 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 210
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 211 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 215
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 216 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
       ID: 141
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
@@ -3539,146 +3631,201 @@ Types:
       ByteSize: 8
       Pointee: 137 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 183
+      ID: 227
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1008
+      ID: 1113
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1007 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1112 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1035
+      ID: 1140
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1034 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1139 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1041
+      ID: 1146
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1040 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1145 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 180
+      ID: 224
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*string.array
+      Pointee: 223 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 297
+      ID: 361
+      Name: '*[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 360 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[][][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 359
+      Name: '*[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 358 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 357
+      Name: '*[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 356 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 355
+      Name: '*[][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 354 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 353
+      Name: '*[][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 352 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 341
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType [][]uint.array
+      Pointee: 340 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 303
+      ID: 347
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []bool.array
+      Pointee: 346 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 783
+      ID: 888
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 782 GoSliceDataType []float64.array
+      Pointee: 887 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1044
+      ID: 1149
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1043 GoSliceDataType []interface {}.array
+      Pointee: 1148 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 1025
+      ID: 177
+      Name: '*[]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 174 GoSliceHeaderType []main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 351
+      Name: '*[]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 350 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 1130
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1024 GoSliceDataType []main.structWithMap.array
+      Pointee: 1129 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 299
+      ID: 343
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 342 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 301
+      ID: 345
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []string.array
+      Pointee: 344 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 162
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 295
+      ID: 339
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType []uint.array
+      Pointee: 338 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 305
+      ID: 349
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 304 GoSliceDataType []uint16.array
+      Pointee: 348 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 781
+      ID: 886
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 780 GoSliceDataType []uint8.array
+      Pointee: 885 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 913
+      ID: 1018
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.985952e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1019 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 543
+      ID: 648
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 931392
       GoKind: 22
-      Pointee: 544 GoSliceHeaderType archive/tar.headerError
+      Pointee: 649 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 546
+      ID: 651
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 545 GoSliceDataType archive/tar.headerError.array
+      Pointee: 650 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 848
+      ID: 953
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.435072e+06
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 954 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 796
+      ID: 901
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 931584
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 902 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 798
+      ID: 903
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 799 StructureType archive/zip.dirWriter
+      Pointee: 904 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 892
+      ID: 997
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.904096e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 998 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 824
+      ID: 929
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.057792e+06
       GoKind: 22
-      Pointee: 825 StructureType archive/zip.nopCloser
+      Pointee: 930 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 826
+      ID: 931
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.058048e+06
       GoKind: 22
-      Pointee: 827 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 932 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3687,435 +3834,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 871
+      ID: 976
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.174048e+06
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType bufio.Reader
+      Pointee: 977 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 900
+      ID: 1005
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.948832e+06
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType bufio.Writer
+      Pointee: 1006 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 951
+      ID: 1056
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.266912e+06
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1057 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 453
+      ID: 558
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 913824
       GoKind: 22
-      Pointee: 342 BaseType compress/flate.CorruptInputError
+      Pointee: 447 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 454
+      ID: 559
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 913920
       GoKind: 22
-      Pointee: 343 GoStringHeaderType compress/flate.InternalError
+      Pointee: 448 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 345
+      ID: 450
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 344 GoStringDataType compress/flate.InternalError.str
+      Pointee: 449 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 846
+      ID: 951
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.424672e+06
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 952 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 792
+      ID: 897
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 914016
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 898 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 868
+      ID: 973
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.725376e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 974 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 691
+      ID: 796
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.203328e+06
       GoKind: 22
-      Pointee: 692 StructureType context.deadlineExceededError
+      Pointee: 797 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 535
+      ID: 640
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926016
       GoKind: 22
-      Pointee: 356 BaseType crypto/aes.KeySizeError
+      Pointee: 461 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 536
+      ID: 641
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 357 BaseType crypto/des.KeySizeError
+      Pointee: 462 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 537
+      ID: 642
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 358 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 463 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 863
+      ID: 968
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.666112e+06
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 969 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 640
+      ID: 745
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.0656e+06
       GoKind: 22
-      Pointee: 641 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 746 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 894
+      ID: 999
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904608e+06
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1000 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 924
+      ID: 1029
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.1192e+06
       GoKind: 22
-      Pointee: 925 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1030 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 898
+      ID: 1003
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.90512e+06
       GoKind: 22
-      Pointee: 899 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1004 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 896
+      ID: 1001
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904864e+06
       GoKind: 22
-      Pointee: 897 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1002 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 890
+      ID: 995
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.902304e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 996 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 538
+      ID: 643
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926784
       GoKind: 22
-      Pointee: 359 BaseType crypto/rc4.KeySizeError
+      Pointee: 464 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 911
+      ID: 1016
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.983072e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1017 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 886
+      ID: 991
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.87168e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 992 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 461
+      ID: 566
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 915648
       GoKind: 22
-      Pointee: 346 BaseType crypto/tls.AlertError
+      Pointee: 451 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 629
+      ID: 734
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.0464e+06
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 735 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 977
+      ID: 1082
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.378432e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1083 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 457
+      ID: 562
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 915360
       GoKind: 22
-      Pointee: 458 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 563 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 455
+      ID: 560
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 915264
       GoKind: 22
-      Pointee: 456 StructureType crypto/tls.RecordHeaderError
+      Pointee: 561 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 628
+      ID: 733
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.044736e+06
       GoKind: 22
-      Pointee: 583 BaseType crypto/tls.alert
+      Pointee: 688 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 856
+      ID: 961
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.558976e+06
       GoKind: 22
-      Pointee: 857 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 962 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 459
+      ID: 564
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 460 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 565 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 861
+      ID: 966
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.641152e+06
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 967 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 726
+      ID: 831
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.425152e+06
       GoKind: 22
-      Pointee: 727 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 832 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 745
+      ID: 850
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.04224e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 851 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 531
+      ID: 636
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 532 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 637 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 525
+      ID: 630
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 924576
       GoKind: 22
-      Pointee: 526 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 631 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 527
+      ID: 632
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 924672
       GoKind: 22
-      Pointee: 528 StructureType crypto/x509.HostnameError
+      Pointee: 633 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 524
+      ID: 629
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 355 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 460 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 634
+      ID: 739
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.05216e+06
       GoKind: 22
-      Pointee: 635 StructureType crypto/x509.SystemRootsError
+      Pointee: 740 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 533
+      ID: 638
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 925152
       GoKind: 22
-      Pointee: 534 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 639 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 529
+      ID: 634
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 530 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 635 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 547
+      ID: 652
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 548 StructureType encoding/asn1.StructuralError
+      Pointee: 653 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 551
+      ID: 656
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932064
       GoKind: 22
-      Pointee: 552 StructureType encoding/asn1.SyntaxError
+      Pointee: 657 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 549
+      ID: 654
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 931968
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 655 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 442
+      ID: 547
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 337 BaseType encoding/base64.CorruptInputError
+      Pointee: 442 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 814
+      ID: 919
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.041792e+06
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 920 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 445
+      ID: 550
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 338 BaseType encoding/hex.InvalidByteError
+      Pointee: 443 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 413
+      ID: 518
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 414 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 519 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 618
+      ID: 723
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.037952e+06
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 724 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 405
+      ID: 510
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 906240
       GoKind: 22
-      Pointee: 406 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 511 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 411
+      ID: 516
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 906528
       GoKind: 22
-      Pointee: 412 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 517 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 409
+      ID: 514
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 906432
       GoKind: 22
-      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 515 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 407
+      ID: 512
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 906336
       GoKind: 22
-      Pointee: 408 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 513 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 957
+      ID: 1062
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.292448e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1063 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 415
+      ID: 520
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 416 StructureType encoding/json.jsonError
+      Pointee: 521 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 822
+      ID: 927
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.05472e+06
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 928 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 519
+      ID: 624
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 520 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 625 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 517
+      ID: 622
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 518 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 623 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 521
+      ID: 626
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923616
       GoKind: 22
-      Pointee: 352 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 457 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 354
+      ID: 459
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 353 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 458 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 522
+      ID: 627
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 628 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 935
+      ID: 1040
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.15904e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1041 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4124,19 +4271,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 381
+      ID: 486
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896640
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType errors.errorString
+      Pointee: 487 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 585
+      ID: 690
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.022848e+06
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType errors.joinError
+      Pointee: 691 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4152,813 +4299,813 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 945
+      ID: 1050
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.259232e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType fmt.pp
+      Pointee: 1051 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 587
+      ID: 692
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.02464e+06
       GoKind: 22
-      Pointee: 588 UnresolvedPointeeType fmt.wrapError
+      Pointee: 693 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 589
+      ID: 694
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.024768e+06
       GoKind: 22
-      Pointee: 590 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 695 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 443
+      ID: 548
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 912192
       GoKind: 22
-      Pointee: 444 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 549 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 424
+      ID: 529
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 530 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 426
+      ID: 531
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 427 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 532 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 758
+      ID: 863
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 909216
       GoKind: 22
-      Pointee: 759 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 864 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 430
+      ID: 535
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 909792
       GoKind: 22
-      Pointee: 431 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 536 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 760
+      ID: 865
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 909312
       GoKind: 22
-      Pointee: 761 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 866 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 428
+      ID: 533
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 333
+      ID: 438
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 423
+      ID: 528
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 909120
       GoKind: 22
-      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 330
+      ID: 435
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 429
+      ID: 534
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 334 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 439 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 336
+      ID: 441
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 834
+      ID: 939
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.208832e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 940 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 921
+      ID: 1026
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.057248e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1027 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 541
+      ID: 646
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 930336
       GoKind: 22
-      Pointee: 542 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 647 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 700
+      ID: 805
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.212416e+06
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 806 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 953
+      ID: 1058
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.26896e+06
       GoKind: 22
-      Pointee: 954 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1059 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 468
+      ID: 573
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 469 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 574 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 475
+      ID: 580
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 920064
       GoKind: 22
-      Pointee: 476 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 581 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 470
+      ID: 575
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 351 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 456 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 473
+      ID: 578
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 919968
       GoKind: 22
-      Pointee: 474 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 579 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 471
+      ID: 576
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 919872
       GoKind: 22
-      Pointee: 472 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 577 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 491
+      ID: 596
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 921984
       GoKind: 22
-      Pointee: 492 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 597 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 495
+      ID: 600
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 922176
       GoKind: 22
-      Pointee: 496 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 601 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 493
+      ID: 598
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 494 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 599 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 489
+      ID: 594
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 921888
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 595 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 785
+      ID: 890
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 784 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 889 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 503
+      ID: 608
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 504 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 609 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 497
+      ID: 602
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 498 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 603 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 501
+      ID: 606
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 502 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 607 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 499
+      ID: 604
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 500 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 605 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 505
+      ID: 610
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 922656
       GoKind: 22
-      Pointee: 506 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 511
+      ID: 616
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 922944
       GoKind: 22
-      Pointee: 512 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 617 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 513
+      ID: 618
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 923040
       GoKind: 22
-      Pointee: 514 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 619 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 509
+      ID: 614
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 922848
       GoKind: 22
-      Pointee: 510 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 615 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 507
+      ID: 612
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 508 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 515
+      ID: 620
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 923232
       GoKind: 22
-      Pointee: 516 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 621 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 432
+      ID: 537
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 910944
       GoKind: 22
-      Pointee: 433 StructureType github.com/cihub/seelog.baseError
+      Pointee: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 874
+      ID: 979
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.80224e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 980 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 434
+      ID: 539
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 911040
       GoKind: 22
-      Pointee: 435 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 540 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 854
+      ID: 959
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.557696e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 960 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 810
+      ID: 915
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.04064e+06
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 844
+      ID: 949
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.422752e+06
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 950 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 438
+      ID: 543
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 911232
       GoKind: 22
-      Pointee: 439 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 544 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 909
+      ID: 1014
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.975296e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1015 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 928
+      ID: 1033
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.13184e+06
       GoKind: 22
-      Pointee: 923 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1028 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 927
+      ID: 1032
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.131456e+06
       GoKind: 22
-      Pointee: 926 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1031 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 812
+      ID: 917
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.040768e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 436
+      ID: 541
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 437 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 542 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 440
+      ID: 545
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 441 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 546 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 876
+      ID: 981
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.804032e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 982 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 917
+      ID: 1022
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.011424e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1023 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 919
+      ID: 1024
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.04192e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1025 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 731
+      ID: 836
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.437472e+06
       GoKind: 22
-      Pointee: 732 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 837 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 644
+      ID: 749
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.066368e+06
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 750 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 642
+      ID: 747
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.06624e+06
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 748 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 646
+      ID: 751
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.070336e+06
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 752 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 648
+      ID: 753
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.070464e+06
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 754 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 865
+      ID: 970
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.668416e+06
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 971 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 636
+      ID: 741
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.0528e+06
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 742 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 446
+      ID: 551
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 912864
       GoKind: 22
-      Pointee: 447 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 552 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 969
+      ID: 1074
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.35488e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1075 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 702
+      ID: 807
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.220992e+06
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 808 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 675
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.199872e+06
       GoKind: 22
-      Pointee: 676 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 669
+      ID: 774
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.199488e+06
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 775 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 604
+      ID: 709
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.031936e+06
       GoKind: 22
-      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 710 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 681
+      ID: 786
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.200256e+06
       GoKind: 22
-      Pointee: 682 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 787 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 603
+      ID: 708
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.031808e+06
       GoKind: 22
-      Pointee: 582 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 687 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 673
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.199744e+06
       GoKind: 22
-      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 671
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.199616e+06
       GoKind: 22
-      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 679
+      ID: 784
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.200128e+06
       GoKind: 22
-      Pointee: 680 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 785 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 677
+      ID: 782
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.2e+06
       GoKind: 22
-      Pointee: 678 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 783 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 973
+      ID: 1078
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.367488e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1079 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 685
+      ID: 790
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.20064e+06
       GoKind: 22
-      Pointee: 686 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 791 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 608
+      ID: 713
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.032192e+06
       GoKind: 22
-      Pointee: 609 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 714 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 606
+      ID: 711
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.032064e+06
       GoKind: 22
-      Pointee: 607 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 712 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 683
+      ID: 788
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.200512e+06
       GoKind: 22
-      Pointee: 684 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 789 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 563
+      ID: 668
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944832
       GoKind: 22
-      Pointee: 364 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 469 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 366
+      ID: 471
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 365 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 470 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 748
+      ID: 853
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.66688e+06
       GoKind: 22
-      Pointee: 749 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 854 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 652
+      ID: 757
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.085184e+06
       GoKind: 22
-      Pointee: 653 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 758 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 840
+      ID: 945
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.2608e+06
       GoKind: 22
-      Pointee: 841 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 946 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 933
+      ID: 1038
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.1472e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1039 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 828
+      ID: 933
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.087488e+06
       GoKind: 22
-      Pointee: 829 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 934 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 564
+      ID: 669
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 946080
       GoKind: 22
-      Pointee: 367 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 472 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 710
+      ID: 815
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.262464e+06
       GoKind: 22
-      Pointee: 711 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 816 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 567
+      ID: 672
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 946368
       GoKind: 22
-      Pointee: 568 StructureType golang.org/x/net/http2.connError
+      Pointee: 673 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 566
+      ID: 671
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946272
       GoKind: 22
-      Pointee: 371 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 476 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 373
+      ID: 478
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 372 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 477 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 570
+      ID: 675
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 946560
       GoKind: 22
-      Pointee: 377 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 482 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 379
+      ID: 484
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 378 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 483 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 569
+      ID: 674
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 946464
       GoKind: 22
-      Pointee: 374 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 479 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 376
+      ID: 481
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 375 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 480 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 565
+      ID: 670
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946176
       GoKind: 22
-      Pointee: 368 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 473 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 370
+      ID: 475
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 369 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 474 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 931
+      ID: 1036
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.14528e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1037 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 571
+      ID: 676
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 946656
       GoKind: 22
-      Pointee: 572 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 677 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 573
+      ID: 678
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 946752
       GoKind: 22
-      Pointee: 380 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 485 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 559
+      ID: 664
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 560 StructureType google.golang.org/grpc.dropError
+      Pointee: 665 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 708
+      ID: 813
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.25952e+06
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 814 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 733
+      ID: 838
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.444832e+06
       GoKind: 22
-      Pointee: 734 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 839 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 561
+      ID: 666
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 943104
       GoKind: 22
-      Pointee: 562 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 667 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 880
+      ID: 985
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.809632e+06
       GoKind: 22
-      Pointee: 881 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 986 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 838
+      ID: 943
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.256064e+06
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 944 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 650
+      ID: 755
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.079424e+06
       GoKind: 22
-      Pointee: 651 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 756 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 800
+      ID: 905
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 943200
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 906 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 539
+      ID: 644
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 928224
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 645 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 638
+      ID: 743
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.056128e+06
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 744 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 706
+      ID: 811
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.227392e+06
       GoKind: 22
-      Pointee: 707 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 812 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 704
+      ID: 809
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.227136e+06
       GoKind: 22
-      Pointee: 705 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 810 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 553
+      ID: 658
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932928
       GoKind: 22
-      Pointee: 554 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 659 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 555
+      ID: 660
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 933024
       GoKind: 22
-      Pointee: 556 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 661 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 483
+      ID: 588
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 589 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 888
+      ID: 993
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.900256e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 994 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 574
+      ID: 679
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 947520
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType html/template.Error
+      Pointee: 680 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -5002,129 +5149,129 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 735
+      ID: 840
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.211552e+06
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType internal/abi.Type
+      Pointee: 841 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 451
+      ID: 556
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 913536
       GoKind: 22
-      Pointee: 452 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 557 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 449
+      ID: 554
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 913440
       GoKind: 22
-      Pointee: 450 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 555 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 786
+      ID: 891
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 901440
       GoKind: 22
-      Pointee: 787 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 892 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 667
+      ID: 772
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.19872e+06
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 773 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 975
+      ID: 1080
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.373152e+06
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1081 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 665
+      ID: 770
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.198592e+06
       GoKind: 22
-      Pointee: 666 StructureType internal/poll.errNetClosing
+      Pointee: 771 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 385
+      ID: 490
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900672
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 491 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 448
+      ID: 553
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 913248
       GoKind: 22
-      Pointee: 339 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 444 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 341
+      ID: 446
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 340 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 445 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 622
+      ID: 727
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.043072e+06
       GoKind: 22
-      Pointee: 623 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 728 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 832
+      ID: 937
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.190016e+06
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType io.PipeWriter
+      Pointee: 938 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 830
+      ID: 935
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.189632e+06
       GoKind: 22
-      Pointee: 831 StructureType io.discard
+      Pointee: 936 StructureType io.discard
     - __kind: PointerType
-      ID: 804
+      ID: 909
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.023104e+06
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType io.multiWriter
+      Pointee: 910 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 663
+      ID: 768
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.19808e+06
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType io/fs.PathError
+      Pointee: 769 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 878
+      ID: 983
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.804256e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 984 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 190
+      ID: 234
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 386048
       GoKind: 22
-      Pointee: 191 StructureType main.deepMap2
+      Pointee: 235 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1020
+      ID: 1125
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385984
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType main.deepMap3
+      Pointee: 1126 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -5133,19 +5280,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1056
+      ID: 1161
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 385664
       GoKind: 22
-      Pointee: 1057 StructureType main.deepMap8
+      Pointee: 1162 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1071
+      ID: 1176
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385600
       GoKind: 22
-      Pointee: 1072 StructureType main.deepMap9
+      Pointee: 1177 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -5154,12 +5301,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 979
+      ID: 1084
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1085 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5168,33 +5315,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1026
+      ID: 1131
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386240
       GoKind: 22
-      Pointee: 1027 StructureType main.deepPtr8
+      Pointee: 1132 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1028
+      ID: 1133
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386176
       GoKind: 22
-      Pointee: 1029 StructureType main.deepPtr9
+      Pointee: 1134 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 387200
       GoKind: 22
-      Pointee: 181 StructureType main.deepSlice2
+      Pointee: 225 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1005
+      ID: 1110
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387136
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1111 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5203,25 +5350,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1032
+      ID: 1137
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386816
       GoKind: 22
-      Pointee: 1033 StructureType main.deepSlice8
+      Pointee: 1138 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1038
+      ID: 1143
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386752
       GoKind: 22
-      Pointee: 1039 StructureType main.deepSlice9
+      Pointee: 1144 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 176
+      ID: 220
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 175 StructureType main.emptyStruct
+      Pointee: 219 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
@@ -5230,12 +5377,12 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 996
+      ID: 1101
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 896352
       GoKind: 22
-      Pointee: 997 StructureType main.firstBehavior
+      Pointee: 1102 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
@@ -5250,19 +5397,19 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 998
+      ID: 1103
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 896448
       GoKind: 22
-      Pointee: 999 StructureType main.secondBehavior
+      Pointee: 1104 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 984
+      ID: 1089
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 896544
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1090 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -5270,18 +5417,23 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 982
+      ID: 1087
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 981 GoStringDataType main.stringType1.str
+      Pointee: 1086 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType main.stringType2
+      Pointee: 1088 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 242
+      ID: 175
+      Name: '*main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 173 StructureType main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 286
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 385536
@@ -5305,10 +5457,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1002
+      ID: 1107
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1001 GoSliceDataType main.t.array
+      Pointee: 1106 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -5341,30 +5493,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1010
+      ID: 1115
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1011 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1116 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1046
+      ID: 1151
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1047 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1152 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1061
+      ID: 1166
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1062 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1167 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1076
+      ID: 1181
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1077 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1182 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 129
       Name: '*map<int,uint8>'
@@ -5381,10 +5533,10 @@ Types:
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 741
+      ID: 846
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 742 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 847 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -5395,6 +5547,36 @@ Types:
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 188
+      Name: '*map<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 189 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 193
+      Name: '*map<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 194 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 198
+      Name: '*map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 199 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 203
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 204 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 208
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 209 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 213
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 214 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 139
       Name: '*map<uint8,[4]int>'
@@ -5412,710 +5594,740 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 487
+      ID: 592
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 921312
       GoKind: 22
-      Pointee: 488 StructureType math/big.ErrNaN
+      Pointee: 593 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 794
+      ID: 899
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 916128
       GoKind: 22
-      Pointee: 795 StructureType mime/multipart.writerOnly·1
+      Pointee: 900 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 694
+      ID: 799
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.206656e+06
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType net.AddrError
+      Pointee: 800 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 720
+      ID: 825
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.420992e+06
       GoKind: 22
-      Pointee: 721 UnresolvedPointeeType net.DNSError
+      Pointee: 826 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 939
+      ID: 1044
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.231904e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType net.IPConn
+      Pointee: 1045 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 718
+      ID: 823
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.420672e+06
       GoKind: 22
-      Pointee: 719 UnresolvedPointeeType net.OpError
+      Pointee: 824 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 696
+      ID: 801
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.206784e+06
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType net.ParseError
+      Pointee: 802 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 949
+      ID: 1054
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.260256e+06
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType net.TCPConn
+      Pointee: 1055 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 959
+      ID: 1064
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.30576e+06
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType net.UDPConn
+      Pointee: 1065 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 947
+      ID: 1052
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.259744e+06
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType net.UnixConn
+      Pointee: 1053 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 693
+      ID: 798
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.205888e+06
       GoKind: 22
-      Pointee: 656 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 761 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 658
+      ID: 763
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 657 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 762 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 620
+      ID: 725
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.038848e+06
       GoKind: 22
-      Pointee: 621 StructureType net.canceledError
+      Pointee: 726 StructureType net.canceledError
     - __kind: PointerType
-      ID: 915
+      ID: 1020
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.008832e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType net.conn
+      Pointee: 1021 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 767
+      ID: 872
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.84704e+06
       GoKind: 22
-      Pointee: 768 StructureType net.dialResult·1
+      Pointee: 873 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 961
+      ID: 1066
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.310016e+06
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType net.netFD
+      Pointee: 1067 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 417
+      ID: 522
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907968
       GoKind: 22
-      Pointee: 418 UnresolvedPointeeType net.notFoundError
+      Pointee: 523 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 419
+      ID: 524
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 420 StructureType net.result·2
+      Pointee: 525 StructureType net.result·2
     - __kind: PointerType
-      ID: 943
+      ID: 1048
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.246272e+06
       GoKind: 22
-      Pointee: 944 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1049 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 941
+      ID: 1046
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.245792e+06
       GoKind: 22
-      Pointee: 942 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1047 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 698
+      ID: 803
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.207424e+06
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType net.temporaryError
+      Pointee: 804 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 722
+      ID: 827
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.421152e+06
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType net.timeoutError
+      Pointee: 828 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 610
+      ID: 715
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.034624e+06
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 716 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 788
+      ID: 893
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 903744
       GoKind: 22
-      Pointee: 789 StructureType net/http.bufioFlushWriter
+      Pointee: 894 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 394
+      ID: 499
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 904416
       GoKind: 22
-      Pointee: 309 BaseType net/http.http2ConnectionError
+      Pointee: 414 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 395
+      ID: 500
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 396 StructureType net/http.http2GoAwayError
+      Pointee: 501 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 714
+      ID: 819
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.416672e+06
       GoKind: 22
-      Pointee: 715 StructureType net/http.http2StreamError
+      Pointee: 820 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 399
+      ID: 504
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 400 StructureType net/http.http2connError
+      Pointee: 505 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 850
+      ID: 955
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.554176e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 956 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 398
+      ID: 503
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 22
-      Pointee: 313 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 418 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 315
+      ID: 420
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 402
+      ID: 507
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 905280
       GoKind: 22
-      Pointee: 319 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 424 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 321
+      ID: 426
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 425 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 401
+      ID: 506
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 905184
       GoKind: 22
-      Pointee: 316 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 421 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 318
+      ID: 423
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 422 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 689
+      ID: 794
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.20256e+06
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 795 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 616
+      ID: 721
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.035264e+06
       GoKind: 22
-      Pointee: 617 StructureType net/http.http2noCachedConnError
+      Pointee: 722 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 904
+      ID: 1009
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.951136e+06
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1010 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 397
+      ID: 502
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 310 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 415 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 312
+      ID: 417
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 416 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 790
+      ID: 895
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 905376
       GoKind: 22
-      Pointee: 791 StructureType net/http.http2stickyErrWriter
+      Pointee: 896 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 612
+      ID: 717
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.03488e+06
       GoKind: 22
-      Pointee: 613 StructureType net/http.nothingWrittenError
+      Pointee: 718 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 852
+      ID: 957
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.175296e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType net/http.persistConn
+      Pointee: 958 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 808
+      ID: 913
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.034752e+06
       GoKind: 22
-      Pointee: 809 StructureType net/http.persistConnWriter
+      Pointee: 914 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 842
+      ID: 947
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.416832e+06
       GoKind: 22
-      Pointee: 843 StructureType net/http.readWriteCloserBody
+      Pointee: 948 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 403
+      ID: 508
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 404 StructureType net/http.requestBodyReadError
+      Pointee: 509 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 716
+      ID: 821
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.417952e+06
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 822 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 687
+      ID: 792
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.202432e+06
       GoKind: 22
-      Pointee: 688 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 793 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 614
+      ID: 719
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.035008e+06
       GoKind: 22
-      Pointee: 615 StructureType net/http.transportReadFromServerError
+      Pointee: 720 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 884
+      ID: 989
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.84368e+06
       GoKind: 22
-      Pointee: 885 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 990 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 392
+      ID: 497
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 903648
       GoKind: 22
-      Pointee: 393 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 498 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 906
+      ID: 1011
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.952928e+06
       GoKind: 22
-      Pointee: 907 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1012 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 818
+      ID: 923
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.047552e+06
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 924 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 479
+      ID: 584
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 920256
       GoKind: 22
-      Pointee: 480 StructureType net/netip.parseAddrError
+      Pointee: 585 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 477
+      ID: 582
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 478 StructureType net/netip.parsePrefixError
+      Pointee: 583 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 858
+      ID: 963
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.117792e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType net/smtp.Client
+      Pointee: 964 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 820
+      ID: 925
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.052416e+06
       GoKind: 22
-      Pointee: 821 StructureType net/smtp.dataCloser
+      Pointee: 926 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 463
+      ID: 568
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 916320
       GoKind: 22
-      Pointee: 464 UnresolvedPointeeType net/textproto.Error
+      Pointee: 569 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 462
+      ID: 567
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 916224
       GoKind: 22
-      Pointee: 347 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 452 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 349
+      ID: 454
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 348 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 453 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 816
+      ID: 921
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.046784e+06
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 922 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 724
+      ID: 829
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.421472e+06
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType net/url.Error
+      Pointee: 830 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 421
+      ID: 526
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 322 GoStringHeaderType net/url.EscapeError
+      Pointee: 427 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 324
+      ID: 429
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType net/url.EscapeError.str
+      Pointee: 428 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 422
+      ID: 527
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 908832
       GoKind: 22
-      Pointee: 325 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 430 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 327
+      ID: 432
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 431 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 288
+      ID: 332
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 289 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 280
+      ID: 324
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 281 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 228
+      ID: 272
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 229 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 247
+      ID: 291
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 248 StructureType noalg.map.group[bool]main.node
+      Pointee: 292 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 186
+      ID: 230
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1016
+      ID: 1121
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1017 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1122 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1052
+      ID: 1157
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1053 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1158 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1067
+      ID: 1172
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1068 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1173 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 196
+      ID: 240
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[int]int
+      Pointee: 241 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1082
+      ID: 1187
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1083 StructureType noalg.map.group[int]interface {}
+      Pointee: 1188 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 255
+      ID: 299
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 256 StructureType noalg.map.group[int]uint8
+      Pointee: 300 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 237
+      ID: 281
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 238 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 220
+      ID: 264
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 221 StructureType noalg.map.group[string][]string
+      Pointee: 265 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 774
+      ID: 879
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 212
+      ID: 256
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 213 StructureType noalg.map.group[string]int
+      Pointee: 257 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 204
+      ID: 248
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 205 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 249 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 271
+      ID: 364
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 373
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 381
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 389
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 397
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 405
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 315
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 272 StructureType noalg.map.group[uint8][4]int
+      Pointee: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 263
+      ID: 307
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 264 StructureType noalg.map.group[uint8]uint8
+      Pointee: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 967
+      ID: 1072
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.349504e+06
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType os.File
+      Pointee: 1073 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 591
+      ID: 696
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.02592e+06
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType os.LinkError
+      Pointee: 697 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 659
+      ID: 764
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.191424e+06
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType os.SyscallError
+      Pointee: 765 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 965
+      ID: 1070
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.348032e+06
       GoKind: 22
-      Pointee: 966 StructureType os.fileWithoutReadFrom
+      Pointee: 1071 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 963
+      ID: 1068
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.347296e+06
       GoKind: 22
-      Pointee: 964 StructureType os.fileWithoutWriteTo
+      Pointee: 1069 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 624
+      ID: 729
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.043456e+06
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType os/exec.Error
+      Pointee: 730 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 770
+      ID: 875
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.089056e+06
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 876 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 836
+      ID: 941
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.213696e+06
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 942 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 626
+      ID: 731
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.043584e+06
       GoKind: 22
-      Pointee: 627 StructureType os/exec.wrappedError
+      Pointee: 732 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 558
+      ID: 663
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 938112
       GoKind: 22
-      Pointee: 361 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 466 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 363
+      ID: 468
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 362 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 467 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 557
+      ID: 662
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 938016
       GoKind: 22
-      Pointee: 360 BaseType os/user.UnknownUserIdError
+      Pointee: 465 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 387
+      ID: 492
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 901344
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType reflect.ValueError
+      Pointee: 493 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 485
+      ID: 590
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 920928
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 591 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 595
+      ID: 700
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.027456e+06
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 701 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 599
+      ID: 704
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.029248e+06
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 705 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 597
+      ID: 702
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.027584e+06
       GoKind: 22
-      Pointee: 598 StructureType runtime.boundsError
+      Pointee: 703 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 661
+      ID: 766
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.196928e+06
       GoKind: 22
-      Pointee: 662 StructureType runtime.errorAddressString
+      Pointee: 767 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 593
+      ID: 698
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.027072e+06
       GoKind: 22
-      Pointee: 576 GoStringHeaderType runtime.errorString
+      Pointee: 681 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 578
+      ID: 683
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 577 GoStringDataType runtime.errorString.str
+      Pointee: 682 GoStringDataType runtime.errorString.str
     - __kind: PointerType
-      ID: 594
+      ID: 699
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.0272e+06
       GoKind: 22
-      Pointee: 579 GoStringHeaderType runtime.plainError
+      Pointee: 684 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 581
+      ID: 686
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 580 GoStringDataType runtime.plainError.str
+      Pointee: 685 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 737
+      ID: 842
       Name: '*runtime.synctestBubble'
       ByteSize: 8
       GoRuntimeType: 1.551936e+06
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType runtime.synctestBubble
+      Pointee: 843 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 383
+      ID: 488
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 900000
       GoKind: 22
-      Pointee: 384 StructureType runtime.synctestDeadlockError
+      Pointee: 489 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
-      ID: 601
+      ID: 706
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.029504e+06
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType strconv.NumError
+      Pointee: 707 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6124,168 +6336,198 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 178
+      ID: 222
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 177 GoStringDataType string.str
+      Pointee: 221 GoStringDataType string.str
     - __kind: PointerType
-      ID: 902
+      ID: 1007
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.949856e+06
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType strings.Builder
+      Pointee: 1008 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 806
+      ID: 911
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.029632e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 912 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 802
+      ID: 907
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 971104
       GoKind: 22
-      Pointee: 803 StructureType struct { io.Writer }
+      Pointee: 908 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 713
+      ID: 818
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.416032e+06
       GoKind: 22
-      Pointee: 712 BaseType syscall.Errno
+      Pointee: 817 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 286 StructureType table<[4]int,[4]int>
+      Pointee: 330 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 147
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 278 StructureType table<[4]int,uint8>
+      Pointee: 322 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 115
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 226 StructureType table<[4]string,[2]int>
+      Pointee: 270 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 127
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 245 StructureType table<bool,main.node>
+      Pointee: 289 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 184 StructureType table<int,*main.deepMap2>
+      Pointee: 228 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1013
+      ID: 1118
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1014 StructureType table<int,*main.deepMap3>
+      Pointee: 1119 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1049
+      ID: 1154
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1050 StructureType table<int,*main.deepMap8>
+      Pointee: 1155 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1064
+      ID: 1169
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1065 StructureType table<int,*main.deepMap9>
+      Pointee: 1170 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 194 StructureType table<int,int>
+      Pointee: 238 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1079
+      ID: 1184
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1080 StructureType table<int,interface {}>
+      Pointee: 1185 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 253 StructureType table<int,uint8>
+      Pointee: 297 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 122
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 235 StructureType table<string,[]main.structWithMap>
+      Pointee: 279 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 110
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 218 StructureType table<string,[]string>
+      Pointee: 262 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 744
+      ID: 849
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 772 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 877 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 210 StructureType table<string,int>
+      Pointee: 254 StructureType table<string,int>
     - __kind: PointerType
       ID: 100
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 202 StructureType table<string,main.nestedStruct>
+      Pointee: 246 StructureType table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 191
+      Name: '*table<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 362 StructureType table<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 196
+      Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 371 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 201
+      Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 379 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 206
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 387 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 211
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 395 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 216
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 403 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 142
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 269 StructureType table<uint8,[4]int>
+      Pointee: 313 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 137
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 261 StructureType table<uint8,uint8>
+      Pointee: 305 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 937
+      ID: 1042
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.159424e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1043 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 654
+      ID: 759
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.089024e+06
       GoKind: 22
-      Pointee: 655 StructureType text/template.ExecError
+      Pointee: 760 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 729
+      ID: 834
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.622144e+06
       GoKind: 22
-      Pointee: 730 UnresolvedPointeeType time.Location
+      Pointee: 835 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 390
+      ID: 495
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902208
       GoKind: 22
-      Pointee: 391 UnresolvedPointeeType time.ParseError
+      Pointee: 496 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 389
+      ID: 494
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902112
       GoKind: 22
-      Pointee: 306 GoStringHeaderType time.fileSizeError
+      Pointee: 411 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 308
+      ID: 413
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType time.fileSizeError.str
+      Pointee: 412 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6329,52 +6571,52 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 481
+      ID: 586
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 920352
       GoKind: 22
-      Pointee: 482 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 587 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 929
+      ID: 1034
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.134912e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1035 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 465
+      ID: 570
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 916512
       GoKind: 22
-      Pointee: 466 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 571 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 467
+      ID: 572
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 350 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 455 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 631
+      ID: 736
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.047296e+06
       GoKind: 22
-      Pointee: 632 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 737 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 633
+      ID: 738
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.047424e+06
       GoKind: 22
-      Pointee: 584 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 689 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1185
+      ID: 1290
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1142
+      ID: 1247
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6389,7 +6631,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1140
+      ID: 1245
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6404,7 +6646,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1104
+      ID: 1209
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6419,7 +6661,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1102
+      ID: 1207
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6434,7 +6676,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1150
+      ID: 1255
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6449,7 +6691,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1103
+      ID: 1208
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6464,7 +6706,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1122
+      ID: 1227
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6479,7 +6721,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1091
+      ID: 1196
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6494,7 +6736,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1088
+      ID: 1193
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6509,7 +6751,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1166
+      ID: 1271
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6524,7 +6766,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1164
+      ID: 1269
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6557,7 +6799,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1174
+      ID: 1279
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6572,7 +6814,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1127
+      ID: 1232
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6587,7 +6829,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1128
+      ID: 1233
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6602,7 +6844,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1123
+      ID: 1228
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6617,7 +6859,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1124
+      ID: 1229
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6632,7 +6874,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1125
+      ID: 1230
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6647,7 +6889,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1126
+      ID: 1231
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6662,7 +6904,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1179
+      ID: 1284
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6686,7 +6928,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1176
+      ID: 1281
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6701,7 +6943,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1193
+      ID: 1298
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6716,7 +6958,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1196
+      ID: 1303
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6724,14 +6966,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 176 PointerType *main.emptyStruct
+            Type: 220 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: e}
+                  Variable: {subprogram: 111, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1195
+      ID: 1302
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6739,14 +6981,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 StructureType main.emptyStruct
+            Type: 219 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 110, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1141
+      ID: 1246
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6761,7 +7003,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1132
+      ID: 1237
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6776,7 +7018,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1131
+      ID: 1236
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6791,7 +7033,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1138
+      ID: 1243
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6806,7 +7048,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1137
+      ID: 1242
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6821,7 +7063,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1133
+      ID: 1238
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6836,7 +7078,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1135
+      ID: 1240
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6851,10 +7093,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1198
+      ID: 1305
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1134
+      ID: 1239
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6878,16 +7120,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1199
+      ID: 1306
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1200
+      ID: 1307
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1136
+      ID: 1241
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1197
+      ID: 1304
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6898,11 +7140,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 112, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1201
+      ID: 1308
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6913,11 +7155,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1202
+      ID: 1309
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6928,11 +7170,11 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: a}
+                  Variable: {subprogram: 117, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1094
+      ID: 1199
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6947,7 +7189,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1095
+      ID: 1200
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6962,7 +7204,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1096
+      ID: 1201
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6977,7 +7219,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1093
+      ID: 1198
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6992,7 +7234,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1092
+      ID: 1197
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7007,7 +7249,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1139
+      ID: 1244
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7022,7 +7264,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1168
+      ID: 1273
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7037,7 +7279,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1148
+      ID: 1253
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7052,7 +7294,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1154
+      ID: 1259
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7067,7 +7309,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1152
+      ID: 1257
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7082,7 +7324,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1163
+      ID: 1268
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7097,7 +7339,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1162
+      ID: 1267
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7112,7 +7354,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1153
+      ID: 1258
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7127,7 +7369,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1161
+      ID: 1266
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7142,7 +7384,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1160
+      ID: 1265
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7157,7 +7399,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1146
+      ID: 1251
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7172,7 +7414,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1147
+      ID: 1252
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7187,7 +7429,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1145
+      ID: 1250
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7202,7 +7444,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1155
+      ID: 1260
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7217,7 +7459,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1159
+      ID: 1264
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7232,7 +7474,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1158
+      ID: 1263
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7247,7 +7489,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1157
+      ID: 1262
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7262,7 +7504,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1156
+      ID: 1261
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7277,7 +7519,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1191
+      ID: 1296
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7292,7 +7534,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1165
+      ID: 1270
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7343,7 +7585,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1173
+      ID: 1278
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7367,7 +7609,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1180
+      ID: 1285
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7391,7 +7633,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1182
+      ID: 1287
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7424,7 +7666,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1288
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7439,7 +7681,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1190
+      ID: 1295
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7454,7 +7696,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1274
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7469,7 +7711,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1151
+      ID: 1256
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7484,7 +7726,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1272
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7499,7 +7741,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1089
+      ID: 1194
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7514,7 +7756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1108
+      ID: 1213
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7529,7 +7771,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1106
+      ID: 1211
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7544,7 +7786,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1119
+      ID: 1224
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7559,7 +7801,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1120
+      ID: 1225
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7574,7 +7816,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1111
+      ID: 1216
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7589,7 +7831,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1112
+      ID: 1217
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7604,7 +7846,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1113
+      ID: 1218
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7619,7 +7861,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1110
+      ID: 1215
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7634,7 +7876,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1109
+      ID: 1214
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7649,7 +7891,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1107
+      ID: 1212
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7664,7 +7906,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1186
+      ID: 1291
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7679,7 +7921,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1116
+      ID: 1221
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7694,7 +7936,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1117
+      ID: 1222
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7709,7 +7951,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1118
+      ID: 1223
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7724,7 +7966,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1115
+      ID: 1220
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7739,7 +7981,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1114
+      ID: 1219
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7754,7 +7996,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1177
+      ID: 1282
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7769,7 +8011,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1149
+      ID: 1254
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7784,7 +8026,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1090
+      ID: 1195
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7799,7 +8041,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1172
+      ID: 1277
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7814,7 +8056,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
+      ID: 1286
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7829,7 +8071,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1129
+      ID: 1234
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7844,7 +8086,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1130
+      ID: 1235
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7859,7 +8101,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1178
+      ID: 1283
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7883,7 +8125,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1143
+      ID: 1248
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7898,7 +8140,37 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1144
+      ID: 1300
+      Name: Probe[main.testStructWithCyclicMaps]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 186 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 1299
+      Name: Probe[main.testStructWithCyclicSlices]
+      ByteSize: 145
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 173 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
+    - __kind: EventRootType
+      ID: 1249
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7913,7 +8185,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1194
+      ID: 1301
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7921,14 +8193,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 173 StructureType main.aStruct
+            Type: 217 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1189
+      ID: 1294
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7943,7 +8215,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1188
+      ID: 1293
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7958,7 +8230,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1187
+      ID: 1292
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7991,7 +8263,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1121
+      ID: 1226
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8006,7 +8278,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1099
+      ID: 1204
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -8021,7 +8293,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1100
+      ID: 1205
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8036,7 +8308,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1101
+      ID: 1206
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8051,7 +8323,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1098
+      ID: 1203
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8066,7 +8338,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1097
+      ID: 1202
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8081,7 +8353,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1171
+      ID: 1276
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8096,7 +8368,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1175
+      ID: 1280
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8111,7 +8383,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1192
+      ID: 1297
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8126,7 +8398,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1170
+      ID: 1275
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8141,7 +8413,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1105
+      ID: 1210
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -8156,7 +8428,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1184
+      ID: 1289
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8304,7 +8576,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 275
+      ID: 319
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 682880
@@ -8313,7 +8585,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 232
+      ID: 276
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683168
@@ -8330,7 +8602,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 762
+      ID: 867
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684416
@@ -8354,14 +8626,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 182 GoSliceDataType []*main.deepSlice2.array
+      Data: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 226
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1003
+      ID: 1108
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477824
@@ -8369,21 +8641,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1004 PointerType **main.deepSlice3
+          Type: 1109 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1007 GoSliceDataType []*main.deepSlice3.array
+      Data: 1112 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1007
+      ID: 1112
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 1005 PointerType *main.deepSlice3
+      Element: 1110 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1030
+      ID: 1135
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477504
@@ -8391,21 +8663,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1031 PointerType **main.deepSlice8
+          Type: 1136 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1034 GoSliceDataType []*main.deepSlice8.array
+      Data: 1139 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1034
+      ID: 1139
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 1032 PointerType *main.deepSlice8
+      Element: 1137 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1036
+      ID: 1141
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477440
@@ -8413,19 +8685,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1037 PointerType **main.deepSlice9
+          Type: 1142 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1040 GoSliceDataType []*main.deepSlice9.array
+      Data: 1145 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1040
+      ID: 1145
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 1038 PointerType *main.deepSlice9
+      Element: 1143 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -8442,102 +8714,237 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 179 GoSliceDataType []*string.array
+      Data: 223 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 223
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 336
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 152 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 328
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 147 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 277
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 115 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 295
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 236
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1022
+      ID: 1127
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 1013 PointerType *table<int,*main.deepMap3>
+      Element: 1118 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1058
+      ID: 1163
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 1049 PointerType *table<int,*main.deepMap8>
+      Element: 1154 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1073
+      ID: 1178
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 1064 PointerType *table<int,*main.deepMap9>
+      Element: 1169 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 244
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1086
+      ID: 1191
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 1079 PointerType *table<int,interface {}>
+      Element: 1184 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 303
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 132 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 287
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 268
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 778
+      ID: 883
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 8192
-      Element: 744 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 849 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 260
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 252
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 100 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 369
+      Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 191 PointerType *table<struct {},main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 377
+      Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 196 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 385
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 201 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 393
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 206 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 401
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 211 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 409
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 216 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 320
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 142 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 311
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 137 PointerType *table<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 184
+      Name: '[][][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 185 PointerType *[][][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 360 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 360
+      Name: '[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 182
+      Name: '[][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 183 PointerType *[][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 358 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 358
+      Name: '[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 180
+      Name: '[][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 181 PointerType *[][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 356 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 356
+      Name: '[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 178
+      Name: '[][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 179 PointerType *[][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 354 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 354
+      Name: '[][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 176
+      Name: '[][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 177 PointerType *[]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 352 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 352
+      Name: '[][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 174 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
       ID: 161
       Name: '[][]uint'
@@ -8553,9 +8960,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 296 GoSliceDataType [][]uint.array
+      Data: 340 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 340
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 160 GoSliceHeaderType []uint
@@ -8575,14 +8982,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 302 GoSliceDataType []bool.array
+      Data: 346 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 346
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 757
+      ID: 862
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487104
@@ -8597,14 +9004,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 782 GoSliceDataType []float64.array
+      Data: 887 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 782
+      ID: 887
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 15 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1042
+      ID: 1147
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487552
@@ -8619,14 +9026,35 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1043 GoSliceDataType []interface {}.array
+      Data: 1148 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1043
+      ID: 1148
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 241
+      ID: 174
+      Name: '[]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 175 PointerType *main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 350 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 350
+      Name: '[]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 173 StructureType main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 285
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 478144
@@ -8634,16 +9062,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 242 PointerType *main.structWithMap
+          Type: 286 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1024 GoSliceDataType []main.structWithMap.array
+      Data: 1129 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1024
+      ID: 1129
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -8662,102 +9090,132 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 298 GoSliceDataType []main.structWithNoStrings.array
+      Data: 342 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 342
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 337
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 289 StructureType noalg.map.group[[4]int][4]int
+      Element: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 329
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 281 StructureType noalg.map.group[[4]int]uint8
+      Element: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 278
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 229 StructureType noalg.map.group[[4]string][2]int
+      Element: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 296
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 248 StructureType noalg.map.group[bool]main.node
+      Element: 292 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 237
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 187 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1023
+      ID: 1128
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 1017 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1122 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1059
+      ID: 1164
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 1053 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1158 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1074
+      ID: 1179
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 1068 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1173 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 245
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[int]int
+      Element: 241 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1087
+      ID: 1192
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 1083 StructureType noalg.map.group[int]interface {}
+      Element: 1188 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 304
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 256 StructureType noalg.map.group[int]uint8
+      Element: 300 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 288
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 238 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 269
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 221 StructureType noalg.map.group[string][]string
+      Element: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 779
+      ID: 884
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 2048
-      Element: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 261
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 213 StructureType noalg.map.group[string]int
+      Element: 257 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 253
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 205 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 249 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 370
+      Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 378
+      Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 386
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 394
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 402
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 410
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 321
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 272 StructureType noalg.map.group[uint8][4]int
+      Element: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 312
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 264 StructureType noalg.map.group[uint8]uint8
+      Element: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 166
       Name: '[]string'
@@ -8774,9 +9232,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 300 GoSliceDataType []string.array
+      Data: 344 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 344
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -8796,9 +9254,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 294 GoSliceDataType []uint.array
+      Data: 338 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 338
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 17 BaseType uint
@@ -8818,14 +9276,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 304 GoSliceDataType []uint16.array
+      Data: 348 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 304
+      ID: 348
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 751
+      ID: 856
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 486080
@@ -8840,18 +9298,18 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 780 GoSliceDataType []uint8.array
+      Data: 885 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 780
+      ID: 885
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 1019
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 544
+      ID: 649
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 931488
@@ -8866,32 +9324,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 545 GoSliceDataType archive/tar.headerError.array
+      Data: 650 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 545
+      ID: 650
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 954
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 902
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 904
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.12032e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 998
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 930
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.564896e+06
@@ -8901,7 +9359,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 932
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -8911,15 +9369,15 @@ Types:
       GoRuntimeType: 585184
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 977
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 1006
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 1057
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -8945,13 +9403,13 @@ Types:
       GoRuntimeType: 584928
       GoKind: 15
     - __kind: BaseType
-      ID: 342
+      ID: 447
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834656
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 343
+      ID: 448
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 834752
@@ -8959,115 +9417,115 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 345 PointerType *compress/flate.InternalError.str
+          Type: 450 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 344 GoStringDataType compress/flate.InternalError.str
+      Data: 449 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 344
+      ID: 449
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 952
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 898
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 974
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 692
+      ID: 797
       Name: context.deadlineExceededError
       GoRuntimeType: 1.479296e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 356
+      ID: 461
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 2
     - __kind: BaseType
-      ID: 357
+      ID: 462
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837344
       GoKind: 2
     - __kind: BaseType
-      ID: 358
+      ID: 463
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837440
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 969
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 641
+      ID: 746
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.28928e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 1000
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 925
+      ID: 1030
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 899
+      ID: 1004
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 897
+      ID: 1002
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 996
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 359
+      ID: 464
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837536
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 1017
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 992
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 346
+      ID: 451
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835232
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 735
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 1083
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 458
+      ID: 563
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 456
+      ID: 561
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.729984e+06
@@ -9078,38 +9536,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 762 ArrayType [5]uint8
+          Type: 867 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 583
+      ID: 688
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 993472
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 857
+      ID: 962
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 460
+      ID: 565
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 967
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 727
+      ID: 832
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 851
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 532
+      ID: 637
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.732864e+06
@@ -9117,21 +9575,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 745 PointerType *crypto/x509.Certificate
+          Type: 850 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 765 BaseType crypto/x509.InvalidReason
+          Type: 870 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 526
+      ID: 631
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.117888e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 528
+      ID: 633
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.599008e+06
@@ -9139,24 +9597,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 745 PointerType *crypto/x509.Certificate
+          Type: 850 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 355
+      ID: 460
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836864
       GoKind: 2
     - __kind: BaseType
-      ID: 765
+      ID: 870
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 590368
       GoKind: 2
     - __kind: StructureType
-      ID: 635
+      ID: 740
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.560896e+06
@@ -9166,13 +9624,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 534
+      ID: 639
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.118144e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 530
+      ID: 635
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.732672e+06
@@ -9180,15 +9638,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 745 PointerType *crypto/x509.Certificate
+          Type: 850 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 745 PointerType *crypto/x509.Certificate
+          Type: 850 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 548
+      ID: 653
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.435712e+06
@@ -9198,7 +9656,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 552
+      ID: 657
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.435872e+06
@@ -9208,55 +9666,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 655
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 337
+      ID: 442
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834176
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 920
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 338
+      ID: 443
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 834368
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 414
+      ID: 519
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 724
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 406
+      ID: 511
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 412
+      ID: 517
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 410
+      ID: 515
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 408
+      ID: 513
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 1063
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 416
+      ID: 521
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.419712e+06
@@ -9266,19 +9724,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 928
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 520
+      ID: 625
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 518
+      ID: 623
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 352
+      ID: 457
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -9286,21 +9744,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 354 PointerType *encoding/xml.UnmarshalError.str
+          Type: 459 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 353 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 458 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 353
+      ID: 458
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 628
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 1041
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9317,11 +9775,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 487
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 691
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9337,15 +9795,15 @@ Types:
       GoRuntimeType: 585120
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 1051
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 588
+      ID: 693
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 590
+      ID: 695
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9355,11 +9813,11 @@ Types:
       GoRuntimeType: 476032
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 444
+      ID: 549
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 425
+      ID: 530
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.728832e+06
@@ -9367,7 +9825,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 755 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 860 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -9375,25 +9833,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 427
+      ID: 532
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 759
+      ID: 864
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 431
+      ID: 536
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.114176e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 761
+      ID: 866
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 833600
@@ -9401,17 +9859,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 437
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 755
+      ID: 860
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.21872e+06
@@ -9419,7 +9877,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 756 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 861 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9434,7 +9892,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 757 GoSliceHeaderType []float64
+          Type: 862 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -9443,10 +9901,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 758 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 863 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 760 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 865 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 166 GoSliceHeaderType []string
@@ -9460,13 +9918,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 756
+      ID: 861
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586976
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 433
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 833504
@@ -9474,17 +9932,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 434
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 334
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 833696
@@ -9492,59 +9950,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 336 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 441 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 335
+      ID: 440
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 940
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 1027
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 542
+      ID: 647
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 806
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 954
+      ID: 1059
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 469
+      ID: 574
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 476
+      ID: 581
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.11712e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 351
+      ID: 456
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 835904
       GoKind: 2
     - __kind: StructureType
-      ID: 474
+      ID: 579
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.116992e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 472
+      ID: 577
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.597088e+06
@@ -9557,7 +10015,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 492
+      ID: 597
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.597888e+06
@@ -9570,7 +10028,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 496
+      ID: 601
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.732096e+06
@@ -9586,7 +10044,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 494
+      ID: 599
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.429632e+06
@@ -9596,7 +10054,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 490
+      ID: 595
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.429312e+06
@@ -9606,14 +10064,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 740
+      ID: 845
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.500096e+06
       GoKind: 21
-      HeaderType: 742 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 847 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 764
+      ID: 869
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.05088e+06
@@ -9628,14 +10086,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 784 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 889 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 784
+      ID: 889
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 504
+      ID: 609
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.598208e+06
@@ -9643,12 +10101,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 740 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 845 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 740 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 845 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 498
+      ID: 603
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.429792e+06
@@ -9658,7 +10116,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 502
+      ID: 607
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.732288e+06
@@ -9669,12 +10127,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 500
+      ID: 605
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.598048e+06
@@ -9687,7 +10145,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 506
+      ID: 611
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.429952e+06
@@ -9695,9 +10153,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 728 StructureType time.Time
+          Type: 833 StructureType time.Time
     - __kind: StructureType
-      ID: 512
+      ID: 617
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.598528e+06
@@ -9710,7 +10168,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 514
+      ID: 619
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.430272e+06
@@ -9720,7 +10178,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 510
+      ID: 615
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.598368e+06
@@ -9733,7 +10191,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 508
+      ID: 613
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.430112e+06
@@ -9743,7 +10201,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 516
+      ID: 621
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.598688e+06
@@ -9756,7 +10214,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 433
+      ID: 538
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.421952e+06
@@ -9766,11 +10224,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 980
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 435
+      ID: 540
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.422112e+06
@@ -9778,21 +10236,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 433 StructureType github.com/cihub/seelog.baseError
+          Type: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 960
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 916
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 950
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 439
+      ID: 544
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.422432e+06
@@ -9800,13 +10258,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 433 StructureType github.com/cihub/seelog.baseError
+          Type: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 1015
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 923
+      ID: 1028
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.106208e+06
@@ -9814,12 +10272,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 909 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1014 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 926
+      ID: 1031
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.131072e+06
@@ -9827,7 +10285,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 909 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1014 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9835,11 +10293,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 918
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 437
+      ID: 542
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.422272e+06
@@ -9847,9 +10305,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 433 StructureType github.com/cihub/seelog.baseError
+          Type: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 441
+      ID: 546
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.422592e+06
@@ -9857,64 +10315,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 433 StructureType github.com/cihub/seelog.baseError
+          Type: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 982
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 1023
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 1025
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 732
+      ID: 837
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 750
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 748
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 752
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 754
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 971
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 742
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 447
+      ID: 552
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.423552e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 1075
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 808
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 676
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.841888e+06
@@ -9930,11 +10388,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 775
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 605
+      ID: 710
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.701536e+06
@@ -9947,7 +10405,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 682
+      ID: 787
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.842336e+06
@@ -9963,13 +10421,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 582
+      ID: 687
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 990784
       GoKind: 8
     - __kind: StructureType
-      ID: 674
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.841664e+06
@@ -9985,13 +10443,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 766
+      ID: 871
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 831776
       GoKind: 8
     - __kind: StructureType
-      ID: 672
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.84144e+06
@@ -9999,15 +10457,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 766 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 871 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 766 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 871 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 680
+      ID: 785
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.755488e+06
@@ -10020,7 +10478,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 678
+      ID: 783
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.842112e+06
@@ -10036,11 +10494,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 1079
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 791
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.623104e+06
@@ -10050,19 +10508,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 609
+      ID: 714
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.283264e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 607
+      ID: 712
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.283136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 684
+      ID: 789
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.75568e+06
@@ -10075,7 +10533,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 364
+      ID: 469
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839360
@@ -10083,21 +10541,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 366 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 471 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 365 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 470 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 365
+      ID: 470
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 749
+      ID: 854
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 653
+      ID: 758
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.447552e+06
@@ -10107,7 +10565,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 841
+      ID: 946
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.677248e+06
@@ -10115,13 +10573,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 867 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 972 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 1039
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 867
+      ID: 972
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.127872e+06
@@ -10134,7 +10592,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 829
+      ID: 934
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.569696e+06
@@ -10144,19 +10602,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 367
+      ID: 472
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 839936
       GoKind: 10
     - __kind: BaseType
-      ID: 747
+      ID: 852
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.003936e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 711
+      ID: 816
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.880416e+06
@@ -10167,12 +10625,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 747 BaseType golang.org/x/net/http2.ErrCode
+          Type: 852 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 568
+      ID: 673
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.605728e+06
@@ -10180,12 +10638,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 747 BaseType golang.org/x/net/http2.ErrCode
+          Type: 852 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 371
+      ID: 476
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840128
@@ -10193,17 +10651,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 373 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 478 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 372 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 477 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 372
+      ID: 477
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 377
+      ID: 482
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840320
@@ -10211,17 +10669,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 379 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 484 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 378 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 483 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 378
+      ID: 483
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 374
+      ID: 479
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -10229,17 +10687,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 376 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 481 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 375 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 480 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 375
+      ID: 480
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 368
+      ID: 473
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840032
@@ -10247,21 +10705,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 370 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 475 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 369 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 474 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 369
+      ID: 474
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 1037
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 572
+      ID: 677
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.448192e+06
@@ -10271,13 +10729,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 380
+      ID: 485
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840416
       GoKind: 2
     - __kind: StructureType
-      ID: 560
+      ID: 665
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.443232e+06
@@ -10287,11 +10745,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 814
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 734
+      ID: 839
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.908192e+06
@@ -10307,7 +10765,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 562
+      ID: 667
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.605248e+06
@@ -10320,7 +10778,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 881
+      ID: 986
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.96624e+06
@@ -10328,16 +10786,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 908 GoInterfaceType io.Reader
+          Type: 1013 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 944
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 651
+      ID: 756
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.567296e+06
@@ -10347,29 +10805,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 906
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 645
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 744
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 707
+      ID: 812
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 705
+      ID: 810
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.510816e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 554
+      ID: 659
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.436512e+06
@@ -10379,7 +10837,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 556
+      ID: 661
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.436672e+06
@@ -10389,267 +10847,351 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 589
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 287
+      ID: 331
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 288 PointerType *noalg.map.group[[4]int][4]int
+          Type: 332 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 293 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 333 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 337 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 279
+      ID: 323
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 280 PointerType *noalg.map.group[[4]int]uint8
+          Type: 324 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 285 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 325 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 329 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 227
+      ID: 271
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 228 PointerType *noalg.map.group[[4]string][2]int
+          Type: 272 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 234 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 273 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 278 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 246
+      ID: 290
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 247 PointerType *noalg.map.group[bool]main.node
+          Type: 291 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 248 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 252 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 292 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 296 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 185
+      ID: 229
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 186 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 230 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1015
+      ID: 1120
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1016 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1121 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1017 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1023 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1122 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1128 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1051
+      ID: 1156
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1052 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1157 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1053 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1059 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1158 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1164 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1066
+      ID: 1171
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1067 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1172 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1068 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1074 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1173 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1179 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 239
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[int]int
+          Type: 240 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[int]int
-      GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 241 StructureType noalg.map.group[int]int
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1081
+      ID: 1186
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1082 PointerType *noalg.map.group[int]interface {}
+          Type: 1187 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1083 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1087 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1188 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1192 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 254
+      ID: 298
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 255 PointerType *noalg.map.group[int]uint8
+          Type: 299 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 256 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 260 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 300 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 304 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 236
+      ID: 280
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 237 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 281 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 282 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 288 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 219
+      ID: 263
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 220 PointerType *noalg.map.group[string][]string
+          Type: 264 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 221 StructureType noalg.map.group[string][]string
-      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 265 StructureType noalg.map.group[string][]string
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 773
+      ID: 878
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 774 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 879 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 779 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 884 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 211
+      ID: 255
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 212 PointerType *noalg.map.group[string]int
+          Type: 256 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 213 StructureType noalg.map.group[string]int
-      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 257 StructureType noalg.map.group[string]int
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 203
+      ID: 247
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 204 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 248 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 249 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 270
+      ID: 363
+      Name: groupReference<struct {},main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 364 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 370 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 372
+      Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 373 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 380
+      Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 381 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 386 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 388
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 389 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 394 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 396
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 397 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 402 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 404
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 405 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 410 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 314
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 271 PointerType *noalg.map.group[uint8][4]int
+          Type: 315 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 272 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 277 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 316 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 321 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 262
+      ID: 306
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 263 PointerType *noalg.map.group[uint8]uint8
+          Type: 307 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 264 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 308 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 312 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 994
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 680
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -10696,41 +11238,41 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 841
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 452
+      ID: 557
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 450
+      ID: 555
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 787
+      ID: 892
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 773
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 1081
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 666
+      ID: 771
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.476096e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 491
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 339
+      ID: 444
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 834560
@@ -10738,17 +11280,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 341 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 446 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 340 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 445 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 340
+      ID: 445
       Name: internal/runtime/cgroup.stringError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 623
+      ID: 728
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.558656e+06
@@ -10756,9 +11298,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 735 PointerType *internal/abi.Type
+          Type: 840 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 988
+      ID: 1093
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.473536e+06
@@ -10771,11 +11313,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 938
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 873
+      ID: 978
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.18976e+06
@@ -10788,7 +11330,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 908
+      ID: 1013
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.023232e+06
@@ -10801,7 +11343,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 860
+      ID: 965
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -10827,25 +11369,25 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 831
+      ID: 936
       Name: io.discard
       GoRuntimeType: 1.462656e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 910
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 769
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 984
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 173
+      ID: 217
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -10861,7 +11403,7 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 174 StructureType main.nestedStruct
+          Type: 218 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
@@ -10901,7 +11443,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 191
+      ID: 235
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.186304e+06
@@ -10909,9 +11451,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1009 GoMapType map[int]*main.deepMap3
+          Type: 1114 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1126
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -10923,9 +11465,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1045 GoMapType map[int]*main.deepMap8
+          Type: 1150 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1057
+      ID: 1162
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.185536e+06
@@ -10933,9 +11475,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1060 GoMapType map[int]*main.deepMap9
+          Type: 1165 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1072
+      ID: 1177
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.185408e+06
@@ -10943,7 +11485,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1075 GoMapType map[int]interface {}
+          Type: 1180 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -10963,9 +11505,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 979 PointerType *main.deepPtr3
+          Type: 1084 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 1085
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -10977,9 +11519,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1026 PointerType *main.deepPtr8
+          Type: 1131 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1027
+      ID: 1132
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.186688e+06
@@ -10987,9 +11529,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1028 PointerType *main.deepPtr9
+          Type: 1133 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1029
+      ID: 1134
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18656e+06
@@ -11009,7 +11551,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 181
+      ID: 225
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.188608e+06
@@ -11017,9 +11559,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1003 GoSliceHeaderType []*main.deepSlice3
+          Type: 1108 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1111
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11031,9 +11573,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1030 GoSliceHeaderType []*main.deepSlice8
+          Type: 1135 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1033
+      ID: 1138
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.18784e+06
@@ -11041,9 +11583,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1036 GoSliceHeaderType []*main.deepSlice9
+          Type: 1141 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1039
+      ID: 1144
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.187712e+06
@@ -11051,9 +11593,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1042 GoSliceHeaderType []interface {}
+          Type: 1147 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 175
+      ID: 219
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -11069,16 +11611,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 986 StructureType sync.Mutex
+          Type: 1091 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 989 StructureType sync.Once
+          Type: 1094 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 992 StructureType sync.WaitGroup
+          Type: 1097 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 995 StructureType sync/atomic.Int32
+          Type: 1100 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -11108,7 +11650,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 997
+      ID: 1102
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.412192e+06
@@ -11118,7 +11660,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 174
+      ID: 218
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.462176e+06
@@ -11153,7 +11695,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 999
+      ID: 1104
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.412352e+06
@@ -11173,7 +11715,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 1090
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11184,17 +11726,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 982 PointerType *main.stringType1.str
+          Type: 1087 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 981 GoStringDataType main.stringType1.str
+      Data: 1086 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 981
+      ID: 1086
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 1088
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11207,6 +11749,54 @@ Types:
         - Name: a
           Offset: 0
           Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 186
+      Name: main.structWithCyclicMaps
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: m1
+          Offset: 0
+          Type: 187 GoMapType map[struct {}]main.structWithCyclicMaps
+        - Name: m2
+          Offset: 8
+          Type: 192 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m3
+          Offset: 16
+          Type: 197 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m4
+          Offset: 24
+          Type: 202 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m5
+          Offset: 32
+          Type: 207 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m6
+          Offset: 40
+          Type: 212 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 173
+      Name: main.structWithCyclicSlices
+      ByteSize: 144
+      GoKind: 25
+      RawFields:
+        - Name: s1
+          Offset: 0
+          Type: 174 GoSliceHeaderType []main.structWithCyclicSlices
+        - Name: s2
+          Offset: 24
+          Type: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+        - Name: s3
+          Offset: 48
+          Type: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+        - Name: s4
+          Offset: 72
+          Type: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+        - Name: s5
+          Offset: 96
+          Type: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+        - Name: s6
+          Offset: 120
+          Type: 184 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 90
       Name: main.structWithMap
@@ -11249,16 +11839,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1000 PointerType **main.t
+          Type: 1105 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1001 GoSliceDataType main.t.array
+      Data: 1106 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1001
+      ID: 1106
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -11315,8 +11905,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 292 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 336 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 145
       Name: map<[4]int,uint8>
@@ -11350,8 +11940,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 284 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 328 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 113
       Name: map<[4]string,[2]int>
@@ -11385,8 +11975,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 233 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 277 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 125
       Name: map<bool,main.node>
@@ -11420,8 +12010,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 251 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 248 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 295 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 292 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -11455,10 +12045,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 236 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1011
+      ID: 1116
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -11471,7 +12061,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1012 PointerType **table<int,*main.deepMap3>
+          Type: 1117 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11490,10 +12080,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1022 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1017 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1127 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1122 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1047
+      ID: 1152
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -11506,7 +12096,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1048 PointerType **table<int,*main.deepMap8>
+          Type: 1153 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11525,10 +12115,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1058 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1053 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1163 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1158 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1062
+      ID: 1167
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -11541,7 +12131,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1063 PointerType **table<int,*main.deepMap9>
+          Type: 1168 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11560,8 +12150,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1073 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1068 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1178 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1173 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 93
       Name: map<int,int>
@@ -11595,10 +12185,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
-      GroupType: 197 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 244 GoSliceDataType []*table<int,int>.array
+      GroupType: 241 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1077
+      ID: 1182
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -11611,7 +12201,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1078 PointerType **table<int,interface {}>
+          Type: 1183 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11630,8 +12220,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1086 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1083 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1191 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1188 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 130
       Name: map<int,uint8>
@@ -11665,8 +12255,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 259 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 256 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 303 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 300 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<string,[]main.structWithMap>
@@ -11700,8 +12290,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 287 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 108
       Name: map<string,[]string>
@@ -11735,10 +12325,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 221 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 268 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 742
+      ID: 847
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -11751,7 +12341,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 743 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 848 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11770,8 +12360,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 778 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 883 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -11805,8 +12395,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 216 GoSliceDataType []*table<string,int>.array
-      GroupType: 213 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 260 GoSliceDataType []*table<string,int>.array
+      GroupType: 257 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 98
       Name: map<string,main.nestedStruct>
@@ -11840,8 +12430,218 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 208 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 249 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 189
+      Name: map<struct {},main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 190 PointerType **table<struct {},main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 369 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 194
+      Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 195 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 377 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 199
+      Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 200 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 385 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 204
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 205 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 393 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 209
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 210 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 401 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 214
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 215 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 409 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 140
       Name: map<uint8,[4]int>
@@ -11875,8 +12675,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 276 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 272 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 320 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 135
       Name: map<uint8,uint8>
@@ -11910,8 +12710,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 267 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 264 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 311 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 148
       Name: map[[4]int][4]int
@@ -11948,26 +12748,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1009
+      ID: 1114
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.129536e+06
       GoKind: 21
-      HeaderType: 1011 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1116 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1045
+      ID: 1150
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.128896e+06
       GoKind: 21
-      HeaderType: 1047 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1152 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1060
+      ID: 1165
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.128768e+06
       GoKind: 21
-      HeaderType: 1062 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1167 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
@@ -11976,12 +12776,12 @@ Types:
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1075
+      ID: 1180
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.12864e+06
       GoKind: 21
-      HeaderType: 1077 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1182 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
@@ -12018,6 +12818,42 @@ Types:
       GoKind: 21
       HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
+      ID: 187
+      Name: map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 189 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 192
+      Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 194 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 197
+      Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 199 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 202
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 204 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 207
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 209 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 212
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 214 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
       ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
@@ -12032,7 +12868,7 @@ Types:
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 488
+      ID: 593
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.428832e+06
@@ -12042,7 +12878,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 795
+      ID: 900
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.425632e+06
@@ -12052,11 +12888,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 800
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 763
+      ID: 868
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.595808e+06
@@ -12069,35 +12905,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 721
+      ID: 826
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 1045
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 719
+      ID: 824
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 802
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 1055
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 1065
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 1053
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 656
+      ID: 761
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.113792e+06
@@ -12105,27 +12941,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 658 PointerType *net.UnknownNetworkError.str
+          Type: 763 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 657 GoStringDataType net.UnknownNetworkError.str
+      Data: 762 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 657
+      ID: 762
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 621
+      ID: 726
       Name: net.canceledError
       GoRuntimeType: 1.284288e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 1021
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 768
+      ID: 873
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.105504e+06
@@ -12133,7 +12969,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -12144,27 +12980,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 1067
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 956
+      ID: 1061
       Name: net.noReadFrom
       GoRuntimeType: 1.114048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 955
+      ID: 1060
       Name: net.noWriteTo
       GoRuntimeType: 1.11392e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 418
+      ID: 523
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 420
+      ID: 525
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.72864e+06
@@ -12172,7 +13008,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 750 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 855 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -12180,7 +13016,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 944
+      ID: 1049
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.288512e+06
@@ -12188,12 +13024,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 956 StructureType net.noReadFrom
+          Type: 1061 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 949 PointerType *net.TCPConn
+          Type: 1054 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 942
+      ID: 1047
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.287968e+06
@@ -12201,24 +13037,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 955 StructureType net.noWriteTo
+          Type: 1060 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 949 PointerType *net.TCPConn
+          Type: 1054 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 804
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 828
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 716
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 789
+      ID: 894
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.417152e+06
@@ -12228,19 +13064,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 309
+      ID: 414
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832256
       GoKind: 10
     - __kind: BaseType
-      ID: 739
+      ID: 844
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 990880
       GoKind: 10
     - __kind: StructureType
-      ID: 396
+      ID: 501
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.726912e+06
@@ -12251,12 +13087,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 739 BaseType net/http.http2ErrCode
+          Type: 844 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 715
+      ID: 820
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.89872e+06
@@ -12267,12 +13103,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 739 BaseType net/http.http2ErrCode
+          Type: 844 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 400
+      ID: 505
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.595328e+06
@@ -12280,16 +13116,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 739 BaseType net/http.http2ErrCode
+          Type: 844 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 956
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 418
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832448
@@ -12297,17 +13133,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 420 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 419
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 424
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -12315,17 +13151,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *net/http.http2headerFieldNameError.str
+          Type: 426 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 320 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 425 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 425
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 421
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832544
@@ -12333,31 +13169,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *net/http.http2headerFieldValueError.str
+          Type: 423 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 317 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 422 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 422
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 795
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 617
+      ID: 722
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.28352e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 1010
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 415
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832352
@@ -12365,17 +13201,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 417 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 416 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 416
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 791
+      ID: 896
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.824576e+06
@@ -12383,18 +13219,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 882 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 987 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 883 BaseType time.Duration
+          Type: 988 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 33 PointerType *error
     - __kind: GoInterfaceType
-      ID: 882
+      ID: 987
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.416352e+06
@@ -12407,14 +13243,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 870
+      ID: 975
       Name: net/http.incomparable
       GoRuntimeType: 903456
       GoKind: 17
       HasCount: true
       Element: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 613
+      ID: 718
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.554816e+06
@@ -12424,11 +13260,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 958
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 914
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.554656e+06
@@ -12436,9 +13272,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 852 PointerType *net/http.persistConn
+          Type: 957 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 843
+      ID: 948
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.799552e+06
@@ -12446,15 +13282,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 870 ArrayType net/http.incomparable
+          Type: 975 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 871 PointerType *bufio.Reader
+          Type: 976 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 873 GoInterfaceType io.ReadWriteCloser
+          Type: 978 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 404
+      ID: 509
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.418112e+06
@@ -12464,17 +13300,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 822
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 688
+      ID: 793
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.478976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 615
+      ID: 720
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.554976e+06
@@ -12484,7 +13320,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 885
+      ID: 990
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.025216e+06
@@ -12492,16 +13328,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 393
+      ID: 498
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 907
+      ID: 1012
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.04096e+06
@@ -12509,13 +13345,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 900 PointerType *bufio.Writer
+          Type: 1005 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 924
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 480
+      ID: 585
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.731712e+06
@@ -12531,7 +13367,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 478
+      ID: 583
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.597248e+06
@@ -12544,11 +13380,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 964
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 821
+      ID: 926
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.599168e+06
@@ -12556,16 +13392,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 858 PointerType *net/smtp.Client
+          Type: 963 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 860 GoInterfaceType io.WriteCloser
+          Type: 965 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 464
+      ID: 569
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 347
+      ID: 452
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835328
@@ -12573,25 +13409,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 349 PointerType *net/textproto.ProtocolError.str
+          Type: 454 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 348 GoStringDataType net/textproto.ProtocolError.str
+      Data: 453 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 348
+      ID: 453
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 922
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 830
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 427
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833216
@@ -12599,17 +13435,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *net/url.EscapeError.str
+          Type: 429 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 323 GoStringDataType net/url.EscapeError.str
+      Data: 428 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 428
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 430
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833312
@@ -12617,179 +13453,227 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *net/url.InvalidHostError.str
+          Type: 432 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 326 GoStringDataType net/url.InvalidHostError.str
+      Data: 431 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 431
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: ArrayType
-      ID: 290
+      ID: 334
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 682976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 291 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 335 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 282
+      ID: 326
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 283 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 327 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 230
+      ID: 274
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 231 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 275 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 249
+      ID: 293
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 250 StructureType noalg.struct { key bool; elem main.node }
+      Element: 294 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 188
+      ID: 232
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 233 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1018
+      ID: 1123
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1019 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1124 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1054
+      ID: 1159
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1055 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1160 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1069
+      ID: 1174
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681632
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1070 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1175 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 198
+      ID: 242
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 199 StructureType noalg.struct { key int; elem int }
+      Element: 243 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1084
+      ID: 1189
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1085 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1190 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 257
+      ID: 301
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 258 StructureType noalg.struct { key int; elem uint8 }
+      Element: 302 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 239
+      ID: 283
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 240 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 284 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 222
+      ID: 266
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 223 StructureType noalg.struct { key string; elem []string }
+      Element: 267 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 776
+      ID: 881
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 759488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 777 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 882 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 214
+      ID: 258
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem int }
+      Element: 259 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 206
+      ID: 250
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 207 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 251 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 273
+      ID: 366
+      Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+      ByteSize: 384
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 367 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 375
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 376 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 383
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 384 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 391
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 392 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 399
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 400 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 407
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 408 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 317
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 684032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 274 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 318 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 265
+      ID: 309
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 684128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 266 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 310 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 289
+      ID: 333
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.295296e+06
@@ -12800,9 +13684,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 290 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 334 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 281
+      ID: 325
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.295552e+06
@@ -12813,9 +13697,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 282 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 326 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 229
+      ID: 273
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.295808e+06
@@ -12826,9 +13710,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 230 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 274 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 248
+      ID: 292
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.296064e+06
@@ -12839,9 +13723,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 249 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 293 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 187
+      ID: 231
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.29504e+06
@@ -12852,9 +13736,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 232 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1017
+      ID: 1122
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.294784e+06
@@ -12865,9 +13749,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1018 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1123 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1053
+      ID: 1158
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.293504e+06
@@ -12878,9 +13762,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1054 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1159 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1068
+      ID: 1173
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.293248e+06
@@ -12891,9 +13775,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1069 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1174 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 197
+      ID: 241
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.292224e+06
@@ -12904,9 +13788,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 198 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 242 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1083
+      ID: 1188
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.292992e+06
@@ -12917,9 +13801,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1084 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1189 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 256
+      ID: 300
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.29632e+06
@@ -12930,9 +13814,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 257 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 301 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 238
+      ID: 282
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.296576e+06
@@ -12943,9 +13827,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 239 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 283 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 221
+      ID: 265
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.296832e+06
@@ -12956,9 +13840,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 266 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 775
+      ID: 880
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.35776e+06
@@ -12969,9 +13853,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 776 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 881 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 213
+      ID: 257
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.297088e+06
@@ -12982,9 +13866,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 258 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 205
+      ID: 249
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.297344e+06
@@ -12995,9 +13879,81 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 206 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 250 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 272
+      ID: 365
+      Name: noalg.map.group[struct {}]main.structWithCyclicMaps
+      ByteSize: 392
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 366 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 374
+      Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 375 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 382
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 383 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 390
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 391 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 398
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 399 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 406
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 407 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 316
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.2976e+06
@@ -13008,9 +13964,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 273 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 317 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 264
+      ID: 308
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.297856e+06
@@ -13021,9 +13977,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 265 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 309 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 291
+      ID: 335
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.295168e+06
@@ -13031,12 +13987,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
     - __kind: StructureType
-      ID: 283
+      ID: 327
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.295424e+06
@@ -13044,12 +14000,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 231
+      ID: 275
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.29568e+06
@@ -13057,12 +14013,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 232 ArrayType [4]string
+          Type: 276 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 250
+      ID: 294
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.295936e+06
@@ -13075,7 +14031,7 @@ Types:
           Offset: 8
           Type: 156 StructureType main.node
     - __kind: StructureType
-      ID: 189
+      ID: 233
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.294912e+06
@@ -13086,9 +14042,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 190 PointerType *main.deepMap2
+          Type: 234 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1019
+      ID: 1124
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.294656e+06
@@ -13099,9 +14055,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1020 PointerType *main.deepMap3
+          Type: 1125 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1055
+      ID: 1160
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.293376e+06
@@ -13112,9 +14068,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1056 PointerType *main.deepMap8
+          Type: 1161 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1070
+      ID: 1175
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.29312e+06
@@ -13125,9 +14081,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1071 PointerType *main.deepMap9
+          Type: 1176 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 199
+      ID: 243
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.292096e+06
@@ -13140,7 +14096,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1085
+      ID: 1190
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.292864e+06
@@ -13153,7 +14109,7 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 258
+      ID: 302
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.296192e+06
@@ -13166,7 +14122,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 240
+      ID: 284
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.296448e+06
@@ -13177,9 +14133,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 241 GoSliceHeaderType []main.structWithMap
+          Type: 285 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 223
+      ID: 267
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.296704e+06
@@ -13192,7 +14148,7 @@ Types:
           Offset: 16
           Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 777
+      ID: 882
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.357632e+06
@@ -13203,9 +14159,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 215
+      ID: 259
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.29696e+06
@@ -13218,7 +14174,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 207
+      ID: 251
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.297216e+06
@@ -13229,9 +14185,81 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 174 StructureType main.nestedStruct
+          Type: 218 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 274
+      ID: 367
+      Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 186 StructureType main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 376
+      Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 187 GoMapType map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 384
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 192 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 392
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 197 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 400
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 202 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 408
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 207 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 318
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.297472e+06
@@ -13242,9 +14270,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
     - __kind: StructureType
-      ID: 266
+      ID: 310
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.297728e+06
@@ -13257,19 +14285,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 1073
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 697
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 765
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 966
+      ID: 1071
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.35888e+06
@@ -13277,12 +14305,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 972 StructureType os.noReadFrom
+          Type: 1077 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 967 PointerType *os.File
+          Type: 1072 PointerType *os.File
     - __kind: StructureType
-      ID: 964
+      ID: 1069
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.35808e+06
@@ -13290,36 +14318,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 971 StructureType os.noWriteTo
+          Type: 1076 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 967 PointerType *os.File
+          Type: 1072 PointerType *os.File
     - __kind: StructureType
-      ID: 972
+      ID: 1077
       Name: os.noReadFrom
       GoRuntimeType: 1.11136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 971
+      ID: 1076
       Name: os.noWriteTo
       GoRuntimeType: 1.111232e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 730
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 876
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 942
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 627
+      ID: 732
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.702112e+06
@@ -13332,7 +14360,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 361
+      ID: 466
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 838592
@@ -13340,39 +14368,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 363 PointerType *os/user.UnknownGroupIdError.str
+          Type: 468 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 362 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 467 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 362
+      ID: 467
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 360
+      ID: 465
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 838496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 493
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 591
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 701
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 705
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 598
+      ID: 703
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.887584e+06
@@ -13389,15 +14417,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 769 BaseType runtime.boundsErrorCode
+          Type: 874 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 769
+      ID: 874
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585312
       GoKind: 8
     - __kind: StructureType
-      ID: 662
+      ID: 767
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.752416e+06
@@ -13410,7 +14438,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 576
+      ID: 681
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 989440
@@ -13418,17 +14446,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 578 PointerType *runtime.errorString.str
+          Type: 683 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 577 GoStringDataType runtime.errorString.str
+      Data: 682 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 577
+      ID: 682
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 579
+      ID: 684
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 989536
@@ -13436,21 +14464,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 581 PointerType *runtime.plainError.str
+          Type: 686 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 580 GoStringDataType runtime.plainError.str
+      Data: 685 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 580
+      ID: 685
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 843
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 384
+      ID: 489
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.595008e+06
@@ -13461,9 +14489,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: bubble
           Offset: 16
-          Type: 737 PointerType *runtime.synctestBubble
+          Type: 842 PointerType *runtime.synctestBubble
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 707
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -13475,25 +14503,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 178 PointerType *string.str
+          Type: 222 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 177 GoStringDataType string.str
+      Data: 221 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 177
+      ID: 221
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 1008
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 912
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 803
+      ID: 908
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.454912e+06
@@ -13503,7 +14531,13 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 986
+      ID: 368
+      Name: struct {}
+      GoRuntimeType: 842240
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 1091
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.463456e+06
@@ -13511,12 +14545,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 987 StructureType sync.noCopy
+          Type: 1092 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 988 StructureType internal/sync.Mutex
+          Type: 1093 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 989
+      ID: 1094
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.612352e+06
@@ -13524,15 +14558,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 987 StructureType sync.noCopy
+          Type: 1092 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 990 StructureType sync/atomic.Bool
+          Type: 1095 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 986 StructureType sync.Mutex
+          Type: 1091 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 992
+      ID: 1097
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.61216e+06
@@ -13540,21 +14574,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 987 StructureType sync.noCopy
+          Type: 1092 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 993 StructureType sync/atomic.Uint64
+          Type: 1098 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 987
+      ID: 1092
       Name: sync.noCopy
       GoRuntimeType: 988384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 990
+      ID: 1095
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.464576e+06
@@ -13562,12 +14596,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 991 StructureType sync/atomic.noCopy
+          Type: 1096 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 995
+      ID: 1100
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464736e+06
@@ -13575,12 +14609,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 991 StructureType sync/atomic.noCopy
+          Type: 1096 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 993
+      ID: 1098
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612736e+06
@@ -13588,33 +14622,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 991 StructureType sync/atomic.noCopy
+          Type: 1096 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 994 StructureType sync/atomic.align64
+          Type: 1099 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 994
+      ID: 1099
       Name: sync/atomic.align64
       GoRuntimeType: 988576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 991
+      ID: 1096
       Name: sync/atomic.noCopy
       GoRuntimeType: 988480
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 712
+      ID: 817
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.28288e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 286
+      ID: 330
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -13636,9 +14670,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 287 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 331 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 278
+      ID: 322
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13660,9 +14694,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 279 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 323 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 226
+      ID: 270
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -13684,9 +14718,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 227 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 271 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 245
+      ID: 289
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -13708,9 +14742,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 246 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 290 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 184
+      ID: 228
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -13732,9 +14766,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 229 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1014
+      ID: 1119
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -13756,9 +14790,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1015 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1120 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1050
+      ID: 1155
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -13780,9 +14814,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1051 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1156 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1065
+      ID: 1170
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -13804,9 +14838,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1066 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1171 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 194
+      ID: 238
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -13828,9 +14862,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<int,int>
+          Type: 239 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1080
+      ID: 1185
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -13852,9 +14886,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1081 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1186 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 253
+      ID: 297
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13876,9 +14910,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 254 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 298 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 235
+      ID: 279
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -13900,9 +14934,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 236 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 280 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 218
+      ID: 262
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -13924,9 +14958,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 263 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 772
+      ID: 877
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -13948,9 +14982,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 773 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 878 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 210
+      ID: 254
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -13972,9 +15006,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 211 GoSwissMapGroupsType groupReference<string,int>
+          Type: 255 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 202
+      ID: 246
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -13996,9 +15030,153 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 203 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 247 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 269
+      ID: 362
+      Name: table<struct {},main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 363 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 371
+      Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 372 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 379
+      Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 380 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 387
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 388 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 395
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 396 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 403
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 404 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 313
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -14020,9 +15198,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 270 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 314 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 261
+      ID: 305
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -14044,13 +15222,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 306 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 1043
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 760
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.706528e+06
@@ -14063,21 +15241,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 883
+      ID: 988
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.91504e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 730
+      ID: 835
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 391
+      ID: 496
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 728
+      ID: 833
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.372192e+06
@@ -14091,9 +15269,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 729 PointerType *time.Location
+          Type: 834 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 411
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 831392
@@ -14101,13 +15279,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *time.fileSizeError.str
+          Type: 413 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 307 GoStringDataType time.fileSizeError.str
+      Data: 412 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 412
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -14153,7 +15331,7 @@ Types:
       GoRuntimeType: 585248
       GoKind: 26
     - __kind: StructureType
-      ID: 750
+      ID: 855
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.062688e+06
@@ -14161,13 +15339,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 751 GoSliceHeaderType []uint8
+          Type: 856 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 752 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 857 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 753 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 858 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -14182,18 +15360,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 754 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 859 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 754
+      ID: 859
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995104
       GoKind: 9
     - __kind: StructureType
-      ID: 752
+      ID: 857
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.926048e+06
@@ -14218,21 +15396,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 482
+      ID: 587
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 753
+      ID: 858
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 1035
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 466
+      ID: 571
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.425952e+06
@@ -14242,13 +15420,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 350
+      ID: 455
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 2
     - __kind: StructureType
-      ID: 632
+      ID: 737
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.702304e+06
@@ -14261,11 +15439,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 584
+      ID: 689
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 993952
       GoKind: 5
-MaxTypeID: 1202
+MaxTypeID: 1309
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17ff520", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 1054 EventRootType Probe[main.stackC]
+          Type: 1124 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x8901ac", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 1009 EventRootType Probe[main.testAny]
+          Type: 1079 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88db2c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 1011 EventRootType Probe[main.testAnyPtr]
+          Type: 1081 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88dbac", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 971 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1041 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 973 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1043 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 1019 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1089 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88e200", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 972 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1042 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 991 EventRootType Probe[main.testBigStruct]
+          Type: 1061 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c890", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 960 EventRootType Probe[main.testBoolArray]
+          Type: 1030 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 957 EventRootType Probe[main.testByteArray]
+          Type: 1027 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c230", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 1035 EventRootType Probe[main.testChannel]
+          Type: 1105 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88f7b0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 1033 EventRootType Probe[main.testCombinedByte]
+          Type: 1103 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88f530", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 1043 EventRootType Probe[main.testCycle]
+          Type: 1113 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fa50", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 996 EventRootType Probe[main.testDeepMap1]
+          Type: 1066 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cc70", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 997 EventRootType Probe[main.testDeepMap7]
+          Type: 1067 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88cc80", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 992 EventRootType Probe[main.testDeepPtr1]
+          Type: 1062 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c960", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 993 EventRootType Probe[main.testDeepPtr7]
+          Type: 1063 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c970", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 994 EventRootType Probe[main.testDeepSlice1]
+          Type: 1064 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb10", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 995 EventRootType Probe[main.testDeepSlice7]
+          Type: 1065 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb20", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 1045 EventRootType Probe[main.testEmptySlice]
+          Type: 1115 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x88fe50", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 1048 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1118 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x88fe80", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 1062 EventRootType Probe[main.testEmptyString]
+          Type: 1132 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x890290", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 108
-          Type: 1064 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x8905a0", Frameless: true}]
+        - ID: 110
+          Type: 1136 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x8905d0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 109
-          Type: 1065 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x8905b0", Frameless: true}]
+        - ID: 111
+          Type: 1137 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x8905e0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 1010 EventRootType Probe[main.testError]
+          Type: 1080 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88db90", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 1001 EventRootType Probe[main.testEsotericHeap]
+          Type: 1071 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d12c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 1000 EventRootType Probe[main.testEsotericStack]
+          Type: 1070 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d03c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 1006 EventRootType Probe[main.testFrameless]
+          Type: 1076 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88d860", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 1007 EventRootType Probe[main.testFramelessArray]
+          Type: 1077 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88d870", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 1002 EventRootType Probe[main.testInlinedBA]
+          Type: 1072 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d56c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 1003 EventRootType Probe[main.testInlinedBB]
+          Type: 1073 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d5fc", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 1004 EventRootType Probe[main.testInlinedBBA]
+          Type: 1074 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d6cc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 111
-          Type: 1067 EventRootType Probe[main.testInlinedBBB]
+        - ID: 113
+          Type: 1139 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d658", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 1005 EventRootType Probe[main.testInlinedBC]
+          Type: 1075 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d74c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 112
-          Type: 1068 EventRootType Probe[main.testInlinedBCA]
+        - ID: 114
+          Type: 1140 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d75c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 113
-          Type: 1069 EventRootType Probe[main.testInlinedBCB]
+        - ID: 115
+          Type: 1141 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88d810", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 110
-          Type: 1066 EventRootType Probe[main.testInlinedPrint]
+        - ID: 112
+          Type: 1138 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d3cc"
               Frameless: true
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 114
-          Type: 1070 EventRootType Probe[main.testInlinedSq]
+        - ID: 116
+          Type: 1142 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88d864", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 115
-          Type: 1071 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 117
+          Type: 1143 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88d894"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 963 EventRootType Probe[main.testInt16Array]
+          Type: 1033 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 964 EventRootType Probe[main.testInt32Array]
+          Type: 1034 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 965 EventRootType Probe[main.testInt64Array]
+          Type: 1035 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 962 EventRootType Probe[main.testInt8Array]
+          Type: 1032 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 961 EventRootType Probe[main.testIntArray]
+          Type: 1031 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 1008 EventRootType Probe[main.testInterface]
+          Type: 1078 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88db10", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 1037 EventRootType Probe[main.testLinkedList]
+          Type: 1107 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88f960", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 1017 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1087 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88e1e0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 1023 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1093 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88e240", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 1021 EventRootType Probe[main.testMapIntToInt]
+          Type: 1091 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88e220", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 1032 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1102 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88e2d0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 1031 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1101 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88e2c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 1022 EventRootType Probe[main.testMapMassive]
+          Type: 1092 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e230", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 1030 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1100 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88e2b0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 1029 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1099 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88e2a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 1015 EventRootType Probe[main.testMapStringToInt]
+          Type: 1085 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88e1c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 1016 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1086 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88e1d0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 1014 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1084 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88e1b0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 1024 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1094 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88e250", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 1027 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1097 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88e280", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 1028 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1098 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88e290", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 1025 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1095 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88e260", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 1026 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1096 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88e270", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 1060 EventRootType Probe[main.testMassiveString]
+          Type: 1130 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x890270", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 1034 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1104 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f610", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 1042 EventRootType Probe[main.testNilPointer]
+          Type: 1112 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fa30", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 1052 EventRootType Probe[main.testNilSlice]
+          Type: 1122 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x88fec0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 1049 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1119 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x88fe90", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 1051 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1121 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x88feb0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 1059 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1129 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x890260", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 1038 EventRootType Probe[main.testPointerLoop]
+          Type: 1108 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88f970", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 1020 EventRootType Probe[main.testPointerToMap]
+          Type: 1090 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88e210", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 1036 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1106 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88f950", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 958 EventRootType Probe[main.testRuneArray]
+          Type: 1028 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 977 EventRootType Probe[main.testSingleBool]
+          Type: 1047 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 975 EventRootType Probe[main.testSingleByte]
+          Type: 1045 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c690", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 988 EventRootType Probe[main.testSingleFloat32]
+          Type: 1058 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 989 EventRootType Probe[main.testSingleFloat64]
+          Type: 1059 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 978 EventRootType Probe[main.testSingleInt]
+          Type: 1048 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 980 EventRootType Probe[main.testSingleInt16]
+          Type: 1050 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 981 EventRootType Probe[main.testSingleInt32]
+          Type: 1051 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 982 EventRootType Probe[main.testSingleInt64]
+          Type: 1052 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 979 EventRootType Probe[main.testSingleInt8]
+          Type: 1049 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 976 EventRootType Probe[main.testSingleRune]
+          Type: 1046 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6a0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 1055 EventRootType Probe[main.testSingleString]
+          Type: 1125 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x890210", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 983 EventRootType Probe[main.testSingleUint]
+          Type: 1053 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 985 EventRootType Probe[main.testSingleUint16]
+          Type: 1055 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 986 EventRootType Probe[main.testSingleUint32]
+          Type: 1056 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 987 EventRootType Probe[main.testSingleUint64]
+          Type: 1057 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 984 EventRootType Probe[main.testSingleUint8]
+          Type: 1054 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 1046 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1116 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x88fe60", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 1018 EventRootType Probe[main.testSmallMap]
+          Type: 1088 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88e1f0", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 959 EventRootType Probe[main.testStringArray]
+          Type: 1029 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 1041 EventRootType Probe[main.testStringPointer]
+          Type: 1111 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fa10", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 1050 EventRootType Probe[main.testStringSlice]
+          Type: 1120 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x88fea0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 998 EventRootType Probe[main.testStringType1]
+          Type: 1068 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 999 EventRootType Probe[main.testStringType2]
+          Type: 1069 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 107
-          Type: 1063 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x8904a0", Frameless: true}]
+        - ID: 109
+          Type: 1135 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x8904d0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 1047 EventRootType Probe[main.testStructSlice]
+          Type: 1117 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x88fe70", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,8 +1425,34 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 1012 EventRootType Probe[main.testStructWithAny]
+          Type: 1082 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x88dc10", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicMaps}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 108
+          Type: 1134 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x8903e0", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicSlices
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicSlices}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 107
+          Type: 1133 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x8903d0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1439,7 +1465,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 1013 EventRootType Probe[main.testStructWithMap]
+          Type: 1083 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e1a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1479,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 1056 EventRootType Probe[main.testThreeStrings]
+          Type: 1126 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x890220", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1493,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 1057 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1127 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x890230", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1507,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 1058 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1128 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x890250", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1521,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 990 EventRootType Probe[main.testTypeAlias]
+          Type: 1060 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1535,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 968 EventRootType Probe[main.testUint16Array]
+          Type: 1038 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1549,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 969 EventRootType Probe[main.testUint32Array]
+          Type: 1039 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1563,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 970 EventRootType Probe[main.testUint64Array]
+          Type: 1040 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1577,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 967 EventRootType Probe[main.testUint8Array]
+          Type: 1037 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1591,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 966 EventRootType Probe[main.testUintArray]
+          Type: 1036 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1605,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 1040 EventRootType Probe[main.testUintPointer]
+          Type: 1110 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88f9a0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1619,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 1044 EventRootType Probe[main.testUintSlice]
+          Type: 1114 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x88fe40", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1633,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 1061 EventRootType Probe[main.testUnitializedString]
+          Type: 1131 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x890280", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1647,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 1039 EventRootType Probe[main.testUnsafePointer]
+          Type: 1109 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88f980", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1661,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 974 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1044 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1675,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 1053 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1123 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x88fed0", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3279,14 +3305,50 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 107
+      Name: main.testStructWithCyclicSlices
+      OutOfLinePCRanges: [0x8903d0..0x8903e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 175 StructureType main.structWithCyclicSlices
+          Locations:
+            - Range: 0x8903d0..0x8903e0
+              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 108
+      Name: main.testStructWithCyclicMaps
+      OutOfLinePCRanges: [0x8903e0..0x890400]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 188 StructureType main.structWithCyclicMaps
+          Locations:
+            - Range: 0x8903e0..0x890400
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0x8904a0..0x8904c0]
+      OutOfLinePCRanges: [0x8904d0..0x8904f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 175 StructureType main.aStruct
+          Type: 219 StructureType main.aStruct
           Locations:
-            - Range: 0x8904a0..0x8904c0
+            - Range: 0x8904d0..0x8904f0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3304,29 +3366,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8905a0..0x8905b0]
+      OutOfLinePCRanges: [0x8905d0..0x8905e0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 177 StructureType main.emptyStruct
-          Locations: [{Range: 0x8905a0..0x8905b0, Pieces: []}]
+          Type: 221 StructureType main.emptyStruct
+          Locations: [{Range: 0x8905d0..0x8905e0, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8905b0..0x8905c0]
+      OutOfLinePCRanges: [0x8905e0..0x8905f0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 178 PointerType *main.emptyStruct
+          Type: 222 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8905b0..0x8905c0
+            - Range: 0x8905e0..0x8905f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 112
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88d3c0..0x88d430]
       InlinePCRanges:
@@ -3356,28 +3418,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 113
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d658..0x88d690]
           RootRanges: [0x88d5f0..0x88d6c0]
       Variables: []
-    - ID: 112
+    - ID: 114
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d75c..0x88d7a0]
           RootRanges: [0x88d740..0x88d860]
       Variables: []
-    - ID: 113
+    - ID: 115
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d810..0x88d848]
           RootRanges: [0x88d740..0x88d860]
       Variables: []
-    - ID: 114
+    - ID: 116
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3391,7 +3453,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 117
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3416,20 +3478,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 897
+      ID: 967
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 898 PointerType *main.deepSlice3
+      Pointee: 968 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 918
+      ID: 988
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 919 PointerType *main.deepSlice8
+      Pointee: 989 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 924
+      ID: 994
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 925 PointerType *main.deepSlice9
+      Pointee: 995 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 79
       Name: '**main.stringType2'
@@ -3437,7 +3499,7 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 893
+      ID: 963
       Name: '**main.t'
       ByteSize: 8
       Pointee: 160 PointerType *main.t
@@ -3449,146 +3511,201 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 185
+      ID: 229
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 228 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 901
+      ID: 971
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 900 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 970 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 922
+      ID: 992
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 921 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 991 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 928
+      ID: 998
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 927 GoSliceDataType []*main.deepSlice9.array
-    - __kind: PointerType
-      ID: 182
-      Name: '*[]*string.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType []*string.array
-    - __kind: PointerType
-      ID: 224
-      Name: '*[][]uint.array'
-      ByteSize: 8
-      Pointee: 223 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 230
-      Name: '*[]bool.array'
-      ByteSize: 8
-      Pointee: 229 GoSliceDataType []bool.array
-    - __kind: PointerType
-      ID: 684
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 683 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 931
-      Name: '*[]interface {}.array'
-      ByteSize: 8
-      Pointee: 930 GoSliceDataType []interface {}.array
-    - __kind: PointerType
-      ID: 912
-      Name: '*[]main.structWithMap.array'
-      ByteSize: 8
-      Pointee: 911 GoSliceDataType []main.structWithMap.array
+      Pointee: 997 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 226
+      Name: '*[]*string.array'
+      ByteSize: 8
+      Pointee: 225 GoSliceDataType []*string.array
+    - __kind: PointerType
+      ID: 288
+      Name: '*[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 287 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 187
+      Name: '*[][][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 184 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 286
+      Name: '*[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 285 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 182 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 284
+      Name: '*[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 283 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 180 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 282
+      Name: '*[][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 281 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 178 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 280
+      Name: '*[][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 279 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 268
+      Name: '*[][]uint.array'
+      ByteSize: 8
+      Pointee: 267 GoSliceDataType [][]uint.array
+    - __kind: PointerType
+      ID: 274
+      Name: '*[]bool.array'
+      ByteSize: 8
+      Pointee: 273 GoSliceDataType []bool.array
+    - __kind: PointerType
+      ID: 754
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 753 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 1001
+      Name: '*[]interface {}.array'
+      ByteSize: 8
+      Pointee: 1000 GoSliceDataType []interface {}.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 176 GoSliceHeaderType []main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 278
+      Name: '*[]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 277 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 982
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 981 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 270
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 269 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 228
+      ID: 272
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []string.array
+      Pointee: 271 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 164
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 162 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 222
+      ID: 266
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType []uint.array
+      Pointee: 265 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 232
+      ID: 276
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType []uint16.array
+      Pointee: 275 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 682
+      ID: 752
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 681 GoSliceDataType []uint8.array
+      Pointee: 751 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 809
+      ID: 879
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.848928e+06
       GoKind: 22
-      Pointee: 810 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 880 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 458
+      ID: 528
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858432
       GoKind: 22
-      Pointee: 459 GoSliceHeaderType archive/tar.headerError
+      Pointee: 529 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 461
+      ID: 531
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 460 GoSliceDataType archive/tar.headerError.array
+      Pointee: 530 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 749
+      ID: 819
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.25312e+06
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 820 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 697
+      ID: 767
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858624
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 768 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 699
+      ID: 769
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858720
       GoKind: 22
-      Pointee: 700 StructureType archive/zip.dirWriter
+      Pointee: 770 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 796
+      ID: 866
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.773216e+06
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 867 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 725
+      ID: 795
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.01664e+06
       GoKind: 22
-      Pointee: 726 StructureType archive/zip.nopCloser
+      Pointee: 796 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 727
+      ID: 797
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.016896e+06
       GoKind: 22
-      Pointee: 728 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 798 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3622,30 +3739,30 @@ Types:
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 905
+      ID: 975
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 906 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 976 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 935
+      ID: 1005
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 936 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1006 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 944
+      ID: 1014
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 945 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1015 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 96
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 97 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 953
+      ID: 1023
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 954 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1024 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 133
       Name: '*bucket<int,uint8>'
@@ -3662,10 +3779,10 @@ Types:
       ByteSize: 8
       Pointee: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 650
+      ID: 720
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 106
       Name: '*bucket<string,int>'
@@ -3677,6 +3794,36 @@ Types:
       ByteSize: 8
       Pointee: 102 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
+      ID: 192
+      Name: '*bucket<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 193 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 197
+      Name: '*bucket<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 198 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 202
+      Name: '*bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 203 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 207
+      Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 208 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 212
+      Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 213 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 217
+      Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 218 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
       ID: 143
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
@@ -3687,393 +3834,393 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 773
+      ID: 843
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.029408e+06
       GoKind: 22
-      Pointee: 774 UnresolvedPointeeType bufio.Reader
+      Pointee: 844 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 798
+      ID: 868
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.814656e+06
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType bufio.Writer
+      Pointee: 869 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 845
+      ID: 915
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.122368e+06
       GoKind: 22
-      Pointee: 846 UnresolvedPointeeType bytes.Buffer
+      Pointee: 916 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 371
+      ID: 441
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 266 BaseType compress/flate.CorruptInputError
+      Pointee: 336 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 372
+      ID: 442
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 267 GoStringHeaderType compress/flate.InternalError
+      Pointee: 337 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 269
+      ID: 339
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType compress/flate.InternalError.str
+      Pointee: 338 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 747
+      ID: 817
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.24336e+06
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 818 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 693
+      ID: 763
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841248
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 764 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 769
+      ID: 839
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.59984e+06
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 840 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 602
+      ID: 672
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.117792e+06
       GoKind: 22
-      Pointee: 603 StructureType context.deadlineExceededError
+      Pointee: 673 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 451
+      ID: 521
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853344
       GoKind: 22
-      Pointee: 280 BaseType crypto/aes.KeySizeError
+      Pointee: 350 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 452
+      ID: 522
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853536
       GoKind: 22
-      Pointee: 281 BaseType crypto/des.KeySizeError
+      Pointee: 351 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 759
+      ID: 829
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.373792e+06
       GoKind: 22
-      Pointee: 760 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 830 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 784
+      ID: 854
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.678848e+06
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 855 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 453
+      ID: 523
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853824
       GoKind: 22
-      Pointee: 282 BaseType crypto/rc4.KeySizeError
+      Pointee: 352 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 792
+      ID: 862
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.7704e+06
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 863 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 786
+      ID: 856
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.679296e+06
       GoKind: 22
-      Pointee: 787 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 857 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 788
+      ID: 858
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.679744e+06
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 859 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 377
+      ID: 447
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842688
       GoKind: 22
-      Pointee: 270 BaseType crypto/tls.AlertError
+      Pointee: 340 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 542
+      ID: 612
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.00448e+06
       GoKind: 22
-      Pointee: 543 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 613 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 871
+      ID: 941
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.231488e+06
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 942 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 375
+      ID: 445
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842496
       GoKind: 22
-      Pointee: 376 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 446 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 373
+      ID: 443
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842400
       GoKind: 22
-      Pointee: 374 StructureType crypto/tls.RecordHeaderError
+      Pointee: 444 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 541
+      ID: 611
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.002816e+06
       GoKind: 22
-      Pointee: 498 BaseType crypto/tls.alert
+      Pointee: 568 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 757
+      ID: 827
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.370912e+06
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 828 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 764
+      ID: 834
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.449984e+06
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 835 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 637
+      ID: 707
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.24368e+06
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 708 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 652
+      ID: 722
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90608e+06
       GoKind: 22
-      Pointee: 653 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 723 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 447
+      ID: 517
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852288
       GoKind: 22
-      Pointee: 448 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 518 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 441
+      ID: 511
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851808
       GoKind: 22
-      Pointee: 442 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 512 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 443
+      ID: 513
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 851904
       GoKind: 22
-      Pointee: 444 StructureType crypto/x509.HostnameError
+      Pointee: 514 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 440
+      ID: 510
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851712
       GoKind: 22
-      Pointee: 279 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 349 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 547
+      ID: 617
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010368e+06
       GoKind: 22
-      Pointee: 548 StructureType crypto/x509.SystemRootsError
+      Pointee: 618 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 449
+      ID: 519
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852384
       GoKind: 22
-      Pointee: 450 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 520 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 445
+      ID: 515
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 446 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 516 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 462
+      ID: 532
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 858912
       GoKind: 22
-      Pointee: 463 StructureType encoding/asn1.StructuralError
+      Pointee: 533 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 466
+      ID: 536
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859104
       GoKind: 22
-      Pointee: 467 StructureType encoding/asn1.SyntaxError
+      Pointee: 537 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 464
+      ID: 534
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 859008
       GoKind: 22
-      Pointee: 465 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 535 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 363
+      ID: 433
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839328
       GoKind: 22
-      Pointee: 264 BaseType encoding/base64.CorruptInputError
+      Pointee: 334 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 715
+      ID: 785
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 999616
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 786 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 366
+      ID: 436
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840192
       GoKind: 22
-      Pointee: 265 BaseType encoding/hex.InvalidByteError
+      Pointee: 335 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 334
+      ID: 404
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 834048
       GoKind: 22
-      Pointee: 335 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 405 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 533
+      ID: 603
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995264
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 604 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 326
+      ID: 396
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833664
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 397 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 332
+      ID: 402
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 833952
       GoKind: 22
-      Pointee: 333 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 403 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 330
+      ID: 400
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 331 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 401 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 328
+      ID: 398
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833760
       GoKind: 22
-      Pointee: 329 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 399 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 851
+      ID: 921
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.147936e+06
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 922 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 336
+      ID: 406
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834432
       GoKind: 22
-      Pointee: 337 StructureType encoding/json.jsonError
+      Pointee: 407 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 723
+      ID: 793
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.013184e+06
       GoKind: 22
-      Pointee: 724 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 794 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 435
+      ID: 505
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 436 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 506 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 433
+      ID: 503
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 22
-      Pointee: 434 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 504 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 437
+      ID: 507
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 276 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 346 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 278
+      ID: 348
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 347 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 438
+      ID: 508
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 850944
       GoKind: 22
-      Pointee: 439 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 509 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 829
+      ID: 899
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.017888e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 900 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4082,19 +4229,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 304
+      ID: 374
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824352
       GoKind: 22
-      Pointee: 305 UnresolvedPointeeType errors.errorString
+      Pointee: 375 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 500
+      ID: 570
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 979904
       GoKind: 22
-      Pointee: 501 UnresolvedPointeeType errors.joinError
+      Pointee: 571 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4110,806 +4257,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 839
+      ID: 909
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.113664e+06
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType fmt.pp
+      Pointee: 910 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 502
+      ID: 572
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 981696
       GoKind: 22
-      Pointee: 503 UnresolvedPointeeType fmt.wrapError
+      Pointee: 573 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 504
+      ID: 574
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 981824
       GoKind: 22
-      Pointee: 505 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 575 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 364
+      ID: 434
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839712
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 435 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 345
+      ID: 415
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 22
-      Pointee: 346 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 416 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 347
+      ID: 417
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 22
-      Pointee: 348 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 418 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 665
+      ID: 735
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 736 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 351
+      ID: 421
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837216
       GoKind: 22
-      Pointee: 352 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 422 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 667
+      ID: 737
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 349
+      ID: 419
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 22
-      Pointee: 258 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 260
+      ID: 330
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 259 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 344
+      ID: 414
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836544
       GoKind: 22
-      Pointee: 255 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 325 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 257
+      ID: 327
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 256 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 326 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 350
+      ID: 420
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 261 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 263
+      ID: 333
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 737
+      ID: 807
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.123552e+06
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 808 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 817
+      ID: 887
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.921088e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 888 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 456
+      ID: 526
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857376
       GoKind: 22
-      Pointee: 457 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 527 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 611
+      ID: 681
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.12688e+06
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 682 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 847
+      ID: 917
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.123904e+06
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 918 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 384
+      ID: 454
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 455 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 391
+      ID: 461
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847296
       GoKind: 22
-      Pointee: 392 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 462 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 386
+      ID: 456
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 22
-      Pointee: 275 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 345 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 389
+      ID: 459
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847200
       GoKind: 22
-      Pointee: 390 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 387
+      ID: 457
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 22
-      Pointee: 388 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 458 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 407
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849216
       GoKind: 22
-      Pointee: 408 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 411
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849408
       GoKind: 22
-      Pointee: 412 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 409
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849312
       GoKind: 22
-      Pointee: 410 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 405
+      ID: 475
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849120
       GoKind: 22
-      Pointee: 406 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 476 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 686
+      ID: 756
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 685 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 755 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 419
+      ID: 489
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849792
       GoKind: 22
-      Pointee: 420 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 413
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 22
-      Pointee: 414 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 417
+      ID: 487
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 22
-      Pointee: 418 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 415
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849600
       GoKind: 22
-      Pointee: 416 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 421
+      ID: 491
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 849888
       GoKind: 22
-      Pointee: 422 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 427
+      ID: 497
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850176
       GoKind: 22
-      Pointee: 428 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 429
+      ID: 499
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850272
       GoKind: 22
-      Pointee: 430 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 425
+      ID: 495
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 850080
       GoKind: 22
-      Pointee: 426 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 423
+      ID: 493
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 849984
       GoKind: 22
-      Pointee: 424 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 431
+      ID: 501
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850464
       GoKind: 22
-      Pointee: 432 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 353
+      ID: 423
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838368
       GoKind: 22
-      Pointee: 354 StructureType github.com/cihub/seelog.baseError
+      Pointee: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 776
+      ID: 846
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.675936e+06
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 847 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 355
+      ID: 425
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838464
       GoKind: 22
-      Pointee: 356 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 426 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 755
+      ID: 825
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.369792e+06
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 826 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 711
+      ID: 781
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 998592
       GoKind: 22
-      Pointee: 712 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 782 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 745
+      ID: 815
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.24144e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 359
+      ID: 429
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838656
       GoKind: 22
-      Pointee: 360 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 430 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 807
+      ID: 877
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.839136e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 878 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 822
+      ID: 892
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.992544e+06
       GoKind: 22
-      Pointee: 819 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 889 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 821
+      ID: 891
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.99216e+06
       GoKind: 22
-      Pointee: 820 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 890 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 713
+      ID: 783
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 998720
       GoKind: 22
-      Pointee: 714 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 357
+      ID: 427
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838560
       GoKind: 22
-      Pointee: 358 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 428 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 361
+      ID: 431
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838752
       GoKind: 22
-      Pointee: 362 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 780
+      ID: 850
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.677504e+06
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 851 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 813
+      ID: 883
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.875008e+06
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 884 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 815
+      ID: 885
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.90576e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 886 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 642
+      ID: 712
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.25552e+06
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 713 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 555
+      ID: 625
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.024576e+06
       GoKind: 22
-      Pointee: 556 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 626 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 553
+      ID: 623
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024448e+06
       GoKind: 22
-      Pointee: 554 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 624 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 557
+      ID: 627
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.028544e+06
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 628 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 559
+      ID: 629
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.028672e+06
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 630 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 766
+      ID: 836
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.477632e+06
       GoKind: 22
-      Pointee: 767 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 837 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 549
+      ID: 619
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.011136e+06
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 620 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 367
+      ID: 437
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840384
       GoKind: 22
-      Pointee: 368 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 438 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 863
+      ID: 933
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.210592e+06
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 934 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 613
+      ID: 683
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.135072e+06
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 684 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 586
+      ID: 656
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.113952e+06
       GoKind: 22
-      Pointee: 587 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 580
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.113568e+06
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 651 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 519
+      ID: 589
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 989120
       GoKind: 22
-      Pointee: 520 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 592
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114336e+06
       GoKind: 22
-      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 518
+      ID: 588
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 988992
       GoKind: 22
-      Pointee: 497 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 567 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 584
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.113824e+06
       GoKind: 22
-      Pointee: 585 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 582
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.113696e+06
       GoKind: 22
-      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 590
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 588
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.11408e+06
       GoKind: 22
-      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 867
+      ID: 937
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.221632e+06
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 938 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 596
+      ID: 666
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.11472e+06
       GoKind: 22
-      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 523
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989376
       GoKind: 22
-      Pointee: 524 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 521
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989248
       GoKind: 22
-      Pointee: 522 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 594
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.114592e+06
       GoKind: 22
-      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 478
+      ID: 548
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871008
       GoKind: 22
-      Pointee: 287 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 357 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 289
+      ID: 359
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 358 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 655
+      ID: 725
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.476096e+06
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 726 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 563
+      ID: 633
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.04352e+06
       GoKind: 22
-      Pointee: 564 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 634 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 743
+      ID: 813
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.173984e+06
       GoKind: 22
-      Pointee: 744 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 814 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 827
+      ID: 897
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.00752e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 898 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 729
+      ID: 799
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.045824e+06
       GoKind: 22
-      Pointee: 730 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 800 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 479
+      ID: 549
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872256
       GoKind: 22
-      Pointee: 290 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 360 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 621
+      ID: 691
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.175648e+06
       GoKind: 22
-      Pointee: 622 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 692 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 482
+      ID: 552
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872544
       GoKind: 22
-      Pointee: 483 StructureType golang.org/x/net/http2.connError
+      Pointee: 553 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 481
+      ID: 551
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872448
       GoKind: 22
-      Pointee: 294 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 364 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 296
+      ID: 366
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 295 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 365 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 485
+      ID: 555
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872736
       GoKind: 22
-      Pointee: 300 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 370 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 302
+      ID: 372
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 301 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 371 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 484
+      ID: 554
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872640
       GoKind: 22
-      Pointee: 297 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 367 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 299
+      ID: 369
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 368 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 480
+      ID: 550
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872352
       GoKind: 22
-      Pointee: 291 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 361 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 293
+      ID: 363
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 292 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 362 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 825
+      ID: 895
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.0056e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 896 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 486
+      ID: 556
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872832
       GoKind: 22
-      Pointee: 487 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 557 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 488
+      ID: 558
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 872928
       GoKind: 22
-      Pointee: 303 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 373 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 474
+      ID: 544
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866400
       GoKind: 22
-      Pointee: 475 StructureType google.golang.org/grpc.dropError
+      Pointee: 545 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 619
+      ID: 689
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.172576e+06
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 690 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 644
+      ID: 714
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.26288e+06
       GoKind: 22
-      Pointee: 645 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 715 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 476
+      ID: 546
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869280
       GoKind: 22
-      Pointee: 477 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 547 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 790
+      ID: 860
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.684224e+06
       GoKind: 22
-      Pointee: 791 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 861 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 741
+      ID: 811
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.16912e+06
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 812 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 561
+      ID: 631
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.03776e+06
       GoKind: 22
-      Pointee: 562 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 632 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 701
+      ID: 771
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869376
       GoKind: 22
-      Pointee: 702 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 772 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 454
+      ID: 524
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855264
       GoKind: 22
-      Pointee: 455 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 525 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 551
+      ID: 621
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.014592e+06
       GoKind: 22
-      Pointee: 552 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 622 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 617
+      ID: 687
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.140832e+06
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 688 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 615
+      ID: 685
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.140576e+06
       GoKind: 22
-      Pointee: 616 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 686 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 468
+      ID: 538
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 22
-      Pointee: 469 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 539 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 470
+      ID: 540
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 860064
       GoKind: 22
-      Pointee: 471 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 541 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 399
+      ID: 469
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847680
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 470 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 778
+      ID: 848
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.676608e+06
       GoKind: 22
-      Pointee: 779 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 849 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 151
       Name: '*hash<[4]int,[4]int>'
@@ -4936,30 +5083,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 903
+      ID: 973
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 904 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 974 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 933
+      ID: 1003
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 934 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1004 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 942
+      ID: 1012
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 943 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1013 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 95 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 951
+      ID: 1021
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 952 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1022 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '*hash<int,uint8>'
@@ -4976,10 +5123,10 @@ Types:
       ByteSize: 8
       Pointee: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 648
+      ID: 718
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 649 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 719 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '*hash<string,int>'
@@ -4991,6 +5138,36 @@ Types:
       ByteSize: 8
       Pointee: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
+      ID: 190
+      Name: '*hash<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 191 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 195
+      Name: '*hash<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 196 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 200
+      Name: '*hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 201 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 205
+      Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 206 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 210
+      Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 211 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 215
+      Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 216 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
       ID: 141
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
@@ -5001,12 +5178,12 @@ Types:
       ByteSize: 8
       Pointee: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 489
+      ID: 559
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873696
       GoKind: 22
-      Pointee: 490 UnresolvedPointeeType html/template.Error
+      Pointee: 560 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -5050,96 +5227,96 @@ Types:
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 369
+      ID: 439
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840768
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 440 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 687
+      ID: 757
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 828960
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 758 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 578
+      ID: 648
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.1128e+06
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 649 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 869
+      ID: 939
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.226304e+06
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType internal/poll.FD
+      Pointee: 940 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 576
+      ID: 646
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.112672e+06
       GoKind: 22
-      Pointee: 577 StructureType internal/poll.errNetClosing
+      Pointee: 647 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 306
+      ID: 376
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828096
       GoKind: 22
-      Pointee: 307 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 377 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 733
+      ID: 803
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.10384e+06
       GoKind: 22
-      Pointee: 734 UnresolvedPointeeType io.PipeWriter
+      Pointee: 804 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 731
+      ID: 801
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.103456e+06
       GoKind: 22
-      Pointee: 732 StructureType io.discard
+      Pointee: 802 StructureType io.discard
     - __kind: PointerType
-      ID: 705
+      ID: 775
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 980160
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType io.multiWriter
+      Pointee: 776 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 574
+      ID: 644
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112416e+06
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType io/fs.PathError
+      Pointee: 645 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 782
+      ID: 852
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.677728e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 853 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 189
+      ID: 233
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 356352
       GoKind: 22
-      Pointee: 190 StructureType main.deepMap2
+      Pointee: 234 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 908
+      ID: 978
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356288
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType main.deepMap3
+      Pointee: 979 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -5148,19 +5325,19 @@ Types:
       GoKind: 22
       Pointee: 76 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 938
+      ID: 1008
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 355968
       GoKind: 22
-      Pointee: 939 StructureType main.deepMap8
+      Pointee: 1009 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 947
+      ID: 1017
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355904
       GoKind: 22
-      Pointee: 948 StructureType main.deepMap9
+      Pointee: 1018 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -5169,12 +5346,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 873
+      ID: 943
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356864
       GoKind: 22
-      Pointee: 874 UnresolvedPointeeType main.deepPtr3
+      Pointee: 944 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5183,33 +5360,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 913
+      ID: 983
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356544
       GoKind: 22
-      Pointee: 914 StructureType main.deepPtr8
+      Pointee: 984 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 915
+      ID: 985
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356480
       GoKind: 22
-      Pointee: 916 StructureType main.deepPtr9
+      Pointee: 986 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 357504
       GoKind: 22
-      Pointee: 183 StructureType main.deepSlice2
+      Pointee: 227 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 898
+      ID: 968
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357440
       GoKind: 22
-      Pointee: 899 UnresolvedPointeeType main.deepSlice3
+      Pointee: 969 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5218,25 +5395,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 919
+      ID: 989
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357120
       GoKind: 22
-      Pointee: 920 StructureType main.deepSlice8
+      Pointee: 990 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 925
+      ID: 995
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 357056
       GoKind: 22
-      Pointee: 926 StructureType main.deepSlice9
+      Pointee: 996 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 178
+      ID: 222
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 177 StructureType main.emptyStruct
+      Pointee: 221 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 86
       Name: '*main.esotericHeap'
@@ -5245,12 +5422,12 @@ Types:
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 889
+      ID: 959
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 824064
       GoKind: 22
-      Pointee: 890 StructureType main.firstBehavior
+      Pointee: 960 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 159
       Name: '*main.node'
@@ -5265,19 +5442,19 @@ Types:
       GoKind: 22
       Pointee: 174 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 891
+      ID: 961
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824160
       GoKind: 22
-      Pointee: 892 StructureType main.secondBehavior
+      Pointee: 962 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 878
+      ID: 948
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824256
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType main.somethingImpl
+      Pointee: 949 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
@@ -5285,18 +5462,23 @@ Types:
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 876
+      ID: 946
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 875 GoStringDataType main.stringType1.str
+      Pointee: 945 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType main.stringType2
+      Pointee: 947 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 206
+      ID: 177
+      Name: '*main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 175 StructureType main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 250
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 355840
@@ -5320,10 +5502,10 @@ Types:
       GoKind: 22
       Pointee: 161 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 895
+      ID: 965
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 894 GoSliceDataType main.t.array
+      Pointee: 964 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 172
       Name: '*main.threeStringStruct'
@@ -5337,580 +5519,580 @@ Types:
       GoKind: 22
       Pointee: 103 GoMapType map[string]int
     - __kind: PointerType
-      ID: 403
+      ID: 473
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848544
       GoKind: 22
-      Pointee: 404 StructureType math/big.ErrNaN
+      Pointee: 474 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 695
+      ID: 765
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843168
       GoKind: 22
-      Pointee: 696 StructureType mime/multipart.writerOnly·1
+      Pointee: 766 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 605
+      ID: 675
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.12112e+06
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType net.AddrError
+      Pointee: 676 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 631
+      ID: 701
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.23968e+06
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType net.DNSError
+      Pointee: 702 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 833
+      ID: 903
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.085856e+06
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType net.IPConn
+      Pointee: 904 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 629
+      ID: 699
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.23936e+06
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType net.OpError
+      Pointee: 700 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 607
+      ID: 677
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121248e+06
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType net.ParseError
+      Pointee: 678 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 843
+      ID: 913
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.115712e+06
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType net.TCPConn
+      Pointee: 914 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 853
+      ID: 923
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.160672e+06
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType net.UDPConn
+      Pointee: 924 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 841
+      ID: 911
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.1152e+06
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType net.UnixConn
+      Pointee: 912 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 604
+      ID: 674
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.120352e+06
       GoKind: 22
-      Pointee: 567 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 637 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 569
+      ID: 639
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 568 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 638 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 535
+      ID: 605
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 996032
       GoKind: 22
-      Pointee: 536 StructureType net.canceledError
+      Pointee: 606 StructureType net.canceledError
     - __kind: PointerType
-      ID: 811
+      ID: 881
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.872704e+06
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType net.conn
+      Pointee: 882 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 674
+      ID: 744
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.716928e+06
       GoKind: 22
-      Pointee: 675 StructureType net.dialResult·1
+      Pointee: 745 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 855
+      ID: 925
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.164928e+06
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType net.netFD
+      Pointee: 926 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 338
+      ID: 408
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835392
       GoKind: 22
-      Pointee: 339 UnresolvedPointeeType net.notFoundError
+      Pointee: 409 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 340
+      ID: 410
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 836064
       GoKind: 22
-      Pointee: 341 StructureType net.result·2
+      Pointee: 411 StructureType net.result·2
     - __kind: PointerType
-      ID: 837
+      ID: 907
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.099744e+06
       GoKind: 22
-      Pointee: 838 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 908 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 835
+      ID: 905
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.099264e+06
       GoKind: 22
-      Pointee: 836 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 906 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 609
+      ID: 679
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.121888e+06
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType net.temporaryError
+      Pointee: 680 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 633
+      ID: 703
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.23984e+06
       GoKind: 22
-      Pointee: 634 UnresolvedPointeeType net.timeoutError
+      Pointee: 704 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 525
+      ID: 595
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 991808
       GoKind: 22
-      Pointee: 526 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 596 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 689
+      ID: 759
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831264
       GoKind: 22
-      Pointee: 690 StructureType net/http.bufioFlushWriter
+      Pointee: 760 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 315
+      ID: 385
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 831936
       GoKind: 22
-      Pointee: 236 BaseType net/http.http2ConnectionError
+      Pointee: 306 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 316
+      ID: 386
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 832032
       GoKind: 22
-      Pointee: 317 StructureType net/http.http2GoAwayError
+      Pointee: 387 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 625
+      ID: 695
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.23552e+06
       GoKind: 22
-      Pointee: 626 StructureType net/http.http2StreamError
+      Pointee: 696 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 320
+      ID: 390
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832512
       GoKind: 22
-      Pointee: 321 StructureType net/http.http2connError
+      Pointee: 391 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 751
+      ID: 821
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.366432e+06
       GoKind: 22
-      Pointee: 752 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 822 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 319
+      ID: 389
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832416
       GoKind: 22
-      Pointee: 240 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 310 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 242
+      ID: 312
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 241 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 311 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 323
+      ID: 393
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832704
       GoKind: 22
-      Pointee: 246 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 316 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 248
+      ID: 318
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 247 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 317 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 322
+      ID: 392
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832608
       GoKind: 22
-      Pointee: 243 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 313 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 245
+      ID: 315
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 244 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 314 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 600
+      ID: 670
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.116896e+06
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 671 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 531
+      ID: 601
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992448
       GoKind: 22
-      Pointee: 532 StructureType net/http.http2noCachedConnError
+      Pointee: 602 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 802
+      ID: 872
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.816704e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 873 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 318
+      ID: 388
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832320
       GoKind: 22
-      Pointee: 237 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 307 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 239
+      ID: 309
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 238 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 308 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 691
+      ID: 761
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832800
       GoKind: 22
-      Pointee: 692 StructureType net/http.http2stickyErrWriter
+      Pointee: 762 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 527
+      ID: 597
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 992064
       GoKind: 22
-      Pointee: 528 StructureType net/http.nothingWrittenError
+      Pointee: 598 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 753
+      ID: 823
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.030656e+06
       GoKind: 22
-      Pointee: 754 UnresolvedPointeeType net/http.persistConn
+      Pointee: 824 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 709
+      ID: 779
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 991936
       GoKind: 22
-      Pointee: 710 StructureType net/http.persistConnWriter
+      Pointee: 780 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 735
+      ID: 805
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.115872e+06
       GoKind: 22
-      Pointee: 736 StructureType net/http.readWriteCloserBody
+      Pointee: 806 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 324
+      ID: 394
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 832896
       GoKind: 22
-      Pointee: 325 StructureType net/http.requestBodyReadError
+      Pointee: 395 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 627
+      ID: 697
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.23664e+06
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 698 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 598
+      ID: 668
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.116768e+06
       GoKind: 22
-      Pointee: 599 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 669 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 529
+      ID: 599
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992192
       GoKind: 22
-      Pointee: 530 StructureType net/http.transportReadFromServerError
+      Pointee: 600 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 313
+      ID: 383
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831168
       GoKind: 22
-      Pointee: 314 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 384 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 804
+      ID: 874
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.81824e+06
       GoKind: 22
-      Pointee: 805 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 875 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 719
+      ID: 789
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.005504e+06
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 790 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 395
+      ID: 465
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847488
       GoKind: 22
-      Pointee: 396 StructureType net/netip.parseAddrError
+      Pointee: 466 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 393
+      ID: 463
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847392
       GoKind: 22
-      Pointee: 394 StructureType net/netip.parsePrefixError
+      Pointee: 464 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 761
+      ID: 831
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.98032e+06
       GoKind: 22
-      Pointee: 762 UnresolvedPointeeType net/smtp.Client
+      Pointee: 832 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 721
+      ID: 791
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.010624e+06
       GoKind: 22
-      Pointee: 722 StructureType net/smtp.dataCloser
+      Pointee: 792 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 379
+      ID: 449
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843360
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType net/textproto.Error
+      Pointee: 450 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 378
+      ID: 448
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843264
       GoKind: 22
-      Pointee: 271 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 341 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 273
+      ID: 343
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 342 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 717
+      ID: 787
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.004864e+06
       GoKind: 22
-      Pointee: 718 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 788 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 635
+      ID: 705
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.24016e+06
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType net/url.Error
+      Pointee: 706 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 342
+      ID: 412
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836160
       GoKind: 22
-      Pointee: 249 GoStringHeaderType net/url.EscapeError
+      Pointee: 319 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 251
+      ID: 321
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 250 GoStringDataType net/url.EscapeError.str
+      Pointee: 320 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 343
+      ID: 413
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836256
       GoKind: 22
-      Pointee: 252 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 322 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 254
+      ID: 324
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 253 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 323 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 861
+      ID: 931
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.202176e+06
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType os.File
+      Pointee: 932 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 506
+      ID: 576
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 982976
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType os.LinkError
+      Pointee: 577 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 570
+      ID: 640
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105376e+06
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType os.SyscallError
+      Pointee: 641 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 859
+      ID: 929
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.199232e+06
       GoKind: 22
-      Pointee: 860 StructureType os.fileWithoutReadFrom
+      Pointee: 930 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 857
+      ID: 927
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.198496e+06
       GoKind: 22
-      Pointee: 858 StructureType os.fileWithoutWriteTo
+      Pointee: 928 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 537
+      ID: 607
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001536e+06
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType os/exec.Error
+      Pointee: 608 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 677
+      ID: 747
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.952288e+06
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 748 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 739
+      ID: 809
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.127904e+06
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 810 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 539
+      ID: 609
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.001664e+06
       GoKind: 22
-      Pointee: 540 StructureType os/exec.wrappedError
+      Pointee: 610 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 473
+      ID: 543
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864480
       GoKind: 22
-      Pointee: 284 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 354 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 286
+      ID: 356
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 355 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 472
+      ID: 542
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864384
       GoKind: 22
-      Pointee: 283 BaseType os/user.UnknownUserIdError
+      Pointee: 353 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 308
+      ID: 378
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 828864
       GoKind: 22
-      Pointee: 309 UnresolvedPointeeType reflect.ValueError
+      Pointee: 379 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 401
+      ID: 471
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848160
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 472 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 509
+      ID: 579
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984512
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 580 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 514
+      ID: 584
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986432
       GoKind: 22
-      Pointee: 515 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 585 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 511
+      ID: 581
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 984640
       GoKind: 22
-      Pointee: 512 StructureType runtime.boundsError
+      Pointee: 582 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 572
+      ID: 642
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.110752e+06
       GoKind: 22
-      Pointee: 573 StructureType runtime.errorAddressString
+      Pointee: 643 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 508
+      ID: 578
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984256
       GoKind: 22
-      Pointee: 491 GoStringHeaderType runtime.errorString
+      Pointee: 561 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 493
+      ID: 563
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 492 GoStringDataType runtime.errorString.str
+      Pointee: 562 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
@@ -5919,24 +6101,24 @@ Types:
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 513
+      ID: 583
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 986176
       GoKind: 22
-      Pointee: 494 GoStringHeaderType runtime.plainError
+      Pointee: 564 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 496
+      ID: 566
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 495 GoStringDataType runtime.plainError.str
+      Pointee: 565 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 516
+      ID: 586
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 986688
       GoKind: 22
-      Pointee: 517 UnresolvedPointeeType strconv.NumError
+      Pointee: 587 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -5945,78 +6127,78 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 180
+      ID: 224
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 179 GoStringDataType string.str
+      Pointee: 223 GoStringDataType string.str
     - __kind: PointerType
-      ID: 800
+      ID: 870
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.815424e+06
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType strings.Builder
+      Pointee: 871 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 707
+      ID: 777
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 986816
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 778 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 703
+      ID: 773
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 704 StructureType struct { io.Writer }
+      Pointee: 774 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 624
+      ID: 694
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.23488e+06
       GoKind: 22
-      Pointee: 623 BaseType syscall.Errno
+      Pointee: 693 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 831
+      ID: 901
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.018272e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 902 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 565
+      ID: 635
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.04736e+06
       GoKind: 22
-      Pointee: 566 StructureType text/template.ExecError
+      Pointee: 636 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 640
+      ID: 710
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.431552e+06
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType time.Location
+      Pointee: 711 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 311
+      ID: 381
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829728
       GoKind: 22
-      Pointee: 312 UnresolvedPointeeType time.ParseError
+      Pointee: 382 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 310
+      ID: 380
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829632
       GoKind: 22
-      Pointee: 233 GoStringHeaderType time.fileSizeError
+      Pointee: 303 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 235
+      ID: 305
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 234 GoStringDataType time.fileSizeError.str
+      Pointee: 304 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6060,59 +6242,59 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 794
+      ID: 864
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.77168e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 865 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 397
+      ID: 467
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 22
-      Pointee: 398 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 468 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 823
+      ID: 893
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.994848e+06
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 894 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 381
+      ID: 451
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843744
       GoKind: 22
-      Pointee: 382 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 452 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 383
+      ID: 453
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 843840
       GoKind: 22
-      Pointee: 274 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 344 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 544
+      ID: 614
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005248e+06
       GoKind: 22
-      Pointee: 545 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 615 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 546
+      ID: 616
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005376e+06
       GoKind: 22
-      Pointee: 499 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 569 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1054
+      ID: 1124
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1011
+      ID: 1081
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6127,7 +6309,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1009
+      ID: 1079
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6142,7 +6324,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 973
+      ID: 1043
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6157,7 +6339,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 971
+      ID: 1041
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6172,7 +6354,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1019
+      ID: 1089
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6187,7 +6369,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 972
+      ID: 1042
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6202,7 +6384,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 991
+      ID: 1061
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6217,7 +6399,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 960
+      ID: 1030
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6232,7 +6414,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 957
+      ID: 1027
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6247,7 +6429,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1035
+      ID: 1105
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6262,7 +6444,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1033
+      ID: 1103
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6295,7 +6477,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1043
+      ID: 1113
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6310,7 +6492,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 996
+      ID: 1066
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6325,7 +6507,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 997
+      ID: 1067
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6340,7 +6522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 992
+      ID: 1062
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6355,7 +6537,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 993
+      ID: 1063
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6370,7 +6552,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 994
+      ID: 1064
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6385,7 +6567,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 995
+      ID: 1065
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6400,7 +6582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1048
+      ID: 1118
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6424,7 +6606,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1045
+      ID: 1115
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6439,7 +6621,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1062
+      ID: 1132
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6454,7 +6636,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1065
+      ID: 1137
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6462,14 +6644,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 178 PointerType *main.emptyStruct
+            Type: 222 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: e}
+                  Variable: {subprogram: 111, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1064
+      ID: 1136
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6477,14 +6659,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 177 StructureType main.emptyStruct
+            Type: 221 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 110, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1010
+      ID: 1080
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6499,7 +6681,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1001
+      ID: 1071
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6514,7 +6696,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1000
+      ID: 1070
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6529,7 +6711,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1007
+      ID: 1077
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6544,7 +6726,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1006
+      ID: 1076
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6559,7 +6741,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1002
+      ID: 1072
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6574,7 +6756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1004
+      ID: 1074
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6589,10 +6771,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1067
+      ID: 1139
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1003
+      ID: 1073
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6616,16 +6798,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1068
+      ID: 1140
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1069
+      ID: 1141
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1005
+      ID: 1075
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1066
+      ID: 1138
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6636,11 +6818,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 112, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1070
+      ID: 1142
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6651,11 +6833,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1071
+      ID: 1143
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6666,11 +6848,11 @@ Types:
             Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: a}
+                  Variable: {subprogram: 117, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 963
+      ID: 1033
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6685,7 +6867,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 964
+      ID: 1034
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6700,7 +6882,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 965
+      ID: 1035
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6715,7 +6897,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 962
+      ID: 1032
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6730,7 +6912,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 961
+      ID: 1031
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6745,7 +6927,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1008
+      ID: 1078
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6760,7 +6942,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1037
+      ID: 1107
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6775,7 +6957,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1017
+      ID: 1087
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6790,7 +6972,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1023
+      ID: 1093
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6805,7 +6987,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1021
+      ID: 1091
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6820,7 +7002,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1032
+      ID: 1102
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6835,7 +7017,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1031
+      ID: 1101
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6850,7 +7032,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1022
+      ID: 1092
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6865,7 +7047,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1030
+      ID: 1100
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6880,7 +7062,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1029
+      ID: 1099
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6895,7 +7077,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1015
+      ID: 1085
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6910,7 +7092,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1016
+      ID: 1086
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6925,7 +7107,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1014
+      ID: 1084
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6940,7 +7122,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1024
+      ID: 1094
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6955,7 +7137,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1028
+      ID: 1098
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6970,7 +7152,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1027
+      ID: 1097
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6985,7 +7167,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1026
+      ID: 1096
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7000,7 +7182,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1025
+      ID: 1095
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7015,7 +7197,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1060
+      ID: 1130
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7030,7 +7212,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1034
+      ID: 1104
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7081,7 +7263,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1042
+      ID: 1112
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7105,7 +7287,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1049
+      ID: 1119
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7129,7 +7311,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1051
+      ID: 1121
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7162,7 +7344,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1052
+      ID: 1122
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7177,7 +7359,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1059
+      ID: 1129
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7192,7 +7374,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1038
+      ID: 1108
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7207,7 +7389,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1020
+      ID: 1090
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7222,7 +7404,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1036
+      ID: 1106
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7237,7 +7419,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 958
+      ID: 1028
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7252,7 +7434,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 977
+      ID: 1047
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7267,7 +7449,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 975
+      ID: 1045
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7282,7 +7464,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 988
+      ID: 1058
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7297,7 +7479,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 989
+      ID: 1059
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7312,7 +7494,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 980
+      ID: 1050
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7327,7 +7509,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 981
+      ID: 1051
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7342,7 +7524,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 982
+      ID: 1052
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7357,7 +7539,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 979
+      ID: 1049
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7372,7 +7554,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 978
+      ID: 1048
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7387,7 +7569,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 976
+      ID: 1046
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7402,7 +7584,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1055
+      ID: 1125
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7417,7 +7599,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 985
+      ID: 1055
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7432,7 +7614,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 986
+      ID: 1056
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7447,7 +7629,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 987
+      ID: 1057
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7462,7 +7644,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 984
+      ID: 1054
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7477,7 +7659,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 983
+      ID: 1053
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7492,7 +7674,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1046
+      ID: 1116
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7507,7 +7689,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1018
+      ID: 1088
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7522,7 +7704,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 959
+      ID: 1029
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7537,7 +7719,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1041
+      ID: 1111
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7552,7 +7734,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1050
+      ID: 1120
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7567,7 +7749,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 998
+      ID: 1068
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7582,7 +7764,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 999
+      ID: 1069
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7597,7 +7779,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1047
+      ID: 1117
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7621,7 +7803,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1012
+      ID: 1082
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7636,7 +7818,37 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1013
+      ID: 1134
+      Name: Probe[main.testStructWithCyclicMaps]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 188 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 1133
+      Name: Probe[main.testStructWithCyclicSlices]
+      ByteSize: 145
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 175 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
+    - __kind: EventRootType
+      ID: 1083
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7651,7 +7863,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1063
+      ID: 1135
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7659,14 +7871,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 175 StructureType main.aStruct
+            Type: 219 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1058
+      ID: 1128
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7681,7 +7893,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1057
+      ID: 1127
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7696,7 +7908,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1056
+      ID: 1126
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7729,7 +7941,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 990
+      ID: 1060
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7744,7 +7956,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 968
+      ID: 1038
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7759,7 +7971,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 969
+      ID: 1039
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7774,7 +7986,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 970
+      ID: 1040
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7789,7 +8001,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 967
+      ID: 1037
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7804,7 +8016,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 966
+      ID: 1036
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7819,7 +8031,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1040
+      ID: 1110
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7834,7 +8046,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1044
+      ID: 1114
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7849,7 +8061,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1061
+      ID: 1131
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7864,7 +8076,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1039
+      ID: 1109
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7879,7 +8091,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 974
+      ID: 1044
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -7894,7 +8106,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1053
+      ID: 1123
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7961,7 +8173,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 624288
+      GoRuntimeType: 624384
       GoKind: 17
       Count: 2
       HasCount: true
@@ -7994,7 +8206,7 @@ Types:
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 624384
+      GoRuntimeType: 624480
       GoKind: 17
       Count: 2
       HasCount: true
@@ -8027,7 +8239,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 624480
+      GoRuntimeType: 624576
       GoKind: 17
       Count: 2
       HasCount: true
@@ -8036,13 +8248,13 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 624192
+      GoRuntimeType: 624288
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 216
+      ID: 260
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 622752
@@ -8051,7 +8263,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 201
+      ID: 245
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 623040
@@ -8068,16 +8280,16 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 669
+      ID: 739
       Name: '[5]uint8'
       ByteSize: 5
-      GoRuntimeType: 624096
+      GoRuntimeType: 624192
       GoKind: 17
       Count: 5
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 186
+      ID: 230
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 620064
@@ -8101,14 +8313,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []*main.deepSlice2.array
+      Data: 228 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 228
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 896
+      ID: 966
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446976
@@ -8116,21 +8328,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 897 PointerType **main.deepSlice3
+          Type: 967 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 900 GoSliceDataType []*main.deepSlice3.array
+      Data: 970 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 900
+      ID: 970
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 898 PointerType *main.deepSlice3
+      Element: 968 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 917
+      ID: 987
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446656
@@ -8138,21 +8350,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 918 PointerType **main.deepSlice8
+          Type: 988 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 921 GoSliceDataType []*main.deepSlice8.array
+      Data: 991 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 921
+      ID: 991
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 919 PointerType *main.deepSlice8
+      Element: 989 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 923
+      ID: 993
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446592
@@ -8160,19 +8372,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 924 PointerType **main.deepSlice9
+          Type: 994 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 927 GoSliceDataType []*main.deepSlice9.array
+      Data: 997 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 927
+      ID: 997
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 925 PointerType *main.deepSlice9
+      Element: 995 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -8189,12 +8401,117 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 181 GoSliceDataType []*string.array
+      Data: 225 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 225
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
+    - __kind: GoSliceHeaderType
+      ID: 186
+      Name: '[][][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 187 PointerType *[][][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 287 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 287
+      Name: '[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 184 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 184
+      Name: '[][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 185 PointerType *[][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 285 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 285
+      Name: '[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 182 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 182
+      Name: '[][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 183 PointerType *[][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 283 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 283
+      Name: '[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 180 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 180
+      Name: '[][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 181 PointerType *[][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 281 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 281
+      Name: '[][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 178 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 178
+      Name: '[][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 179 PointerType *[]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 279 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 279
+      Name: '[][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 176 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
       ID: 163
       Name: '[][]uint'
@@ -8210,9 +8527,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 223 GoSliceDataType [][]uint.array
+      Data: 267 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 267
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 162 GoSliceHeaderType []uint
@@ -8232,104 +8549,134 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []bool.array
+      Data: 273 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 273
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 264
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
       Element: 154 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 263
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
       Element: 149 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 247
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
       Element: 117 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 254
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
       Element: 129 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 235
       Name: '[]bucket<int,*main.deepMap2>.array'
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 910
+      ID: 980
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 906 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 976 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 940
+      ID: 1010
       Name: '[]bucket<int,*main.deepMap8>.array'
       ByteSize: 2048
-      Element: 936 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1006 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 949
+      ID: 1019
       Name: '[]bucket<int,*main.deepMap9>.array'
       ByteSize: 2048
-      Element: 945 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1015 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 237
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 97 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 956
+      ID: 1026
       Name: '[]bucket<int,interface {}>.array'
       ByteSize: 2048
-      Element: 954 GoHMapBucketType bucket<int,interface {}>
+      Element: 1024 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 256
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
       Element: 134 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 251
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 243
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 680
+      ID: 750
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 2048
-      Element: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 241
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 107 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 240
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
       Element: 102 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 292
+      Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 193 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 294
+      Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 198 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 296
+      Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 203 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 298
+      Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 208 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 300
+      Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 213 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 302
+      Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 2048
+      Element: 218 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 261
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
       Element: 144 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 258
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
       Element: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 664
+      ID: 734
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454208
@@ -8344,14 +8691,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 683 GoSliceDataType []float64.array
+      Data: 753 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 753
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 929
+      ID: 999
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454656
@@ -8366,56 +8713,83 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 930 GoSliceDataType []interface {}.array
+      Data: 1000 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 930
+      ID: 1000
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 218
+      ID: 262
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 216 ArrayType [4]int
+      Element: 260 ArrayType [4]int
     - __kind: ArrayType
-      ID: 200
+      ID: 244
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 201 ArrayType [4]string
+      Element: 245 ArrayType [4]string
     - __kind: ArrayType
-      ID: 208
+      ID: 252
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 187
+      ID: 231
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 194
+      ID: 238
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 213
+      ID: 289
+      Name: '[]key<struct {}>'
+      Count: 8
+      HasCount: true
+      Element: 290 StructureType struct {}
+    - __kind: ArrayType
+      ID: 257
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 205
+      ID: 176
+      Name: '[]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 177 PointerType *main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 277 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 277
+      Name: '[]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 175 StructureType main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 249
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 447296
@@ -8423,16 +8797,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 206 PointerType *main.structWithMap
+          Type: 250 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 911 GoSliceDataType []main.structWithMap.array
+      Data: 981 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 911
+      ID: 981
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 92 StructureType main.structWithMap
@@ -8451,9 +8825,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 225 GoSliceDataType []main.structWithNoStrings.array
+      Data: 269 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 269
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 167 StructureType main.structWithNoStrings
@@ -8473,9 +8847,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 227 GoSliceDataType []string.array
+      Data: 271 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 271
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
@@ -8495,9 +8869,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 221 GoSliceDataType []uint.array
+      Data: 265 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 265
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 12 BaseType uint
@@ -8517,14 +8891,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 231 GoSliceDataType []uint16.array
+      Data: 275 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 275
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 658
+      ID: 728
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 453184
@@ -8539,116 +8913,158 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 681 GoSliceDataType []uint8.array
+      Data: 751 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 681
+      ID: 751
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 188
+      ID: 232
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 189 PointerType *main.deepMap2
+      Element: 233 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 907
+      ID: 977
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 908 PointerType *main.deepMap3
+      Element: 978 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 937
+      ID: 1007
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 938 PointerType *main.deepMap8
+      Element: 1008 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 946
+      ID: 1016
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 947 PointerType *main.deepMap9
+      Element: 1017 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 202
+      ID: 246
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 215
+      ID: 259
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 216 ArrayType [4]int
+      Element: 260 ArrayType [4]int
     - __kind: ArrayType
-      ID: 204
+      ID: 248
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 205 GoSliceHeaderType []main.structWithMap
+      Element: 249 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 198
+      ID: 242
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 168 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 679
+      ID: 749
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 192
+      ID: 236
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 955
+      ID: 1025
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 195
+      ID: 239
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 176 StructureType main.nestedStruct
+      Element: 220 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 209
+      ID: 253
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 158 StructureType main.node
     - __kind: ArrayType
-      ID: 211
+      ID: 291
+      Name: '[]val<main.structWithCyclicMaps>'
+      ByteSize: 384
+      Count: 8
+      HasCount: true
+      Element: 188 StructureType main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 293
+      Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 189 GoMapType map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 295
+      Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 194 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 297
+      Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 199 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 299
+      Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 204 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 301
+      Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 209 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: ArrayType
+      ID: 255
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 810
+      ID: 880
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 459
+      ID: 529
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858528
@@ -8663,32 +9079,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 460 GoSliceDataType archive/tar.headerError.array
+      Data: 530 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 530
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 820
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 768
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 700
+      ID: 770
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.078464e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 867
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 726
+      ID: 796
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.376512e+06
@@ -8698,7 +9114,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 728
+      ID: 798
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -8714,18 +9130,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 218 ArrayType []key<[4]int>
+          Type: 262 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 215 ArrayType []val<[4]int>
+          Type: 259 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 153 PointerType *bucket<[4]int,[4]int>
-      KeyType: 216 ArrayType [4]int
-      ValueType: 216 ArrayType [4]int
+      KeyType: 260 ArrayType [4]int
+      ValueType: 260 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 149
       Name: bucket<[4]int,uint8>
@@ -8733,17 +9149,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 218 ArrayType []key<[4]int>
+          Type: 262 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 211 ArrayType []val<uint8>
+          Type: 255 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 148 PointerType *bucket<[4]int,uint8>
-      KeyType: 216 ArrayType [4]int
+      KeyType: 260 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 117
@@ -8752,17 +9168,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 200 ArrayType []key<[4]string>
+          Type: 244 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 202 ArrayType []val<[2]int>
+          Type: 246 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 116 PointerType *bucket<[4]string,[2]int>
-      KeyType: 201 ArrayType [4]string
+      KeyType: 245 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 129
@@ -8771,13 +9187,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 208 ArrayType []key<bool>
+          Type: 252 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 209 ArrayType []val<main.node>
+          Type: 253 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 128 PointerType *bucket<bool,main.node>
@@ -8790,75 +9206,75 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 188 ArrayType []val<*main.deepMap2>
+          Type: 232 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 71 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 189 PointerType *main.deepMap2
+      ValueType: 233 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 906
+      ID: 976
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 907 ArrayType []val<*main.deepMap3>
+          Type: 977 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 905 PointerType *bucket<int,*main.deepMap3>
+          Type: 975 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 908 PointerType *main.deepMap3
+      ValueType: 978 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 936
+      ID: 1006
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 937 ArrayType []val<*main.deepMap8>
+          Type: 1007 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 935 PointerType *bucket<int,*main.deepMap8>
+          Type: 1005 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 938 PointerType *main.deepMap8
+      ValueType: 1008 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 945
+      ID: 1015
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 946 ArrayType []val<*main.deepMap9>
+          Type: 1016 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 944 PointerType *bucket<int,*main.deepMap9>
+          Type: 1014 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 947 PointerType *main.deepMap9
+      ValueType: 1017 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 97
       Name: bucket<int,int>
@@ -8866,35 +9282,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 192 ArrayType []val<int>
+          Type: 236 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 96 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 954
+      ID: 1024
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 955 ArrayType []val<interface {}>
+          Type: 1025 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 953 PointerType *bucket<int,interface {}>
+          Type: 1023 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 83 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -8904,13 +9320,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<int>
+          Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 211 ArrayType []val<uint8>
+          Type: 255 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 133 PointerType *bucket<int,uint8>
@@ -8923,18 +9339,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 204 ArrayType []val<[]main.structWithMap>
+          Type: 248 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 123 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 205 GoSliceHeaderType []main.structWithMap
+      ValueType: 249 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 112
       Name: bucket<string,[]string>
@@ -8942,37 +9358,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 198 ArrayType []val<[]string>
+          Type: 242 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 111 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 168 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 651
+      ID: 721
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 679 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 749 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 107
       Name: bucket<string,int>
@@ -8980,13 +9396,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 192 ArrayType []val<int>
+          Type: 236 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 106 PointerType *bucket<string,int>
@@ -8999,18 +9415,132 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 194 ArrayType []key<string>
+          Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 195 ArrayType []val<main.nestedStruct>
+          Type: 239 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 101 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 176 StructureType main.nestedStruct
+      ValueType: 220 StructureType main.nestedStruct
+    - __kind: GoHMapBucketType
+      ID: 193
+      Name: bucket<struct {},main.structWithCyclicMaps>
+      ByteSize: 400
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 291 ArrayType []val<main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 392
+          Type: 192 PointerType *bucket<struct {},main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 188 StructureType main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 198
+      Name: bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 293 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 197 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 189 GoMapType map[struct {}]main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 203
+      Name: bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 295 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 202 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 194 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 208
+      Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 297 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 207 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 199 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 213
+      Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 299 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 212 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 204 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoHMapBucketType
+      ID: 218
+      Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 80
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 230 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 289 ArrayType []key<struct {}>
+        - Name: values
+          Offset: 8
+          Type: 301 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: overflow
+          Offset: 72
+          Type: 217 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      KeyType: 290 StructureType struct {}
+      ValueType: 209 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
       ID: 144
       Name: bucket<uint8,[4]int>
@@ -9018,18 +9548,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 213 ArrayType []key<uint8>
+          Type: 257 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 215 ArrayType []val<[4]int>
+          Type: 259 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 143 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 216 ArrayType [4]int
+      ValueType: 260 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 139
       Name: bucket<uint8,uint8>
@@ -9037,28 +9567,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 230 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 213 ArrayType []key<uint8>
+          Type: 257 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 211 ArrayType []val<uint8>
+          Type: 255 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 138 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 774
+      ID: 844
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 869
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 846
+      ID: 916
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9084,13 +9614,13 @@ Types:
       GoRuntimeType: 532256
       GoKind: 15
     - __kind: BaseType
-      ID: 266
+      ID: 336
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764640
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 337
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764736
@@ -9098,91 +9628,91 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *compress/flate.InternalError.str
+          Type: 339 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType compress/flate.InternalError.str
+      Data: 338 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 338
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 818
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 764
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 840
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 603
+      ID: 673
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296288e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 280
+      ID: 350
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767232
       GoKind: 2
     - __kind: BaseType
-      ID: 281
+      ID: 351
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767328
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 760
+      ID: 830
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 855
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 282
+      ID: 352
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767424
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 863
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 787
+      ID: 857
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 859
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 270
+      ID: 340
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765216
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 543
+      ID: 613
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 942
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 376
+      ID: 446
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 374
+      ID: 444
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.605024e+06
@@ -9193,34 +9723,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 669 ArrayType [5]uint8
+          Type: 739 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 670 GoInterfaceType net.Conn
+          Type: 740 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 498
+      ID: 568
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951488
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 828
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 835
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 708
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 653
+      ID: 723
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 448
+      ID: 518
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.608096e+06
@@ -9228,21 +9758,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 652 PointerType *crypto/x509.Certificate
+          Type: 722 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 672 BaseType crypto/x509.InvalidReason
+          Type: 742 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 442
+      ID: 512
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.075776e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 444
+      ID: 514
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.408864e+06
@@ -9250,24 +9780,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 652 PointerType *crypto/x509.Certificate
+          Type: 722 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 279
+      ID: 349
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 766848
       GoKind: 2
     - __kind: BaseType
-      ID: 672
+      ID: 742
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537760
       GoKind: 2
     - __kind: StructureType
-      ID: 548
+      ID: 618
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.372832e+06
@@ -9277,13 +9807,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 450
+      ID: 520
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.076032e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 446
+      ID: 516
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.607904e+06
@@ -9291,15 +9821,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 652 PointerType *crypto/x509.Certificate
+          Type: 722 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 652 PointerType *crypto/x509.Certificate
+          Type: 722 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 463
+      ID: 533
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.25376e+06
@@ -9309,7 +9839,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 467
+      ID: 537
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.25392e+06
@@ -9319,55 +9849,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 465
+      ID: 535
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 264
+      ID: 334
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764256
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 786
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 265
+      ID: 335
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764448
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 335
+      ID: 405
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 604
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 397
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 333
+      ID: 403
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 331
+      ID: 401
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 329
+      ID: 399
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 922
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 337
+      ID: 407
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.2384e+06
@@ -9377,19 +9907,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 724
+      ID: 794
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 436
+      ID: 506
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 434
+      ID: 504
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 346
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766752
@@ -9397,21 +9927,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *encoding/xml.UnmarshalError.str
+          Type: 348 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 347 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 347
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 439
+      ID: 509
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 900
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9428,11 +9958,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 305
+      ID: 375
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 501
+      ID: 571
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9448,15 +9978,15 @@ Types:
       GoRuntimeType: 532448
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 910
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 503
+      ID: 573
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 505
+      ID: 575
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9466,11 +9996,11 @@ Types:
       GoRuntimeType: 445376
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 435
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 346
+      ID: 416
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.603296e+06
@@ -9478,7 +10008,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 662 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 732 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -9486,25 +10016,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 348
+      ID: 418
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 736
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 352
+      ID: 422
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.072192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 738
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 258
+      ID: 328
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763680
@@ -9512,17 +10042,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 260 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 259 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 259
+      ID: 329
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 662
+      ID: 732
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.074112e+06
@@ -9530,7 +10060,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 663 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 733 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -9545,7 +10075,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 664 GoSliceHeaderType []float64
+          Type: 734 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -9554,10 +10084,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 665 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 667 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 737 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 168 GoSliceHeaderType []string
@@ -9571,13 +10101,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 663
+      ID: 733
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534304
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 255
+      ID: 325
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763584
@@ -9585,17 +10115,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 257 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 327 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 256 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 326 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 256
+      ID: 326
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 331
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763776
@@ -9603,59 +10133,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 262 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 332
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 808
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 888
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 457
+      ID: 527
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 682
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 918
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 455
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 392
+      ID: 462
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.075008e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 275
+      ID: 345
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 765888
       GoKind: 2
     - __kind: StructureType
-      ID: 390
+      ID: 460
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.07488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 388
+      ID: 458
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.406944e+06
@@ -9668,7 +10198,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 408
+      ID: 478
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.407744e+06
@@ -9681,7 +10211,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 412
+      ID: 482
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.607328e+06
@@ -9697,7 +10227,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 410
+      ID: 480
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.24816e+06
@@ -9707,7 +10237,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 406
+      ID: 476
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.24784e+06
@@ -9717,14 +10247,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 647
+      ID: 717
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135328e+06
       GoKind: 21
-      HeaderType: 649 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 719 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 671
+      ID: 741
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.00896e+06
@@ -9739,14 +10269,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 685 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 755 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 685
+      ID: 755
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 420
+      ID: 490
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.408064e+06
@@ -9754,12 +10284,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 647 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 717 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 647 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 717 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 414
+      ID: 484
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.24832e+06
@@ -9769,7 +10299,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 418
+      ID: 488
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.60752e+06
@@ -9780,12 +10310,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 671 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 416
+      ID: 486
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.407904e+06
@@ -9798,7 +10328,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 422
+      ID: 492
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.24848e+06
@@ -9806,9 +10336,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 639 StructureType time.Time
+          Type: 709 StructureType time.Time
     - __kind: StructureType
-      ID: 428
+      ID: 498
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.408384e+06
@@ -9821,7 +10351,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 430
+      ID: 500
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.2488e+06
@@ -9831,7 +10361,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 426
+      ID: 496
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.408224e+06
@@ -9844,7 +10374,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 424
+      ID: 494
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.24864e+06
@@ -9854,7 +10384,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 432
+      ID: 502
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.408544e+06
@@ -9867,7 +10397,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 354
+      ID: 424
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.24064e+06
@@ -9877,11 +10407,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 847
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 356
+      ID: 426
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.2408e+06
@@ -9889,21 +10419,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 354 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 826
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 712
+      ID: 782
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 816
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 360
+      ID: 430
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.24112e+06
@@ -9911,13 +10441,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 354 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 878
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 819
+      ID: 889
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.968384e+06
@@ -9925,12 +10455,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 807 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 877 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 820
+      ID: 890
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.991776e+06
@@ -9938,7 +10468,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 807 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 877 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -9946,11 +10476,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 714
+      ID: 784
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 358
+      ID: 428
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.24096e+06
@@ -9958,9 +10488,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 354 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 362
+      ID: 432
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.24128e+06
@@ -9968,64 +10498,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 354 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 851
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 884
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 886
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 713
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 556
+      ID: 626
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 554
+      ID: 624
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 628
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 630
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 767
+      ID: 837
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 620
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 368
+      ID: 438
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.24224e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 934
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 684
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 587
+      ID: 657
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.712e+06
@@ -10041,11 +10571,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 520
+      ID: 590
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.5096e+06
@@ -10058,7 +10588,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 593
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.712448e+06
@@ -10074,13 +10604,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 497
+      ID: 567
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 948896
       GoKind: 8
     - __kind: StructureType
-      ID: 585
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.711776e+06
@@ -10096,13 +10626,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 673
+      ID: 743
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 761856
       GoKind: 8
     - __kind: StructureType
-      ID: 583
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.711552e+06
@@ -10110,15 +10640,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 673 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 743 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 673 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 743 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 591
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.630144e+06
@@ -10131,7 +10661,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 589
+      ID: 659
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.712224e+06
@@ -10147,11 +10677,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 938
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 597
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.432512e+06
@@ -10161,19 +10691,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 524
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.195168e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 522
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.19504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 595
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.630336e+06
@@ -10186,7 +10716,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 357
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769248
@@ -10194,21 +10724,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 359 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 288 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 358 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 358
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 726
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 564
+      ID: 634
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.2656e+06
@@ -10218,7 +10748,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 744
+      ID: 814
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.486464e+06
@@ -10226,13 +10756,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 768 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 838 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 898
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 768
+      ID: 838
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.085888e+06
@@ -10245,7 +10775,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 730
+      ID: 800
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.381312e+06
@@ -10255,19 +10785,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 290
+      ID: 360
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769824
       GoKind: 10
     - __kind: BaseType
-      ID: 654
+      ID: 724
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 962144
       GoKind: 10
     - __kind: StructureType
-      ID: 622
+      ID: 692
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.750528e+06
@@ -10278,12 +10808,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 654 BaseType golang.org/x/net/http2.ErrCode
+          Type: 724 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 483
+      ID: 553
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.415744e+06
@@ -10291,12 +10821,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 654 BaseType golang.org/x/net/http2.ErrCode
+          Type: 724 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 294
+      ID: 364
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770016
@@ -10304,17 +10834,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 296 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 366 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 295 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 365 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 295
+      ID: 365
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 300
+      ID: 370
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770208
@@ -10322,17 +10852,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 302 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 372 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 301 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 371 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 301
+      ID: 371
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 367
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770112
@@ -10340,17 +10870,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 369 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 368 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 368
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 291
+      ID: 361
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769920
@@ -10358,21 +10888,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 293 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 363 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 292 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 362 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 292
+      ID: 362
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 896
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 487
+      ID: 557
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.26624e+06
@@ -10382,13 +10912,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 303
+      ID: 373
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770304
       GoKind: 2
     - __kind: StructureType
-      ID: 475
+      ID: 545
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.26128e+06
@@ -10398,11 +10928,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 690
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 715
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.776288e+06
@@ -10418,7 +10948,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 477
+      ID: 547
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.415264e+06
@@ -10431,7 +10961,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 791
+      ID: 861
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.82976e+06
@@ -10439,16 +10969,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 670 GoInterfaceType net.Conn
+          Type: 740 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 806 GoInterfaceType io.Reader
+          Type: 876 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 812
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 562
+      ID: 632
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.378912e+06
@@ -10458,29 +10988,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 702
+      ID: 772
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 455
+      ID: 525
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 552
+      ID: 622
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 688
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 616
+      ID: 686
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.326048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 469
+      ID: 539
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.25456e+06
@@ -10490,7 +11020,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 471
+      ID: 541
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.25472e+06
@@ -10500,11 +11030,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 470
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 779
+      ID: 849
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -10540,7 +11070,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 154 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 220 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 264 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 147
       Name: hash<[4]int,uint8>
@@ -10574,7 +11104,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 149 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 219 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 263 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 115
       Name: hash<[4]string,[2]int>
@@ -10608,7 +11138,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 117 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 203 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 247 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 127
       Name: hash<bool,main.node>
@@ -10642,7 +11172,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 129 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 210 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 254 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 70
       Name: hash<int,*main.deepMap2>
@@ -10676,9 +11206,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 191 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 235 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 904
+      ID: 974
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -10699,20 +11229,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 905 PointerType *bucket<int,*main.deepMap3>
+          Type: 975 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 905 PointerType *bucket<int,*main.deepMap3>
+          Type: 975 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 906 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 910 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 976 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 980 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 934
+      ID: 1004
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -10733,20 +11263,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 935 PointerType *bucket<int,*main.deepMap8>
+          Type: 1005 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 935 PointerType *bucket<int,*main.deepMap8>
+          Type: 1005 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 936 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 940 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1006 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1010 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 943
+      ID: 1013
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -10767,18 +11297,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 944 PointerType *bucket<int,*main.deepMap9>
+          Type: 1014 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 944 PointerType *bucket<int,*main.deepMap9>
+          Type: 1014 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 945 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 949 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1015 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1019 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 95
       Name: hash<int,int>
@@ -10812,9 +11342,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 97 GoHMapBucketType bucket<int,int>
-      BucketsType: 193 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 237 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 952
+      ID: 1022
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -10835,18 +11365,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 953 PointerType *bucket<int,interface {}>
+          Type: 1023 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 953 PointerType *bucket<int,interface {}>
+          Type: 1023 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 954 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 956 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1024 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1026 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 132
       Name: hash<int,uint8>
@@ -10880,7 +11410,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 134 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 212 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 256 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 122
       Name: hash<string,[]main.structWithMap>
@@ -10914,7 +11444,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 207 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 251 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 110
       Name: hash<string,[]string>
@@ -10948,9 +11478,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 112 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 199 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 243 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 649
+      ID: 719
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -10971,18 +11501,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 650 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 651 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 680 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 750 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 105
       Name: hash<string,int>
@@ -11016,7 +11546,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 107 GoHMapBucketType bucket<string,int>
-      BucketsType: 197 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 241 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 100
       Name: hash<string,main.nestedStruct>
@@ -11050,7 +11580,211 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 102 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 196 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 240 GoSliceDataType []bucket<string,main.nestedStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 191
+      Name: hash<struct {},main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 192 PointerType *bucket<struct {},main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 192 PointerType *bucket<struct {},main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 193 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+      BucketsType: 292 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 196
+      Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 197 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 197 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 198 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 294 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 201
+      Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 202 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 202 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 203 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 296 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 206
+      Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 207 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 207 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 208 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 298 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 211
+      Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 212 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 212 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 213 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 300 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+    - __kind: GoHMapHeaderType
+      ID: 216
+      Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 217 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 217 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 218 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 302 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 142
       Name: hash<uint8,[4]int>
@@ -11084,7 +11818,7 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 144 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 217 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 261 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 137
       Name: hash<uint8,uint8>
@@ -11118,9 +11852,9 @@ Types:
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
       BucketType: 139 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 214 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 258 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 490
+      ID: 560
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11167,37 +11901,37 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 440
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 758
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 649
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 940
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 577
+      ID: 647
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293248e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 307
+      ID: 377
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 734
+      ID: 804
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 775
+      ID: 845
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.103584e+06
@@ -11210,7 +11944,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 806
+      ID: 876
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 980288
@@ -11223,7 +11957,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 763
+      ID: 833
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.068608e+06
@@ -11249,25 +11983,25 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 732
+      ID: 802
       Name: io.discard
       GoRuntimeType: 1.280608e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 776
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 645
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 853
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 175
+      ID: 219
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -11283,7 +12017,7 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 176 StructureType main.nestedStruct
+          Type: 220 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 89
       Name: main.behavior
@@ -11323,7 +12057,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 190
+      ID: 234
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.100128e+06
@@ -11331,9 +12065,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 902 GoMapType map[int]*main.deepMap3
+          Type: 972 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 979
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11345,9 +12079,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 932 GoMapType map[int]*main.deepMap8
+          Type: 1002 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 939
+      ID: 1009
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.09936e+06
@@ -11355,9 +12089,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 941 GoMapType map[int]*main.deepMap9
+          Type: 1011 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 948
+      ID: 1018
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.099232e+06
@@ -11365,7 +12099,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 950 GoMapType map[int]interface {}
+          Type: 1020 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -11385,9 +12119,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 873 PointerType *main.deepPtr3
+          Type: 943 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 874
+      ID: 944
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11399,9 +12133,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 913 PointerType *main.deepPtr8
+          Type: 983 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 914
+      ID: 984
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.100512e+06
@@ -11409,9 +12143,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 915 PointerType *main.deepPtr9
+          Type: 985 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 916
+      ID: 986
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.100384e+06
@@ -11431,7 +12165,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 183
+      ID: 227
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.102432e+06
@@ -11439,9 +12173,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 896 GoSliceHeaderType []*main.deepSlice3
+          Type: 966 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 899
+      ID: 969
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11453,9 +12187,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 917 GoSliceHeaderType []*main.deepSlice8
+          Type: 987 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 920
+      ID: 990
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.101664e+06
@@ -11463,9 +12197,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 923 GoSliceHeaderType []*main.deepSlice9
+          Type: 993 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 926
+      ID: 996
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101536e+06
@@ -11473,9 +12207,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 929 GoSliceHeaderType []interface {}
+          Type: 999 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 177
+      ID: 221
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -11491,16 +12225,16 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 880 StructureType sync.Mutex
+          Type: 950 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 881 StructureType sync.Once
+          Type: 951 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 884 StructureType sync.WaitGroup
+          Type: 954 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 888 StructureType sync/atomic.Int32
+          Type: 958 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
@@ -11530,7 +12264,7 @@ Types:
           Offset: 56
           Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 890
+      ID: 960
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.23168e+06
@@ -11540,7 +12274,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 176
+      ID: 220
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.280128e+06
@@ -11575,7 +12309,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 892
+      ID: 962
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.23184e+06
@@ -11595,7 +12329,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 949
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11606,17 +12340,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 876 PointerType *main.stringType1.str
+          Type: 946 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 875 GoStringDataType main.stringType1.str
+      Data: 945 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 875
+      ID: 945
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 947
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11629,6 +12363,54 @@ Types:
         - Name: a
           Offset: 0
           Type: 83 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 188
+      Name: main.structWithCyclicMaps
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: m1
+          Offset: 0
+          Type: 189 GoMapType map[struct {}]main.structWithCyclicMaps
+        - Name: m2
+          Offset: 8
+          Type: 194 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m3
+          Offset: 16
+          Type: 199 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m4
+          Offset: 24
+          Type: 204 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m5
+          Offset: 32
+          Type: 209 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m6
+          Offset: 40
+          Type: 214 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 175
+      Name: main.structWithCyclicSlices
+      ByteSize: 144
+      GoKind: 25
+      RawFields:
+        - Name: s1
+          Offset: 0
+          Type: 176 GoSliceHeaderType []main.structWithCyclicSlices
+        - Name: s2
+          Offset: 24
+          Type: 178 GoSliceHeaderType [][]main.structWithCyclicSlices
+        - Name: s3
+          Offset: 48
+          Type: 180 GoSliceHeaderType [][][]main.structWithCyclicSlices
+        - Name: s4
+          Offset: 72
+          Type: 182 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+        - Name: s5
+          Offset: 96
+          Type: 184 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+        - Name: s6
+          Offset: 120
+          Type: 186 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 92
       Name: main.structWithMap
@@ -11671,16 +12453,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 893 PointerType **main.t
+          Type: 963 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 894 GoSliceDataType main.t.array
+      Data: 964 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 894
+      ID: 964
       Name: main.t.array
       ByteSize: 2048
       Element: 160 PointerType *main.t
@@ -11740,26 +12522,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 902
+      ID: 972
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879840
       GoKind: 21
-      HeaderType: 904 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 974 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 932
+      ID: 1002
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879360
       GoKind: 21
-      HeaderType: 934 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1004 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 941
+      ID: 1011
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879264
       GoKind: 21
-      HeaderType: 943 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1013 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 93
       Name: map[int]int
@@ -11768,12 +12550,12 @@ Types:
       GoKind: 21
       HeaderType: 95 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 950
+      ID: 1020
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879168
       GoKind: 21
-      HeaderType: 952 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1022 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 130
       Name: map[int]uint8
@@ -11810,6 +12592,42 @@ Types:
       GoKind: 21
       HeaderType: 100 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
+      ID: 189
+      Name: map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 191 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 194
+      Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 196 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 199
+      Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 201 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 204
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 206 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 209
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 211 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 214
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 216 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
       ID: 140
       Name: map[uint8][4]int
       ByteSize: 8
@@ -11824,7 +12642,7 @@ Types:
       GoKind: 21
       HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 404
+      ID: 474
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.24752e+06
@@ -11834,7 +12652,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 696
+      ID: 766
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.24432e+06
@@ -11844,11 +12662,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 676
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 670
+      ID: 740
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.405664e+06
@@ -11861,35 +12679,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 702
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 904
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 700
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 678
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 914
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 924
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 912
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 567
+      ID: 637
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.071808e+06
@@ -11897,27 +12715,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 569 PointerType *net.UnknownNetworkError.str
+          Type: 639 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 568 GoStringDataType net.UnknownNetworkError.str
+      Data: 638 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 568
+      ID: 638
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 536
+      ID: 606
       Name: net.canceledError
       GoRuntimeType: 1.196064e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 882
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 675
+      ID: 745
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.96768e+06
@@ -11925,7 +12743,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 670 GoInterfaceType net.Conn
+          Type: 740 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -11936,27 +12754,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 926
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 920
       Name: net.noReadFrom
       GoRuntimeType: 1.072064e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 849
+      ID: 919
       Name: net.noWriteTo
       GoRuntimeType: 1.071936e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 339
+      ID: 409
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 341
+      ID: 411
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.603104e+06
@@ -11964,7 +12782,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 657 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 727 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -11972,7 +12790,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 838
+      ID: 908
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.144e+06
@@ -11980,12 +12798,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 850 StructureType net.noReadFrom
+          Type: 920 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 843 PointerType *net.TCPConn
+          Type: 913 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 836
+      ID: 906
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.143456e+06
@@ -11993,24 +12811,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 849 StructureType net.noWriteTo
+          Type: 919 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 843 PointerType *net.TCPConn
+          Type: 913 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 680
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 634
+      ID: 704
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 526
+      ID: 596
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 690
+      ID: 760
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.23584e+06
@@ -12020,19 +12838,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 236
+      ID: 306
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762336
       GoKind: 10
     - __kind: BaseType
-      ID: 646
+      ID: 716
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 948992
       GoKind: 10
     - __kind: StructureType
-      ID: 317
+      ID: 387
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.601184e+06
@@ -12043,12 +12861,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 646 BaseType net/http.http2ErrCode
+          Type: 716 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 626
+      ID: 696
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.76656e+06
@@ -12059,12 +12877,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 646 BaseType net/http.http2ErrCode
+          Type: 716 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 321
+      ID: 391
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.405184e+06
@@ -12072,16 +12890,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 646 BaseType net/http.http2ErrCode
+          Type: 716 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 752
+      ID: 822
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 240
+      ID: 310
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762528
@@ -12089,17 +12907,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 242 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 312 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 241 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 311 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 241
+      ID: 311
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 246
+      ID: 316
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762720
@@ -12107,17 +12925,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 248 PointerType *net/http.http2headerFieldNameError.str
+          Type: 318 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 247 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 317 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 247
+      ID: 317
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 243
+      ID: 313
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762624
@@ -12125,31 +12943,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 245 PointerType *net/http.http2headerFieldValueError.str
+          Type: 315 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 244 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 314 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 244
+      ID: 314
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 671
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 532
+      ID: 602
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.195424e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 873
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 237
+      ID: 307
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762432
@@ -12157,17 +12975,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 239 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 309 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 238 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 308 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 238
+      ID: 308
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 692
+      ID: 762
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.601952e+06
@@ -12175,22 +12993,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 670 GoInterfaceType net.Conn
+          Type: 740 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 771 BaseType time.Duration
+          Type: 841 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 33 PointerType *error
     - __kind: ArrayType
-      ID: 772
+      ID: 842
       Name: net/http.incomparable
       GoRuntimeType: 830976
       GoKind: 17
       HasCount: true
       Element: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 528
+      ID: 598
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.367072e+06
@@ -12200,11 +13018,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 754
+      ID: 824
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 710
+      ID: 780
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.366912e+06
@@ -12212,9 +13030,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 753 PointerType *net/http.persistConn
+          Type: 823 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 736
+      ID: 806
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.673248e+06
@@ -12222,15 +13040,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 772 ArrayType net/http.incomparable
+          Type: 842 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 773 PointerType *bufio.Reader
+          Type: 843 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 775 GoInterfaceType io.ReadWriteCloser
+          Type: 845 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 325
+      ID: 395
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.2368e+06
@@ -12240,17 +13058,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 698
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 599
+      ID: 669
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.295968e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 530
+      ID: 600
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.367232e+06
@@ -12260,11 +13078,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 314
+      ID: 384
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 805
+      ID: 875
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.9048e+06
@@ -12272,13 +13090,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 798 PointerType *bufio.Writer
+          Type: 868 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 790
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 396
+      ID: 466
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.606944e+06
@@ -12294,7 +13112,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 394
+      ID: 464
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.407104e+06
@@ -12307,11 +13125,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 762
+      ID: 832
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 792
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.409024e+06
@@ -12319,16 +13137,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 761 PointerType *net/smtp.Client
+          Type: 831 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 763 GoInterfaceType io.WriteCloser
+          Type: 833 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 450
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 341
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765312
@@ -12336,25 +13154,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *net/textproto.ProtocolError.str
+          Type: 343 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 272 GoStringDataType net/textproto.ProtocolError.str
+      Data: 342 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 342
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 718
+      ID: 788
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 706
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 249
+      ID: 319
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763296
@@ -12362,17 +13180,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 251 PointerType *net/url.EscapeError.str
+          Type: 321 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 250 GoStringDataType net/url.EscapeError.str
+      Data: 320 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 250
+      ID: 320
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 252
+      ID: 322
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763392
@@ -12380,29 +13198,29 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 254 PointerType *net/url.InvalidHostError.str
+          Type: 324 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 253 GoStringDataType net/url.InvalidHostError.str
+      Data: 323 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 253
+      ID: 323
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 932
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 577
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 641
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 860
+      ID: 930
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.212192e+06
@@ -12410,12 +13228,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 866 StructureType os.noReadFrom
+          Type: 936 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 861 PointerType *os.File
+          Type: 931 PointerType *os.File
     - __kind: StructureType
-      ID: 858
+      ID: 928
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.211392e+06
@@ -12423,36 +13241,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 865 StructureType os.noWriteTo
+          Type: 935 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 861 PointerType *os.File
+          Type: 931 PointerType *os.File
     - __kind: StructureType
-      ID: 866
+      ID: 936
       Name: os.noReadFrom
       GoRuntimeType: 1.069504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 865
+      ID: 935
       Name: os.noWriteTo
       GoRuntimeType: 1.069376e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 608
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 748
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 810
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 540
+      ID: 610
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.510176e+06
@@ -12465,7 +13283,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 354
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768480
@@ -12473,39 +13291,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *os/user.UnknownGroupIdError.str
+          Type: 356 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 285 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 355 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 355
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 283
+      ID: 353
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768384
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 309
+      ID: 379
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 472
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 580
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 515
+      ID: 585
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 512
+      ID: 582
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.756128e+06
@@ -12522,15 +13340,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 676 BaseType runtime.boundsErrorCode
+          Type: 746 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 676
+      ID: 746
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532640
       GoKind: 8
     - __kind: StructureType
-      ID: 573
+      ID: 643
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.627072e+06
@@ -12543,7 +13361,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 491
+      ID: 561
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 947840
@@ -12551,13 +13369,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 493 PointerType *runtime.errorString.str
+          Type: 563 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 492 GoStringDataType runtime.errorString.str
+      Data: 562 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 492
+      ID: 562
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
@@ -12565,7 +13383,7 @@ Types:
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 494
+      ID: 564
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948416
@@ -12573,17 +13391,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 496 PointerType *runtime.plainError.str
+          Type: 566 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 495 GoStringDataType runtime.plainError.str
+      Data: 565 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 495
+      ID: 565
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 517
+      ID: 587
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12595,25 +13413,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 180 PointerType *string.str
+          Type: 224 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 179 GoStringDataType string.str
+      Data: 223 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 179
+      ID: 223
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 871
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 778
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 704
+      ID: 774
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.272768e+06
@@ -12623,7 +13441,13 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 880
+      ID: 290
+      Name: struct {}
+      GoRuntimeType: 772128
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 950
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281408e+06
@@ -12636,7 +13460,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 881
+      ID: 951
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282528e+06
@@ -12644,12 +13468,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 882 StructureType sync/atomic.Uint32
+          Type: 952 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 880 StructureType sync.Mutex
+          Type: 950 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 884
+      ID: 954
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421376e+06
@@ -12657,21 +13481,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 885 StructureType sync.noCopy
+          Type: 955 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 886 StructureType sync/atomic.Uint64
+          Type: 956 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 885
+      ID: 955
       Name: sync.noCopy
       GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 888
+      ID: 958
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282848e+06
@@ -12679,12 +13503,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 883 StructureType sync/atomic.noCopy
+          Type: 953 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 882
+      ID: 952
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.283008e+06
@@ -12692,12 +13516,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 883 StructureType sync/atomic.noCopy
+          Type: 953 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 886
+      ID: 956
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.42176e+06
@@ -12705,37 +13529,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 883 StructureType sync/atomic.noCopy
+          Type: 953 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 887 StructureType sync/atomic.align64
+          Type: 957 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 887
+      ID: 957
       Name: sync/atomic.align64
       GoRuntimeType: 946976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 883
+      ID: 953
       Name: sync/atomic.noCopy
       GoRuntimeType: 946880
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 623
+      ID: 693
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.194656e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 902
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 566
+      ID: 636
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.514592e+06
@@ -12748,21 +13572,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 771
+      ID: 841
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.7824e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 711
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 312
+      ID: 382
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 639
+      ID: 709
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.224416e+06
@@ -12776,9 +13600,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 640 PointerType *time.Location
+          Type: 710 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 233
+      ID: 303
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761472
@@ -12786,13 +13610,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 235 PointerType *time.fileSizeError.str
+          Type: 305 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 234 GoStringDataType time.fileSizeError.str
+      Data: 304 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 234
+      ID: 304
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -12838,11 +13662,11 @@ Types:
       GoRuntimeType: 532576
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 865
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 727
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.926528e+06
@@ -12850,13 +13674,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 658 GoSliceHeaderType []uint8
+          Type: 728 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 659 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 729 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 660 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 730 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -12871,18 +13695,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 661 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 731 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 661
+      ID: 731
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 953120
       GoKind: 9
     - __kind: StructureType
-      ID: 659
+      ID: 729
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.792896e+06
@@ -12907,21 +13731,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 398
+      ID: 468
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 660
+      ID: 730
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536224
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 894
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 382
+      ID: 452
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.24464e+06
@@ -12931,13 +13755,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 274
+      ID: 344
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765408
       GoKind: 2
     - __kind: StructureType
-      ID: 545
+      ID: 615
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510368e+06
@@ -12950,11 +13774,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 499
+      ID: 569
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 951968
       GoKind: 5
-MaxTypeID: 1071
+MaxTypeID: 1143
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 1169 EventRootType Probe[main.stackC]
+          Type: 1274 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84d92c", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 1124 EventRootType Probe[main.testAny]
+          Type: 1229 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b22c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 1126 EventRootType Probe[main.testAnyPtr]
+          Type: 1231 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b2ac", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 1086 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1191 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 1088 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1193 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 1134 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1239 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84b900", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 1087 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1192 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 1106 EventRootType Probe[main.testBigStruct]
+          Type: 1211 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849fd0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 1075 EventRootType Probe[main.testBoolArray]
+          Type: 1180 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 1072 EventRootType Probe[main.testByteArray]
+          Type: 1177 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849970", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 1150 EventRootType Probe[main.testChannel]
+          Type: 1255 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84cf50", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 1148 EventRootType Probe[main.testCombinedByte]
+          Type: 1253 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84ccd0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 1158 EventRootType Probe[main.testCycle]
+          Type: 1263 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d1f0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 1111 EventRootType Probe[main.testDeepMap1]
+          Type: 1216 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3b0", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 1112 EventRootType Probe[main.testDeepMap7]
+          Type: 1217 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3c0", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 1107 EventRootType Probe[main.testDeepPtr1]
+          Type: 1212 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0a0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 1108 EventRootType Probe[main.testDeepPtr7]
+          Type: 1213 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0b0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 1109 EventRootType Probe[main.testDeepSlice1]
+          Type: 1214 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a250", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 1110 EventRootType Probe[main.testDeepSlice7]
+          Type: 1215 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a260", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 1160 EventRootType Probe[main.testEmptySlice]
+          Type: 1265 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 1163 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1268 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84d600", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 1177 EventRootType Probe[main.testEmptyString]
+          Type: 1282 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84da10", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 108
-          Type: 1179 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84dd20", Frameless: true}]
+        - ID: 110
+          Type: 1286 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x84dd50", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 109
-          Type: 1180 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x84dd30", Frameless: true}]
+        - ID: 111
+          Type: 1287 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x84dd60", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 1125 EventRootType Probe[main.testError]
+          Type: 1230 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b290", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 1116 EventRootType Probe[main.testEsotericHeap]
+          Type: 1221 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84a84c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 1115 EventRootType Probe[main.testEsotericStack]
+          Type: 1220 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a77c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 1121 EventRootType Probe[main.testFrameless]
+          Type: 1226 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84af70", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 1122 EventRootType Probe[main.testFramelessArray]
+          Type: 1227 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84af80", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 1117 EventRootType Probe[main.testInlinedBA]
+          Type: 1222 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84ac8c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 1118 EventRootType Probe[main.testInlinedBB]
+          Type: 1223 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84ad1c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 1119 EventRootType Probe[main.testInlinedBBA]
+          Type: 1224 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84addc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 111
-          Type: 1182 EventRootType Probe[main.testInlinedBBB]
+        - ID: 113
+          Type: 1289 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84ad78", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 1120 EventRootType Probe[main.testInlinedBC]
+          Type: 1225 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84ae5c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 112
-          Type: 1183 EventRootType Probe[main.testInlinedBCA]
+        - ID: 114
+          Type: 1290 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84ae6c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 113
-          Type: 1184 EventRootType Probe[main.testInlinedBCB]
+        - ID: 115
+          Type: 1291 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84af20", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 110
-          Type: 1181 EventRootType Probe[main.testInlinedPrint]
+        - ID: 112
+          Type: 1288 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84aaec"
               Frameless: true
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 114
-          Type: 1185 EventRootType Probe[main.testInlinedSq]
+        - ID: 116
+          Type: 1292 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84af74", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 115
-          Type: 1186 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 117
+          Type: 1293 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84afa4"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 1078 EventRootType Probe[main.testInt16Array]
+          Type: 1183 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 1079 EventRootType Probe[main.testInt32Array]
+          Type: 1184 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 1080 EventRootType Probe[main.testInt64Array]
+          Type: 1185 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 1077 EventRootType Probe[main.testInt8Array]
+          Type: 1182 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 1076 EventRootType Probe[main.testIntArray]
+          Type: 1181 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 1123 EventRootType Probe[main.testInterface]
+          Type: 1228 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b210", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 1152 EventRootType Probe[main.testLinkedList]
+          Type: 1257 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d100", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 1132 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1237 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84b8e0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 1138 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1243 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84b940", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 1136 EventRootType Probe[main.testMapIntToInt]
+          Type: 1241 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84b920", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 1147 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1252 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84b9d0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 1146 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1251 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84b9c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 1137 EventRootType Probe[main.testMapMassive]
+          Type: 1242 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84b930", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 1145 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1250 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84b9b0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 1144 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1249 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84b9a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 1130 EventRootType Probe[main.testMapStringToInt]
+          Type: 1235 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84b8c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 1131 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1236 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84b8d0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 1129 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1234 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84b8b0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 1139 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1244 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84b950", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 1142 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1247 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84b980", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 1143 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1248 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84b990", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 1140 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1245 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84b960", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 1141 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1246 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84b970", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 1175 EventRootType Probe[main.testMassiveString]
+          Type: 1280 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84d9f0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 1149 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1254 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84cdb0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 1157 EventRootType Probe[main.testNilPointer]
+          Type: 1262 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d1d0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 1167 EventRootType Probe[main.testNilSlice]
+          Type: 1272 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84d640", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 1164 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1269 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84d610", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 1166 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1271 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84d630", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 1174 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1279 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84d9e0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 1153 EventRootType Probe[main.testPointerLoop]
+          Type: 1258 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d110", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 1135 EventRootType Probe[main.testPointerToMap]
+          Type: 1240 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84b910", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 1151 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1256 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d0f0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 1073 EventRootType Probe[main.testRuneArray]
+          Type: 1178 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 1092 EventRootType Probe[main.testSingleBool]
+          Type: 1197 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 1090 EventRootType Probe[main.testSingleByte]
+          Type: 1195 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849dd0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 1103 EventRootType Probe[main.testSingleFloat32]
+          Type: 1208 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 1104 EventRootType Probe[main.testSingleFloat64]
+          Type: 1209 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 1093 EventRootType Probe[main.testSingleInt]
+          Type: 1198 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 1095 EventRootType Probe[main.testSingleInt16]
+          Type: 1200 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 1096 EventRootType Probe[main.testSingleInt32]
+          Type: 1201 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 1097 EventRootType Probe[main.testSingleInt64]
+          Type: 1202 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 1094 EventRootType Probe[main.testSingleInt8]
+          Type: 1199 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 1091 EventRootType Probe[main.testSingleRune]
+          Type: 1196 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849de0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 1170 EventRootType Probe[main.testSingleString]
+          Type: 1275 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84d990", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 1098 EventRootType Probe[main.testSingleUint]
+          Type: 1203 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 1100 EventRootType Probe[main.testSingleUint16]
+          Type: 1205 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 1101 EventRootType Probe[main.testSingleUint32]
+          Type: 1206 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 1102 EventRootType Probe[main.testSingleUint64]
+          Type: 1207 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 1099 EventRootType Probe[main.testSingleUint8]
+          Type: 1204 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 1161 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1266 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 1133 EventRootType Probe[main.testSmallMap]
+          Type: 1238 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84b8f0", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 1074 EventRootType Probe[main.testStringArray]
+          Type: 1179 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 1156 EventRootType Probe[main.testStringPointer]
+          Type: 1261 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d1b0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 1165 EventRootType Probe[main.testStringSlice]
+          Type: 1270 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84d620", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 1113 EventRootType Probe[main.testStringType1]
+          Type: 1218 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 1114 EventRootType Probe[main.testStringType2]
+          Type: 1219 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 107
-          Type: 1178 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84dc20", Frameless: true}]
+        - ID: 109
+          Type: 1285 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x84dc50", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 1162 EventRootType Probe[main.testStructSlice]
+          Type: 1267 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,8 +1425,34 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 1127 EventRootType Probe[main.testStructWithAny]
+          Type: 1232 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x84b310", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicMaps}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 108
+          Type: 1284 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x84db60", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicSlices
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicSlices}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 107
+          Type: 1283 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x84db50", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1439,7 +1465,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 1128 EventRootType Probe[main.testStructWithMap]
+          Type: 1233 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84b8a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1479,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 1171 EventRootType Probe[main.testThreeStrings]
+          Type: 1276 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84d9a0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1493,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 1172 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1277 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84d9b0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1507,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 1173 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1278 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84d9d0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1521,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 1105 EventRootType Probe[main.testTypeAlias]
+          Type: 1210 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1535,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 1083 EventRootType Probe[main.testUint16Array]
+          Type: 1188 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1549,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 1084 EventRootType Probe[main.testUint32Array]
+          Type: 1189 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1563,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 1085 EventRootType Probe[main.testUint64Array]
+          Type: 1190 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1577,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 1082 EventRootType Probe[main.testUint8Array]
+          Type: 1187 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1591,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 1081 EventRootType Probe[main.testUintArray]
+          Type: 1186 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1605,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 1155 EventRootType Probe[main.testUintPointer]
+          Type: 1260 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d140", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1619,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 1159 EventRootType Probe[main.testUintSlice]
+          Type: 1264 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1633,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 1176 EventRootType Probe[main.testUnitializedString]
+          Type: 1281 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84da00", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1647,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 1154 EventRootType Probe[main.testUnsafePointer]
+          Type: 1259 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d120", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1661,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 1089 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1194 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1675,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 1168 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1273 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84d650", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3279,14 +3305,50 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 107
+      Name: main.testStructWithCyclicSlices
+      OutOfLinePCRanges: [0x84db50..0x84db60]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 173 StructureType main.structWithCyclicSlices
+          Locations:
+            - Range: 0x84db50..0x84db60
+              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 108
+      Name: main.testStructWithCyclicMaps
+      OutOfLinePCRanges: [0x84db60..0x84db80]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 186 StructureType main.structWithCyclicMaps
+          Locations:
+            - Range: 0x84db60..0x84db80
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0x84dc20..0x84dc40]
+      OutOfLinePCRanges: [0x84dc50..0x84dc70]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 173 StructureType main.aStruct
+          Type: 217 StructureType main.aStruct
           Locations:
-            - Range: 0x84dc20..0x84dc40
+            - Range: 0x84dc50..0x84dc70
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3304,29 +3366,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84dd20..0x84dd30]
+      OutOfLinePCRanges: [0x84dd50..0x84dd60]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 175 StructureType main.emptyStruct
-          Locations: [{Range: 0x84dd20..0x84dd30, Pieces: []}]
+          Type: 219 StructureType main.emptyStruct
+          Locations: [{Range: 0x84dd50..0x84dd60, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x84dd30..0x84dd40]
+      OutOfLinePCRanges: [0x84dd60..0x84dd70]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 176 PointerType *main.emptyStruct
+          Type: 220 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x84dd30..0x84dd40
+            - Range: 0x84dd60..0x84dd70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 112
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84aae0..0x84ab50]
       InlinePCRanges:
@@ -3356,28 +3418,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 113
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84ad78..0x84adb0]
           RootRanges: [0x84ad10..0x84add0]
       Variables: []
-    - ID: 112
+    - ID: 114
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84ae6c..0x84aeb0]
           RootRanges: [0x84ae50..0x84af70]
       Variables: []
-    - ID: 113
+    - ID: 115
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84af20..0x84af58]
           RootRanges: [0x84ae50..0x84af70]
       Variables: []
-    - ID: 114
+    - ID: 116
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3391,7 +3453,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 117
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3416,20 +3478,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 988
+      ID: 1093
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 989 PointerType *main.deepSlice3
+      Pointee: 1094 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1015
+      ID: 1120
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1016 PointerType *main.deepSlice8
+      Pointee: 1121 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1021
+      ID: 1126
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1022 PointerType *main.deepSlice9
+      Pointee: 1127 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3437,7 +3499,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 984
+      ID: 1089
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3474,30 +3536,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 996
+      ID: 1101
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 997 PointerType *table<int,*main.deepMap3>
+      Pointee: 1102 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1032
+      ID: 1137
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1033 PointerType *table<int,*main.deepMap8>
+      Pointee: 1138 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1047
+      ID: 1152
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1048 PointerType *table<int,*main.deepMap9>
+      Pointee: 1153 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1062
+      ID: 1167
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1063 PointerType *table<int,interface {}>
+      Pointee: 1168 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '**table<int,uint8>'
@@ -3514,10 +3576,10 @@ Types:
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 727
+      ID: 832
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 728 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 833 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3529,6 +3591,36 @@ Types:
       ByteSize: 8
       Pointee: 100 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
+      ID: 190
+      Name: '**table<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 191 PointerType *table<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 195
+      Name: '**table<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 196 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 200
+      Name: '**table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 201 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 205
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 206 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 210
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 211 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 215
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 216 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
       ID: 141
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
@@ -3539,146 +3631,201 @@ Types:
       ByteSize: 8
       Pointee: 137 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 183
+      ID: 227
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 992
+      ID: 1097
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 991 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1096 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1019
+      ID: 1124
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1018 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1123 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1025
+      ID: 1130
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1024 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1129 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 180
+      ID: 224
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*string.array
+      Pointee: 223 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 297
+      ID: 361
+      Name: '*[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 360 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[][][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 359
+      Name: '*[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 358 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 357
+      Name: '*[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 356 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 355
+      Name: '*[][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 354 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 353
+      Name: '*[][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 352 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 341
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType [][]uint.array
+      Pointee: 340 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 303
+      ID: 347
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []bool.array
+      Pointee: 346 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 767
+      ID: 872
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 766 GoSliceDataType []float64.array
+      Pointee: 871 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1028
+      ID: 1133
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1027 GoSliceDataType []interface {}.array
+      Pointee: 1132 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 1009
+      ID: 177
+      Name: '*[]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 174 GoSliceHeaderType []main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 351
+      Name: '*[]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 350 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 1114
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1008 GoSliceDataType []main.structWithMap.array
+      Pointee: 1113 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 299
+      ID: 343
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 342 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 301
+      ID: 345
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []string.array
+      Pointee: 344 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 162
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 295
+      ID: 339
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType []uint.array
+      Pointee: 338 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 305
+      ID: 349
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 304 GoSliceDataType []uint16.array
+      Pointee: 348 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 765
+      ID: 870
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 764 GoSliceDataType []uint8.array
+      Pointee: 869 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 897
+      ID: 1002
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.976128e+06
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1003 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 535
+      ID: 640
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 925920
       GoKind: 22
-      Pointee: 536 GoSliceHeaderType archive/tar.headerError
+      Pointee: 641 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 538
+      ID: 643
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 537 GoSliceDataType archive/tar.headerError.array
+      Pointee: 642 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 832
+      ID: 937
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.430016e+06
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 938 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 780
+      ID: 885
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 886 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 782
+      ID: 887
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 783 StructureType archive/zip.dirWriter
+      Pointee: 888 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 880
+      ID: 985
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.895808e+06
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 986 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 808
+      ID: 913
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.052544e+06
       GoKind: 22
-      Pointee: 809 StructureType archive/zip.nopCloser
+      Pointee: 914 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 810
+      ID: 915
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.0528e+06
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 916 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3687,421 +3834,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 855
+      ID: 960
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.164256e+06
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType bufio.Reader
+      Pointee: 961 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 884
+      ID: 989
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.94032e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType bufio.Writer
+      Pointee: 990 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 935
+      ID: 1040
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.261536e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1041 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 447
+      ID: 552
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 908544
       GoKind: 22
-      Pointee: 339 BaseType compress/flate.CorruptInputError
+      Pointee: 444 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 448
+      ID: 553
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 340 GoStringHeaderType compress/flate.InternalError
+      Pointee: 445 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 342
+      ID: 447
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 341 GoStringDataType compress/flate.InternalError.str
+      Pointee: 446 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 830
+      ID: 935
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.419456e+06
       GoKind: 22
-      Pointee: 831 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 936 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 776
+      ID: 881
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 882 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 852
+      ID: 957
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.717792e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 958 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 679
+      ID: 784
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.198752e+06
       GoKind: 22
-      Pointee: 680 StructureType context.deadlineExceededError
+      Pointee: 785 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 527
+      ID: 632
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 920544
       GoKind: 22
-      Pointee: 353 BaseType crypto/aes.KeySizeError
+      Pointee: 458 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 528
+      ID: 633
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 354 BaseType crypto/des.KeySizeError
+      Pointee: 459 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 529
+      ID: 634
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921024
       GoKind: 22
-      Pointee: 355 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 460 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 842
+      ID: 947
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.560096e+06
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 948 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 876
+      ID: 981
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.854464e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 982 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 908
+      ID: 1013
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.111584e+06
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1014 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 882
+      ID: 987
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.89632e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 988 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 878
+      ID: 983
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.854912e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 984 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 874
+      ID: 979
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.847296e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 980 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 530
+      ID: 635
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921312
       GoKind: 22
-      Pointee: 356 BaseType crypto/rc4.KeySizeError
+      Pointee: 461 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 892
+      ID: 997
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.945696e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 998 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 864
+      ID: 969
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.80128e+06
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 970 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 453
+      ID: 558
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 343 BaseType crypto/tls.AlertError
+      Pointee: 448 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 619
+      ID: 724
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.041152e+06
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 725 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 961
+      ID: 1066
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.373408e+06
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1067 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 451
+      ID: 556
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 452 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 557 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 449
+      ID: 554
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 450 StructureType crypto/tls.RecordHeaderError
+      Pointee: 555 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 618
+      ID: 723
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.039488e+06
       GoKind: 22
-      Pointee: 575 BaseType crypto/tls.alert
+      Pointee: 680 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 840
+      ID: 945
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.553056e+06
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 946 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 847
+      ID: 952
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.635488e+06
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 953 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 714
+      ID: 819
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.419776e+06
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 820 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 729
+      ID: 834
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.034176e+06
       GoKind: 22
-      Pointee: 730 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 835 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 523
+      ID: 628
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 919584
       GoKind: 22
-      Pointee: 524 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 629 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 517
+      ID: 622
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 919104
       GoKind: 22
-      Pointee: 518 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 623 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 519
+      ID: 624
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 919200
       GoKind: 22
-      Pointee: 520 StructureType crypto/x509.HostnameError
+      Pointee: 625 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 516
+      ID: 621
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 352 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 457 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 624
+      ID: 729
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.046912e+06
       GoKind: 22
-      Pointee: 625 StructureType crypto/x509.SystemRootsError
+      Pointee: 730 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 525
+      ID: 630
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 919680
       GoKind: 22
-      Pointee: 526 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 631 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 521
+      ID: 626
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 919488
       GoKind: 22
-      Pointee: 522 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 627 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 539
+      ID: 644
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 926400
       GoKind: 22
-      Pointee: 540 StructureType encoding/asn1.StructuralError
+      Pointee: 645 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 543
+      ID: 648
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 926592
       GoKind: 22
-      Pointee: 544 StructureType encoding/asn1.SyntaxError
+      Pointee: 649 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 541
+      ID: 646
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 542 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 647 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 437
+      ID: 542
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 337 BaseType encoding/base64.CorruptInputError
+      Pointee: 442 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 798
+      ID: 903
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.036672e+06
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 904 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 440
+      ID: 545
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 907488
       GoKind: 22
-      Pointee: 338 BaseType encoding/hex.InvalidByteError
+      Pointee: 443 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 408
+      ID: 513
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 901344
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 514 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 610
+      ID: 715
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.03296e+06
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 716 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 400
+      ID: 505
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 900960
       GoKind: 22
-      Pointee: 401 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 506 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 406
+      ID: 511
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 901248
       GoKind: 22
-      Pointee: 407 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 512 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 404
+      ID: 509
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 901152
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 510 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 402
+      ID: 507
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 901056
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 508 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 941
+      ID: 1046
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.28656e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1047 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 410
+      ID: 515
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 411 StructureType encoding/json.jsonError
+      Pointee: 516 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 806
+      ID: 911
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.049472e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 912 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 511
+      ID: 616
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 918048
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 617 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 509
+      ID: 614
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 917952
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 615 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 513
+      ID: 618
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918144
       GoKind: 22
-      Pointee: 349 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 454 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 351
+      ID: 456
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 350 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 455 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 514
+      ID: 619
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918240
       GoKind: 22
-      Pointee: 515 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 620 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 919
+      ID: 1024
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.150016e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1025 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4110,19 +4257,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 378
+      ID: 483
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 891648
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType errors.errorString
+      Pointee: 484 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 577
+      ID: 682
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.017856e+06
       GoKind: 22
-      Pointee: 578 UnresolvedPointeeType errors.joinError
+      Pointee: 683 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4138,813 +4285,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 929
+      ID: 1034
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.253856e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType fmt.pp
+      Pointee: 1035 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 579
+      ID: 684
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.019648e+06
       GoKind: 22
-      Pointee: 580 UnresolvedPointeeType fmt.wrapError
+      Pointee: 685 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 581
+      ID: 686
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.019776e+06
       GoKind: 22
-      Pointee: 582 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 687 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 438
+      ID: 543
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 439 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 544 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 419
+      ID: 524
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 904128
       GoKind: 22
-      Pointee: 420 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 525 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 421
+      ID: 526
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 904224
       GoKind: 22
-      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 527 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 742
+      ID: 847
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 743 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 848 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 425
+      ID: 530
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 426 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 531 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 744
+      ID: 849
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 22
-      Pointee: 745 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 850 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 423
+      ID: 528
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 904320
       GoKind: 22
-      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 333
+      ID: 438
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 418
+      ID: 523
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 903840
       GoKind: 22
-      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 330
+      ID: 435
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 424
+      ID: 529
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 904416
       GoKind: 22
-      Pointee: 334 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 439 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 336
+      ID: 441
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 820
+      ID: 925
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.204256e+06
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 926 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 905
+      ID: 1010
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.049184e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1011 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 533
+      ID: 638
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 924864
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 639 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 688
+      ID: 793
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.20784e+06
       GoKind: 22
-      Pointee: 689 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 794 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 937
+      ID: 1042
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.263584e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1043 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 460
+      ID: 565
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 913536
       GoKind: 22
-      Pointee: 461 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 566 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 467
+      ID: 572
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 914592
       GoKind: 22
-      Pointee: 468 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 573 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 462
+      ID: 567
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 348 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 453 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 465
+      ID: 570
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 914496
       GoKind: 22
-      Pointee: 466 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 571 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 463
+      ID: 568
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 464 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 569 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 483
+      ID: 588
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 916512
       GoKind: 22
-      Pointee: 484 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 589 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 487
+      ID: 592
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 916704
       GoKind: 22
-      Pointee: 488 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 593 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 485
+      ID: 590
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 486 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 591 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 481
+      ID: 586
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 916416
       GoKind: 22
-      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 587 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 769
+      ID: 874
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 768 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 873 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 495
+      ID: 600
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 917088
       GoKind: 22
-      Pointee: 496 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 601 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 489
+      ID: 594
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 595 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 493
+      ID: 598
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 494 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 599 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 491
+      ID: 596
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 916896
       GoKind: 22
-      Pointee: 492 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 597 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 497
+      ID: 602
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 917184
       GoKind: 22
-      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 603 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 503
+      ID: 608
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 504 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 609 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 505
+      ID: 610
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 506 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 501
+      ID: 606
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 917376
       GoKind: 22
-      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 607 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 499
+      ID: 604
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 917280
       GoKind: 22
-      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 605 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 507
+      ID: 612
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 917760
       GoKind: 22
-      Pointee: 508 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 427
+      ID: 532
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 905664
       GoKind: 22
-      Pointee: 428 StructureType github.com/cihub/seelog.baseError
+      Pointee: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 858
+      ID: 963
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.793888e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 964 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 429
+      ID: 534
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 905760
       GoKind: 22
-      Pointee: 430 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 535 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 838
+      ID: 943
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.551936e+06
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 944 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 794
+      ID: 899
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.035648e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 900 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 828
+      ID: 933
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.417536e+06
       GoKind: 22
-      Pointee: 829 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 934 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 433
+      ID: 538
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 905952
       GoKind: 22
-      Pointee: 434 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 539 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 895
+      ID: 1000
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.966048e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1001 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 912
+      ID: 1017
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.123168e+06
       GoKind: 22
-      Pointee: 907 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1012 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 911
+      ID: 1016
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.122784e+06
       GoKind: 22
-      Pointee: 910 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1015 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 796
+      ID: 901
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.035776e+06
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 431
+      ID: 536
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 905856
       GoKind: 22
-      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 537 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 435
+      ID: 540
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 906048
       GoKind: 22
-      Pointee: 436 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 541 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 860
+      ID: 965
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.79568e+06
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 966 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 901
+      ID: 1006
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.002784e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1007 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 903
+      ID: 1008
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.033856e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1009 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 719
+      ID: 824
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.432416e+06
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 825 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 632
+      ID: 737
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.060992e+06
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 738 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 630
+      ID: 735
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.060864e+06
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 736 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 634
+      ID: 739
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.06496e+06
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 740 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 636
+      ID: 741
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.065088e+06
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 742 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 849
+      ID: 954
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.66256e+06
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 955 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 626
+      ID: 731
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.047552e+06
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 732 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 441
+      ID: 546
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 907680
       GoKind: 22
-      Pointee: 442 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 547 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 953
+      ID: 1058
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.349632e+06
       GoKind: 22
-      Pointee: 954 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1059 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 690
+      ID: 795
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.216288e+06
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 796 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 663
+      ID: 768
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.19504e+06
       GoKind: 22
-      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 769 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 657
+      ID: 762
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.194656e+06
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 763 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 596
+      ID: 701
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.026944e+06
       GoKind: 22
-      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 702 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 669
+      ID: 774
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195424e+06
       GoKind: 22
-      Pointee: 670 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 595
+      ID: 700
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.026816e+06
       GoKind: 22
-      Pointee: 574 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 679 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 661
+      ID: 766
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.194912e+06
       GoKind: 22
-      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 767 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 659
+      ID: 764
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.194784e+06
       GoKind: 22
-      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 765 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 667
+      ID: 772
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.195296e+06
       GoKind: 22
-      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 773 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 665
+      ID: 770
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195168e+06
       GoKind: 22
-      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 771 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 957
+      ID: 1062
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.36144e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1063 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 673
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.195808e+06
       GoKind: 22
-      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 600
+      ID: 705
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.0272e+06
       GoKind: 22
-      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 706 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 598
+      ID: 703
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.027072e+06
       GoKind: 22
-      Pointee: 599 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 704 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 671
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.19568e+06
       GoKind: 22
-      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 555
+      ID: 660
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 939360
       GoKind: 22
-      Pointee: 361 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 466 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 363
+      ID: 468
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 362 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 467 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 732
+      ID: 837
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.661024e+06
       GoKind: 22
-      Pointee: 733 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 838 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 640
+      ID: 745
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.079808e+06
       GoKind: 22
-      Pointee: 641 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 746 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 826
+      ID: 931
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.25584e+06
       GoKind: 22
-      Pointee: 827 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 932 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 917
+      ID: 1022
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.138144e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1023 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 812
+      ID: 917
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.082112e+06
       GoKind: 22
-      Pointee: 813 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 918 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 556
+      ID: 661
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 940608
       GoKind: 22
-      Pointee: 364 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 469 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 698
+      ID: 803
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.257504e+06
       GoKind: 22
-      Pointee: 699 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 804 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 559
+      ID: 664
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 940896
       GoKind: 22
-      Pointee: 560 StructureType golang.org/x/net/http2.connError
+      Pointee: 665 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 558
+      ID: 663
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940800
       GoKind: 22
-      Pointee: 368 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 473 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 370
+      ID: 475
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 369 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 474 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 562
+      ID: 667
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 941088
       GoKind: 22
-      Pointee: 374 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 479 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 376
+      ID: 481
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 375 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 480 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 561
+      ID: 666
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 940992
       GoKind: 22
-      Pointee: 371 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 476 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 373
+      ID: 478
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 372 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 477 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 557
+      ID: 662
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940704
       GoKind: 22
-      Pointee: 365 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 470 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 367
+      ID: 472
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 366 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 471 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 915
+      ID: 1020
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.136224e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1021 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 563
+      ID: 668
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 941184
       GoKind: 22
-      Pointee: 564 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 669 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 565
+      ID: 670
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 941280
       GoKind: 22
-      Pointee: 377 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 482 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 551
+      ID: 656
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 934560
       GoKind: 22
-      Pointee: 552 StructureType google.golang.org/grpc.dropError
+      Pointee: 657 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 696
+      ID: 801
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.25456e+06
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 802 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 721
+      ID: 826
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.439776e+06
       GoKind: 22
-      Pointee: 722 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 827 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 553
+      ID: 658
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 554 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 659 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 866
+      ID: 971
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.801728e+06
       GoKind: 22
-      Pointee: 867 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 972 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 824
+      ID: 929
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.251104e+06
       GoKind: 22
-      Pointee: 825 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 930 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 638
+      ID: 743
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.074048e+06
       GoKind: 22
-      Pointee: 639 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 744 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 784
+      ID: 889
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 937728
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 890 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 531
+      ID: 636
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 637 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 628
+      ID: 733
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.05088e+06
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 734 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 694
+      ID: 799
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.22256e+06
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 800 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 692
+      ID: 797
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.222304e+06
       GoKind: 22
-      Pointee: 693 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 798 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 545
+      ID: 650
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 927456
       GoKind: 22
-      Pointee: 546 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 651 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 547
+      ID: 652
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 927552
       GoKind: 22
-      Pointee: 548 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 653 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 475
+      ID: 580
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 914976
       GoKind: 22
-      Pointee: 476 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 581 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 872
+      ID: 977
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.842368e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 978 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 566
+      ID: 671
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 942048
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType html/template.Error
+      Pointee: 672 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -4988,103 +5135,103 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 445
+      ID: 550
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 446 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 551 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 443
+      ID: 548
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 444 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 549 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 770
+      ID: 875
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 896160
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 876 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 655
+      ID: 760
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.193888e+06
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 761 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 959
+      ID: 1064
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.367072e+06
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1065 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 653
+      ID: 758
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.19376e+06
       GoKind: 22
-      Pointee: 654 StructureType internal/poll.errNetClosing
+      Pointee: 759 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 380
+      ID: 485
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 895392
       GoKind: 22
-      Pointee: 381 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 486 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 816
+      ID: 921
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.185312e+06
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType io.PipeWriter
+      Pointee: 922 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 814
+      ID: 919
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.184928e+06
       GoKind: 22
-      Pointee: 815 StructureType io.discard
+      Pointee: 920 StructureType io.discard
     - __kind: PointerType
-      ID: 788
+      ID: 893
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.018112e+06
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType io.multiWriter
+      Pointee: 894 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 651
+      ID: 756
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.193504e+06
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType io/fs.PathError
+      Pointee: 757 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 862
+      ID: 967
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.795904e+06
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 968 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 190
+      ID: 234
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 383136
       GoKind: 22
-      Pointee: 191 StructureType main.deepMap2
+      Pointee: 235 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1004
+      ID: 1109
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383072
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType main.deepMap3
+      Pointee: 1110 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -5093,19 +5240,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1040
+      ID: 1145
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 382752
       GoKind: 22
-      Pointee: 1041 StructureType main.deepMap8
+      Pointee: 1146 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1055
+      ID: 1160
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382688
       GoKind: 22
-      Pointee: 1056 StructureType main.deepMap9
+      Pointee: 1161 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -5114,12 +5261,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 963
+      ID: 1068
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383648
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1069 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5128,33 +5275,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1010
+      ID: 1115
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383328
       GoKind: 22
-      Pointee: 1011 StructureType main.deepPtr8
+      Pointee: 1116 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1012
+      ID: 1117
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383264
       GoKind: 22
-      Pointee: 1013 StructureType main.deepPtr9
+      Pointee: 1118 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 384288
       GoKind: 22
-      Pointee: 181 StructureType main.deepSlice2
+      Pointee: 225 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 989
+      ID: 1094
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384224
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1095 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5163,25 +5310,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1016
+      ID: 1121
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 383904
       GoKind: 22
-      Pointee: 1017 StructureType main.deepSlice8
+      Pointee: 1122 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1022
+      ID: 1127
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383840
       GoKind: 22
-      Pointee: 1023 StructureType main.deepSlice9
+      Pointee: 1128 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 176
+      ID: 220
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 175 StructureType main.emptyStruct
+      Pointee: 219 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
@@ -5190,12 +5337,12 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 980
+      ID: 1085
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 891360
       GoKind: 22
-      Pointee: 981 StructureType main.firstBehavior
+      Pointee: 1086 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
@@ -5210,19 +5357,19 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 982
+      ID: 1087
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 891456
       GoKind: 22
-      Pointee: 983 StructureType main.secondBehavior
+      Pointee: 1088 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 968
+      ID: 1073
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 891552
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1074 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -5230,18 +5377,23 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 966
+      ID: 1071
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 965 GoStringDataType main.stringType1.str
+      Pointee: 1070 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType main.stringType2
+      Pointee: 1072 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 242
+      ID: 175
+      Name: '*main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 173 StructureType main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 286
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382624
@@ -5265,10 +5417,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 986
+      ID: 1091
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 985 GoSliceDataType main.t.array
+      Pointee: 1090 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -5301,30 +5453,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 994
+      ID: 1099
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 995 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1100 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1030
+      ID: 1135
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1031 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1136 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1045
+      ID: 1150
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1046 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1151 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1060
+      ID: 1165
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1061 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1166 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 129
       Name: '*map<int,uint8>'
@@ -5341,10 +5493,10 @@ Types:
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 725
+      ID: 830
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 726 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 831 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -5355,6 +5507,36 @@ Types:
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 188
+      Name: '*map<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 189 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 193
+      Name: '*map<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 194 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 198
+      Name: '*map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 199 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 203
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 204 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 208
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 209 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 213
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 214 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 139
       Name: '*map<uint8,[4]int>'
@@ -5372,696 +5554,726 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 479
+      ID: 584
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 915840
       GoKind: 22
-      Pointee: 480 StructureType math/big.ErrNaN
+      Pointee: 585 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 778
+      ID: 883
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 910656
       GoKind: 22
-      Pointee: 779 StructureType mime/multipart.writerOnly·1
+      Pointee: 884 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 682
+      ID: 787
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.20208e+06
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType net.AddrError
+      Pointee: 788 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 708
+      ID: 813
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.415776e+06
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType net.DNSError
+      Pointee: 814 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 923
+      ID: 1028
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.224192e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net.IPConn
+      Pointee: 1029 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 706
+      ID: 811
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.415456e+06
       GoKind: 22
-      Pointee: 707 UnresolvedPointeeType net.OpError
+      Pointee: 812 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 684
+      ID: 789
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.202208e+06
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType net.ParseError
+      Pointee: 790 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 933
+      ID: 1038
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.25488e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net.TCPConn
+      Pointee: 1039 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 943
+      ID: 1048
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.299872e+06
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType net.UDPConn
+      Pointee: 1049 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 931
+      ID: 1036
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.254368e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType net.UnixConn
+      Pointee: 1037 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 681
+      ID: 786
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.201312e+06
       GoKind: 22
-      Pointee: 644 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 749 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 646
+      ID: 751
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 645 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 750 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 612
+      ID: 717
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.033856e+06
       GoKind: 22
-      Pointee: 613 StructureType net.canceledError
+      Pointee: 718 StructureType net.canceledError
     - __kind: PointerType
-      ID: 899
+      ID: 1004
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.999904e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType net.conn
+      Pointee: 1005 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 751
+      ID: 856
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.837664e+06
       GoKind: 22
-      Pointee: 752 StructureType net.dialResult·1
+      Pointee: 857 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 945
+      ID: 1050
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.304128e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType net.netFD
+      Pointee: 1051 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 412
+      ID: 517
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType net.notFoundError
+      Pointee: 518 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 414
+      ID: 519
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 903360
       GoKind: 22
-      Pointee: 415 StructureType net.result·2
+      Pointee: 520 StructureType net.result·2
     - __kind: PointerType
-      ID: 927
+      ID: 1032
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.240416e+06
       GoKind: 22
-      Pointee: 928 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1033 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 925
+      ID: 1030
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.239936e+06
       GoKind: 22
-      Pointee: 926 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1031 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 686
+      ID: 791
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.202848e+06
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType net.temporaryError
+      Pointee: 792 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 710
+      ID: 815
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.415936e+06
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType net.timeoutError
+      Pointee: 816 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 602
+      ID: 707
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.029632e+06
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 708 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 772
+      ID: 877
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 898464
       GoKind: 22
-      Pointee: 773 StructureType net/http.bufioFlushWriter
+      Pointee: 878 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 389
+      ID: 494
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 899136
       GoKind: 22
-      Pointee: 309 BaseType net/http.http2ConnectionError
+      Pointee: 414 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 390
+      ID: 495
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 899232
       GoKind: 22
-      Pointee: 391 StructureType net/http.http2GoAwayError
+      Pointee: 496 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 702
+      ID: 807
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.411616e+06
       GoKind: 22
-      Pointee: 703 StructureType net/http.http2StreamError
+      Pointee: 808 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 394
+      ID: 499
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 899808
       GoKind: 22
-      Pointee: 395 StructureType net/http.http2connError
+      Pointee: 500 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 834
+      ID: 939
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.548416e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 940 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 393
+      ID: 498
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 899712
       GoKind: 22
-      Pointee: 313 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 418 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 315
+      ID: 420
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 397
+      ID: 502
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 900000
       GoKind: 22
-      Pointee: 319 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 424 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 321
+      ID: 426
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 425 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 396
+      ID: 501
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 899904
       GoKind: 22
-      Pointee: 316 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 421 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 318
+      ID: 423
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 422 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 677
+      ID: 782
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.197856e+06
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 783 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 608
+      ID: 713
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.030272e+06
       GoKind: 22
-      Pointee: 609 StructureType net/http.http2noCachedConnError
+      Pointee: 714 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 888
+      ID: 993
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.942368e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 994 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 392
+      ID: 497
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 899616
       GoKind: 22
-      Pointee: 310 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 415 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 312
+      ID: 417
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 416 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 774
+      ID: 879
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 900096
       GoKind: 22
-      Pointee: 775 StructureType net/http.http2stickyErrWriter
+      Pointee: 880 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 604
+      ID: 709
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.029888e+06
       GoKind: 22
-      Pointee: 605 StructureType net/http.nothingWrittenError
+      Pointee: 710 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 836
+      ID: 941
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.165504e+06
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType net/http.persistConn
+      Pointee: 942 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 792
+      ID: 897
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.02976e+06
       GoKind: 22
-      Pointee: 793 StructureType net/http.persistConnWriter
+      Pointee: 898 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 818
+      ID: 923
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.19696e+06
       GoKind: 22
-      Pointee: 819 StructureType net/http.readWriteCloserBody
+      Pointee: 924 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 398
+      ID: 503
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 399 StructureType net/http.requestBodyReadError
+      Pointee: 504 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 704
+      ID: 809
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.412736e+06
       GoKind: 22
-      Pointee: 705 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 810 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 675
+      ID: 780
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.197728e+06
       GoKind: 22
-      Pointee: 676 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 781 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 606
+      ID: 711
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.030016e+06
       GoKind: 22
-      Pointee: 607 StructureType net/http.transportReadFromServerError
+      Pointee: 712 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 870
+      ID: 975
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.834304e+06
       GoKind: 22
-      Pointee: 871 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 976 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 387
+      ID: 492
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 898368
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 493 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 890
+      ID: 995
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.943904e+06
       GoKind: 22
-      Pointee: 891 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 996 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 802
+      ID: 907
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.042304e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 908 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 471
+      ID: 576
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 914784
       GoKind: 22
-      Pointee: 472 StructureType net/netip.parseAddrError
+      Pointee: 577 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 469
+      ID: 574
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 914688
       GoKind: 22
-      Pointee: 470 StructureType net/netip.parsePrefixError
+      Pointee: 575 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 844
+      ID: 949
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.110176e+06
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType net/smtp.Client
+      Pointee: 950 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 804
+      ID: 909
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.047168e+06
       GoKind: 22
-      Pointee: 805 StructureType net/smtp.dataCloser
+      Pointee: 910 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 455
+      ID: 560
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 910848
       GoKind: 22
-      Pointee: 456 UnresolvedPointeeType net/textproto.Error
+      Pointee: 561 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 454
+      ID: 559
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 910752
       GoKind: 22
-      Pointee: 344 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 449 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 346
+      ID: 451
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 345 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 450 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 800
+      ID: 905
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.041536e+06
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 906 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 712
+      ID: 817
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.416256e+06
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType net/url.Error
+      Pointee: 818 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 416
+      ID: 521
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 903456
       GoKind: 22
-      Pointee: 322 GoStringHeaderType net/url.EscapeError
+      Pointee: 427 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 324
+      ID: 429
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType net/url.EscapeError.str
+      Pointee: 428 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 417
+      ID: 522
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 903552
       GoKind: 22
-      Pointee: 325 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 430 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 327
+      ID: 432
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 431 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 288
+      ID: 332
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 289 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 280
+      ID: 324
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 281 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 228
+      ID: 272
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 229 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 247
+      ID: 291
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 248 StructureType noalg.map.group[bool]main.node
+      Pointee: 292 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 186
+      ID: 230
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1000
+      ID: 1105
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1001 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1106 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1036
+      ID: 1141
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1037 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1142 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1051
+      ID: 1156
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1052 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1157 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 196
+      ID: 240
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[int]int
+      Pointee: 241 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1066
+      ID: 1171
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1067 StructureType noalg.map.group[int]interface {}
+      Pointee: 1172 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 255
+      ID: 299
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 256 StructureType noalg.map.group[int]uint8
+      Pointee: 300 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 237
+      ID: 281
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 238 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 220
+      ID: 264
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 221 StructureType noalg.map.group[string][]string
+      Pointee: 265 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 758
+      ID: 863
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 212
+      ID: 256
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 213 StructureType noalg.map.group[string]int
+      Pointee: 257 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 204
+      ID: 248
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 205 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 249 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 271
+      ID: 364
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 373
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 381
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 389
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 397
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 405
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 315
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 272 StructureType noalg.map.group[uint8][4]int
+      Pointee: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 263
+      ID: 307
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 264 StructureType noalg.map.group[uint8]uint8
+      Pointee: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 951
+      ID: 1056
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.342784e+06
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType os.File
+      Pointee: 1057 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 583
+      ID: 688
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.020928e+06
       GoKind: 22
-      Pointee: 584 UnresolvedPointeeType os.LinkError
+      Pointee: 689 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 647
+      ID: 752
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.186848e+06
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType os.SyscallError
+      Pointee: 753 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 949
+      ID: 1054
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.339104e+06
       GoKind: 22
-      Pointee: 950 StructureType os.fileWithoutReadFrom
+      Pointee: 1055 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 947
+      ID: 1052
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.338368e+06
       GoKind: 22
-      Pointee: 948 StructureType os.fileWithoutWriteTo
+      Pointee: 1053 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 614
+      ID: 719
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.038208e+06
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType os/exec.Error
+      Pointee: 720 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 754
+      ID: 859
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.080032e+06
       GoKind: 22
-      Pointee: 755 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 860 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 822
+      ID: 927
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.20912e+06
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 928 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 616
+      ID: 721
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.038336e+06
       GoKind: 22
-      Pointee: 617 StructureType os/exec.wrappedError
+      Pointee: 722 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 550
+      ID: 655
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 932640
       GoKind: 22
-      Pointee: 358 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 463 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 360
+      ID: 465
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 359 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 464 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 549
+      ID: 654
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 932544
       GoKind: 22
-      Pointee: 357 BaseType os/user.UnknownUserIdError
+      Pointee: 462 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 382
+      ID: 487
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 896064
       GoKind: 22
-      Pointee: 383 UnresolvedPointeeType reflect.ValueError
+      Pointee: 488 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 477
+      ID: 582
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 478 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 583 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 587
+      ID: 692
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.022464e+06
       GoKind: 22
-      Pointee: 588 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 693 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 591
+      ID: 696
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.024256e+06
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 697 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 589
+      ID: 694
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.022592e+06
       GoKind: 22
-      Pointee: 590 StructureType runtime.boundsError
+      Pointee: 695 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 649
+      ID: 754
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.192224e+06
       GoKind: 22
-      Pointee: 650 StructureType runtime.errorAddressString
+      Pointee: 755 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 585
+      ID: 690
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.02208e+06
       GoKind: 22
-      Pointee: 568 GoStringHeaderType runtime.errorString
+      Pointee: 673 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 570
+      ID: 675
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 569 GoStringDataType runtime.errorString.str
+      Pointee: 674 GoStringDataType runtime.errorString.str
     - __kind: PointerType
-      ID: 586
+      ID: 691
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.022208e+06
       GoKind: 22
-      Pointee: 571 GoStringHeaderType runtime.plainError
+      Pointee: 676 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 573
+      ID: 678
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 572 GoStringDataType runtime.plainError.str
+      Pointee: 677 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 593
+      ID: 698
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.024512e+06
       GoKind: 22
-      Pointee: 594 UnresolvedPointeeType strconv.NumError
+      Pointee: 699 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6070,168 +6282,198 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 178
+      ID: 222
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 177 GoStringDataType string.str
+      Pointee: 221 GoStringDataType string.str
     - __kind: PointerType
-      ID: 886
+      ID: 991
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.941088e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType strings.Builder
+      Pointee: 992 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 790
+      ID: 895
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.02464e+06
       GoKind: 22
-      Pointee: 791 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 896 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 786
+      ID: 891
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 965440
       GoKind: 22
-      Pointee: 787 StructureType struct { io.Writer }
+      Pointee: 892 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 701
+      ID: 806
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.410976e+06
       GoKind: 22
-      Pointee: 700 BaseType syscall.Errno
+      Pointee: 805 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 286 StructureType table<[4]int,[4]int>
+      Pointee: 330 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 147
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 278 StructureType table<[4]int,uint8>
+      Pointee: 322 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 115
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 226 StructureType table<[4]string,[2]int>
+      Pointee: 270 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 127
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 245 StructureType table<bool,main.node>
+      Pointee: 289 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 184 StructureType table<int,*main.deepMap2>
+      Pointee: 228 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 997
+      ID: 1102
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 998 StructureType table<int,*main.deepMap3>
+      Pointee: 1103 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1033
+      ID: 1138
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1034 StructureType table<int,*main.deepMap8>
+      Pointee: 1139 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1048
+      ID: 1153
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1049 StructureType table<int,*main.deepMap9>
+      Pointee: 1154 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 194 StructureType table<int,int>
+      Pointee: 238 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1063
+      ID: 1168
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1064 StructureType table<int,interface {}>
+      Pointee: 1169 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 253 StructureType table<int,uint8>
+      Pointee: 297 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 122
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 235 StructureType table<string,[]main.structWithMap>
+      Pointee: 279 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 110
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 218 StructureType table<string,[]string>
+      Pointee: 262 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 728
+      ID: 833
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 756 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 861 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 210 StructureType table<string,int>
+      Pointee: 254 StructureType table<string,int>
     - __kind: PointerType
       ID: 100
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 202 StructureType table<string,main.nestedStruct>
+      Pointee: 246 StructureType table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 191
+      Name: '*table<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 362 StructureType table<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 196
+      Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 371 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 201
+      Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 379 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 206
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 387 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 211
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 395 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 216
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 403 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 142
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 269 StructureType table<uint8,[4]int>
+      Pointee: 313 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 137
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 261 StructureType table<uint8,uint8>
+      Pointee: 305 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 921
+      ID: 1026
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.1504e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1027 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 642
+      ID: 747
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.083648e+06
       GoKind: 22
-      Pointee: 643 StructureType text/template.ExecError
+      Pointee: 748 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 717
+      ID: 822
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.61648e+06
       GoKind: 22
-      Pointee: 718 UnresolvedPointeeType time.Location
+      Pointee: 823 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 385
+      ID: 490
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 896928
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType time.ParseError
+      Pointee: 491 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 384
+      ID: 489
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 896832
       GoKind: 22
-      Pointee: 306 GoStringHeaderType time.fileSizeError
+      Pointee: 411 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 308
+      ID: 413
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType time.fileSizeError.str
+      Pointee: 412 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6275,52 +6517,52 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 473
+      ID: 578
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 914880
       GoKind: 22
-      Pointee: 474 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 579 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 913
+      ID: 1018
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.125856e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1019 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 457
+      ID: 562
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 911040
       GoKind: 22
-      Pointee: 458 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 563 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 459
+      ID: 564
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 347 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 452 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 621
+      ID: 726
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.042048e+06
       GoKind: 22
-      Pointee: 622 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 727 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 623
+      ID: 728
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.042176e+06
       GoKind: 22
-      Pointee: 576 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 681 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1169
+      ID: 1274
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1126
+      ID: 1231
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6335,7 +6577,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1124
+      ID: 1229
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6350,7 +6592,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1088
+      ID: 1193
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6365,7 +6607,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1086
+      ID: 1191
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6380,7 +6622,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1134
+      ID: 1239
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6395,7 +6637,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1087
+      ID: 1192
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6410,7 +6652,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1106
+      ID: 1211
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6425,7 +6667,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1075
+      ID: 1180
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6440,7 +6682,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1072
+      ID: 1177
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6455,7 +6697,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1150
+      ID: 1255
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6470,7 +6712,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1148
+      ID: 1253
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6503,7 +6745,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1158
+      ID: 1263
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6518,7 +6760,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1111
+      ID: 1216
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6533,7 +6775,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1112
+      ID: 1217
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6548,7 +6790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1107
+      ID: 1212
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6563,7 +6805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1108
+      ID: 1213
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6578,7 +6820,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1109
+      ID: 1214
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6593,7 +6835,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1110
+      ID: 1215
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6608,7 +6850,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1163
+      ID: 1268
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6632,7 +6874,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1160
+      ID: 1265
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6647,7 +6889,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1177
+      ID: 1282
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6662,7 +6904,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1180
+      ID: 1287
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6670,14 +6912,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 176 PointerType *main.emptyStruct
+            Type: 220 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: e}
+                  Variable: {subprogram: 111, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1179
+      ID: 1286
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6685,14 +6927,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 StructureType main.emptyStruct
+            Type: 219 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 110, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1125
+      ID: 1230
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6707,7 +6949,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1116
+      ID: 1221
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6722,7 +6964,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1115
+      ID: 1220
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6737,7 +6979,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1122
+      ID: 1227
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6752,7 +6994,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1121
+      ID: 1226
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6767,7 +7009,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1117
+      ID: 1222
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6782,7 +7024,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1119
+      ID: 1224
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6797,10 +7039,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1182
+      ID: 1289
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1118
+      ID: 1223
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6824,16 +7066,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1290
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1184
+      ID: 1291
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1120
+      ID: 1225
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1181
+      ID: 1288
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6844,11 +7086,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 112, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1185
+      ID: 1292
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6859,11 +7101,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1186
+      ID: 1293
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6874,11 +7116,11 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: a}
+                  Variable: {subprogram: 117, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1078
+      ID: 1183
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6893,7 +7135,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1079
+      ID: 1184
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6908,7 +7150,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1080
+      ID: 1185
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6923,7 +7165,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1077
+      ID: 1182
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6938,7 +7180,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1076
+      ID: 1181
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6953,7 +7195,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1123
+      ID: 1228
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6968,7 +7210,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1152
+      ID: 1257
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6983,7 +7225,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1132
+      ID: 1237
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6998,7 +7240,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1138
+      ID: 1243
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7013,7 +7255,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1136
+      ID: 1241
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7028,7 +7270,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1147
+      ID: 1252
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7043,7 +7285,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1146
+      ID: 1251
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7058,7 +7300,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1137
+      ID: 1242
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7073,7 +7315,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1145
+      ID: 1250
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7088,7 +7330,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1144
+      ID: 1249
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7103,7 +7345,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1130
+      ID: 1235
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7118,7 +7360,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1131
+      ID: 1236
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7133,7 +7375,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1129
+      ID: 1234
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7148,7 +7390,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1139
+      ID: 1244
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7163,7 +7405,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1143
+      ID: 1248
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7178,7 +7420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1142
+      ID: 1247
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7193,7 +7435,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1141
+      ID: 1246
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7208,7 +7450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1140
+      ID: 1245
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7223,7 +7465,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1175
+      ID: 1280
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7238,7 +7480,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1149
+      ID: 1254
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7289,7 +7531,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1157
+      ID: 1262
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7313,7 +7555,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1164
+      ID: 1269
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7337,7 +7579,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1166
+      ID: 1271
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7370,7 +7612,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1272
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7385,7 +7627,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1174
+      ID: 1279
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7400,7 +7642,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1153
+      ID: 1258
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7415,7 +7657,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1135
+      ID: 1240
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7430,7 +7672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1151
+      ID: 1256
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7445,7 +7687,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1073
+      ID: 1178
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7460,7 +7702,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1092
+      ID: 1197
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7475,7 +7717,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1090
+      ID: 1195
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7490,7 +7732,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1103
+      ID: 1208
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7505,7 +7747,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1104
+      ID: 1209
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7520,7 +7762,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1095
+      ID: 1200
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7535,7 +7777,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1096
+      ID: 1201
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7550,7 +7792,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1097
+      ID: 1202
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7565,7 +7807,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1094
+      ID: 1199
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7580,7 +7822,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1093
+      ID: 1198
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7595,7 +7837,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1091
+      ID: 1196
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7610,7 +7852,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1170
+      ID: 1275
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7625,7 +7867,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1100
+      ID: 1205
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7640,7 +7882,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1101
+      ID: 1206
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7655,7 +7897,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1102
+      ID: 1207
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7670,7 +7912,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1099
+      ID: 1204
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7685,7 +7927,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1098
+      ID: 1203
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7700,7 +7942,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1161
+      ID: 1266
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7715,7 +7957,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1133
+      ID: 1238
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7730,7 +7972,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1074
+      ID: 1179
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7745,7 +7987,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1156
+      ID: 1261
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7760,7 +8002,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1165
+      ID: 1270
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7775,7 +8017,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1113
+      ID: 1218
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7790,7 +8032,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1114
+      ID: 1219
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7805,7 +8047,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1162
+      ID: 1267
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7829,7 +8071,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1127
+      ID: 1232
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7844,7 +8086,37 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1128
+      ID: 1284
+      Name: Probe[main.testStructWithCyclicMaps]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 186 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 1283
+      Name: Probe[main.testStructWithCyclicSlices]
+      ByteSize: 145
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 173 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
+    - __kind: EventRootType
+      ID: 1233
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7859,7 +8131,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1178
+      ID: 1285
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7867,14 +8139,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 173 StructureType main.aStruct
+            Type: 217 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1173
+      ID: 1278
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7889,7 +8161,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1172
+      ID: 1277
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7904,7 +8176,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1171
+      ID: 1276
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7937,7 +8209,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1105
+      ID: 1210
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7952,7 +8224,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1083
+      ID: 1188
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7967,7 +8239,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1084
+      ID: 1189
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7982,7 +8254,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1085
+      ID: 1190
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7997,7 +8269,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1082
+      ID: 1187
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8012,7 +8284,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1081
+      ID: 1186
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8027,7 +8299,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1155
+      ID: 1260
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8042,7 +8314,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1159
+      ID: 1264
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8057,7 +8329,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1176
+      ID: 1281
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8072,7 +8344,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1154
+      ID: 1259
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8087,7 +8359,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1089
+      ID: 1194
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -8102,7 +8374,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1168
+      ID: 1273
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8250,7 +8522,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 275
+      ID: 319
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 678912
@@ -8259,7 +8531,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 232
+      ID: 276
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 679200
@@ -8276,7 +8548,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 746
+      ID: 851
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 680448
@@ -8300,14 +8572,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 182 GoSliceDataType []*main.deepSlice2.array
+      Data: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 226
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 987
+      ID: 1092
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474784
@@ -8315,21 +8587,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 988 PointerType **main.deepSlice3
+          Type: 1093 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 991 GoSliceDataType []*main.deepSlice3.array
+      Data: 1096 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 991
+      ID: 1096
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 989 PointerType *main.deepSlice3
+      Element: 1094 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1014
+      ID: 1119
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474464
@@ -8337,21 +8609,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1015 PointerType **main.deepSlice8
+          Type: 1120 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1018 GoSliceDataType []*main.deepSlice8.array
+      Data: 1123 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1018
+      ID: 1123
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 1016 PointerType *main.deepSlice8
+      Element: 1121 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1020
+      ID: 1125
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474400
@@ -8359,19 +8631,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1021 PointerType **main.deepSlice9
+          Type: 1126 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1024 GoSliceDataType []*main.deepSlice9.array
+      Data: 1129 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1024
+      ID: 1129
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 1022 PointerType *main.deepSlice9
+      Element: 1127 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -8388,102 +8660,237 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 179 GoSliceDataType []*string.array
+      Data: 223 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 223
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 336
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 152 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 328
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 147 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 277
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 115 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 295
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 236
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1006
+      ID: 1111
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 997 PointerType *table<int,*main.deepMap3>
+      Element: 1102 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1042
+      ID: 1147
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 1033 PointerType *table<int,*main.deepMap8>
+      Element: 1138 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1057
+      ID: 1162
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 1048 PointerType *table<int,*main.deepMap9>
+      Element: 1153 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 244
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1070
+      ID: 1175
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 1063 PointerType *table<int,interface {}>
+      Element: 1168 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 303
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 132 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 287
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 268
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 762
+      ID: 867
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 8192
-      Element: 728 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 833 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 260
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 252
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 100 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 369
+      Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 191 PointerType *table<struct {},main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 377
+      Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 196 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 385
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 201 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 393
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 206 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 401
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 211 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 409
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 216 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 320
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 142 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 311
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 137 PointerType *table<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 184
+      Name: '[][][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 185 PointerType *[][][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 360 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 360
+      Name: '[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 182
+      Name: '[][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 183 PointerType *[][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 358 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 358
+      Name: '[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 180
+      Name: '[][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 181 PointerType *[][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 356 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 356
+      Name: '[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 178
+      Name: '[][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 179 PointerType *[][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 354 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 354
+      Name: '[][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 176
+      Name: '[][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 177 PointerType *[]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 352 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 352
+      Name: '[][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 174 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
       ID: 161
       Name: '[][]uint'
@@ -8499,9 +8906,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 296 GoSliceDataType [][]uint.array
+      Data: 340 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 340
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 160 GoSliceHeaderType []uint
@@ -8521,14 +8928,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 302 GoSliceDataType []bool.array
+      Data: 346 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 346
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 741
+      ID: 846
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 483616
@@ -8543,14 +8950,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 766 GoSliceDataType []float64.array
+      Data: 871 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 766
+      ID: 871
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1026
+      ID: 1131
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484064
@@ -8565,14 +8972,35 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1027 GoSliceDataType []interface {}.array
+      Data: 1132 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1027
+      ID: 1132
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 241
+      ID: 174
+      Name: '[]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 175 PointerType *main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 350 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 350
+      Name: '[]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 173 StructureType main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 285
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 475104
@@ -8580,16 +9008,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 242 PointerType *main.structWithMap
+          Type: 286 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1008 GoSliceDataType []main.structWithMap.array
+      Data: 1113 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1008
+      ID: 1113
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -8608,102 +9036,132 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 298 GoSliceDataType []main.structWithNoStrings.array
+      Data: 342 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 342
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 337
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 289 StructureType noalg.map.group[[4]int][4]int
+      Element: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 329
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 281 StructureType noalg.map.group[[4]int]uint8
+      Element: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 278
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 229 StructureType noalg.map.group[[4]string][2]int
+      Element: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 296
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 248 StructureType noalg.map.group[bool]main.node
+      Element: 292 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 237
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 187 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1007
+      ID: 1112
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 1001 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1106 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1043
+      ID: 1148
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 1037 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1142 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1058
+      ID: 1163
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 1052 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1157 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 245
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[int]int
+      Element: 241 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1071
+      ID: 1176
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 1067 StructureType noalg.map.group[int]interface {}
+      Element: 1172 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 304
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 256 StructureType noalg.map.group[int]uint8
+      Element: 300 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 288
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 238 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 269
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 221 StructureType noalg.map.group[string][]string
+      Element: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 763
+      ID: 868
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 2048
-      Element: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 261
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 213 StructureType noalg.map.group[string]int
+      Element: 257 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 253
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 205 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 249 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 370
+      Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 378
+      Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 386
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 394
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 402
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 410
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 321
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 272 StructureType noalg.map.group[uint8][4]int
+      Element: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 312
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 264 StructureType noalg.map.group[uint8]uint8
+      Element: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 166
       Name: '[]string'
@@ -8720,9 +9178,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 300 GoSliceDataType []string.array
+      Data: 344 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 344
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -8742,9 +9200,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 294 GoSliceDataType []uint.array
+      Data: 338 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 338
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
@@ -8764,14 +9222,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 304 GoSliceDataType []uint16.array
+      Data: 348 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 304
+      ID: 348
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 735
+      ID: 840
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 482592
@@ -8786,18 +9244,18 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 764 GoSliceDataType []uint8.array
+      Data: 869 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 764
+      ID: 869
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 1003
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 536
+      ID: 641
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 926016
@@ -8812,32 +9270,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 537 GoSliceDataType archive/tar.headerError.array
+      Data: 642 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 537
+      ID: 642
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 938
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 886
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 783
+      ID: 888
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.114784e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 986
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 914
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.558976e+06
@@ -8847,7 +9305,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 916
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -8857,15 +9315,15 @@ Types:
       GoRuntimeType: 581184
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 961
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 990
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 1041
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -8891,13 +9349,13 @@ Types:
       GoRuntimeType: 580928
       GoKind: 15
     - __kind: BaseType
-      ID: 339
+      ID: 444
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830528
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 340
+      ID: 445
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 830624
@@ -8905,109 +9363,109 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 342 PointerType *compress/flate.InternalError.str
+          Type: 447 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 341 GoStringDataType compress/flate.InternalError.str
+      Data: 446 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 341
+      ID: 446
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 831
+      ID: 936
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 882
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 958
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 680
+      ID: 785
       Name: context.deadlineExceededError
       GoRuntimeType: 1.473216e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 353
+      ID: 458
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833120
       GoKind: 2
     - __kind: BaseType
-      ID: 354
+      ID: 459
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833216
       GoKind: 2
     - __kind: BaseType
-      ID: 355
+      ID: 460
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833312
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 948
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 982
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 1014
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 988
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 984
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 980
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 356
+      ID: 461
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833408
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 998
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 970
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 343
+      ID: 448
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 831104
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 725
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 1067
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 452
+      ID: 557
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 450
+      ID: 555
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.7224e+06
@@ -9018,34 +9476,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 746 ArrayType [5]uint8
+          Type: 851 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 575
+      ID: 680
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 988256
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 946
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 953
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 820
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 730
+      ID: 835
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 524
+      ID: 629
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.72528e+06
@@ -9053,21 +9511,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 729 PointerType *crypto/x509.Certificate
+          Type: 834 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 749 BaseType crypto/x509.InvalidReason
+          Type: 854 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 518
+      ID: 623
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.112352e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 520
+      ID: 625
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.593696e+06
@@ -9075,24 +9533,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 729 PointerType *crypto/x509.Certificate
+          Type: 834 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 352
+      ID: 457
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 832736
       GoKind: 2
     - __kind: BaseType
-      ID: 749
+      ID: 854
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 586368
       GoKind: 2
     - __kind: StructureType
-      ID: 625
+      ID: 730
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.554976e+06
@@ -9102,13 +9560,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 526
+      ID: 631
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.112608e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 522
+      ID: 627
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.725088e+06
@@ -9116,15 +9574,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 729 PointerType *crypto/x509.Certificate
+          Type: 834 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 729 PointerType *crypto/x509.Certificate
+          Type: 834 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 540
+      ID: 645
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.430656e+06
@@ -9134,7 +9592,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 544
+      ID: 649
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.430816e+06
@@ -9144,55 +9602,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 542
+      ID: 647
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 337
+      ID: 442
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830144
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 904
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 338
+      ID: 443
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 830336
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 514
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 716
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 401
+      ID: 506
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 407
+      ID: 512
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 510
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 508
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 1047
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 411
+      ID: 516
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.414496e+06
@@ -9202,19 +9660,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 912
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 617
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 615
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 349
+      ID: 454
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -9222,21 +9680,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 351 PointerType *encoding/xml.UnmarshalError.str
+          Type: 456 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 350 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 455 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 350
+      ID: 455
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 515
+      ID: 620
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 1025
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9253,11 +9711,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 484
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 578
+      ID: 683
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9273,15 +9731,15 @@ Types:
       GoRuntimeType: 581120
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 1035
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 580
+      ID: 685
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 582
+      ID: 687
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9291,11 +9749,11 @@ Types:
       GoRuntimeType: 473056
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 439
+      ID: 544
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 420
+      ID: 525
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.721248e+06
@@ -9303,7 +9761,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 739 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 844 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -9311,25 +9769,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 422
+      ID: 527
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 743
+      ID: 848
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 426
+      ID: 531
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.10864e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 745
+      ID: 850
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 829568
@@ -9337,17 +9795,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 437
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 739
+      ID: 844
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.210208e+06
@@ -9355,7 +9813,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 740 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 845 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9370,7 +9828,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 741 GoSliceHeaderType []float64
+          Type: 846 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -9379,10 +9837,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 742 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 847 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 744 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 849 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 166 GoSliceHeaderType []string
@@ -9396,13 +9854,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 740
+      ID: 845
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 582976
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 433
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 829472
@@ -9410,17 +9868,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 434
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 334
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 829664
@@ -9428,59 +9886,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 336 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 441 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 335
+      ID: 440
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 926
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 1011
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 639
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 689
+      ID: 794
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 1043
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 461
+      ID: 566
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 468
+      ID: 573
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.111584e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 348
+      ID: 453
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 831776
       GoKind: 2
     - __kind: StructureType
-      ID: 466
+      ID: 571
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.111456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 464
+      ID: 569
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.591776e+06
@@ -9493,7 +9951,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 484
+      ID: 589
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.592576e+06
@@ -9506,7 +9964,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 488
+      ID: 593
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.724512e+06
@@ -9522,7 +9980,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 486
+      ID: 591
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.424256e+06
@@ -9532,7 +9990,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 482
+      ID: 587
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.423936e+06
@@ -9542,14 +10000,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 724
+      ID: 829
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.494336e+06
       GoKind: 21
-      HeaderType: 726 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 831 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 748
+      ID: 853
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.045632e+06
@@ -9564,14 +10022,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 768 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 873 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 768
+      ID: 873
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 496
+      ID: 601
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.592896e+06
@@ -9579,12 +10037,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 724 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 829 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 724 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 829 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 490
+      ID: 595
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.424416e+06
@@ -9594,7 +10052,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 494
+      ID: 599
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.724704e+06
@@ -9605,12 +10063,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 492
+      ID: 597
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.592736e+06
@@ -9623,7 +10081,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 498
+      ID: 603
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.424576e+06
@@ -9631,9 +10089,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 716 StructureType time.Time
+          Type: 821 StructureType time.Time
     - __kind: StructureType
-      ID: 504
+      ID: 609
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.593216e+06
@@ -9646,7 +10104,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 506
+      ID: 611
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.424896e+06
@@ -9656,7 +10114,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 502
+      ID: 607
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.593056e+06
@@ -9669,7 +10127,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 500
+      ID: 605
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.424736e+06
@@ -9679,7 +10137,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 508
+      ID: 613
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.593376e+06
@@ -9692,7 +10150,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 428
+      ID: 533
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.416736e+06
@@ -9702,11 +10160,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 964
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 430
+      ID: 535
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.416896e+06
@@ -9714,21 +10172,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 428 StructureType github.com/cihub/seelog.baseError
+          Type: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 944
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 900
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 829
+      ID: 934
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 434
+      ID: 539
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.417216e+06
@@ -9736,13 +10194,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 428 StructureType github.com/cihub/seelog.baseError
+          Type: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 1001
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 907
+      ID: 1012
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.098592e+06
@@ -9750,12 +10208,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 895 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1000 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 910
+      ID: 1015
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.1224e+06
@@ -9763,7 +10221,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 895 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1000 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9771,11 +10229,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 902
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 432
+      ID: 537
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.417056e+06
@@ -9783,9 +10241,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 428 StructureType github.com/cihub/seelog.baseError
+          Type: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 436
+      ID: 541
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.417376e+06
@@ -9793,64 +10251,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 428 StructureType github.com/cihub/seelog.baseError
+          Type: 533 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 966
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 1007
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 1009
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 825
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 738
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 736
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 740
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 742
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 955
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 732
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 442
+      ID: 547
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.418336e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 954
+      ID: 1059
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 796
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 664
+      ID: 769
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.832512e+06
@@ -9866,11 +10324,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 763
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 597
+      ID: 702
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.695296e+06
@@ -9883,7 +10341,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 670
+      ID: 775
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.83296e+06
@@ -9899,13 +10357,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 574
+      ID: 679
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 985568
       GoKind: 8
     - __kind: StructureType
-      ID: 662
+      ID: 767
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.832288e+06
@@ -9921,13 +10379,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 750
+      ID: 855
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 827744
       GoKind: 8
     - __kind: StructureType
-      ID: 660
+      ID: 765
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.832064e+06
@@ -9935,15 +10393,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 750 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 855 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 750 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 855 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 668
+      ID: 773
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.746752e+06
@@ -9956,7 +10414,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 666
+      ID: 771
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.832736e+06
@@ -9972,11 +10430,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 1063
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 674
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.61744e+06
@@ -9986,19 +10444,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 601
+      ID: 706
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.278048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 599
+      ID: 704
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.27792e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 672
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.746944e+06
@@ -10011,7 +10469,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 361
+      ID: 466
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835232
@@ -10019,21 +10477,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 363 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 468 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 362 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 467 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 362
+      ID: 467
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 733
+      ID: 838
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 641
+      ID: 746
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.442496e+06
@@ -10043,7 +10501,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 827
+      ID: 932
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.671392e+06
@@ -10051,13 +10509,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 851 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 956 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 1023
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 851
+      ID: 956
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.122336e+06
@@ -10070,7 +10528,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 813
+      ID: 918
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.563936e+06
@@ -10080,19 +10538,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 364
+      ID: 469
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 835808
       GoKind: 10
     - __kind: BaseType
-      ID: 731
+      ID: 836
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 998720
       GoKind: 10
     - __kind: StructureType
-      ID: 699
+      ID: 804
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.871488e+06
@@ -10103,12 +10561,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 731 BaseType golang.org/x/net/http2.ErrCode
+          Type: 836 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 560
+      ID: 665
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.600416e+06
@@ -10116,12 +10574,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 731 BaseType golang.org/x/net/http2.ErrCode
+          Type: 836 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 368
+      ID: 473
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836000
@@ -10129,17 +10587,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 370 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 475 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 369 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 474 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 369
+      ID: 474
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 374
+      ID: 479
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836192
@@ -10147,17 +10605,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 376 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 481 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 375 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 480 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 375
+      ID: 480
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 371
+      ID: 476
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836096
@@ -10165,17 +10623,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 373 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 478 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 372 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 477 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 372
+      ID: 477
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 365
+      ID: 470
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 835904
@@ -10183,21 +10641,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 367 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 472 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 366 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 471 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 366
+      ID: 471
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 1021
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 564
+      ID: 669
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.443136e+06
@@ -10207,13 +10665,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 377
+      ID: 482
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836288
       GoKind: 2
     - __kind: StructureType
-      ID: 552
+      ID: 657
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.438176e+06
@@ -10223,11 +10681,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 802
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 827
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.899392e+06
@@ -10243,7 +10701,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 554
+      ID: 659
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.599936e+06
@@ -10256,7 +10714,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 867
+      ID: 972
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.95696e+06
@@ -10264,16 +10722,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 894 GoInterfaceType io.Reader
+          Type: 999 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 825
+      ID: 930
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 639
+      ID: 744
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.561536e+06
@@ -10283,29 +10741,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 890
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 637
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 734
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 800
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 693
+      ID: 798
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.504896e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 546
+      ID: 651
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.431456e+06
@@ -10315,7 +10773,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 548
+      ID: 653
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.431616e+06
@@ -10325,267 +10783,351 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 476
+      ID: 581
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 287
+      ID: 331
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 288 PointerType *noalg.map.group[[4]int][4]int
+          Type: 332 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 293 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 333 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 337 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 279
+      ID: 323
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 280 PointerType *noalg.map.group[[4]int]uint8
+          Type: 324 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 285 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 325 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 329 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 227
+      ID: 271
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 228 PointerType *noalg.map.group[[4]string][2]int
+          Type: 272 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 234 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 273 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 278 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 246
+      ID: 290
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 247 PointerType *noalg.map.group[bool]main.node
+          Type: 291 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 248 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 252 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 292 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 296 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 185
+      ID: 229
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 186 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 230 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 999
+      ID: 1104
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1000 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1105 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1001 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1007 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1106 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1112 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1035
+      ID: 1140
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1036 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1141 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1037 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1043 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1142 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1148 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1050
+      ID: 1155
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1051 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1156 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1052 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1058 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1157 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1163 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 239
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[int]int
+          Type: 240 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[int]int
-      GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 241 StructureType noalg.map.group[int]int
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1065
+      ID: 1170
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1066 PointerType *noalg.map.group[int]interface {}
+          Type: 1171 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1067 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1071 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1172 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1176 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 254
+      ID: 298
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 255 PointerType *noalg.map.group[int]uint8
+          Type: 299 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 256 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 260 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 300 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 304 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 236
+      ID: 280
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 237 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 281 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 282 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 288 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 219
+      ID: 263
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 220 PointerType *noalg.map.group[string][]string
+          Type: 264 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 221 StructureType noalg.map.group[string][]string
-      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 265 StructureType noalg.map.group[string][]string
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 757
+      ID: 862
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 758 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 863 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 763 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 868 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 211
+      ID: 255
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 212 PointerType *noalg.map.group[string]int
+          Type: 256 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 213 StructureType noalg.map.group[string]int
-      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 257 StructureType noalg.map.group[string]int
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 203
+      ID: 247
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 204 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 248 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 249 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 270
+      ID: 363
+      Name: groupReference<struct {},main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 364 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 370 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 372
+      Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 373 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 380
+      Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 381 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 386 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 388
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 389 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 394 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 396
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 397 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 402 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 404
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 405 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 410 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 314
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 271 PointerType *noalg.map.group[uint8][4]int
+          Type: 315 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 272 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 277 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 316 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 321 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 262
+      ID: 306
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 263 PointerType *noalg.map.group[uint8]uint8
+          Type: 307 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 264 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 308 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 312 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 978
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 672
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -10632,37 +11174,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 446
+      ID: 551
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 444
+      ID: 549
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 876
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 761
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 1065
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 654
+      ID: 759
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.470016e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 381
+      ID: 486
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 972
+      ID: 1077
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.467456e+06
@@ -10675,11 +11217,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 922
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 857
+      ID: 962
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.185056e+06
@@ -10692,7 +11234,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 894
+      ID: 999
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.01824e+06
@@ -10705,7 +11247,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 846
+      ID: 951
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.104928e+06
@@ -10731,25 +11273,25 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 815
+      ID: 920
       Name: io.discard
       GoRuntimeType: 1.457376e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 894
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 757
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 968
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 173
+      ID: 217
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -10765,7 +11307,7 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 174 StructureType main.nestedStruct
+          Type: 218 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
@@ -10805,7 +11347,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 191
+      ID: 235
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.1816e+06
@@ -10813,9 +11355,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 993 GoMapType map[int]*main.deepMap3
+          Type: 1098 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1110
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -10827,9 +11369,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1029 GoMapType map[int]*main.deepMap8
+          Type: 1134 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1041
+      ID: 1146
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.180832e+06
@@ -10837,9 +11379,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1044 GoMapType map[int]*main.deepMap9
+          Type: 1149 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1056
+      ID: 1161
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.180704e+06
@@ -10847,7 +11389,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1059 GoMapType map[int]interface {}
+          Type: 1164 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -10867,9 +11409,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 963 PointerType *main.deepPtr3
+          Type: 1068 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 1069
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -10881,9 +11423,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1010 PointerType *main.deepPtr8
+          Type: 1115 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1011
+      ID: 1116
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.181984e+06
@@ -10891,9 +11433,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1012 PointerType *main.deepPtr9
+          Type: 1117 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1013
+      ID: 1118
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.181856e+06
@@ -10913,7 +11455,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 181
+      ID: 225
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.183904e+06
@@ -10921,9 +11463,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 987 GoSliceHeaderType []*main.deepSlice3
+          Type: 1092 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 1095
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -10935,9 +11477,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1014 GoSliceHeaderType []*main.deepSlice8
+          Type: 1119 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1017
+      ID: 1122
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.183136e+06
@@ -10945,9 +11487,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1020 GoSliceHeaderType []*main.deepSlice9
+          Type: 1125 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1023
+      ID: 1128
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.183008e+06
@@ -10955,9 +11497,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1026 GoSliceHeaderType []interface {}
+          Type: 1131 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 175
+      ID: 219
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -10973,16 +11515,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 970 StructureType sync.Mutex
+          Type: 1075 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 973 StructureType sync.Once
+          Type: 1078 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 976 StructureType sync.WaitGroup
+          Type: 1081 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 979 StructureType sync/atomic.Int32
+          Type: 1084 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -11012,7 +11554,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 981
+      ID: 1086
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.407616e+06
@@ -11022,7 +11564,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 174
+      ID: 218
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.456896e+06
@@ -11057,7 +11599,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 983
+      ID: 1088
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.407776e+06
@@ -11077,7 +11619,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 1074
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11088,17 +11630,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 966 PointerType *main.stringType1.str
+          Type: 1071 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 965 GoStringDataType main.stringType1.str
+      Data: 1070 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 965
+      ID: 1070
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 1072
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11111,6 +11653,54 @@ Types:
         - Name: a
           Offset: 0
           Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 186
+      Name: main.structWithCyclicMaps
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: m1
+          Offset: 0
+          Type: 187 GoMapType map[struct {}]main.structWithCyclicMaps
+        - Name: m2
+          Offset: 8
+          Type: 192 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m3
+          Offset: 16
+          Type: 197 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m4
+          Offset: 24
+          Type: 202 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m5
+          Offset: 32
+          Type: 207 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m6
+          Offset: 40
+          Type: 212 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 173
+      Name: main.structWithCyclicSlices
+      ByteSize: 144
+      GoKind: 25
+      RawFields:
+        - Name: s1
+          Offset: 0
+          Type: 174 GoSliceHeaderType []main.structWithCyclicSlices
+        - Name: s2
+          Offset: 24
+          Type: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+        - Name: s3
+          Offset: 48
+          Type: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+        - Name: s4
+          Offset: 72
+          Type: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+        - Name: s5
+          Offset: 96
+          Type: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+        - Name: s6
+          Offset: 120
+          Type: 184 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 90
       Name: main.structWithMap
@@ -11153,16 +11743,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 984 PointerType **main.t
+          Type: 1089 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 985 GoSliceDataType main.t.array
+      Data: 1090 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 985
+      ID: 1090
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -11216,8 +11806,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 292 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 336 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 145
       Name: map<[4]int,uint8>
@@ -11248,8 +11838,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 284 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 328 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 113
       Name: map<[4]string,[2]int>
@@ -11280,8 +11870,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 233 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 277 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 125
       Name: map<bool,main.node>
@@ -11312,8 +11902,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 251 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 248 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 295 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 292 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -11344,10 +11934,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 236 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 995
+      ID: 1100
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -11360,7 +11950,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 996 PointerType **table<int,*main.deepMap3>
+          Type: 1101 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11376,10 +11966,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1006 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1001 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1111 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1106 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1031
+      ID: 1136
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -11392,7 +11982,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1032 PointerType **table<int,*main.deepMap8>
+          Type: 1137 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11408,10 +11998,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1042 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1037 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1147 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1142 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1046
+      ID: 1151
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -11424,7 +12014,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1047 PointerType **table<int,*main.deepMap9>
+          Type: 1152 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11440,8 +12030,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1057 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1052 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1162 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1157 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 93
       Name: map<int,int>
@@ -11472,10 +12062,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
-      GroupType: 197 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 244 GoSliceDataType []*table<int,int>.array
+      GroupType: 241 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1061
+      ID: 1166
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -11488,7 +12078,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1062 PointerType **table<int,interface {}>
+          Type: 1167 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11504,8 +12094,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1070 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1067 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1175 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1172 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 130
       Name: map<int,uint8>
@@ -11536,8 +12126,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 259 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 256 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 303 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 300 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<string,[]main.structWithMap>
@@ -11568,8 +12158,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 287 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 108
       Name: map<string,[]string>
@@ -11600,10 +12190,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 221 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 268 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 726
+      ID: 831
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -11616,7 +12206,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 727 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 832 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11632,8 +12222,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 762 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 759 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 867 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -11664,8 +12254,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 216 GoSliceDataType []*table<string,int>.array
-      GroupType: 213 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 260 GoSliceDataType []*table<string,int>.array
+      GroupType: 257 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 98
       Name: map<string,main.nestedStruct>
@@ -11696,8 +12286,200 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 208 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 249 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 189
+      Name: map<struct {},main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 190 PointerType **table<struct {},main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 369 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 194
+      Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 195 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 377 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 199
+      Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 200 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 385 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 204
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 205 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 393 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 209
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 210 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 401 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 214
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 215 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 409 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 140
       Name: map<uint8,[4]int>
@@ -11728,8 +12510,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 276 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 272 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 320 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 135
       Name: map<uint8,uint8>
@@ -11760,8 +12542,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 267 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 264 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 311 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 148
       Name: map[[4]int][4]int
@@ -11798,26 +12580,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 993
+      ID: 1098
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124e+06
       GoKind: 21
-      HeaderType: 995 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1100 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1029
+      ID: 1134
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.12336e+06
       GoKind: 21
-      HeaderType: 1031 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1136 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1044
+      ID: 1149
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.123232e+06
       GoKind: 21
-      HeaderType: 1046 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1151 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
@@ -11826,12 +12608,12 @@ Types:
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1059
+      ID: 1164
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.123104e+06
       GoKind: 21
-      HeaderType: 1061 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1166 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
@@ -11868,6 +12650,42 @@ Types:
       GoKind: 21
       HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
+      ID: 187
+      Name: map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 189 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 192
+      Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 194 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 197
+      Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 199 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 202
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 204 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 207
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 209 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 212
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 214 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
       ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
@@ -11882,7 +12700,7 @@ Types:
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 480
+      ID: 585
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.423616e+06
@@ -11892,7 +12710,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 779
+      ID: 884
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.420416e+06
@@ -11902,11 +12720,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 788
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 747
+      ID: 852
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.590496e+06
@@ -11919,35 +12737,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 814
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 1029
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 707
+      ID: 812
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 790
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 1039
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 1049
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 1037
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 644
+      ID: 749
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.108256e+06
@@ -11955,27 +12773,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 646 PointerType *net.UnknownNetworkError.str
+          Type: 751 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 645 GoStringDataType net.UnknownNetworkError.str
+      Data: 750 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 645
+      ID: 750
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 613
+      ID: 718
       Name: net.canceledError
       GoRuntimeType: 1.279072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 1005
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 752
+      ID: 857
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.097888e+06
@@ -11983,7 +12801,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -11994,27 +12812,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 1051
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 940
+      ID: 1045
       Name: net.noReadFrom
       GoRuntimeType: 1.108512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 939
+      ID: 1044
       Name: net.noWriteTo
       GoRuntimeType: 1.108384e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 518
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 415
+      ID: 520
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.721056e+06
@@ -12022,7 +12840,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 734 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 839 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -12030,7 +12848,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 928
+      ID: 1033
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.282624e+06
@@ -12038,12 +12856,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 940 StructureType net.noReadFrom
+          Type: 1045 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 933 PointerType *net.TCPConn
+          Type: 1038 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 926
+      ID: 1031
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.28208e+06
@@ -12051,24 +12869,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 939 StructureType net.noWriteTo
+          Type: 1044 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 933 PointerType *net.TCPConn
+          Type: 1038 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 792
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 816
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 708
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 773
+      ID: 878
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.411936e+06
@@ -12078,19 +12896,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 309
+      ID: 414
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 828224
       GoKind: 10
     - __kind: BaseType
-      ID: 723
+      ID: 828
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 985664
       GoKind: 10
     - __kind: StructureType
-      ID: 391
+      ID: 496
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.719328e+06
@@ -12101,12 +12919,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 723 BaseType net/http.http2ErrCode
+          Type: 828 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 703
+      ID: 808
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.890688e+06
@@ -12117,12 +12935,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 723 BaseType net/http.http2ErrCode
+          Type: 828 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 395
+      ID: 500
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.590016e+06
@@ -12130,16 +12948,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 723 BaseType net/http.http2ErrCode
+          Type: 828 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 940
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 418
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828416
@@ -12147,17 +12965,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 420 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 419
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 424
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 828608
@@ -12165,17 +12983,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *net/http.http2headerFieldNameError.str
+          Type: 426 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 320 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 425 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 425
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 421
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 828512
@@ -12183,31 +13001,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *net/http.http2headerFieldValueError.str
+          Type: 423 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 317 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 422 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 422
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 783
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 609
+      ID: 714
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.278304e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 994
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 415
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828320
@@ -12215,17 +13033,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 417 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 416 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 416
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 775
+      ID: 880
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.8152e+06
@@ -12233,18 +13051,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 868 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 973 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 869 BaseType time.Duration
+          Type: 974 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 33 PointerType *error
     - __kind: GoInterfaceType
-      ID: 868
+      ID: 973
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.411296e+06
@@ -12257,14 +13075,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 854
+      ID: 959
       Name: net/http.incomparable
       GoRuntimeType: 898176
       GoKind: 17
       HasCount: true
       Element: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 605
+      ID: 710
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.549056e+06
@@ -12274,11 +13092,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 942
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 793
+      ID: 898
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.548896e+06
@@ -12286,9 +13104,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 836 PointerType *net/http.persistConn
+          Type: 941 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 819
+      ID: 924
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.7912e+06
@@ -12296,15 +13114,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 854 ArrayType net/http.incomparable
+          Type: 959 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 855 PointerType *bufio.Reader
+          Type: 960 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 857 GoInterfaceType io.ReadWriteCloser
+          Type: 962 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 399
+      ID: 504
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.412896e+06
@@ -12314,17 +13132,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 705
+      ID: 810
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 676
+      ID: 781
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.472896e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 607
+      ID: 712
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.549216e+06
@@ -12334,7 +13152,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 871
+      ID: 976
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.016864e+06
@@ -12342,16 +13160,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 747 GoInterfaceType net.Conn
+          Type: 852 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 493
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 891
+      ID: 996
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.032896e+06
@@ -12359,13 +13177,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 884 PointerType *bufio.Writer
+          Type: 989 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 908
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 472
+      ID: 577
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.724128e+06
@@ -12381,7 +13199,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 470
+      ID: 575
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.591936e+06
@@ -12394,11 +13212,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 950
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 805
+      ID: 910
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.593856e+06
@@ -12406,16 +13224,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 844 PointerType *net/smtp.Client
+          Type: 949 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 846 GoInterfaceType io.WriteCloser
+          Type: 951 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 456
+      ID: 561
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 344
+      ID: 449
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 831200
@@ -12423,25 +13241,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 346 PointerType *net/textproto.ProtocolError.str
+          Type: 451 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 345 GoStringDataType net/textproto.ProtocolError.str
+      Data: 450 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 345
+      ID: 450
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 906
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 818
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 427
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 829184
@@ -12449,17 +13267,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *net/url.EscapeError.str
+          Type: 429 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 323 GoStringDataType net/url.EscapeError.str
+      Data: 428 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 428
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 430
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 829280
@@ -12467,179 +13285,227 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *net/url.InvalidHostError.str
+          Type: 432 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 326 GoStringDataType net/url.InvalidHostError.str
+      Data: 431 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 431
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: ArrayType
-      ID: 290
+      ID: 334
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 679008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 291 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 335 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 282
+      ID: 326
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 679104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 283 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 327 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 230
+      ID: 274
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 679392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 231 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 275 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 249
+      ID: 293
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 679488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 250 StructureType noalg.struct { key bool; elem main.node }
+      Element: 294 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 188
+      ID: 232
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 678336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 233 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1002
+      ID: 1107
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1003 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1108 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1038
+      ID: 1143
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 677760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1039 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1144 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1053
+      ID: 1158
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1054 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1159 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 198
+      ID: 242
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 676416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 199 StructureType noalg.struct { key int; elem int }
+      Element: 243 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1068
+      ID: 1173
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 677568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1069 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1174 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 257
+      ID: 301
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 679584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 258 StructureType noalg.struct { key int; elem uint8 }
+      Element: 302 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 239
+      ID: 283
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 679680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 240 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 284 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 222
+      ID: 266
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 679776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 223 StructureType noalg.struct { key string; elem []string }
+      Element: 267 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 760
+      ID: 865
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 754592
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 761 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 866 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 214
+      ID: 258
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 679872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem int }
+      Element: 259 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 206
+      ID: 250
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 679968
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 207 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 251 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 273
+      ID: 366
+      Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+      ByteSize: 384
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 367 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 375
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 376 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 383
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 384 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 391
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 392 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 399
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 400 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 407
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 408 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 317
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 680064
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 274 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 318 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 265
+      ID: 309
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 680160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 266 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 310 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 289
+      ID: 333
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.29008e+06
@@ -12650,9 +13516,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 290 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 334 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 281
+      ID: 325
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.290336e+06
@@ -12663,9 +13529,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 282 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 326 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 229
+      ID: 273
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.290592e+06
@@ -12676,9 +13542,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 230 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 274 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 248
+      ID: 292
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.290848e+06
@@ -12689,9 +13555,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 249 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 293 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 187
+      ID: 231
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.289824e+06
@@ -12702,9 +13568,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 232 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1001
+      ID: 1106
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.289568e+06
@@ -12715,9 +13581,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1002 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1107 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1037
+      ID: 1142
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.288288e+06
@@ -12728,9 +13594,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1038 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1143 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1052
+      ID: 1157
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.288032e+06
@@ -12741,9 +13607,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1053 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1158 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 197
+      ID: 241
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.287008e+06
@@ -12754,9 +13620,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 198 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 242 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1067
+      ID: 1172
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.287776e+06
@@ -12767,9 +13633,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1068 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1173 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 256
+      ID: 300
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.291104e+06
@@ -12780,9 +13646,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 257 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 301 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 238
+      ID: 282
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.29136e+06
@@ -12793,9 +13659,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 239 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 283 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 221
+      ID: 265
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.291616e+06
@@ -12806,9 +13672,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 266 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 759
+      ID: 864
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.3528e+06
@@ -12819,9 +13685,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 760 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 865 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 213
+      ID: 257
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.291872e+06
@@ -12832,9 +13698,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 258 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 205
+      ID: 249
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.292128e+06
@@ -12845,9 +13711,81 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 206 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 250 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 272
+      ID: 365
+      Name: noalg.map.group[struct {}]main.structWithCyclicMaps
+      ByteSize: 392
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 366 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 374
+      Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 375 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 382
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 383 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 390
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 391 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 398
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 399 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 406
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 407 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 316
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.292384e+06
@@ -12858,9 +13796,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 273 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 317 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 264
+      ID: 308
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.29264e+06
@@ -12871,9 +13809,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 265 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 309 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 291
+      ID: 335
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.289952e+06
@@ -12881,12 +13819,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
     - __kind: StructureType
-      ID: 283
+      ID: 327
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.290208e+06
@@ -12894,12 +13832,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 231
+      ID: 275
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.290464e+06
@@ -12907,12 +13845,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 232 ArrayType [4]string
+          Type: 276 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 250
+      ID: 294
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.29072e+06
@@ -12925,7 +13863,7 @@ Types:
           Offset: 8
           Type: 156 StructureType main.node
     - __kind: StructureType
-      ID: 189
+      ID: 233
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.289696e+06
@@ -12936,9 +13874,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 190 PointerType *main.deepMap2
+          Type: 234 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1003
+      ID: 1108
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.28944e+06
@@ -12949,9 +13887,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1004 PointerType *main.deepMap3
+          Type: 1109 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1039
+      ID: 1144
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.28816e+06
@@ -12962,9 +13900,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1040 PointerType *main.deepMap8
+          Type: 1145 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1054
+      ID: 1159
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.287904e+06
@@ -12975,9 +13913,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1055 PointerType *main.deepMap9
+          Type: 1160 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 199
+      ID: 243
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.28688e+06
@@ -12990,7 +13928,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1069
+      ID: 1174
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.287648e+06
@@ -13003,7 +13941,7 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 258
+      ID: 302
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.290976e+06
@@ -13016,7 +13954,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 240
+      ID: 284
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.291232e+06
@@ -13027,9 +13965,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 241 GoSliceHeaderType []main.structWithMap
+          Type: 285 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 223
+      ID: 267
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.291488e+06
@@ -13042,7 +13980,7 @@ Types:
           Offset: 16
           Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 761
+      ID: 866
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.352672e+06
@@ -13053,9 +13991,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 748 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 215
+      ID: 259
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.291744e+06
@@ -13068,7 +14006,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 207
+      ID: 251
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.292e+06
@@ -13079,9 +14017,81 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 174 StructureType main.nestedStruct
+          Type: 218 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 274
+      ID: 367
+      Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 186 StructureType main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 376
+      Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 187 GoMapType map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 384
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 192 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 392
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 197 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 400
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 202 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 408
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 207 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 318
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.292256e+06
@@ -13092,9 +14102,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
     - __kind: StructureType
-      ID: 266
+      ID: 310
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.292512e+06
@@ -13107,19 +14117,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 1057
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 584
+      ID: 689
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 753
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 950
+      ID: 1055
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.351232e+06
@@ -13127,12 +14137,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 956 StructureType os.noReadFrom
+          Type: 1061 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 951 PointerType *os.File
+          Type: 1056 PointerType *os.File
     - __kind: StructureType
-      ID: 948
+      ID: 1053
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.350432e+06
@@ -13140,36 +14150,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 955 StructureType os.noWriteTo
+          Type: 1060 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 951 PointerType *os.File
+          Type: 1056 PointerType *os.File
     - __kind: StructureType
-      ID: 956
+      ID: 1061
       Name: os.noReadFrom
       GoRuntimeType: 1.105824e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 955
+      ID: 1060
       Name: os.noWriteTo
       GoRuntimeType: 1.105696e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 720
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 755
+      ID: 860
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 928
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 617
+      ID: 722
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.695872e+06
@@ -13182,7 +14192,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 358
+      ID: 463
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 834464
@@ -13190,39 +14200,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 360 PointerType *os/user.UnknownGroupIdError.str
+          Type: 465 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 359 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 464 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 359
+      ID: 464
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 357
+      ID: 462
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 834368
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 383
+      ID: 488
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 478
+      ID: 583
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 588
+      ID: 693
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 697
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 695
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.879104e+06
@@ -13239,15 +14249,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 753 BaseType runtime.boundsErrorCode
+          Type: 858 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 753
+      ID: 858
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 581312
       GoKind: 8
     - __kind: StructureType
-      ID: 650
+      ID: 755
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.74368e+06
@@ -13260,7 +14270,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 568
+      ID: 673
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 984320
@@ -13268,17 +14278,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 570 PointerType *runtime.errorString.str
+          Type: 675 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 569 GoStringDataType runtime.errorString.str
+      Data: 674 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 569
+      ID: 674
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 571
+      ID: 676
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 984416
@@ -13286,17 +14296,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 573 PointerType *runtime.plainError.str
+          Type: 678 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 572 GoStringDataType runtime.plainError.str
+      Data: 677 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 572
+      ID: 677
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 594
+      ID: 699
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -13308,25 +14318,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 178 PointerType *string.str
+          Type: 222 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 177 GoStringDataType string.str
+      Data: 221 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 177
+      ID: 221
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 992
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 791
+      ID: 896
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 787
+      ID: 892
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.449696e+06
@@ -13336,7 +14346,13 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 970
+      ID: 368
+      Name: struct {}
+      GoRuntimeType: 838112
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 1075
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.458176e+06
@@ -13344,12 +14360,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 971 StructureType sync.noCopy
+          Type: 1076 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 972 StructureType internal/sync.Mutex
+          Type: 1077 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 973
+      ID: 1078
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.606688e+06
@@ -13357,15 +14373,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 971 StructureType sync.noCopy
+          Type: 1076 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 974 StructureType sync/atomic.Uint32
+          Type: 1079 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 970 StructureType sync.Mutex
+          Type: 1075 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 976
+      ID: 1081
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.60688e+06
@@ -13373,21 +14389,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 971 StructureType sync.noCopy
+          Type: 1076 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 977 StructureType sync/atomic.Uint64
+          Type: 1082 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 971
+      ID: 1076
       Name: sync.noCopy
       GoRuntimeType: 983264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 979
+      ID: 1084
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.459456e+06
@@ -13395,12 +14411,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 975 StructureType sync/atomic.noCopy
+          Type: 1080 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 974
+      ID: 1079
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.459616e+06
@@ -13408,12 +14424,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 975 StructureType sync/atomic.noCopy
+          Type: 1080 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 977
+      ID: 1082
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607264e+06
@@ -13421,33 +14437,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 975 StructureType sync/atomic.noCopy
+          Type: 1080 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 978 StructureType sync/atomic.align64
+          Type: 1083 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 978
+      ID: 1083
       Name: sync/atomic.align64
       GoRuntimeType: 983456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 975
+      ID: 1080
       Name: sync/atomic.noCopy
       GoRuntimeType: 983360
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 700
+      ID: 805
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.277664e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 286
+      ID: 330
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -13469,9 +14485,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 287 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 331 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 278
+      ID: 322
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13493,9 +14509,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 279 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 323 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 226
+      ID: 270
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -13517,9 +14533,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 227 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 271 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 245
+      ID: 289
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -13541,9 +14557,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 246 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 290 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 184
+      ID: 228
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -13565,9 +14581,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 229 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 998
+      ID: 1103
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -13589,9 +14605,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 999 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1104 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1034
+      ID: 1139
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -13613,9 +14629,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1035 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1140 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1049
+      ID: 1154
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -13637,9 +14653,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1050 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1155 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 194
+      ID: 238
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -13661,9 +14677,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<int,int>
+          Type: 239 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1064
+      ID: 1169
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -13685,9 +14701,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1065 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1170 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 253
+      ID: 297
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13709,9 +14725,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 254 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 298 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 235
+      ID: 279
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -13733,9 +14749,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 236 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 280 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 218
+      ID: 262
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -13757,9 +14773,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 263 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 756
+      ID: 861
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -13781,9 +14797,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 757 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 862 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 210
+      ID: 254
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -13805,9 +14821,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 211 GoSwissMapGroupsType groupReference<string,int>
+          Type: 255 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 202
+      ID: 246
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -13829,9 +14845,153 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 203 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 247 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 269
+      ID: 362
+      Name: table<struct {},main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 363 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 371
+      Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 372 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 379
+      Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 380 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 387
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 388 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 395
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 396 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 403
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 404 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 313
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -13853,9 +15013,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 270 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 314 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 261
+      ID: 305
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13877,13 +15037,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 306 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 1027
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 643
+      ID: 748
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.700288e+06
@@ -13896,21 +15056,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 869
+      ID: 974
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.905248e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 718
+      ID: 823
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 491
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 716
+      ID: 821
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.366112e+06
@@ -13924,9 +15084,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 717 PointerType *time.Location
+          Type: 822 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 411
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 827360
@@ -13934,13 +15094,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *time.fileSizeError.str
+          Type: 413 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 307 GoStringDataType time.fileSizeError.str
+      Data: 412 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 412
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -13986,7 +15146,7 @@ Types:
       GoRuntimeType: 581248
       GoKind: 26
     - __kind: StructureType
-      ID: 734
+      ID: 839
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.054304e+06
@@ -13994,13 +15154,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 735 GoSliceHeaderType []uint8
+          Type: 840 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 736 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 841 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 737 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 842 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -14015,18 +15175,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 738 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 843 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 738
+      ID: 843
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 989888
       GoKind: 9
     - __kind: StructureType
-      ID: 736
+      ID: 841
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.916e+06
@@ -14051,21 +15211,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 474
+      ID: 579
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 737
+      ID: 842
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 584896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 1019
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 458
+      ID: 563
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.420736e+06
@@ -14075,13 +15235,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 347
+      ID: 452
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 831296
       GoKind: 2
     - __kind: StructureType
-      ID: 622
+      ID: 727
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.696064e+06
@@ -14094,11 +15254,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 576
+      ID: 681
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 988736
       GoKind: 5
-MaxTypeID: 1186
+MaxTypeID: 1293
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x131d360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 1185 EventRootType Probe[main.stackC]
+          Type: 1290 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x809fac", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 1140 EventRootType Probe[main.testAny]
+          Type: 1245 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807a0c", Frameless: true}]
           Condition: null
     - id: testAnyPtr
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 1142 EventRootType Probe[main.testAnyPtr]
+          Type: 1247 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807a7c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 1102 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1207 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 1104 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1209 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 1150 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1255 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x808060", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 1103 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1208 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 1122 EventRootType Probe[main.testBigStruct]
+          Type: 1227 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 1091 EventRootType Probe[main.testBoolArray]
+          Type: 1196 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 1088 EventRootType Probe[main.testByteArray]
+          Type: 1193 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806280", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 1166 EventRootType Probe[main.testChannel]
+          Type: 1271 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x809650", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 1164 EventRootType Probe[main.testCombinedByte]
+          Type: 1269 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x8093d0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 1174 EventRootType Probe[main.testCycle]
+          Type: 1279 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x8098d0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -196,7 +196,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 1127 EventRootType Probe[main.testDeepMap1]
+          Type: 1232 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c70", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -213,7 +213,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 1128 EventRootType Probe[main.testDeepMap7]
+          Type: 1233 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806c80", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -230,7 +230,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 1123 EventRootType Probe[main.testDeepPtr1]
+          Type: 1228 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x806990", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -247,7 +247,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 1124 EventRootType Probe[main.testDeepPtr7]
+          Type: 1229 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069a0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -264,7 +264,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 1125 EventRootType Probe[main.testDeepSlice1]
+          Type: 1230 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b10", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -281,7 +281,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 1126 EventRootType Probe[main.testDeepSlice7]
+          Type: 1231 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b20", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -295,7 +295,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 1176 EventRootType Probe[main.testEmptySlice]
+          Type: 1281 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x809c80", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -309,7 +309,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 1179 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1284 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -323,7 +323,7 @@ Probes:
       subprogram: {subprogram: 106}
       events:
         - ID: 106
-          Type: 1193 EventRootType Probe[main.testEmptyString]
+          Type: 1298 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80a070", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -334,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 108
-          Type: 1195 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x80a310", Frameless: true}]
+        - ID: 110
+          Type: 1302 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x80a330", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -347,11 +347,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 109
-          Type: 1196 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x80a320", Frameless: true}]
+        - ID: 111
+          Type: 1303 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x80a340", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -364,7 +364,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 1141 EventRootType Probe[main.testError]
+          Type: 1246 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807a60", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -378,7 +378,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 1132 EventRootType Probe[main.testEsotericHeap]
+          Type: 1237 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8070ac", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -392,7 +392,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 1131 EventRootType Probe[main.testEsotericStack]
+          Type: 1236 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x806fec", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -406,7 +406,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 1137 EventRootType Probe[main.testFrameless]
+          Type: 1242 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807780", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -420,7 +420,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 1138 EventRootType Probe[main.testFramelessArray]
+          Type: 1243 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x807790", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -434,7 +434,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 1133 EventRootType Probe[main.testInlinedBA]
+          Type: 1238 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8074bc", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -448,7 +448,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 1134 EventRootType Probe[main.testInlinedBB]
+          Type: 1239 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x80754c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -462,7 +462,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 1135 EventRootType Probe[main.testInlinedBBA]
+          Type: 1240 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x80760c", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -473,10 +473,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 111
-          Type: 1198 EventRootType Probe[main.testInlinedBBB]
+        - ID: 113
+          Type: 1305 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8075a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -490,7 +490,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 1136 EventRootType Probe[main.testInlinedBC]
+          Type: 1241 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x80767c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -501,10 +501,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 112
-          Type: 1199 EventRootType Probe[main.testInlinedBCA]
+        - ID: 114
+          Type: 1306 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80768c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -515,10 +515,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 113
-          Type: 1200 EventRootType Probe[main.testInlinedBCB]
+        - ID: 115
+          Type: 1307 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807730", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -530,10 +530,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 110
-          Type: 1197 EventRootType Probe[main.testInlinedPrint]
+        - ID: 112
+          Type: 1304 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x80732c"
               Frameless: true
@@ -554,10 +554,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 114
-          Type: 1201 EventRootType Probe[main.testInlinedSq]
+        - ID: 116
+          Type: 1308 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807784", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -569,10 +569,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 115
-          Type: 1202 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 117
+          Type: 1309 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8077b4"
               Frameless: false
@@ -590,7 +590,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 1094 EventRootType Probe[main.testInt16Array]
+          Type: 1199 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -604,7 +604,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 1095 EventRootType Probe[main.testInt32Array]
+          Type: 1200 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -618,7 +618,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 1096 EventRootType Probe[main.testInt64Array]
+          Type: 1201 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -632,7 +632,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 1093 EventRootType Probe[main.testInt8Array]
+          Type: 1198 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 1092 EventRootType Probe[main.testIntArray]
+          Type: 1197 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -660,7 +660,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 1139 EventRootType Probe[main.testInterface]
+          Type: 1244 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x8079f0", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -674,7 +674,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 1168 EventRootType Probe[main.testLinkedList]
+          Type: 1273 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x8097e0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -688,7 +688,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 1148 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1253 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x808040", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -702,7 +702,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 1154 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1259 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x8080a0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -716,7 +716,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 1152 EventRootType Probe[main.testMapIntToInt]
+          Type: 1257 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x808080", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -730,7 +730,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 1163 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1268 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x808130", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -744,7 +744,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 1162 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1267 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x808120", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -758,7 +758,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 1153 EventRootType Probe[main.testMapMassive]
+          Type: 1258 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x808090", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -772,7 +772,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 1161 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1266 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x808110", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -786,7 +786,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 1160 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1265 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x808100", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -800,7 +800,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 1146 EventRootType Probe[main.testMapStringToInt]
+          Type: 1251 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x808020", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -814,7 +814,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 1147 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1252 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x808030", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -828,7 +828,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 1145 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1250 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x808010", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -842,7 +842,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 1155 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1260 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x8080b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -856,7 +856,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 1158 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1263 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x8080e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -870,7 +870,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 1159 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1264 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x8080f0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -884,7 +884,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 1156 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1261 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x8080c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -898,7 +898,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 1157 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1262 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x8080d0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -912,7 +912,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 1191 EventRootType Probe[main.testMassiveString]
+          Type: 1296 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80a050", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -926,7 +926,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 1165 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1270 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x8094b0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -940,7 +940,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 1173 EventRootType Probe[main.testNilPointer]
+          Type: 1278 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x8098b0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -954,7 +954,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 1183 EventRootType Probe[main.testNilSlice]
+          Type: 1288 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x809cf0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -968,7 +968,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 1180 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1285 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -982,7 +982,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 1182 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1287 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x809ce0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -996,7 +996,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 1190 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1295 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80a040", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1010,7 +1010,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 1169 EventRootType Probe[main.testPointerLoop]
+          Type: 1274 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x8097f0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1024,7 +1024,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 1151 EventRootType Probe[main.testPointerToMap]
+          Type: 1256 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x808070", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1038,7 +1038,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 1167 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1272 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x8097d0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -1052,7 +1052,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 1089 EventRootType Probe[main.testRuneArray]
+          Type: 1194 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1066,7 +1066,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 1108 EventRootType Probe[main.testSingleBool]
+          Type: 1213 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1080,7 +1080,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 1106 EventRootType Probe[main.testSingleByte]
+          Type: 1211 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x8066e0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1094,7 +1094,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 1119 EventRootType Probe[main.testSingleFloat32]
+          Type: 1224 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1108,7 +1108,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 1120 EventRootType Probe[main.testSingleFloat64]
+          Type: 1225 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1122,7 +1122,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 1109 EventRootType Probe[main.testSingleInt]
+          Type: 1214 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1136,7 +1136,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 1111 EventRootType Probe[main.testSingleInt16]
+          Type: 1216 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1150,7 +1150,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 1112 EventRootType Probe[main.testSingleInt32]
+          Type: 1217 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1164,7 +1164,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 1113 EventRootType Probe[main.testSingleInt64]
+          Type: 1218 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1178,7 +1178,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 1110 EventRootType Probe[main.testSingleInt8]
+          Type: 1215 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1192,7 +1192,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 1107 EventRootType Probe[main.testSingleRune]
+          Type: 1212 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x8066f0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1206,7 +1206,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 1186 EventRootType Probe[main.testSingleString]
+          Type: 1291 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80a000", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 1114 EventRootType Probe[main.testSingleUint]
+          Type: 1219 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1234,7 +1234,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 1116 EventRootType Probe[main.testSingleUint16]
+          Type: 1221 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1248,7 +1248,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 1117 EventRootType Probe[main.testSingleUint32]
+          Type: 1222 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1262,7 +1262,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 1118 EventRootType Probe[main.testSingleUint64]
+          Type: 1223 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1276,7 +1276,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 1115 EventRootType Probe[main.testSingleUint8]
+          Type: 1220 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1290,7 +1290,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 1177 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1282 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x809c90", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1304,7 +1304,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 1149 EventRootType Probe[main.testSmallMap]
+          Type: 1254 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x808050", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1318,7 +1318,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 1090 EventRootType Probe[main.testStringArray]
+          Type: 1195 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1332,7 +1332,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 1172 EventRootType Probe[main.testStringPointer]
+          Type: 1277 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809890", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1346,7 +1346,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 1181 EventRootType Probe[main.testStringSlice]
+          Type: 1286 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x809cd0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -1363,7 +1363,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 1129 EventRootType Probe[main.testStringType1]
+          Type: 1234 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1380,7 +1380,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 1130 EventRootType Probe[main.testStringType2]
+          Type: 1235 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1391,11 +1391,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 107
-          Type: 1194 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80a240", Frameless: true}]
+        - ID: 109
+          Type: 1301 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80a260", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1408,7 +1408,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 1178 EventRootType Probe[main.testStructSlice]
+          Type: 1283 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -1425,8 +1425,34 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 1143 EventRootType Probe[main.testStructWithAny]
+          Type: 1248 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x807ad0", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicMaps}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 108
+          Type: 1300 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x80a1b0", Frameless: true}]
+          Condition: null
+    - id: testStructWithCyclicSlices
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithCyclicSlices}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 107
+          Type: 1299 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x80a1a0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1439,7 +1465,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 1144 EventRootType Probe[main.testStructWithMap]
+          Type: 1249 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808000", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1453,7 +1479,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 1187 EventRootType Probe[main.testThreeStrings]
+          Type: 1292 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80a010", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1467,7 +1493,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 1188 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1293 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80a020", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1481,7 +1507,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 1189 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1294 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80a030", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1495,7 +1521,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 1121 EventRootType Probe[main.testTypeAlias]
+          Type: 1226 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1509,7 +1535,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 1099 EventRootType Probe[main.testUint16Array]
+          Type: 1204 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1523,7 +1549,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 1100 EventRootType Probe[main.testUint32Array]
+          Type: 1205 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1537,7 +1563,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 1101 EventRootType Probe[main.testUint64Array]
+          Type: 1206 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1551,7 +1577,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 1098 EventRootType Probe[main.testUint8Array]
+          Type: 1203 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1565,7 +1591,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 1097 EventRootType Probe[main.testUintArray]
+          Type: 1202 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1579,7 +1605,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 1171 EventRootType Probe[main.testUintPointer]
+          Type: 1276 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809820", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1593,7 +1619,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 1175 EventRootType Probe[main.testUintSlice]
+          Type: 1280 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x809c70", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1607,7 +1633,7 @@ Probes:
       subprogram: {subprogram: 105}
       events:
         - ID: 105
-          Type: 1192 EventRootType Probe[main.testUnitializedString]
+          Type: 1297 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80a060", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1621,7 +1647,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 1170 EventRootType Probe[main.testUnsafePointer]
+          Type: 1275 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809800", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1635,7 +1661,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 1105 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1210 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1649,7 +1675,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 1184 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1289 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x809d00", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3275,14 +3301,50 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 107
+      Name: main.testStructWithCyclicSlices
+      OutOfLinePCRanges: [0x80a1a0..0x80a1b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 173 StructureType main.structWithCyclicSlices
+          Locations:
+            - Range: 0x80a1a0..0x80a1b0
+              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 108
+      Name: main.testStructWithCyclicMaps
+      OutOfLinePCRanges: [0x80a1b0..0x80a1c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 186 StructureType main.structWithCyclicMaps
+          Locations:
+            - Range: 0x80a1b0..0x80a1c0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80a240..0x80a260]
+      OutOfLinePCRanges: [0x80a260..0x80a280]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 173 StructureType main.aStruct
+          Type: 217 StructureType main.aStruct
           Locations:
-            - Range: 0x80a240..0x80a260
+            - Range: 0x80a260..0x80a280
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3300,29 +3362,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80a310..0x80a320]
+      OutOfLinePCRanges: [0x80a330..0x80a340]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 175 StructureType main.emptyStruct
-          Locations: [{Range: 0x80a310..0x80a320, Pieces: []}]
+          Type: 219 StructureType main.emptyStruct
+          Locations: [{Range: 0x80a330..0x80a340, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80a320..0x80a330]
+      OutOfLinePCRanges: [0x80a340..0x80a350]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 176 PointerType *main.emptyStruct
+          Type: 220 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80a320..0x80a330
+            - Range: 0x80a340..0x80a350
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 112
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x807320..0x807390]
       InlinePCRanges:
@@ -3352,28 +3414,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 113
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x8075a4..0x8075d8]
           RootRanges: [0x807540..0x807600]
       Variables: []
-    - ID: 112
+    - ID: 114
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x80768c..0x8076c0, 0x8076c8..0x8076cc]
           RootRanges: [0x807670..0x807780]
       Variables: []
-    - ID: 113
+    - ID: 115
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x807730..0x807764]
           RootRanges: [0x807670..0x807780]
       Variables: []
-    - ID: 114
+    - ID: 116
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3387,7 +3449,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 117
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3412,20 +3474,20 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1004
+      ID: 1109
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1005 PointerType *main.deepSlice3
+      Pointee: 1110 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1031
+      ID: 1136
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1032 PointerType *main.deepSlice8
+      Pointee: 1137 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1037
+      ID: 1142
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1038 PointerType *main.deepSlice9
+      Pointee: 1143 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 77
       Name: '**main.stringType2'
@@ -3433,7 +3495,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1000
+      ID: 1105
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3470,30 +3532,30 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1012
+      ID: 1117
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1013 PointerType *table<int,*main.deepMap3>
+      Pointee: 1118 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1048
+      ID: 1153
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1049 PointerType *table<int,*main.deepMap8>
+      Pointee: 1154 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1063
+      ID: 1168
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1064 PointerType *table<int,*main.deepMap9>
+      Pointee: 1169 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 94
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 95 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1078
+      ID: 1183
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1079 PointerType *table<int,interface {}>
+      Pointee: 1184 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 131
       Name: '**table<int,uint8>'
@@ -3510,10 +3572,10 @@ Types:
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 743
+      ID: 848
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 744 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 849 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3525,6 +3587,36 @@ Types:
       ByteSize: 8
       Pointee: 100 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
+      ID: 190
+      Name: '**table<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 191 PointerType *table<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 195
+      Name: '**table<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 196 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 200
+      Name: '**table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 201 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 205
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 206 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 210
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 211 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 215
+      Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 216 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
       ID: 141
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
@@ -3535,146 +3627,201 @@ Types:
       ByteSize: 8
       Pointee: 137 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 183
+      ID: 227
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1008
+      ID: 1113
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1007 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1112 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1035
+      ID: 1140
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1034 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1139 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1041
+      ID: 1146
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1040 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1145 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 180
+      ID: 224
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*string.array
+      Pointee: 223 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 297
+      ID: 361
+      Name: '*[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 360 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[][][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 359
+      Name: '*[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 358 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[][][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 357
+      Name: '*[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 356 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[][][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 355
+      Name: '*[][][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 354 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[][]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 353
+      Name: '*[][]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 352 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 341
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType [][]uint.array
+      Pointee: 340 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 303
+      ID: 347
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []bool.array
+      Pointee: 346 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 783
+      ID: 888
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 782 GoSliceDataType []float64.array
+      Pointee: 887 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1044
+      ID: 1149
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1043 GoSliceDataType []interface {}.array
+      Pointee: 1148 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 1025
+      ID: 177
+      Name: '*[]main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 174 GoSliceHeaderType []main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 351
+      Name: '*[]main.structWithCyclicSlices.array'
+      ByteSize: 8
+      Pointee: 350 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: PointerType
+      ID: 1130
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1024 GoSliceDataType []main.structWithMap.array
+      Pointee: 1129 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 299
+      ID: 343
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 342 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 301
+      ID: 345
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []string.array
+      Pointee: 344 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 162
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 295
+      ID: 339
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType []uint.array
+      Pointee: 338 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 305
+      ID: 349
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 304 GoSliceDataType []uint16.array
+      Pointee: 348 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 781
+      ID: 886
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 780 GoSliceDataType []uint8.array
+      Pointee: 885 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 913
+      ID: 1018
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.985184e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1019 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 543
+      ID: 648
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 930688
       GoKind: 22
-      Pointee: 544 GoSliceHeaderType archive/tar.headerError
+      Pointee: 649 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 546
+      ID: 651
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 545 GoSliceDataType archive/tar.headerError.array
+      Pointee: 650 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 848
+      ID: 953
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.434368e+06
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 954 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 796
+      ID: 901
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 930880
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 902 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 798
+      ID: 903
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 930976
       GoKind: 22
-      Pointee: 799 StructureType archive/zip.dirWriter
+      Pointee: 904 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 892
+      ID: 997
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.903328e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 998 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 824
+      ID: 929
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.057088e+06
       GoKind: 22
-      Pointee: 825 StructureType archive/zip.nopCloser
+      Pointee: 930 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 826
+      ID: 931
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.057344e+06
       GoKind: 22
-      Pointee: 827 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 932 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3683,435 +3830,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 871
+      ID: 976
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.17328e+06
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType bufio.Reader
+      Pointee: 977 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 900
+      ID: 1005
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.948064e+06
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType bufio.Writer
+      Pointee: 1006 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 951
+      ID: 1056
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.266144e+06
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1057 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 453
+      ID: 558
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 913216
       GoKind: 22
-      Pointee: 342 BaseType compress/flate.CorruptInputError
+      Pointee: 447 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 454
+      ID: 559
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 913312
       GoKind: 22
-      Pointee: 343 GoStringHeaderType compress/flate.InternalError
+      Pointee: 448 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 345
+      ID: 450
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 344 GoStringDataType compress/flate.InternalError.str
+      Pointee: 449 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 846
+      ID: 951
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.423968e+06
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 952 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 792
+      ID: 897
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 913408
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 898 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 868
+      ID: 973
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.724832e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 974 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 691
+      ID: 796
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.202624e+06
       GoKind: 22
-      Pointee: 692 StructureType context.deadlineExceededError
+      Pointee: 797 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 535
+      ID: 640
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925312
       GoKind: 22
-      Pointee: 356 BaseType crypto/aes.KeySizeError
+      Pointee: 461 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 536
+      ID: 641
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925504
       GoKind: 22
-      Pointee: 357 BaseType crypto/des.KeySizeError
+      Pointee: 462 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 537
+      ID: 642
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 358 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 463 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 863
+      ID: 968
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.665568e+06
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 969 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 640
+      ID: 745
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.064896e+06
       GoKind: 22
-      Pointee: 641 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 746 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 894
+      ID: 999
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.90384e+06
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1000 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 924
+      ID: 1029
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.118432e+06
       GoKind: 22
-      Pointee: 925 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1030 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 898
+      ID: 1003
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.904352e+06
       GoKind: 22
-      Pointee: 899 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1004 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 896
+      ID: 1001
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904096e+06
       GoKind: 22
-      Pointee: 897 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1002 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 890
+      ID: 995
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.901536e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 996 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 538
+      ID: 643
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926080
       GoKind: 22
-      Pointee: 359 BaseType crypto/rc4.KeySizeError
+      Pointee: 464 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 911
+      ID: 1016
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.982304e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1017 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 886
+      ID: 991
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.870912e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 992 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 461
+      ID: 566
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 914944
       GoKind: 22
-      Pointee: 346 BaseType crypto/tls.AlertError
+      Pointee: 451 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 629
+      ID: 734
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.045696e+06
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 735 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 977
+      ID: 1082
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.377664e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1083 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 457
+      ID: 562
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 914656
       GoKind: 22
-      Pointee: 458 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 563 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 455
+      ID: 560
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 456 StructureType crypto/tls.RecordHeaderError
+      Pointee: 561 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 628
+      ID: 733
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.044032e+06
       GoKind: 22
-      Pointee: 583 BaseType crypto/tls.alert
+      Pointee: 688 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 856
+      ID: 961
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.558432e+06
       GoKind: 22
-      Pointee: 857 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 962 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 459
+      ID: 564
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 914752
       GoKind: 22
-      Pointee: 460 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 565 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 861
+      ID: 966
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.640608e+06
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 967 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 726
+      ID: 831
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.424448e+06
       GoKind: 22
-      Pointee: 727 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 832 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 745
+      ID: 850
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.041472e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 851 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 531
+      ID: 636
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 924352
       GoKind: 22
-      Pointee: 532 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 637 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 525
+      ID: 630
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 923872
       GoKind: 22
-      Pointee: 526 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 631 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 527
+      ID: 632
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 923968
       GoKind: 22
-      Pointee: 528 StructureType crypto/x509.HostnameError
+      Pointee: 633 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 524
+      ID: 629
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 355 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 460 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 634
+      ID: 739
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.051456e+06
       GoKind: 22
-      Pointee: 635 StructureType crypto/x509.SystemRootsError
+      Pointee: 740 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 533
+      ID: 638
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 534 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 639 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 529
+      ID: 634
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 924256
       GoKind: 22
-      Pointee: 530 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 635 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 547
+      ID: 652
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 931168
       GoKind: 22
-      Pointee: 548 StructureType encoding/asn1.StructuralError
+      Pointee: 653 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 551
+      ID: 656
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931360
       GoKind: 22
-      Pointee: 552 StructureType encoding/asn1.SyntaxError
+      Pointee: 657 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 549
+      ID: 654
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 931264
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 655 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 442
+      ID: 547
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 911200
       GoKind: 22
-      Pointee: 337 BaseType encoding/base64.CorruptInputError
+      Pointee: 442 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 814
+      ID: 919
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.041088e+06
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 920 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 445
+      ID: 550
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 912064
       GoKind: 22
-      Pointee: 338 BaseType encoding/hex.InvalidByteError
+      Pointee: 443 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 413
+      ID: 518
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 906016
       GoKind: 22
-      Pointee: 414 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 519 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 618
+      ID: 723
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.037248e+06
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 724 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 405
+      ID: 510
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 905632
       GoKind: 22
-      Pointee: 406 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 511 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 411
+      ID: 516
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 905920
       GoKind: 22
-      Pointee: 412 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 517 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 409
+      ID: 514
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 905824
       GoKind: 22
-      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 515 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 407
+      ID: 512
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 905728
       GoKind: 22
-      Pointee: 408 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 513 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 957
+      ID: 1062
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.29168e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1063 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 415
+      ID: 520
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 906400
       GoKind: 22
-      Pointee: 416 StructureType encoding/json.jsonError
+      Pointee: 521 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 822
+      ID: 927
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.054016e+06
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 928 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 519
+      ID: 624
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 520 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 625 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 517
+      ID: 622
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 922720
       GoKind: 22
-      Pointee: 518 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 623 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 521
+      ID: 626
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 352 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 457 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 354
+      ID: 459
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 353 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 458 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 522
+      ID: 627
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923008
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 628 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 935
+      ID: 1040
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.158272e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1041 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4120,19 +4267,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 381
+      ID: 486
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896032
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType errors.errorString
+      Pointee: 487 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 585
+      ID: 690
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.022144e+06
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType errors.joinError
+      Pointee: 691 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4148,813 +4295,813 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 945
+      ID: 1050
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.258464e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType fmt.pp
+      Pointee: 1051 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 587
+      ID: 692
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.023936e+06
       GoKind: 22
-      Pointee: 588 UnresolvedPointeeType fmt.wrapError
+      Pointee: 693 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 589
+      ID: 694
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.024064e+06
       GoKind: 22
-      Pointee: 590 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 695 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 443
+      ID: 548
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 444 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 549 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 424
+      ID: 529
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 908800
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 530 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 426
+      ID: 531
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 908896
       GoKind: 22
-      Pointee: 427 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 532 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 758
+      ID: 863
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 759 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 864 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 430
+      ID: 535
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 909184
       GoKind: 22
-      Pointee: 431 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 536 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 760
+      ID: 865
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 761 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 866 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 428
+      ID: 533
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 908992
       GoKind: 22
-      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 333
+      ID: 438
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 423
+      ID: 528
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 330
+      ID: 435
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 429
+      ID: 534
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 909088
       GoKind: 22
-      Pointee: 334 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 439 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 336
+      ID: 441
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 834
+      ID: 939
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.208128e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 940 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 921
+      ID: 1026
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.05648e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1027 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 541
+      ID: 646
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 929632
       GoKind: 22
-      Pointee: 542 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 647 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 700
+      ID: 805
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.211712e+06
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 806 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 953
+      ID: 1058
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.268192e+06
       GoKind: 22
-      Pointee: 954 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1059 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 468
+      ID: 573
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 469 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 574 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 475
+      ID: 580
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 919360
       GoKind: 22
-      Pointee: 476 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 581 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 470
+      ID: 575
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 919072
       GoKind: 22
-      Pointee: 351 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 456 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 473
+      ID: 578
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 474 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 579 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 471
+      ID: 576
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 919168
       GoKind: 22
-      Pointee: 472 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 577 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 491
+      ID: 596
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 492 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 597 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 495
+      ID: 600
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 921472
       GoKind: 22
-      Pointee: 496 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 601 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 493
+      ID: 598
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 494 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 599 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 489
+      ID: 594
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 595 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 785
+      ID: 890
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 784 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 889 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 503
+      ID: 608
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 921856
       GoKind: 22
-      Pointee: 504 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 609 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 497
+      ID: 602
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 921568
       GoKind: 22
-      Pointee: 498 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 603 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 501
+      ID: 606
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 502 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 607 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 499
+      ID: 604
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 921664
       GoKind: 22
-      Pointee: 500 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 605 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 505
+      ID: 610
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 921952
       GoKind: 22
-      Pointee: 506 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 511
+      ID: 616
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 922240
       GoKind: 22
-      Pointee: 512 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 617 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 513
+      ID: 618
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 922336
       GoKind: 22
-      Pointee: 514 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 619 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 509
+      ID: 614
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 922144
       GoKind: 22
-      Pointee: 510 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 615 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 507
+      ID: 612
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 922048
       GoKind: 22
-      Pointee: 508 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 515
+      ID: 620
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 922528
       GoKind: 22
-      Pointee: 516 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 621 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 432
+      ID: 537
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 910336
       GoKind: 22
-      Pointee: 433 StructureType github.com/cihub/seelog.baseError
+      Pointee: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 874
+      ID: 979
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.801696e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 980 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 434
+      ID: 539
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 910432
       GoKind: 22
-      Pointee: 435 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 540 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 854
+      ID: 959
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.557152e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 960 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 810
+      ID: 915
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.039936e+06
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 844
+      ID: 949
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.422048e+06
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 950 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 438
+      ID: 543
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 910624
       GoKind: 22
-      Pointee: 439 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 544 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 909
+      ID: 1014
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.974528e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1015 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 928
+      ID: 1033
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.131072e+06
       GoKind: 22
-      Pointee: 923 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1028 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 927
+      ID: 1032
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.130688e+06
       GoKind: 22
-      Pointee: 926 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1031 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 812
+      ID: 917
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.040064e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 436
+      ID: 541
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 910528
       GoKind: 22
-      Pointee: 437 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 542 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 440
+      ID: 545
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 910720
       GoKind: 22
-      Pointee: 441 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 546 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 876
+      ID: 981
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.803488e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 982 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 917
+      ID: 1022
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.010656e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1023 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 919
+      ID: 1024
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.041152e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1025 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 731
+      ID: 836
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.436768e+06
       GoKind: 22
-      Pointee: 732 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 837 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 644
+      ID: 749
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.065664e+06
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 750 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 642
+      ID: 747
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.065536e+06
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 748 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 646
+      ID: 751
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.069632e+06
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 752 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 648
+      ID: 753
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.06976e+06
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 754 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 865
+      ID: 970
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.667872e+06
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 971 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 636
+      ID: 741
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.052096e+06
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 742 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 446
+      ID: 551
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 912256
       GoKind: 22
-      Pointee: 447 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 552 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 969
+      ID: 1074
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.354112e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1075 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 702
+      ID: 807
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.220288e+06
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 808 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 675
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.199168e+06
       GoKind: 22
-      Pointee: 676 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 669
+      ID: 774
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.198784e+06
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 775 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 604
+      ID: 709
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.031232e+06
       GoKind: 22
-      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 710 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 681
+      ID: 786
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.199552e+06
       GoKind: 22
-      Pointee: 682 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 787 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 603
+      ID: 708
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.031104e+06
       GoKind: 22
-      Pointee: 582 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 687 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 673
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.19904e+06
       GoKind: 22
-      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 671
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.198912e+06
       GoKind: 22
-      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 679
+      ID: 784
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.199424e+06
       GoKind: 22
-      Pointee: 680 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 785 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 677
+      ID: 782
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.199296e+06
       GoKind: 22
-      Pointee: 678 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 783 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 973
+      ID: 1078
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.36672e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1079 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 685
+      ID: 790
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.199936e+06
       GoKind: 22
-      Pointee: 686 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 791 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 608
+      ID: 713
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.031488e+06
       GoKind: 22
-      Pointee: 609 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 714 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 606
+      ID: 711
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.03136e+06
       GoKind: 22
-      Pointee: 607 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 712 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 683
+      ID: 788
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.199808e+06
       GoKind: 22
-      Pointee: 684 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 789 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 563
+      ID: 668
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944128
       GoKind: 22
-      Pointee: 364 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 469 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 366
+      ID: 471
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 365 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 470 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 748
+      ID: 853
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.666336e+06
       GoKind: 22
-      Pointee: 749 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 854 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 652
+      ID: 757
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.08448e+06
       GoKind: 22
-      Pointee: 653 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 758 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 840
+      ID: 945
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.260096e+06
       GoKind: 22
-      Pointee: 841 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 946 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 933
+      ID: 1038
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.146432e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1039 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 828
+      ID: 933
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.086784e+06
       GoKind: 22
-      Pointee: 829 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 934 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 564
+      ID: 669
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 945376
       GoKind: 22
-      Pointee: 367 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 472 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 710
+      ID: 815
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.26176e+06
       GoKind: 22
-      Pointee: 711 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 816 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 567
+      ID: 672
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 945664
       GoKind: 22
-      Pointee: 568 StructureType golang.org/x/net/http2.connError
+      Pointee: 673 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 566
+      ID: 671
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945568
       GoKind: 22
-      Pointee: 371 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 476 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 373
+      ID: 478
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 372 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 477 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 570
+      ID: 675
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 945856
       GoKind: 22
-      Pointee: 377 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 482 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 379
+      ID: 484
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 378 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 483 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 569
+      ID: 674
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 945760
       GoKind: 22
-      Pointee: 374 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 479 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 376
+      ID: 481
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 375 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 480 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 565
+      ID: 670
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945472
       GoKind: 22
-      Pointee: 368 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 473 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 370
+      ID: 475
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 369 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 474 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 931
+      ID: 1036
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.144512e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1037 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 571
+      ID: 676
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 945952
       GoKind: 22
-      Pointee: 572 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 677 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 573
+      ID: 678
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 946048
       GoKind: 22
-      Pointee: 380 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 485 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 559
+      ID: 664
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 560 StructureType google.golang.org/grpc.dropError
+      Pointee: 665 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 708
+      ID: 813
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.258816e+06
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 814 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 733
+      ID: 838
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.444128e+06
       GoKind: 22
-      Pointee: 734 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 839 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 561
+      ID: 666
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942400
       GoKind: 22
-      Pointee: 562 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 667 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 880
+      ID: 985
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.809088e+06
       GoKind: 22
-      Pointee: 881 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 986 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 838
+      ID: 943
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.25536e+06
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 944 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 650
+      ID: 755
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.07872e+06
       GoKind: 22
-      Pointee: 651 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 756 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 800
+      ID: 905
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 942496
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 906 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 539
+      ID: 644
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 927520
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 645 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 638
+      ID: 743
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.055424e+06
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 744 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 706
+      ID: 811
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.226688e+06
       GoKind: 22
-      Pointee: 707 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 812 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 704
+      ID: 809
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.226432e+06
       GoKind: 22
-      Pointee: 705 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 810 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 553
+      ID: 658
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932224
       GoKind: 22
-      Pointee: 554 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 659 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 555
+      ID: 660
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 932320
       GoKind: 22
-      Pointee: 556 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 661 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 483
+      ID: 588
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 919744
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 589 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 888
+      ID: 993
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.899488e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 994 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 574
+      ID: 679
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 946816
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType html/template.Error
+      Pointee: 680 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -4998,129 +5145,129 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 735
+      ID: 840
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.210784e+06
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType internal/abi.Type
+      Pointee: 841 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 451
+      ID: 556
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 912928
       GoKind: 22
-      Pointee: 452 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 557 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 449
+      ID: 554
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 912832
       GoKind: 22
-      Pointee: 450 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 555 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 786
+      ID: 891
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 900832
       GoKind: 22
-      Pointee: 787 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 892 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 667
+      ID: 772
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.198016e+06
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 773 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 975
+      ID: 1080
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.372384e+06
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1081 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 665
+      ID: 770
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.197888e+06
       GoKind: 22
-      Pointee: 666 StructureType internal/poll.errNetClosing
+      Pointee: 771 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 385
+      ID: 490
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900064
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 491 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 448
+      ID: 553
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 912640
       GoKind: 22
-      Pointee: 339 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 444 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 341
+      ID: 446
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 340 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 445 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 622
+      ID: 727
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.042368e+06
       GoKind: 22
-      Pointee: 623 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 728 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 832
+      ID: 937
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.189312e+06
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType io.PipeWriter
+      Pointee: 938 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 830
+      ID: 935
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.188928e+06
       GoKind: 22
-      Pointee: 831 StructureType io.discard
+      Pointee: 936 StructureType io.discard
     - __kind: PointerType
-      ID: 804
+      ID: 909
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.0224e+06
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType io.multiWriter
+      Pointee: 910 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 663
+      ID: 768
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.197376e+06
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType io/fs.PathError
+      Pointee: 769 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 878
+      ID: 983
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.803712e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 984 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 190
+      ID: 234
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 385952
       GoKind: 22
-      Pointee: 191 StructureType main.deepMap2
+      Pointee: 235 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1020
+      ID: 1125
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385888
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType main.deepMap3
+      Pointee: 1126 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -5129,19 +5276,19 @@ Types:
       GoKind: 22
       Pointee: 74 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1056
+      ID: 1161
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 385568
       GoKind: 22
-      Pointee: 1057 StructureType main.deepMap8
+      Pointee: 1162 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1071
+      ID: 1176
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385504
       GoKind: 22
-      Pointee: 1072 StructureType main.deepMap9
+      Pointee: 1177 StructureType main.deepMap9
     - __kind: PointerType
       ID: 57
       Name: '*main.deepPtr2'
@@ -5150,12 +5297,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 979
+      ID: 1084
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1085 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5164,33 +5311,33 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1026
+      ID: 1131
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386144
       GoKind: 22
-      Pointee: 1027 StructureType main.deepPtr8
+      Pointee: 1132 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1028
+      ID: 1133
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386080
       GoKind: 22
-      Pointee: 1029 StructureType main.deepPtr9
+      Pointee: 1134 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 64
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 387104
       GoKind: 22
-      Pointee: 181 StructureType main.deepSlice2
+      Pointee: 225 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1005
+      ID: 1110
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387040
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1111 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5199,25 +5346,25 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1032
+      ID: 1137
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386720
       GoKind: 22
-      Pointee: 1033 StructureType main.deepSlice8
+      Pointee: 1138 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1038
+      ID: 1143
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386656
       GoKind: 22
-      Pointee: 1039 StructureType main.deepSlice9
+      Pointee: 1144 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 176
+      ID: 220
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 175 StructureType main.emptyStruct
+      Pointee: 219 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 84
       Name: '*main.esotericHeap'
@@ -5226,12 +5373,12 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 996
+      ID: 1101
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 895744
       GoKind: 22
-      Pointee: 997 StructureType main.firstBehavior
+      Pointee: 1102 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
@@ -5246,19 +5393,19 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 998
+      ID: 1103
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 895840
       GoKind: 22
-      Pointee: 999 StructureType main.secondBehavior
+      Pointee: 1104 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 984
+      ID: 1089
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 895936
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1090 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -5266,18 +5413,23 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 982
+      ID: 1087
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 981 GoStringDataType main.stringType1.str
+      Pointee: 1086 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType main.stringType2
+      Pointee: 1088 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 242
+      ID: 175
+      Name: '*main.structWithCyclicSlices'
+      ByteSize: 8
+      Pointee: 173 StructureType main.structWithCyclicSlices
+    - __kind: PointerType
+      ID: 286
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 385440
@@ -5301,10 +5453,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1002
+      ID: 1107
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1001 GoSliceDataType main.t.array
+      Pointee: 1106 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -5337,30 +5489,30 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1010
+      ID: 1115
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1011 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1116 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1046
+      ID: 1151
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1047 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1152 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1061
+      ID: 1166
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1062 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1167 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 92
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 93 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1076
+      ID: 1181
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1077 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1182 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 129
       Name: '*map<int,uint8>'
@@ -5377,10 +5529,10 @@ Types:
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 741
+      ID: 846
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 742 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 847 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -5391,6 +5543,36 @@ Types:
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 188
+      Name: '*map<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 189 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 193
+      Name: '*map<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 194 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 198
+      Name: '*map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 199 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 203
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 204 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 208
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 209 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 213
+      Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 214 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 139
       Name: '*map<uint8,[4]int>'
@@ -5408,710 +5590,740 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 487
+      ID: 592
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920608
       GoKind: 22
-      Pointee: 488 StructureType math/big.ErrNaN
+      Pointee: 593 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 794
+      ID: 899
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 915424
       GoKind: 22
-      Pointee: 795 StructureType mime/multipart.writerOnly·1
+      Pointee: 900 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 694
+      ID: 799
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.205952e+06
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType net.AddrError
+      Pointee: 800 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 720
+      ID: 825
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.420288e+06
       GoKind: 22
-      Pointee: 721 UnresolvedPointeeType net.DNSError
+      Pointee: 826 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 939
+      ID: 1044
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.230656e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType net.IPConn
+      Pointee: 1045 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 718
+      ID: 823
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.419968e+06
       GoKind: 22
-      Pointee: 719 UnresolvedPointeeType net.OpError
+      Pointee: 824 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 696
+      ID: 801
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.20608e+06
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType net.ParseError
+      Pointee: 802 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 949
+      ID: 1054
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.259488e+06
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType net.TCPConn
+      Pointee: 1055 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 959
+      ID: 1064
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.304992e+06
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType net.UDPConn
+      Pointee: 1065 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 947
+      ID: 1052
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.258976e+06
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType net.UnixConn
+      Pointee: 1053 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 693
+      ID: 798
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.205184e+06
       GoKind: 22
-      Pointee: 656 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 761 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 658
+      ID: 763
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 657 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 762 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 620
+      ID: 725
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.038144e+06
       GoKind: 22
-      Pointee: 621 StructureType net.canceledError
+      Pointee: 726 StructureType net.canceledError
     - __kind: PointerType
-      ID: 915
+      ID: 1020
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.008064e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType net.conn
+      Pointee: 1021 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 767
+      ID: 872
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.846496e+06
       GoKind: 22
-      Pointee: 768 StructureType net.dialResult·1
+      Pointee: 873 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 961
+      ID: 1066
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.309248e+06
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType net.netFD
+      Pointee: 1067 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 417
+      ID: 522
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907360
       GoKind: 22
-      Pointee: 418 UnresolvedPointeeType net.notFoundError
+      Pointee: 523 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 419
+      ID: 524
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908032
       GoKind: 22
-      Pointee: 420 StructureType net.result·2
+      Pointee: 525 StructureType net.result·2
     - __kind: PointerType
-      ID: 943
+      ID: 1048
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.245024e+06
       GoKind: 22
-      Pointee: 944 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1049 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 941
+      ID: 1046
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.244544e+06
       GoKind: 22
-      Pointee: 942 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1047 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 698
+      ID: 803
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.20672e+06
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType net.temporaryError
+      Pointee: 804 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 722
+      ID: 827
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.420448e+06
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType net.timeoutError
+      Pointee: 828 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 610
+      ID: 715
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.03392e+06
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 716 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 788
+      ID: 893
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 903136
       GoKind: 22
-      Pointee: 789 StructureType net/http.bufioFlushWriter
+      Pointee: 894 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 394
+      ID: 499
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 903808
       GoKind: 22
-      Pointee: 309 BaseType net/http.http2ConnectionError
+      Pointee: 414 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 395
+      ID: 500
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 903904
       GoKind: 22
-      Pointee: 396 StructureType net/http.http2GoAwayError
+      Pointee: 501 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 714
+      ID: 819
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.415968e+06
       GoKind: 22
-      Pointee: 715 StructureType net/http.http2StreamError
+      Pointee: 820 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 399
+      ID: 504
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 904480
       GoKind: 22
-      Pointee: 400 StructureType net/http.http2connError
+      Pointee: 505 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 850
+      ID: 955
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.553632e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 956 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 398
+      ID: 503
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904384
       GoKind: 22
-      Pointee: 313 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 418 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 315
+      ID: 420
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 402
+      ID: 507
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 904672
       GoKind: 22
-      Pointee: 319 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 424 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 321
+      ID: 426
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 425 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 401
+      ID: 506
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 904576
       GoKind: 22
-      Pointee: 316 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 421 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 318
+      ID: 423
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 422 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 689
+      ID: 794
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.201856e+06
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 795 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 616
+      ID: 721
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.03456e+06
       GoKind: 22
-      Pointee: 617 StructureType net/http.http2noCachedConnError
+      Pointee: 722 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 904
+      ID: 1009
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.950368e+06
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1010 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 397
+      ID: 502
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904288
       GoKind: 22
-      Pointee: 310 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 415 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 312
+      ID: 417
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 416 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 790
+      ID: 895
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 904768
       GoKind: 22
-      Pointee: 791 StructureType net/http.http2stickyErrWriter
+      Pointee: 896 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 612
+      ID: 717
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.034176e+06
       GoKind: 22
-      Pointee: 613 StructureType net/http.nothingWrittenError
+      Pointee: 718 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 852
+      ID: 957
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.174528e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType net/http.persistConn
+      Pointee: 958 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 808
+      ID: 913
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.034048e+06
       GoKind: 22
-      Pointee: 809 StructureType net/http.persistConnWriter
+      Pointee: 914 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 842
+      ID: 947
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.416128e+06
       GoKind: 22
-      Pointee: 843 StructureType net/http.readWriteCloserBody
+      Pointee: 948 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 403
+      ID: 508
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 904864
       GoKind: 22
-      Pointee: 404 StructureType net/http.requestBodyReadError
+      Pointee: 509 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 716
+      ID: 821
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.417248e+06
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 822 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 687
+      ID: 792
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.201728e+06
       GoKind: 22
-      Pointee: 688 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 793 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 614
+      ID: 719
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.034304e+06
       GoKind: 22
-      Pointee: 615 StructureType net/http.transportReadFromServerError
+      Pointee: 720 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 884
+      ID: 989
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.843136e+06
       GoKind: 22
-      Pointee: 885 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 990 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 392
+      ID: 497
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 903040
       GoKind: 22
-      Pointee: 393 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 498 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 906
+      ID: 1011
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.95216e+06
       GoKind: 22
-      Pointee: 907 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1012 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 818
+      ID: 923
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.046848e+06
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 924 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 479
+      ID: 584
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 919552
       GoKind: 22
-      Pointee: 480 StructureType net/netip.parseAddrError
+      Pointee: 585 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 477
+      ID: 582
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 919456
       GoKind: 22
-      Pointee: 478 StructureType net/netip.parsePrefixError
+      Pointee: 583 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 858
+      ID: 963
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.117024e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType net/smtp.Client
+      Pointee: 964 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 820
+      ID: 925
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.051712e+06
       GoKind: 22
-      Pointee: 821 StructureType net/smtp.dataCloser
+      Pointee: 926 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 463
+      ID: 568
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 915616
       GoKind: 22
-      Pointee: 464 UnresolvedPointeeType net/textproto.Error
+      Pointee: 569 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 462
+      ID: 567
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 915520
       GoKind: 22
-      Pointee: 347 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 452 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 349
+      ID: 454
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 348 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 453 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 816
+      ID: 921
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.04608e+06
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 922 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 724
+      ID: 829
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.420768e+06
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType net/url.Error
+      Pointee: 830 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 421
+      ID: 526
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 908128
       GoKind: 22
-      Pointee: 322 GoStringHeaderType net/url.EscapeError
+      Pointee: 427 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 324
+      ID: 429
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType net/url.EscapeError.str
+      Pointee: 428 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 422
+      ID: 527
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 325 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 430 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 327
+      ID: 432
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 431 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 288
+      ID: 332
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 289 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 280
+      ID: 324
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 281 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 228
+      ID: 272
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 229 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 247
+      ID: 291
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 248 StructureType noalg.map.group[bool]main.node
+      Pointee: 292 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 186
+      ID: 230
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 187 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1016
+      ID: 1121
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1017 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1122 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1052
+      ID: 1157
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1053 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1158 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1067
+      ID: 1172
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1068 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1173 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 196
+      ID: 240
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[int]int
+      Pointee: 241 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1082
+      ID: 1187
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1083 StructureType noalg.map.group[int]interface {}
+      Pointee: 1188 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 255
+      ID: 299
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 256 StructureType noalg.map.group[int]uint8
+      Pointee: 300 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 237
+      ID: 281
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 238 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 220
+      ID: 264
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 221 StructureType noalg.map.group[string][]string
+      Pointee: 265 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 774
+      ID: 879
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 212
+      ID: 256
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 213 StructureType noalg.map.group[string]int
+      Pointee: 257 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 204
+      ID: 248
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 205 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 249 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 271
+      ID: 364
+      Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 373
+      Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 381
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 389
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 397
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 405
+      Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
+      ByteSize: 8
+      Pointee: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: PointerType
+      ID: 315
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 272 StructureType noalg.map.group[uint8][4]int
+      Pointee: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 263
+      ID: 307
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 264 StructureType noalg.map.group[uint8]uint8
+      Pointee: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 967
+      ID: 1072
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.348736e+06
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType os.File
+      Pointee: 1073 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 591
+      ID: 696
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.025216e+06
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType os.LinkError
+      Pointee: 697 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 659
+      ID: 764
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.19072e+06
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType os.SyscallError
+      Pointee: 765 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 965
+      ID: 1070
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.347264e+06
       GoKind: 22
-      Pointee: 966 StructureType os.fileWithoutReadFrom
+      Pointee: 1071 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 963
+      ID: 1068
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.346528e+06
       GoKind: 22
-      Pointee: 964 StructureType os.fileWithoutWriteTo
+      Pointee: 1069 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 624
+      ID: 729
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.042752e+06
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType os/exec.Error
+      Pointee: 730 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 770
+      ID: 875
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.088288e+06
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 876 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 836
+      ID: 941
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.212992e+06
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 942 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 626
+      ID: 731
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.04288e+06
       GoKind: 22
-      Pointee: 627 StructureType os/exec.wrappedError
+      Pointee: 732 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 558
+      ID: 663
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 361 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 466 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 363
+      ID: 468
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 362 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 467 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 557
+      ID: 662
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 937312
       GoKind: 22
-      Pointee: 360 BaseType os/user.UnknownUserIdError
+      Pointee: 465 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 387
+      ID: 492
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 900736
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType reflect.ValueError
+      Pointee: 493 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 485
+      ID: 590
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 591 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 595
+      ID: 700
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.026752e+06
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 701 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 599
+      ID: 704
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.028544e+06
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 705 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 597
+      ID: 702
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.02688e+06
       GoKind: 22
-      Pointee: 598 StructureType runtime.boundsError
+      Pointee: 703 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 661
+      ID: 766
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.196224e+06
       GoKind: 22
-      Pointee: 662 StructureType runtime.errorAddressString
+      Pointee: 767 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 593
+      ID: 698
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.026368e+06
       GoKind: 22
-      Pointee: 576 GoStringHeaderType runtime.errorString
+      Pointee: 681 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 578
+      ID: 683
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 577 GoStringDataType runtime.errorString.str
+      Pointee: 682 GoStringDataType runtime.errorString.str
     - __kind: PointerType
-      ID: 594
+      ID: 699
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.026496e+06
       GoKind: 22
-      Pointee: 579 GoStringHeaderType runtime.plainError
+      Pointee: 684 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 581
+      ID: 686
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 580 GoStringDataType runtime.plainError.str
+      Pointee: 685 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 737
+      ID: 842
       Name: '*runtime.synctestBubble'
       ByteSize: 8
       GoRuntimeType: 1.551392e+06
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType runtime.synctestBubble
+      Pointee: 843 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 383
+      ID: 488
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 899392
       GoKind: 22
-      Pointee: 384 StructureType runtime.synctestDeadlockError
+      Pointee: 489 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
-      ID: 601
+      ID: 706
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.0288e+06
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType strconv.NumError
+      Pointee: 707 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6120,168 +6332,198 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 178
+      ID: 222
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 177 GoStringDataType string.str
+      Pointee: 221 GoStringDataType string.str
     - __kind: PointerType
-      ID: 902
+      ID: 1007
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.949088e+06
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType strings.Builder
+      Pointee: 1008 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 806
+      ID: 911
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.028928e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 912 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 802
+      ID: 907
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 970400
       GoKind: 22
-      Pointee: 803 StructureType struct { io.Writer }
+      Pointee: 908 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 713
+      ID: 818
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.415328e+06
       GoKind: 22
-      Pointee: 712 BaseType syscall.Errno
+      Pointee: 817 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 286 StructureType table<[4]int,[4]int>
+      Pointee: 330 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 147
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 278 StructureType table<[4]int,uint8>
+      Pointee: 322 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 115
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 226 StructureType table<[4]string,[2]int>
+      Pointee: 270 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 127
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 245 StructureType table<bool,main.node>
+      Pointee: 289 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 72
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 184 StructureType table<int,*main.deepMap2>
+      Pointee: 228 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1013
+      ID: 1118
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1014 StructureType table<int,*main.deepMap3>
+      Pointee: 1119 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1049
+      ID: 1154
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1050 StructureType table<int,*main.deepMap8>
+      Pointee: 1155 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1064
+      ID: 1169
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1065 StructureType table<int,*main.deepMap9>
+      Pointee: 1170 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 95
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 194 StructureType table<int,int>
+      Pointee: 238 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1079
+      ID: 1184
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1080 StructureType table<int,interface {}>
+      Pointee: 1185 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 132
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 253 StructureType table<int,uint8>
+      Pointee: 297 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 122
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 235 StructureType table<string,[]main.structWithMap>
+      Pointee: 279 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 110
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 218 StructureType table<string,[]string>
+      Pointee: 262 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 744
+      ID: 849
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 772 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 877 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 210 StructureType table<string,int>
+      Pointee: 254 StructureType table<string,int>
     - __kind: PointerType
       ID: 100
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 202 StructureType table<string,main.nestedStruct>
+      Pointee: 246 StructureType table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 191
+      Name: '*table<struct {},main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 362 StructureType table<struct {},main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 196
+      Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 371 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 201
+      Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 379 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 206
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 387 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 211
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 395 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: PointerType
+      ID: 216
+      Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
+      ByteSize: 8
+      Pointee: 403 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 142
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 269 StructureType table<uint8,[4]int>
+      Pointee: 313 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 137
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 261 StructureType table<uint8,uint8>
+      Pointee: 305 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 937
+      ID: 1042
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.158656e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1043 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 654
+      ID: 759
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.08832e+06
       GoKind: 22
-      Pointee: 655 StructureType text/template.ExecError
+      Pointee: 760 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 729
+      ID: 834
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6216e+06
       GoKind: 22
-      Pointee: 730 UnresolvedPointeeType time.Location
+      Pointee: 835 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 390
+      ID: 495
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 901600
       GoKind: 22
-      Pointee: 391 UnresolvedPointeeType time.ParseError
+      Pointee: 496 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 389
+      ID: 494
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 901504
       GoKind: 22
-      Pointee: 306 GoStringHeaderType time.fileSizeError
+      Pointee: 411 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 308
+      ID: 413
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType time.fileSizeError.str
+      Pointee: 412 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6325,52 +6567,52 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 481
+      ID: 586
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 919648
       GoKind: 22
-      Pointee: 482 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 587 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 929
+      ID: 1034
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.134144e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1035 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 465
+      ID: 570
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 915808
       GoKind: 22
-      Pointee: 466 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 571 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 467
+      ID: 572
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 350 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 455 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 631
+      ID: 736
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.046592e+06
       GoKind: 22
-      Pointee: 632 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 737 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 633
+      ID: 738
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.04672e+06
       GoKind: 22
-      Pointee: 584 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 689 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1185
+      ID: 1290
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1142
+      ID: 1247
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6385,7 +6627,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1140
+      ID: 1245
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6400,7 +6642,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1104
+      ID: 1209
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6415,7 +6657,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1102
+      ID: 1207
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6430,7 +6672,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1150
+      ID: 1255
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6445,7 +6687,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1103
+      ID: 1208
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6460,7 +6702,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1122
+      ID: 1227
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6475,7 +6717,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1091
+      ID: 1196
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6490,7 +6732,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1088
+      ID: 1193
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6505,7 +6747,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1166
+      ID: 1271
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6520,7 +6762,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1164
+      ID: 1269
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6553,7 +6795,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1174
+      ID: 1279
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6568,7 +6810,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1127
+      ID: 1232
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6583,7 +6825,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1128
+      ID: 1233
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6598,7 +6840,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1123
+      ID: 1228
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6613,7 +6855,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1124
+      ID: 1229
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6628,7 +6870,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1125
+      ID: 1230
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6643,7 +6885,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1126
+      ID: 1231
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6658,7 +6900,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1179
+      ID: 1284
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6682,7 +6924,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1176
+      ID: 1281
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6697,7 +6939,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1193
+      ID: 1298
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6712,7 +6954,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1196
+      ID: 1303
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6720,14 +6962,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 176 PointerType *main.emptyStruct
+            Type: 220 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: e}
+                  Variable: {subprogram: 111, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1195
+      ID: 1302
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6735,14 +6977,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 175 StructureType main.emptyStruct
+            Type: 219 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: e}
+                  Variable: {subprogram: 110, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1141
+      ID: 1246
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6757,7 +6999,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1132
+      ID: 1237
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6772,7 +7014,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1131
+      ID: 1236
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6787,7 +7029,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1138
+      ID: 1243
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6802,7 +7044,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1137
+      ID: 1242
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6817,7 +7059,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1133
+      ID: 1238
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6832,7 +7074,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1135
+      ID: 1240
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6847,10 +7089,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1198
+      ID: 1305
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1134
+      ID: 1239
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6874,16 +7116,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1199
+      ID: 1306
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1200
+      ID: 1307
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1136
+      ID: 1241
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1197
+      ID: 1304
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6894,11 +7136,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 112, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1201
+      ID: 1308
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6909,11 +7151,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1202
+      ID: 1309
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6924,11 +7166,11 @@ Types:
             Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: a}
+                  Variable: {subprogram: 117, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1094
+      ID: 1199
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6943,7 +7185,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1095
+      ID: 1200
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6958,7 +7200,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1096
+      ID: 1201
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6973,7 +7215,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1093
+      ID: 1198
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6988,7 +7230,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1092
+      ID: 1197
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7003,7 +7245,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1139
+      ID: 1244
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7018,7 +7260,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1168
+      ID: 1273
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7033,7 +7275,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1148
+      ID: 1253
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7048,7 +7290,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1154
+      ID: 1259
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7063,7 +7305,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1152
+      ID: 1257
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7078,7 +7320,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1163
+      ID: 1268
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7093,7 +7335,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1162
+      ID: 1267
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7108,7 +7350,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1153
+      ID: 1258
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7123,7 +7365,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1161
+      ID: 1266
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7138,7 +7380,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1160
+      ID: 1265
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7153,7 +7395,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1146
+      ID: 1251
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7168,7 +7410,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1147
+      ID: 1252
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7183,7 +7425,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1145
+      ID: 1250
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7198,7 +7440,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1155
+      ID: 1260
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7213,7 +7455,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1159
+      ID: 1264
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7228,7 +7470,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1158
+      ID: 1263
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7243,7 +7485,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1157
+      ID: 1262
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7258,7 +7500,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1156
+      ID: 1261
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7273,7 +7515,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1191
+      ID: 1296
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7288,7 +7530,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1165
+      ID: 1270
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7339,7 +7581,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1173
+      ID: 1278
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7363,7 +7605,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1180
+      ID: 1285
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7387,7 +7629,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1182
+      ID: 1287
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7420,7 +7662,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1288
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7435,7 +7677,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1190
+      ID: 1295
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7450,7 +7692,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1274
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7465,7 +7707,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1151
+      ID: 1256
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7480,7 +7722,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1272
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7495,7 +7737,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1089
+      ID: 1194
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7510,7 +7752,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1108
+      ID: 1213
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7525,7 +7767,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1106
+      ID: 1211
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7540,7 +7782,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1119
+      ID: 1224
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7555,7 +7797,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1120
+      ID: 1225
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7570,7 +7812,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1111
+      ID: 1216
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7585,7 +7827,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1112
+      ID: 1217
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7600,7 +7842,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1113
+      ID: 1218
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7615,7 +7857,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1110
+      ID: 1215
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7630,7 +7872,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1109
+      ID: 1214
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7645,7 +7887,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1107
+      ID: 1212
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7660,7 +7902,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1186
+      ID: 1291
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7675,7 +7917,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1116
+      ID: 1221
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7690,7 +7932,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1117
+      ID: 1222
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -7705,7 +7947,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1118
+      ID: 1223
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7720,7 +7962,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1115
+      ID: 1220
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -7735,7 +7977,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1114
+      ID: 1219
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7750,7 +7992,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1177
+      ID: 1282
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7765,7 +8007,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1149
+      ID: 1254
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7780,7 +8022,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1090
+      ID: 1195
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7795,7 +8037,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1172
+      ID: 1277
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7810,7 +8052,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
+      ID: 1286
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7825,7 +8067,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1129
+      ID: 1234
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7840,7 +8082,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1130
+      ID: 1235
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7855,7 +8097,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1178
+      ID: 1283
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7879,7 +8121,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1143
+      ID: 1248
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7894,7 +8136,37 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1144
+      ID: 1300
+      Name: Probe[main.testStructWithCyclicMaps]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 186 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 1299
+      Name: Probe[main.testStructWithCyclicSlices]
+      ByteSize: 145
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 173 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
+    - __kind: EventRootType
+      ID: 1249
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7909,7 +8181,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1194
+      ID: 1301
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7917,14 +8189,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 173 StructureType main.aStruct
+            Type: 217 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: x}
+                  Variable: {subprogram: 109, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1189
+      ID: 1294
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7939,7 +8211,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1188
+      ID: 1293
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7954,7 +8226,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1187
+      ID: 1292
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7987,7 +8259,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1121
+      ID: 1226
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8002,7 +8274,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1099
+      ID: 1204
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -8017,7 +8289,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1100
+      ID: 1205
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8032,7 +8304,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1101
+      ID: 1206
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8047,7 +8319,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1098
+      ID: 1203
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8062,7 +8334,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1097
+      ID: 1202
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8077,7 +8349,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1171
+      ID: 1276
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8092,7 +8364,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1175
+      ID: 1280
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8107,7 +8379,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1192
+      ID: 1297
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8122,7 +8394,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1170
+      ID: 1275
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8137,7 +8409,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1105
+      ID: 1210
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -8152,7 +8424,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1184
+      ID: 1289
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8300,7 +8572,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 275
+      ID: 319
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 682656
@@ -8309,7 +8581,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 232
+      ID: 276
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 682944
@@ -8326,7 +8598,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 762
+      ID: 867
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684192
@@ -8350,14 +8622,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 182 GoSliceDataType []*main.deepSlice2.array
+      Data: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 226
       Name: '[]*main.deepSlice2.array'
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1003
+      ID: 1108
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477664
@@ -8365,21 +8637,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1004 PointerType **main.deepSlice3
+          Type: 1109 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1007 GoSliceDataType []*main.deepSlice3.array
+      Data: 1112 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1007
+      ID: 1112
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 1005 PointerType *main.deepSlice3
+      Element: 1110 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1030
+      ID: 1135
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477344
@@ -8387,21 +8659,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1031 PointerType **main.deepSlice8
+          Type: 1136 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1034 GoSliceDataType []*main.deepSlice8.array
+      Data: 1139 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1034
+      ID: 1139
       Name: '[]*main.deepSlice8.array'
       ByteSize: 2048
-      Element: 1032 PointerType *main.deepSlice8
+      Element: 1137 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1036
+      ID: 1141
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477280
@@ -8409,19 +8681,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1037 PointerType **main.deepSlice9
+          Type: 1142 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1040 GoSliceDataType []*main.deepSlice9.array
+      Data: 1145 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1040
+      ID: 1145
       Name: '[]*main.deepSlice9.array'
       ByteSize: 2048
-      Element: 1038 PointerType *main.deepSlice9
+      Element: 1143 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -8438,102 +8710,237 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 179 GoSliceDataType []*string.array
+      Data: 223 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 223
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 336
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 152 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 328
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 147 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 277
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 115 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 295
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 236
       Name: '[]*table<int,*main.deepMap2>.array'
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1022
+      ID: 1127
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 1013 PointerType *table<int,*main.deepMap3>
+      Element: 1118 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1058
+      ID: 1163
       Name: '[]*table<int,*main.deepMap8>.array'
       ByteSize: 8192
-      Element: 1049 PointerType *table<int,*main.deepMap8>
+      Element: 1154 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1073
+      ID: 1178
       Name: '[]*table<int,*main.deepMap9>.array'
       ByteSize: 8192
-      Element: 1064 PointerType *table<int,*main.deepMap9>
+      Element: 1169 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 244
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 95 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1086
+      ID: 1191
       Name: '[]*table<int,interface {}>.array'
       ByteSize: 8192
-      Element: 1079 PointerType *table<int,interface {}>
+      Element: 1184 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 303
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 132 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 287
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 268
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 778
+      ID: 883
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 8192
-      Element: 744 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 849 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 260
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 252
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 100 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 369
+      Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 191 PointerType *table<struct {},main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 377
+      Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 196 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 385
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 201 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 393
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 206 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 401
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 211 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 409
+      Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
+      ByteSize: 8192
+      Element: 216 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoSliceDataType
+      ID: 320
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 142 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 311
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 137 PointerType *table<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 184
+      Name: '[][][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 185 PointerType *[][][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 360 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 360
+      Name: '[][][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 182
+      Name: '[][][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 183 PointerType *[][][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 358 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 358
+      Name: '[][][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 180
+      Name: '[][][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 181 PointerType *[][][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 356 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 356
+      Name: '[][][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 178
+      Name: '[][][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 179 PointerType *[][]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 354 GoSliceDataType [][][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 354
+      Name: '[][][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 176
+      Name: '[][]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 177 PointerType *[]main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 352 GoSliceDataType [][]main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 352
+      Name: '[][]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 174 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
       ID: 161
       Name: '[][]uint'
@@ -8549,9 +8956,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 296 GoSliceDataType [][]uint.array
+      Data: 340 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 340
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 160 GoSliceHeaderType []uint
@@ -8571,14 +8978,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 302 GoSliceDataType []bool.array
+      Data: 346 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 346
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 757
+      ID: 862
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 486944
@@ -8593,14 +9000,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 782 GoSliceDataType []float64.array
+      Data: 887 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 782
+      ID: 887
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 16 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1042
+      ID: 1147
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487392
@@ -8615,14 +9022,35 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1043 GoSliceDataType []interface {}.array
+      Data: 1148 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1043
+      ID: 1148
       Name: '[]interface {}.array'
       ByteSize: 2048
       Element: 81 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 241
+      ID: 174
+      Name: '[]main.structWithCyclicSlices'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 175 PointerType *main.structWithCyclicSlices
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 350 GoSliceDataType []main.structWithCyclicSlices.array
+    - __kind: GoSliceDataType
+      ID: 350
+      Name: '[]main.structWithCyclicSlices.array'
+      ByteSize: 2048
+      Element: 173 StructureType main.structWithCyclicSlices
+    - __kind: GoSliceHeaderType
+      ID: 285
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 477984
@@ -8630,16 +9058,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 242 PointerType *main.structWithMap
+          Type: 286 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1024 GoSliceDataType []main.structWithMap.array
+      Data: 1129 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1024
+      ID: 1129
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -8658,102 +9086,132 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 298 GoSliceDataType []main.structWithNoStrings.array
+      Data: 342 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 342
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 337
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 289 StructureType noalg.map.group[[4]int][4]int
+      Element: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 329
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 281 StructureType noalg.map.group[[4]int]uint8
+      Element: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 278
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 229 StructureType noalg.map.group[[4]string][2]int
+      Element: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 296
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 248 StructureType noalg.map.group[bool]main.node
+      Element: 292 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 237
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       ByteSize: 2048
-      Element: 187 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1023
+      ID: 1128
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 1017 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1122 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1059
+      ID: 1164
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       ByteSize: 2048
-      Element: 1053 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1158 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1074
+      ID: 1179
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       ByteSize: 2048
-      Element: 1068 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1173 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 245
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[int]int
+      Element: 241 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1087
+      ID: 1192
       Name: '[]noalg.map.group[int]interface {}.array'
       ByteSize: 2048
-      Element: 1083 StructureType noalg.map.group[int]interface {}
+      Element: 1188 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 304
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 256 StructureType noalg.map.group[int]uint8
+      Element: 300 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 288
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 238 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 269
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 221 StructureType noalg.map.group[string][]string
+      Element: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 779
+      ID: 884
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 2048
-      Element: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 261
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 213 StructureType noalg.map.group[string]int
+      Element: 257 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 253
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 205 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 249 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 370
+      Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 378
+      Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 386
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 394
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 402
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 410
+      Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
+      ByteSize: 2048
+      Element: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSliceDataType
+      ID: 321
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 272 StructureType noalg.map.group[uint8][4]int
+      Element: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 312
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 264 StructureType noalg.map.group[uint8]uint8
+      Element: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 166
       Name: '[]string'
@@ -8770,9 +9228,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 300 GoSliceDataType []string.array
+      Data: 344 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 344
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -8792,9 +9250,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 294 GoSliceDataType []uint.array
+      Data: 338 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 338
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
@@ -8814,14 +9272,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 304 GoSliceDataType []uint16.array
+      Data: 348 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 304
+      ID: 348
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 751
+      ID: 856
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 485920
@@ -8836,18 +9294,18 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 780 GoSliceDataType []uint8.array
+      Data: 885 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 780
+      ID: 885
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 1019
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 544
+      ID: 649
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 930784
@@ -8862,32 +9320,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 545 GoSliceDataType archive/tar.headerError.array
+      Data: 650 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 545
+      ID: 650
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 954
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 902
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 904
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.119616e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 998
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 930
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.564352e+06
@@ -8897,7 +9355,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 932
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -8907,15 +9365,15 @@ Types:
       GoRuntimeType: 584960
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 977
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 1006
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 1057
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -8941,13 +9399,13 @@ Types:
       GoRuntimeType: 584704
       GoKind: 15
     - __kind: BaseType
-      ID: 342
+      ID: 447
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834048
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 343
+      ID: 448
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 834144
@@ -8955,115 +9413,115 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 345 PointerType *compress/flate.InternalError.str
+          Type: 450 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 344 GoStringDataType compress/flate.InternalError.str
+      Data: 449 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 344
+      ID: 449
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 952
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 898
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 974
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 692
+      ID: 797
       Name: context.deadlineExceededError
       GoRuntimeType: 1.478592e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 356
+      ID: 461
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 2
     - __kind: BaseType
-      ID: 357
+      ID: 462
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 2
     - __kind: BaseType
-      ID: 358
+      ID: 463
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 969
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 641
+      ID: 746
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.288576e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 1000
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 925
+      ID: 1030
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 899
+      ID: 1004
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 897
+      ID: 1002
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 996
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 359
+      ID: 464
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 1017
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 992
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 346
+      ID: 451
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 834624
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 735
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 1083
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 458
+      ID: 563
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 456
+      ID: 561
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.72944e+06
@@ -9074,38 +9532,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 762 ArrayType [5]uint8
+          Type: 867 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 583
+      ID: 688
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 992768
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 857
+      ID: 962
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 460
+      ID: 565
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 967
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 727
+      ID: 832
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 851
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 532
+      ID: 637
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.73232e+06
@@ -9113,21 +9571,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 745 PointerType *crypto/x509.Certificate
+          Type: 850 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 765 BaseType crypto/x509.InvalidReason
+          Type: 870 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 526
+      ID: 631
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.117184e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 528
+      ID: 633
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.598464e+06
@@ -9135,24 +9593,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 745 PointerType *crypto/x509.Certificate
+          Type: 850 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 355
+      ID: 460
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836256
       GoKind: 2
     - __kind: BaseType
-      ID: 765
+      ID: 870
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 590144
       GoKind: 2
     - __kind: StructureType
-      ID: 635
+      ID: 740
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.560352e+06
@@ -9162,13 +9620,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 534
+      ID: 639
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.11744e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 530
+      ID: 635
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.732128e+06
@@ -9176,15 +9634,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 745 PointerType *crypto/x509.Certificate
+          Type: 850 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 745 PointerType *crypto/x509.Certificate
+          Type: 850 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 548
+      ID: 653
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.435008e+06
@@ -9194,7 +9652,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 552
+      ID: 657
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.435168e+06
@@ -9204,55 +9662,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 655
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 337
+      ID: 442
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 833568
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 920
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 338
+      ID: 443
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 833760
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 414
+      ID: 519
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 724
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 406
+      ID: 511
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 412
+      ID: 517
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 410
+      ID: 515
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 408
+      ID: 513
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 1063
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 416
+      ID: 521
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.419008e+06
@@ -9262,19 +9720,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 928
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 520
+      ID: 625
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 518
+      ID: 623
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 352
+      ID: 457
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 836160
@@ -9282,21 +9740,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 354 PointerType *encoding/xml.UnmarshalError.str
+          Type: 459 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 353 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 458 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 353
+      ID: 458
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 628
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 1041
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9313,11 +9771,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 487
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 691
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9333,15 +9791,15 @@ Types:
       GoRuntimeType: 584896
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 1051
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 588
+      ID: 693
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 590
+      ID: 695
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9351,11 +9809,11 @@ Types:
       GoRuntimeType: 475872
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 444
+      ID: 549
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 425
+      ID: 530
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.728288e+06
@@ -9363,7 +9821,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 755 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 860 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -9371,25 +9829,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 427
+      ID: 532
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 759
+      ID: 864
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 431
+      ID: 536
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.113472e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 761
+      ID: 866
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 832992
@@ -9397,17 +9855,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 437
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 755
+      ID: 860
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.217952e+06
@@ -9415,7 +9873,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 756 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 861 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9430,7 +9888,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 757 GoSliceHeaderType []float64
+          Type: 862 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -9439,10 +9897,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 758 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 863 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 760 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 865 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 166 GoSliceHeaderType []string
@@ -9456,13 +9914,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 756
+      ID: 861
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586752
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 433
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 832896
@@ -9470,17 +9928,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 434
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 334
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 833088
@@ -9488,59 +9946,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 336 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 441 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 335 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 335
+      ID: 440
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 940
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 1027
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 542
+      ID: 647
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 806
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 954
+      ID: 1059
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 469
+      ID: 574
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 476
+      ID: 581
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.116416e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 351
+      ID: 456
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 835296
       GoKind: 2
     - __kind: StructureType
-      ID: 474
+      ID: 579
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.116288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 472
+      ID: 577
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.596544e+06
@@ -9553,7 +10011,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 492
+      ID: 597
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.597344e+06
@@ -9566,7 +10024,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 496
+      ID: 601
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.731552e+06
@@ -9582,7 +10040,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 494
+      ID: 599
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.428928e+06
@@ -9592,7 +10050,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 490
+      ID: 595
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.428608e+06
@@ -9602,14 +10060,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 740
+      ID: 845
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.499552e+06
       GoKind: 21
-      HeaderType: 742 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 847 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 764
+      ID: 869
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.050176e+06
@@ -9624,14 +10082,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 784 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 889 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 784
+      ID: 889
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 504
+      ID: 609
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.597664e+06
@@ -9639,12 +10097,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 740 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 845 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 740 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 845 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 498
+      ID: 603
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.429088e+06
@@ -9654,7 +10112,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 502
+      ID: 607
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.731744e+06
@@ -9665,12 +10123,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 500
+      ID: 605
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.597504e+06
@@ -9683,7 +10141,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 506
+      ID: 611
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.429248e+06
@@ -9691,9 +10149,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 728 StructureType time.Time
+          Type: 833 StructureType time.Time
     - __kind: StructureType
-      ID: 512
+      ID: 617
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.597984e+06
@@ -9706,7 +10164,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 514
+      ID: 619
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.429568e+06
@@ -9716,7 +10174,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 510
+      ID: 615
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.597824e+06
@@ -9729,7 +10187,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 508
+      ID: 613
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.429408e+06
@@ -9739,7 +10197,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 516
+      ID: 621
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.598144e+06
@@ -9752,7 +10210,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 433
+      ID: 538
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.421248e+06
@@ -9762,11 +10220,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 980
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 435
+      ID: 540
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.421408e+06
@@ -9774,21 +10232,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 433 StructureType github.com/cihub/seelog.baseError
+          Type: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 960
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 916
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 950
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 439
+      ID: 544
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.421728e+06
@@ -9796,13 +10254,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 433 StructureType github.com/cihub/seelog.baseError
+          Type: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 1015
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 923
+      ID: 1028
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.10544e+06
@@ -9810,12 +10268,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 909 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1014 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 926
+      ID: 1031
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.130304e+06
@@ -9823,7 +10281,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 909 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1014 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9831,11 +10289,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 918
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 437
+      ID: 542
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.421568e+06
@@ -9843,9 +10301,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 433 StructureType github.com/cihub/seelog.baseError
+          Type: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 441
+      ID: 546
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.421888e+06
@@ -9853,64 +10311,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 433 StructureType github.com/cihub/seelog.baseError
+          Type: 538 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 982
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 1023
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 1025
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 732
+      ID: 837
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 750
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 748
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 752
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 754
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 971
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 742
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 447
+      ID: 552
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.422848e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 1075
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 808
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 676
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.841344e+06
@@ -9926,11 +10384,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 775
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 605
+      ID: 710
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.700992e+06
@@ -9943,7 +10401,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 682
+      ID: 787
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.841792e+06
@@ -9959,13 +10417,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 582
+      ID: 687
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 990080
       GoKind: 8
     - __kind: StructureType
-      ID: 674
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.84112e+06
@@ -9981,13 +10439,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 766
+      ID: 871
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 831168
       GoKind: 8
     - __kind: StructureType
-      ID: 672
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.840896e+06
@@ -9995,15 +10453,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 766 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 871 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 766 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 871 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 680
+      ID: 785
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.754944e+06
@@ -10016,7 +10474,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 678
+      ID: 783
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.841568e+06
@@ -10032,11 +10490,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 1079
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 791
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.62256e+06
@@ -10046,19 +10504,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 609
+      ID: 714
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.28256e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 607
+      ID: 712
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.282432e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 684
+      ID: 789
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.755136e+06
@@ -10071,7 +10529,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 364
+      ID: 469
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 838752
@@ -10079,21 +10537,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 366 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 471 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 365 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 470 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 365
+      ID: 470
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 749
+      ID: 854
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 653
+      ID: 758
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.446848e+06
@@ -10103,7 +10561,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 841
+      ID: 946
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.676704e+06
@@ -10111,13 +10569,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 867 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 972 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 1039
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 867
+      ID: 972
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.127168e+06
@@ -10130,7 +10588,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 829
+      ID: 934
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.569152e+06
@@ -10140,19 +10598,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 367
+      ID: 472
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 839328
       GoKind: 10
     - __kind: BaseType
-      ID: 747
+      ID: 852
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.003232e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 711
+      ID: 816
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.879648e+06
@@ -10163,12 +10621,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 747 BaseType golang.org/x/net/http2.ErrCode
+          Type: 852 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 568
+      ID: 673
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.605184e+06
@@ -10176,12 +10634,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 747 BaseType golang.org/x/net/http2.ErrCode
+          Type: 852 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 371
+      ID: 476
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839520
@@ -10189,17 +10647,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 373 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 478 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 372 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 477 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 372
+      ID: 477
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 377
+      ID: 482
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 839712
@@ -10207,17 +10665,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 379 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 484 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 378 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 483 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 378
+      ID: 483
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 374
+      ID: 479
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 839616
@@ -10225,17 +10683,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 376 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 481 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 375 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 480 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 375
+      ID: 480
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 368
+      ID: 473
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839424
@@ -10243,21 +10701,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 370 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 475 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 369 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 474 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 369
+      ID: 474
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 1037
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 572
+      ID: 677
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.447488e+06
@@ -10267,13 +10725,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 380
+      ID: 485
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 839808
       GoKind: 2
     - __kind: StructureType
-      ID: 560
+      ID: 665
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.442528e+06
@@ -10283,11 +10741,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 814
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 734
+      ID: 839
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.907424e+06
@@ -10303,7 +10761,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 562
+      ID: 667
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.604704e+06
@@ -10316,7 +10774,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 881
+      ID: 986
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.965472e+06
@@ -10324,16 +10782,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 908 GoInterfaceType io.Reader
+          Type: 1013 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 944
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 651
+      ID: 756
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.566752e+06
@@ -10343,29 +10801,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 906
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 645
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 744
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 707
+      ID: 812
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 705
+      ID: 810
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.510272e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 554
+      ID: 659
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.435808e+06
@@ -10375,7 +10833,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 556
+      ID: 661
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.435968e+06
@@ -10385,267 +10843,351 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 589
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 287
+      ID: 331
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 288 PointerType *noalg.map.group[[4]int][4]int
+          Type: 332 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 293 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 333 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 337 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 279
+      ID: 323
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 280 PointerType *noalg.map.group[[4]int]uint8
+          Type: 324 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 285 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 325 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 329 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 227
+      ID: 271
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 228 PointerType *noalg.map.group[[4]string][2]int
+          Type: 272 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 234 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 273 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 278 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 246
+      ID: 290
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 247 PointerType *noalg.map.group[bool]main.node
+          Type: 291 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 248 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 252 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 292 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 296 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 185
+      ID: 229
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 186 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 230 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 193 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1015
+      ID: 1120
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1016 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1121 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1017 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1023 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1122 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1128 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1051
+      ID: 1156
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1052 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1157 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1053 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1059 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1158 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1164 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1066
+      ID: 1171
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1067 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1172 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1068 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1074 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1173 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1179 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 239
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[int]int
+          Type: 240 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[int]int
-      GroupSliceType: 201 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 241 StructureType noalg.map.group[int]int
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1081
+      ID: 1186
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1082 PointerType *noalg.map.group[int]interface {}
+          Type: 1187 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1083 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1087 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1188 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1192 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 254
+      ID: 298
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 255 PointerType *noalg.map.group[int]uint8
+          Type: 299 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 256 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 260 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 300 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 304 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 236
+      ID: 280
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 237 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 281 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 282 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 288 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 219
+      ID: 263
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 220 PointerType *noalg.map.group[string][]string
+          Type: 264 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 221 StructureType noalg.map.group[string][]string
-      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 265 StructureType noalg.map.group[string][]string
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 773
+      ID: 878
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 774 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 879 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 779 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 884 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 211
+      ID: 255
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 212 PointerType *noalg.map.group[string]int
+          Type: 256 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 213 StructureType noalg.map.group[string]int
-      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 257 StructureType noalg.map.group[string]int
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 203
+      ID: 247
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 204 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 248 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 249 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 270
+      ID: 363
+      Name: groupReference<struct {},main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 364 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 370 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 372
+      Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 373 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 380
+      Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 381 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 386 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 388
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 389 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 394 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 396
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 397 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 402 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 404
+      Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 405 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 410 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+    - __kind: GoSwissMapGroupsType
+      ID: 314
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 271 PointerType *noalg.map.group[uint8][4]int
+          Type: 315 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 272 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 277 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 316 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 321 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 262
+      ID: 306
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 263 PointerType *noalg.map.group[uint8]uint8
+          Type: 307 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 264 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 268 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 308 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 312 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 994
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 680
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -10692,41 +11234,41 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 841
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 452
+      ID: 557
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 450
+      ID: 555
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 787
+      ID: 892
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 773
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 1081
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 666
+      ID: 771
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.475392e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 491
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 339
+      ID: 444
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 833952
@@ -10734,17 +11276,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 341 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 446 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 340 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 445 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 340
+      ID: 445
       Name: internal/runtime/cgroup.stringError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 623
+      ID: 728
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.558112e+06
@@ -10752,9 +11294,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 735 PointerType *internal/abi.Type
+          Type: 840 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 988
+      ID: 1093
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.472832e+06
@@ -10767,11 +11309,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 938
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 873
+      ID: 978
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.189056e+06
@@ -10784,7 +11326,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 908
+      ID: 1013
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.022528e+06
@@ -10797,7 +11339,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 860
+      ID: 965
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -10823,25 +11365,25 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 831
+      ID: 936
       Name: io.discard
       GoRuntimeType: 1.461952e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 910
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 769
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 984
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 173
+      ID: 217
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -10857,7 +11399,7 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 174 StructureType main.nestedStruct
+          Type: 218 StructureType main.nestedStruct
     - __kind: GoInterfaceType
       ID: 87
       Name: main.behavior
@@ -10897,7 +11439,7 @@ Types:
           Offset: 0
           Type: 68 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 191
+      ID: 235
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.1856e+06
@@ -10905,9 +11447,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1009 GoMapType map[int]*main.deepMap3
+          Type: 1114 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1126
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -10919,9 +11461,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1045 GoMapType map[int]*main.deepMap8
+          Type: 1150 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1057
+      ID: 1162
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.184832e+06
@@ -10929,9 +11471,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1060 GoMapType map[int]*main.deepMap9
+          Type: 1165 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1072
+      ID: 1177
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.184704e+06
@@ -10939,7 +11481,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1075 GoMapType map[int]interface {}
+          Type: 1180 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 56
       Name: main.deepPtr1
@@ -10959,9 +11501,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 979 PointerType *main.deepPtr3
+          Type: 1084 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 1085
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -10973,9 +11515,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1026 PointerType *main.deepPtr8
+          Type: 1131 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1027
+      ID: 1132
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.185984e+06
@@ -10983,9 +11525,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1028 PointerType *main.deepPtr9
+          Type: 1133 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1029
+      ID: 1134
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.185856e+06
@@ -11005,7 +11547,7 @@ Types:
           Offset: 0
           Type: 62 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 181
+      ID: 225
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.187904e+06
@@ -11013,9 +11555,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1003 GoSliceHeaderType []*main.deepSlice3
+          Type: 1108 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1111
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11027,9 +11569,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1030 GoSliceHeaderType []*main.deepSlice8
+          Type: 1135 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1033
+      ID: 1138
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.187136e+06
@@ -11037,9 +11579,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1036 GoSliceHeaderType []*main.deepSlice9
+          Type: 1141 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1039
+      ID: 1144
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.187008e+06
@@ -11047,9 +11589,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1042 GoSliceHeaderType []interface {}
+          Type: 1147 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 175
+      ID: 219
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -11065,16 +11607,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 986 StructureType sync.Mutex
+          Type: 1091 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 989 StructureType sync.Once
+          Type: 1094 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 992 StructureType sync.WaitGroup
+          Type: 1097 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 995 StructureType sync/atomic.Int32
+          Type: 1100 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -11104,7 +11646,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 997
+      ID: 1102
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.411488e+06
@@ -11114,7 +11656,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 174
+      ID: 218
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.461472e+06
@@ -11149,7 +11691,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 999
+      ID: 1104
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.411648e+06
@@ -11169,7 +11711,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 1090
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11180,17 +11722,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 982 PointerType *main.stringType1.str
+          Type: 1087 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 981 GoStringDataType main.stringType1.str
+      Data: 1086 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 981
+      ID: 1086
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 1088
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11203,6 +11745,54 @@ Types:
         - Name: a
           Offset: 0
           Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 186
+      Name: main.structWithCyclicMaps
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: m1
+          Offset: 0
+          Type: 187 GoMapType map[struct {}]main.structWithCyclicMaps
+        - Name: m2
+          Offset: 8
+          Type: 192 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m3
+          Offset: 16
+          Type: 197 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m4
+          Offset: 24
+          Type: 202 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m5
+          Offset: 32
+          Type: 207 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+        - Name: m6
+          Offset: 40
+          Type: 212 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 173
+      Name: main.structWithCyclicSlices
+      ByteSize: 144
+      GoKind: 25
+      RawFields:
+        - Name: s1
+          Offset: 0
+          Type: 174 GoSliceHeaderType []main.structWithCyclicSlices
+        - Name: s2
+          Offset: 24
+          Type: 176 GoSliceHeaderType [][]main.structWithCyclicSlices
+        - Name: s3
+          Offset: 48
+          Type: 178 GoSliceHeaderType [][][]main.structWithCyclicSlices
+        - Name: s4
+          Offset: 72
+          Type: 180 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+        - Name: s5
+          Offset: 96
+          Type: 182 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+        - Name: s6
+          Offset: 120
+          Type: 184 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 90
       Name: main.structWithMap
@@ -11245,16 +11835,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1000 PointerType **main.t
+          Type: 1105 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1001 GoSliceDataType main.t.array
+      Data: 1106 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1001
+      ID: 1106
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -11311,8 +11901,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 292 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 289 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 336 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 333 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 145
       Name: map<[4]int,uint8>
@@ -11346,8 +11936,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 284 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 281 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 328 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 325 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 113
       Name: map<[4]string,[2]int>
@@ -11381,8 +11971,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 233 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 229 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 277 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 273 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 125
       Name: map<bool,main.node>
@@ -11416,8 +12006,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 251 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 248 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 295 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 292 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 70
       Name: map<int,*main.deepMap2>
@@ -11451,10 +12041,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 192 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 187 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 236 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1011
+      ID: 1116
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -11467,7 +12057,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1012 PointerType **table<int,*main.deepMap3>
+          Type: 1117 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11486,10 +12076,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1022 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1017 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1127 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1122 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1047
+      ID: 1152
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -11502,7 +12092,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1048 PointerType **table<int,*main.deepMap8>
+          Type: 1153 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11521,10 +12111,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1058 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1053 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1163 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1158 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1062
+      ID: 1167
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -11537,7 +12127,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1063 PointerType **table<int,*main.deepMap9>
+          Type: 1168 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11556,8 +12146,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1073 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1068 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1178 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1173 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 93
       Name: map<int,int>
@@ -11591,10 +12181,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 200 GoSliceDataType []*table<int,int>.array
-      GroupType: 197 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 244 GoSliceDataType []*table<int,int>.array
+      GroupType: 241 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1077
+      ID: 1182
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -11607,7 +12197,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1078 PointerType **table<int,interface {}>
+          Type: 1183 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11626,8 +12216,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1086 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1083 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1191 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1188 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 130
       Name: map<int,uint8>
@@ -11661,8 +12251,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 259 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 256 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 303 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 300 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<string,[]main.structWithMap>
@@ -11696,8 +12286,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 238 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 287 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 282 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 108
       Name: map<string,[]string>
@@ -11731,10 +12321,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 221 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 268 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 742
+      ID: 847
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -11747,7 +12337,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 743 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 848 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11766,8 +12356,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 778 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 775 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 883 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -11801,8 +12391,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 216 GoSliceDataType []*table<string,int>.array
-      GroupType: 213 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 260 GoSliceDataType []*table<string,int>.array
+      GroupType: 257 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 98
       Name: map<string,main.nestedStruct>
@@ -11836,8 +12426,218 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 208 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 205 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 249 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 189
+      Name: map<struct {},main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 190 PointerType **table<struct {},main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 369 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 365 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 194
+      Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 195 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 377 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 374 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 199
+      Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 200 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 385 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 382 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 204
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 205 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 393 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 390 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 209
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 210 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 401 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 398 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: GoSwissMapHeaderType
+      ID: 214
+      Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 215 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 409 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 406 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 140
       Name: map<uint8,[4]int>
@@ -11871,8 +12671,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 276 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 272 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 320 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 316 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 135
       Name: map<uint8,uint8>
@@ -11906,8 +12706,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 267 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 264 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 311 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 148
       Name: map[[4]int][4]int
@@ -11944,26 +12744,26 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1009
+      ID: 1114
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.128832e+06
       GoKind: 21
-      HeaderType: 1011 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1116 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1045
+      ID: 1150
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.128192e+06
       GoKind: 21
-      HeaderType: 1047 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1152 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1060
+      ID: 1165
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.128064e+06
       GoKind: 21
-      HeaderType: 1062 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1167 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 91
       Name: map[int]int
@@ -11972,12 +12772,12 @@ Types:
       GoKind: 21
       HeaderType: 93 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1075
+      ID: 1180
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.127936e+06
       GoKind: 21
-      HeaderType: 1077 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1182 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 128
       Name: map[int]uint8
@@ -12014,6 +12814,42 @@ Types:
       GoKind: 21
       HeaderType: 98 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
+      ID: 187
+      Name: map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 189 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 192
+      Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 194 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 197
+      Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 199 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 202
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 204 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 207
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 209 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
+      ID: 212
+      Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 8
+      GoKind: 21
+      HeaderType: 214 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: GoMapType
       ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
@@ -12028,7 +12864,7 @@ Types:
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 488
+      ID: 593
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.428128e+06
@@ -12038,7 +12874,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 795
+      ID: 900
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.424928e+06
@@ -12048,11 +12884,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 800
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 763
+      ID: 868
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.595264e+06
@@ -12065,35 +12901,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 721
+      ID: 826
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 1045
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 719
+      ID: 824
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 802
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 1055
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 1065
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 1053
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 656
+      ID: 761
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.113088e+06
@@ -12101,27 +12937,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 658 PointerType *net.UnknownNetworkError.str
+          Type: 763 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 657 GoStringDataType net.UnknownNetworkError.str
+      Data: 762 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 657
+      ID: 762
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 621
+      ID: 726
       Name: net.canceledError
       GoRuntimeType: 1.283584e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 1021
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 768
+      ID: 873
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.104736e+06
@@ -12129,7 +12965,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -12140,27 +12976,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 1067
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 956
+      ID: 1061
       Name: net.noReadFrom
       GoRuntimeType: 1.113344e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 955
+      ID: 1060
       Name: net.noWriteTo
       GoRuntimeType: 1.113216e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 418
+      ID: 523
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 420
+      ID: 525
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.728096e+06
@@ -12168,7 +13004,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 750 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 855 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -12176,7 +13012,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 944
+      ID: 1049
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.287744e+06
@@ -12184,12 +13020,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 956 StructureType net.noReadFrom
+          Type: 1061 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 949 PointerType *net.TCPConn
+          Type: 1054 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 942
+      ID: 1047
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.2872e+06
@@ -12197,24 +13033,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 955 StructureType net.noWriteTo
+          Type: 1060 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 949 PointerType *net.TCPConn
+          Type: 1054 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 804
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 828
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 716
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 789
+      ID: 894
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.416448e+06
@@ -12224,19 +13060,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 309
+      ID: 414
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 831648
       GoKind: 10
     - __kind: BaseType
-      ID: 739
+      ID: 844
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 990176
       GoKind: 10
     - __kind: StructureType
-      ID: 396
+      ID: 501
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.726368e+06
@@ -12247,12 +13083,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 739 BaseType net/http.http2ErrCode
+          Type: 844 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 715
+      ID: 820
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.897952e+06
@@ -12263,12 +13099,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 739 BaseType net/http.http2ErrCode
+          Type: 844 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 400
+      ID: 505
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.594784e+06
@@ -12276,16 +13112,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 739 BaseType net/http.http2ErrCode
+          Type: 844 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 956
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 418
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 831840
@@ -12293,17 +13129,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 420 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 314 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 419
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 424
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 832032
@@ -12311,17 +13147,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *net/http.http2headerFieldNameError.str
+          Type: 426 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 320 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 425 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 425
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 421
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 831936
@@ -12329,31 +13165,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *net/http.http2headerFieldValueError.str
+          Type: 423 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 317 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 422 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 422
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 795
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 617
+      ID: 722
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.282816e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 1010
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 415
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 831744
@@ -12361,17 +13197,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 417 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 311 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 416 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 416
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 791
+      ID: 896
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.824032e+06
@@ -12379,18 +13215,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 882 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 987 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 883 BaseType time.Duration
+          Type: 988 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 33 PointerType *error
     - __kind: GoInterfaceType
-      ID: 882
+      ID: 987
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.415648e+06
@@ -12403,14 +13239,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 870
+      ID: 975
       Name: net/http.incomparable
       GoRuntimeType: 902848
       GoKind: 17
       HasCount: true
       Element: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 613
+      ID: 718
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.554272e+06
@@ -12420,11 +13256,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 958
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 914
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.554112e+06
@@ -12432,9 +13268,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 852 PointerType *net/http.persistConn
+          Type: 957 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 843
+      ID: 948
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.799008e+06
@@ -12442,15 +13278,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 870 ArrayType net/http.incomparable
+          Type: 975 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 871 PointerType *bufio.Reader
+          Type: 976 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 873 GoInterfaceType io.ReadWriteCloser
+          Type: 978 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 404
+      ID: 509
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.417408e+06
@@ -12460,17 +13296,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 822
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 688
+      ID: 793
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.478272e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 615
+      ID: 720
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.554432e+06
@@ -12480,7 +13316,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 885
+      ID: 990
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.024448e+06
@@ -12488,16 +13324,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 763 GoInterfaceType net.Conn
+          Type: 868 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 393
+      ID: 498
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 907
+      ID: 1012
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.040192e+06
@@ -12505,13 +13341,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 900 PointerType *bufio.Writer
+          Type: 1005 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 924
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 480
+      ID: 585
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.731168e+06
@@ -12527,7 +13363,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 478
+      ID: 583
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.596704e+06
@@ -12540,11 +13376,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 964
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 821
+      ID: 926
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.598624e+06
@@ -12552,16 +13388,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 858 PointerType *net/smtp.Client
+          Type: 963 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 860 GoInterfaceType io.WriteCloser
+          Type: 965 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 464
+      ID: 569
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 347
+      ID: 452
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 834720
@@ -12569,25 +13405,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 349 PointerType *net/textproto.ProtocolError.str
+          Type: 454 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 348 GoStringDataType net/textproto.ProtocolError.str
+      Data: 453 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 348
+      ID: 453
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 922
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 830
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 427
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 832608
@@ -12595,17 +13431,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *net/url.EscapeError.str
+          Type: 429 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 323 GoStringDataType net/url.EscapeError.str
+      Data: 428 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 428
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 430
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 832704
@@ -12613,179 +13449,227 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *net/url.InvalidHostError.str
+          Type: 432 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 326 GoStringDataType net/url.InvalidHostError.str
+      Data: 431 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 431
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: ArrayType
-      ID: 290
+      ID: 334
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 682752
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 291 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 335 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 282
+      ID: 326
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 682848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 283 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 327 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 230
+      ID: 274
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 231 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 275 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 249
+      ID: 293
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 250 StructureType noalg.struct { key bool; elem main.node }
+      Element: 294 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 188
+      ID: 232
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 189 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 233 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1018
+      ID: 1123
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 681984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1019 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1124 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1054
+      ID: 1159
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1055 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1160 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1069
+      ID: 1174
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1070 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1175 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 198
+      ID: 242
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 199 StructureType noalg.struct { key int; elem int }
+      Element: 243 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1084
+      ID: 1189
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1085 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1190 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 257
+      ID: 301
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 683328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 258 StructureType noalg.struct { key int; elem uint8 }
+      Element: 302 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 239
+      ID: 283
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 683424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 240 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 284 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 222
+      ID: 266
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 223 StructureType noalg.struct { key string; elem []string }
+      Element: 267 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 776
+      ID: 881
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 758976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 777 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 882 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 214
+      ID: 258
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 683616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem int }
+      Element: 259 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 206
+      ID: 250
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 683712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 207 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 251 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 273
+      ID: 366
+      Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+      ByteSize: 384
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 367 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 375
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 376 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 383
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 384 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 391
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 392 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 399
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 400 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 407
+      Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 64
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 408 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: ArrayType
+      ID: 317
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 683808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 274 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 318 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 265
+      ID: 309
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 683904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 266 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 310 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 289
+      ID: 333
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.294592e+06
@@ -12796,9 +13680,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 290 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 334 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 281
+      ID: 325
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.294848e+06
@@ -12809,9 +13693,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 282 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 326 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 229
+      ID: 273
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.295104e+06
@@ -12822,9 +13706,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 230 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 274 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 248
+      ID: 292
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.29536e+06
@@ -12835,9 +13719,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 249 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 293 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 187
+      ID: 231
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.294336e+06
@@ -12848,9 +13732,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 188 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 232 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1017
+      ID: 1122
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.29408e+06
@@ -12861,9 +13745,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1018 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1123 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1053
+      ID: 1158
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.2928e+06
@@ -12874,9 +13758,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1054 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1159 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1068
+      ID: 1173
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.292544e+06
@@ -12887,9 +13771,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1069 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1174 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 197
+      ID: 241
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.29152e+06
@@ -12900,9 +13784,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 198 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 242 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1083
+      ID: 1188
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.292288e+06
@@ -12913,9 +13797,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1084 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1189 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 256
+      ID: 300
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.295616e+06
@@ -12926,9 +13810,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 257 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 301 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 238
+      ID: 282
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.295872e+06
@@ -12939,9 +13823,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 239 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 283 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 221
+      ID: 265
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.296128e+06
@@ -12952,9 +13836,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 222 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 266 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 775
+      ID: 880
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.357056e+06
@@ -12965,9 +13849,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 776 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 881 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 213
+      ID: 257
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.296384e+06
@@ -12978,9 +13862,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 258 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 205
+      ID: 249
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.29664e+06
@@ -12991,9 +13875,81 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 206 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 250 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 272
+      ID: 365
+      Name: noalg.map.group[struct {}]main.structWithCyclicMaps
+      ByteSize: 392
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 366 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 374
+      Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 375 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 382
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 383 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 390
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 391 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 398
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 399 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 406
+      Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ByteSize: 72
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 407 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+    - __kind: StructureType
+      ID: 316
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.296896e+06
@@ -13004,9 +13960,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 273 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 317 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 264
+      ID: 308
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.297152e+06
@@ -13017,9 +13973,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 265 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 309 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 291
+      ID: 335
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.294464e+06
@@ -13027,12 +13983,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
     - __kind: StructureType
-      ID: 283
+      ID: 327
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.29472e+06
@@ -13040,12 +13996,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 231
+      ID: 275
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.294976e+06
@@ -13053,12 +14009,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 232 ArrayType [4]string
+          Type: 276 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 250
+      ID: 294
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.295232e+06
@@ -13071,7 +14027,7 @@ Types:
           Offset: 8
           Type: 156 StructureType main.node
     - __kind: StructureType
-      ID: 189
+      ID: 233
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.294208e+06
@@ -13082,9 +14038,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 190 PointerType *main.deepMap2
+          Type: 234 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1019
+      ID: 1124
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.293952e+06
@@ -13095,9 +14051,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1020 PointerType *main.deepMap3
+          Type: 1125 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1055
+      ID: 1160
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.292672e+06
@@ -13108,9 +14064,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1056 PointerType *main.deepMap8
+          Type: 1161 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1070
+      ID: 1175
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.292416e+06
@@ -13121,9 +14077,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1071 PointerType *main.deepMap9
+          Type: 1176 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 199
+      ID: 243
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.291392e+06
@@ -13136,7 +14092,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1085
+      ID: 1190
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.29216e+06
@@ -13149,7 +14105,7 @@ Types:
           Offset: 8
           Type: 81 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 258
+      ID: 302
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.295488e+06
@@ -13162,7 +14118,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 240
+      ID: 284
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.295744e+06
@@ -13173,9 +14129,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 241 GoSliceHeaderType []main.structWithMap
+          Type: 285 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 223
+      ID: 267
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.296e+06
@@ -13188,7 +14144,7 @@ Types:
           Offset: 16
           Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 777
+      ID: 882
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.356928e+06
@@ -13199,9 +14155,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 764 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 215
+      ID: 259
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.296256e+06
@@ -13214,7 +14170,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 207
+      ID: 251
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.296512e+06
@@ -13225,9 +14181,81 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 174 StructureType main.nestedStruct
+          Type: 218 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 274
+      ID: 367
+      Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 186 StructureType main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 376
+      Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 187 GoMapType map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 384
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 192 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 392
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 197 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 400
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 202 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 408
+      Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      ByteSize: 8
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 368 StructureType struct {}
+        - Name: elem
+          Offset: 0
+          Type: 207 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+    - __kind: StructureType
+      ID: 318
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.296768e+06
@@ -13238,9 +14266,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 275 ArrayType [4]int
+          Type: 319 ArrayType [4]int
     - __kind: StructureType
-      ID: 266
+      ID: 310
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.297024e+06
@@ -13253,19 +14281,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 1073
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 697
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 765
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 966
+      ID: 1071
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.358112e+06
@@ -13273,12 +14301,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 972 StructureType os.noReadFrom
+          Type: 1077 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 967 PointerType *os.File
+          Type: 1072 PointerType *os.File
     - __kind: StructureType
-      ID: 964
+      ID: 1069
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.357312e+06
@@ -13286,36 +14314,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 971 StructureType os.noWriteTo
+          Type: 1076 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 967 PointerType *os.File
+          Type: 1072 PointerType *os.File
     - __kind: StructureType
-      ID: 972
+      ID: 1077
       Name: os.noReadFrom
       GoRuntimeType: 1.110656e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 971
+      ID: 1076
       Name: os.noWriteTo
       GoRuntimeType: 1.110528e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 730
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 876
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 942
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 627
+      ID: 732
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.701568e+06
@@ -13328,7 +14356,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 361
+      ID: 466
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 837984
@@ -13336,39 +14364,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 363 PointerType *os/user.UnknownGroupIdError.str
+          Type: 468 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 362 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 467 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 362
+      ID: 467
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 360
+      ID: 465
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 837888
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 493
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 591
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 701
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 705
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 598
+      ID: 703
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.886816e+06
@@ -13385,15 +14413,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 769 BaseType runtime.boundsErrorCode
+          Type: 874 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 769
+      ID: 874
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585088
       GoKind: 8
     - __kind: StructureType
-      ID: 662
+      ID: 767
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.751872e+06
@@ -13406,7 +14434,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 576
+      ID: 681
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 988736
@@ -13414,17 +14442,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 578 PointerType *runtime.errorString.str
+          Type: 683 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 577 GoStringDataType runtime.errorString.str
+      Data: 682 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 577
+      ID: 682
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 579
+      ID: 684
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 988832
@@ -13432,21 +14460,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 581 PointerType *runtime.plainError.str
+          Type: 686 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 580 GoStringDataType runtime.plainError.str
+      Data: 685 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 580
+      ID: 685
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 843
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 384
+      ID: 489
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.594464e+06
@@ -13457,9 +14485,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: bubble
           Offset: 16
-          Type: 737 PointerType *runtime.synctestBubble
+          Type: 842 PointerType *runtime.synctestBubble
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 707
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -13471,25 +14499,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 178 PointerType *string.str
+          Type: 222 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 177 GoStringDataType string.str
+      Data: 221 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 177
+      ID: 221
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 1008
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 912
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 803
+      ID: 908
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.454208e+06
@@ -13499,7 +14527,13 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 986
+      ID: 368
+      Name: struct {}
+      GoRuntimeType: 841632
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 1091
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.462752e+06
@@ -13507,12 +14541,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 987 StructureType sync.noCopy
+          Type: 1092 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 988 StructureType internal/sync.Mutex
+          Type: 1093 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 989
+      ID: 1094
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.611808e+06
@@ -13520,15 +14554,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 987 StructureType sync.noCopy
+          Type: 1092 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 990 StructureType sync/atomic.Bool
+          Type: 1095 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 986 StructureType sync.Mutex
+          Type: 1091 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 992
+      ID: 1097
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.611616e+06
@@ -13536,21 +14570,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 987 StructureType sync.noCopy
+          Type: 1092 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 993 StructureType sync/atomic.Uint64
+          Type: 1098 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 987
+      ID: 1092
       Name: sync.noCopy
       GoRuntimeType: 987680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 990
+      ID: 1095
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.463872e+06
@@ -13558,12 +14592,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 991 StructureType sync/atomic.noCopy
+          Type: 1096 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 995
+      ID: 1100
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464032e+06
@@ -13571,12 +14605,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 991 StructureType sync/atomic.noCopy
+          Type: 1096 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 993
+      ID: 1098
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612192e+06
@@ -13584,33 +14618,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 991 StructureType sync/atomic.noCopy
+          Type: 1096 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 994 StructureType sync/atomic.align64
+          Type: 1099 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 994
+      ID: 1099
       Name: sync/atomic.align64
       GoRuntimeType: 987872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 991
+      ID: 1096
       Name: sync/atomic.noCopy
       GoRuntimeType: 987776
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 712
+      ID: 817
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.282176e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 286
+      ID: 330
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -13632,9 +14666,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 287 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 331 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 278
+      ID: 322
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13656,9 +14690,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 279 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 323 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 226
+      ID: 270
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -13680,9 +14714,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 227 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 271 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 245
+      ID: 289
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -13704,9 +14738,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 246 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 290 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 184
+      ID: 228
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -13728,9 +14762,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 185 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 229 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1014
+      ID: 1119
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -13752,9 +14786,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1015 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1120 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1050
+      ID: 1155
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -13776,9 +14810,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1051 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1156 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1065
+      ID: 1170
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -13800,9 +14834,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1066 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1171 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 194
+      ID: 238
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -13824,9 +14858,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<int,int>
+          Type: 239 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1080
+      ID: 1185
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -13848,9 +14882,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1081 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1186 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 253
+      ID: 297
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -13872,9 +14906,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 254 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 298 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 235
+      ID: 279
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -13896,9 +14930,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 236 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 280 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 218
+      ID: 262
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -13920,9 +14954,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 219 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 263 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 772
+      ID: 877
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -13944,9 +14978,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 773 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 878 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 210
+      ID: 254
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -13968,9 +15002,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 211 GoSwissMapGroupsType groupReference<string,int>
+          Type: 255 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 202
+      ID: 246
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -13992,9 +15026,153 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 203 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 247 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 269
+      ID: 362
+      Name: table<struct {},main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 363 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 371
+      Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 372 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 379
+      Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 380 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 387
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 388 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 395
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 396 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 403
+      Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 404 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+    - __kind: StructureType
+      ID: 313
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -14016,9 +15194,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 270 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 314 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 261
+      ID: 305
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -14040,13 +15218,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 262 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 306 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 1043
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 760
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.705984e+06
@@ -14059,21 +15237,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 883
+      ID: 988
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.914272e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 730
+      ID: 835
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 391
+      ID: 496
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 728
+      ID: 833
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.371424e+06
@@ -14087,9 +15265,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 729 PointerType *time.Location
+          Type: 834 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 411
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 830784
@@ -14097,13 +15275,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *time.fileSizeError.str
+          Type: 413 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 307 GoStringDataType time.fileSizeError.str
+      Data: 412 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 412
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -14149,7 +15327,7 @@ Types:
       GoRuntimeType: 585024
       GoKind: 26
     - __kind: StructureType
-      ID: 750
+      ID: 855
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.06192e+06
@@ -14157,13 +15335,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 751 GoSliceHeaderType []uint8
+          Type: 856 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 752 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 857 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 753 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 858 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -14178,18 +15356,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 754 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 859 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 754
+      ID: 859
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 994400
       GoKind: 9
     - __kind: StructureType
-      ID: 752
+      ID: 857
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.92528e+06
@@ -14214,21 +15392,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 482
+      ID: 587
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 753
+      ID: 858
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588672
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 1035
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 466
+      ID: 571
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.425248e+06
@@ -14238,13 +15416,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 350
+      ID: 455
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 834816
       GoKind: 2
     - __kind: StructureType
-      ID: 632
+      ID: 737
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.70176e+06
@@ -14257,11 +15435,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 584
+      ID: 689
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 993248
       GoKind: 5
-MaxTypeID: 1202
+MaxTypeID: 1309
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
@@ -498,62 +498,109 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: ptrRcvr: *main.receiver (declared at line 172, available: )
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: ptrRcvr: *main.receiver (declared at line 200, available: )
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
 	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
 	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
@@ -648,18 +695,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -486,61 +486,108 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
 	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
 	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
@@ -635,18 +682,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
@@ -485,61 +485,108 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
 	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
 	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
@@ -634,18 +681,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
@@ -498,62 +498,109 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: ptrRcvr: *main.receiver (declared at line 172, available: )
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: ptrRcvr: *main.receiver (declared at line 200, available: )
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
 	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
 	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
@@ -648,18 +695,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -486,61 +486,108 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
 	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
 	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
@@ -635,18 +682,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
@@ -485,61 +485,108 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
 	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
 	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
@@ -634,18 +681,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -498,62 +498,109 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: ptrRcvr: *main.receiver (declared at line 172, available: )
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: ptrRcvr: *main.receiver (declared at line 200, available: )
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int
@@ -636,18 +683,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -486,61 +486,108 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int
@@ -623,18 +670,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -485,61 +485,108 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int
@@ -622,18 +669,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -498,62 +498,109 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: ptrRcvr: *main.receiver (declared at line 172, available: )
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: ptrRcvr: *main.receiver (declared at line 200, available: )
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int
@@ -636,18 +683,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -486,61 +486,108 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int
@@ -623,18 +670,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -485,61 +485,108 @@ Package: main
 		Arg: x: string (declared at line 50, available: [50-50])
 	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
 		Var: uninitializedString: string (declared at line 61, available: )
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
-		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
-		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
-		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
-		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
-		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
-		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
-		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
-		Arg: x: main.aStruct (declared at line 56, available: [56-56])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
-		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
-		Arg: x: main.nStruct (declared at line 64, available: [64-64])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
-		Arg: b: main.bStruct (declared at line 68, available: [68-68])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
-		Arg: c: main.cStruct (declared at line 72, available: [72-72])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
-		Arg: w: uint8 (declared at line 76, available: [76-76])
-		Arg: x: main.aStruct (declared at line 76, available: [76-76])
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
-		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
-		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
-		Arg: t: main.threestrings (declared at line 88, available: [88-88])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
-		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
-		Arg: e: main.emptyStruct (declared at line 96, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
-		Arg: e: *main.emptyStruct (declared at line 100, available: [100-100])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
-		Arg: l: main.lotsOfFields (declared at line 104, available: [104-104])
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [107:187]
-		Var: n: main.nStruct (declared at line 111, available: )
-		Var: ns: main.structWithNoStrings (declared at line 120, available: )
-		Var: cs: main.cStruct (declared at line 121, available: )
-		Var: rcvr: main.receiver (declared at line 169, available: )
-		Var: ts: main.threestrings (declared at line 108, available: [107-187])
-		Var: s: main.aStruct (declared at line 114, available: [107-187])
-		Var: b: main.bStruct (declared at line 117, available: [107-187])
-		Var: tenStr: main.tenStrings (declared at line 134, available: [107-187])
-		Var: deep: main.deepStruct1 (declared at line 148, available: [107-187])
-		Var: fields: main.lotsOfFields (declared at line 166, available: [107-187])
-		Var: sta: main.structWithTwoArrays (declared at line 175, available: [107-187])
-		Var: .autotmp_13: [0]uint8 (declared at line 129, available: [107-187])
-		Var: .autotmp_33: main.emptyStruct (declared at line 162, available: [107-187])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31]
+		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.aStruct (declared at line 84, available: [84-84])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: x: main.nStruct (declared at line 92, available: [92-92])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: c: main.cStruct (declared at line 100, available: [100-100])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]
+		Arg: w: uint8 (declared at line 104, available: [104-104])
+		Arg: x: main.aStruct (declared at line 104, available: [104-104])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108]
+		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112]
+		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
+		Arg: t: main.threestrings (declared at line 116, available: [116-116])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
+		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124]
+		Arg: e: main.emptyStruct (declared at line 124, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128]
+		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
+		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236]
+		Var: n: main.nStruct (declared at line 139, available: )
+		Var: ns: main.structWithNoStrings (declared at line 148, available: )
+		Var: cs: main.cStruct (declared at line 149, available: )
+		Var: rcvr: main.receiver (declared at line 197, available: )
+		Var: ts: main.threestrings (declared at line 136, available: [135-236])
+		Var: s: main.aStruct (declared at line 142, available: [135-236])
+		Var: b: main.bStruct (declared at line 145, available: [135-236])
+		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
+		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
+		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
+		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
+		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
+		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
+		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
+		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
+		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
+		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
+		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
 	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int
@@ -622,18 +669,32 @@ Package: main
 		Field: c: string
 	Type: main.oneStringStruct
 		Field: a: string
+	Type: main.structWithCyclicSlices
+		Field: s1: []main.structWithCyclicSlices
+		Field: s2: [][]main.structWithCyclicSlices
+		Field: s3: [][][]main.structWithCyclicSlices
+		Field: s4: [][][][]main.structWithCyclicSlices
+		Field: s5: [][][][][]main.structWithCyclicSlices
+		Field: s6: [][][][][][]main.structWithCyclicSlices
+	Type: main.structWithCyclicMaps
+		Field: m1: map[struct {}]main.structWithCyclicMaps
+		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m3: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m4: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m5: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+		Field: m6: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
 	Type: main.hasUnsupportedFields
 		Field: b: int
 		Field: c: float32
 		Field: d: []uint8
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
-			Arg: r: *main.receiver (declared at line 24, available: [24-24])
-			Arg: a: int (declared at line 24, available: [24-24])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
-			Arg: r: main.receiver (declared at line 28, available: [28-28])
-			Arg: a: int (declared at line 28, available: [28-28])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+			Arg: r: *main.receiver (declared at line 52, available: [52-52])
+			Arg: a: int (declared at line 52, available: [52-52])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+			Arg: r: main.receiver (declared at line 56, available: [56-56])
+			Arg: a: int (declared at line 56, available: [56-56])
 	Type: main.structWithAnArray
 		Field: arr: [5]uint8
 	Type: main.structWithASlice

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testEmptyStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 96
+            "lineNumber": 124
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 162
+            "lineNumber": 190
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testEmptyStructPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 100
+            "lineNumber": 128
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 163
+            "lineNumber": 191
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testStruct",
+      "method": "main.testStructWithCyclicMaps",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testStruct",
+            "function": "main.testStructWithCyclicMaps",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 84
+            "lineNumber": 44
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 143
+            "lineNumber": 235
           },
           {
             "function": "main.main",
@@ -42,41 +42,40 @@
           }
         ],
         "probe": {
-          "id": "testStruct",
+          "id": "testStructWithCyclicMaps",
           "location": {
-            "method": "main.testStruct"
+            "method": "main.testStructWithCyclicMaps"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "x": {
-                "type": "main.aStruct",
+              "a": {
+                "type": "main.structWithCyclicMaps",
                 "fields": {
-                  "aBool": {
-                    "type": "bool",
-                    "value": "true"
+                  "m1": {
+                    "type": "map[struct {}]main.structWithCyclicMaps",
+                    "isNull": true
                   },
-                  "aString": {
-                    "type": "string",
-                    "value": "one"
+                  "m2": {
+                    "type": "map[struct {}]map[struct {}]main.structWithCyclicMaps",
+                    "isNull": true
                   },
-                  "aNumber": {
-                    "type": "int",
-                    "value": "2"
+                  "m3": {
+                    "type": "map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps",
+                    "isNull": true
                   },
-                  "nested": {
-                    "type": "main.nestedStruct",
-                    "fields": {
-                      "anotherInt": {
-                        "type": "int",
-                        "value": "3"
-                      },
-                      "anotherString": {
-                        "type": "string",
-                        "value": "four"
-                      }
-                    }
+                  "m4": {
+                    "type": "map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps",
+                    "isNull": true
+                  },
+                  "m5": {
+                    "type": "map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps",
+                    "isNull": true
+                  },
+                  "m6": {
+                    "type": "map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps",
+                    "isNull": true
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -1,0 +1,477 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testStructWithCyclicSlices",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testStructWithCyclicSlices",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "main.executeStructFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 32
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testStructWithCyclicSlices",
+          "location": {
+            "method": "main.testStructWithCyclicSlices"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "main.structWithCyclicSlices",
+                "fields": {
+                  "s1": {
+                    "type": "[]main.structWithCyclicSlices",
+                    "size": "1",
+                    "elements": [
+                      {
+                        "type": "main.structWithCyclicSlices",
+                        "fields": {
+                          "s1": {
+                            "type": "[]main.structWithCyclicSlices",
+                            "isNull": true
+                          },
+                          "s2": {
+                            "type": "[][]main.structWithCyclicSlices",
+                            "isNull": true
+                          },
+                          "s3": {
+                            "type": "[][][]main.structWithCyclicSlices",
+                            "isNull": true
+                          },
+                          "s4": {
+                            "type": "[][][][]main.structWithCyclicSlices",
+                            "isNull": true
+                          },
+                          "s5": {
+                            "type": "[][][][][]main.structWithCyclicSlices",
+                            "isNull": true
+                          },
+                          "s6": {
+                            "type": "[][][][][][]main.structWithCyclicSlices",
+                            "isNull": true
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "s2": {
+                    "type": "[][]main.structWithCyclicSlices",
+                    "size": "2",
+                    "elements": [
+                      {
+                        "type": "[]main.structWithCyclicSlices",
+                        "elements": []
+                      },
+                      {
+                        "type": "[]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "main.structWithCyclicSlices",
+                            "fields": {
+                              "s1": {
+                                "type": "[]main.structWithCyclicSlices",
+                                "isNull": true
+                              },
+                              "s2": {
+                                "type": "[][]main.structWithCyclicSlices",
+                                "isNull": true
+                              },
+                              "s3": {
+                                "type": "[][][]main.structWithCyclicSlices",
+                                "isNull": true
+                              },
+                              "s4": {
+                                "type": "[][][][]main.structWithCyclicSlices",
+                                "isNull": true
+                              },
+                              "s5": {
+                                "type": "[][][][][]main.structWithCyclicSlices",
+                                "isNull": true
+                              },
+                              "s6": {
+                                "type": "[][][][][][]main.structWithCyclicSlices",
+                                "isNull": true
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "s3": {
+                    "type": "[][][]main.structWithCyclicSlices",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "[][]main.structWithCyclicSlices",
+                        "elements": []
+                      },
+                      {
+                        "type": "[][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[]main.structWithCyclicSlices",
+                            "elements": []
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "main.structWithCyclicSlices",
+                                "fields": {
+                                  "s1": {
+                                    "type": "[]main.structWithCyclicSlices",
+                                    "isNull": true
+                                  },
+                                  "s2": {
+                                    "type": "[][]main.structWithCyclicSlices",
+                                    "isNull": true
+                                  },
+                                  "s3": {
+                                    "type": "[][][]main.structWithCyclicSlices",
+                                    "isNull": true
+                                  },
+                                  "s4": {
+                                    "type": "[][][][]main.structWithCyclicSlices",
+                                    "isNull": true
+                                  },
+                                  "s5": {
+                                    "type": "[][][][][]main.structWithCyclicSlices",
+                                    "isNull": true
+                                  },
+                                  "s6": {
+                                    "type": "[][][][][][]main.structWithCyclicSlices",
+                                    "isNull": true
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "s4": {
+                    "type": "[][][][]main.structWithCyclicSlices",
+                    "size": "4",
+                    "elements": [
+                      {
+                        "type": "[][][]main.structWithCyclicSlices",
+                        "elements": []
+                      },
+                      {
+                        "type": "[][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][]main.structWithCyclicSlices",
+                            "elements": []
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[]main.structWithCyclicSlices",
+                                "elements": []
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[]main.structWithCyclicSlices",
+                                "size": "1",
+                                "elements": [
+                                  {
+                                    "type": "main.structWithCyclicSlices",
+                                    "fields": {
+                                      "s1": {
+                                        "type": "[]main.structWithCyclicSlices",
+                                        "isNull": true
+                                      },
+                                      "s2": {
+                                        "type": "[][]main.structWithCyclicSlices",
+                                        "isNull": true
+                                      },
+                                      "s3": {
+                                        "type": "[][][]main.structWithCyclicSlices",
+                                        "isNull": true
+                                      },
+                                      "s4": {
+                                        "type": "[][][][]main.structWithCyclicSlices",
+                                        "isNull": true
+                                      },
+                                      "s5": {
+                                        "type": "[][][][][]main.structWithCyclicSlices",
+                                        "isNull": true
+                                      },
+                                      "s6": {
+                                        "type": "[][][][][][]main.structWithCyclicSlices",
+                                        "isNull": true
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "s5": {
+                    "type": "[][][][][]main.structWithCyclicSlices",
+                    "size": "5",
+                    "elements": [
+                      {
+                        "type": "[][][][]main.structWithCyclicSlices",
+                        "elements": []
+                      },
+                      {
+                        "type": "[][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][]main.structWithCyclicSlices",
+                            "elements": []
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[][]main.structWithCyclicSlices",
+                                "elements": []
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[][]main.structWithCyclicSlices",
+                                "size": "1",
+                                "elements": [
+                                  {
+                                    "type": "[]main.structWithCyclicSlices",
+                                    "elements": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[][]main.structWithCyclicSlices",
+                                "size": "1",
+                                "elements": [
+                                  {
+                                    "type": "[]main.structWithCyclicSlices",
+                                    "elements": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "s6": {
+                    "type": "[][][][][][]main.structWithCyclicSlices",
+                    "size": "6",
+                    "elements": [
+                      {
+                        "type": "[][][][][]main.structWithCyclicSlices",
+                        "elements": []
+                      },
+                      {
+                        "type": "[][][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][][]main.structWithCyclicSlices",
+                            "elements": []
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[][][]main.structWithCyclicSlices",
+                                "elements": []
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[][][]main.structWithCyclicSlices",
+                                "size": "1",
+                                "elements": [
+                                  {
+                                    "type": "[][]main.structWithCyclicSlices",
+                                    "elements": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[][][]main.structWithCyclicSlices",
+                                "size": "1",
+                                "elements": [
+                                  {
+                                    "type": "[][]main.structWithCyclicSlices",
+                                    "elements": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "[][][][][]main.structWithCyclicSlices",
+                        "size": "1",
+                        "elements": [
+                          {
+                            "type": "[][][][]main.structWithCyclicSlices",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "[][][]main.structWithCyclicSlices",
+                                "size": "1",
+                                "elements": [
+                                  {
+                                    "type": "[][]main.structWithCyclicSlices",
+                                    "size": "1",
+                                    "elements": [
+                                      {
+                                        "type": "[]main.structWithCyclicSlices",
+                                        "elements": []
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testprogs/progs/sample/structs.go
+++ b/pkg/dyninst/testprogs/progs/sample/structs.go
@@ -15,6 +15,34 @@ type hasUnsupportedFields struct {
 	d []uint8
 }
 
+// We had a bug at one point exploring the type graph that required structs
+// with cyclic slices of slices. This reproduces that issue.
+type structWithCyclicSlices struct {
+	s1 []structWithCyclicSlices
+	s2 [][]structWithCyclicSlices
+	s3 [][][]structWithCyclicSlices
+	s4 [][][][]structWithCyclicSlices
+	s5 [][][][][]structWithCyclicSlices
+	s6 [][][][][][]structWithCyclicSlices
+}
+
+//nolint:all
+//go:noinline
+func testStructWithCyclicSlices(a structWithCyclicSlices) {}
+
+type structWithCyclicMaps struct {
+	m1 map[struct{}]structWithCyclicMaps
+	m2 map[struct{}]map[struct{}]structWithCyclicMaps
+	m3 map[struct{}]map[struct{}]map[struct{}]structWithCyclicMaps
+	m4 map[struct{}]map[struct{}]map[struct{}]map[struct{}]structWithCyclicMaps
+	m5 map[struct{}]map[struct{}]map[struct{}]map[struct{}]map[struct{}]structWithCyclicMaps
+	m6 map[struct{}]map[struct{}]map[struct{}]map[struct{}]map[struct{}]map[struct{}]structWithCyclicMaps
+}
+
+//nolint:all
+//go:noinline
+func testStructWithCyclicMaps(a structWithCyclicMaps) {}
+
 //nolint:all
 //go:noinline
 func testStructWithUnsupportedFields(a hasUnsupportedFields) {}
@@ -184,6 +212,27 @@ func executeStructFuncs() {
 		c: 2.0,
 		d: []uint8{3, 4, 5},
 	})
+	testStructWithCyclicSlices(structWithCyclicSlices{
+		s1: []structWithCyclicSlices{
+			{},
+		},
+		s2: [][]structWithCyclicSlices{
+			{}, {{}},
+		},
+		s3: [][][]structWithCyclicSlices{
+			{}, {{}}, {{{}}},
+		},
+		s4: [][][][]structWithCyclicSlices{
+			{}, {{}}, {{{}}}, {{{{}}}},
+		},
+		s5: [][][][][]structWithCyclicSlices{
+			{}, {{}}, {{{}}}, {{{{}}}}, {{{{}}}},
+		},
+		s6: [][][][][][]structWithCyclicSlices{
+			{}, {{}}, {{{}}}, {{{{}}}}, {{{{}}}}, {{{{{}}}}},
+		},
+	})
+	testStructWithCyclicMaps(structWithCyclicMaps{})
 }
 
 type emptyStruct struct{}

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -812,3 +812,13 @@ probes:
   captureSnapshot: true
   capture:
     maxReferenceDepth: 1
+- id: testStructWithCyclicSlices
+  type: LOG_PROBE
+  where:
+    methodName: main.testStructWithCyclicSlices
+  captureSnapshot: true
+- id: testStructWithCyclicMaps
+  type: LOG_PROBE
+  where:
+    methodName: main.testStructWithCyclicMaps
+  captureSnapshot: true


### PR DESCRIPTION
### What does this PR do?

Fixes an error in the product when users attempt to probe a function involving a type that has slices of itself and also slice of slices of itself.

### Motivation

Seen in the wild.

### Describe how you validated your changes

Repro'd the issue and saw it was fixed. Added a test.

### Additional Notes

Backport of #41060 to 7.71.x