### PR TITLE
fix(fleet): Mark all Suse tests as flaky

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -641,7 +641,6 @@ new-e2e-installer-script:
     REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer:
-  allow_failure: true
   extends: .new_e2e_template
   rules:
     - !reference [.on_installer_or_e2e_changes]

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -102,6 +103,9 @@ func TestPackages(t *testing.T) {
 			// TODO: remove once ansible+suse is fully supported
 			if flavor.Flavor == e2eos.Suse && method == InstallMethodAnsible {
 				continue
+			}
+			if flavor.Flavor == e2eos.Suse {
+				flake.Mark(t) // #incident-43183
 			}
 
 			suite := test.t(flavor, flavor.Architecture, method)


### PR DESCRIPTION
### What does this PR do?
Marks all Suse tests as flaky and require new-e2e-installer to pass again

### Motivation
Only skip failing jobs

### Describe how you validated your changes
E2E tests

### Additional Notes
