### PR TITLE
dyninst/decode: fix typos, add bitset

### DIFF
--- a/pkg/dyninst/decode/bitset.go
+++ b/pkg/dyninst/decode/bitset.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package decode
+
+// bitset is a data structure to store a dense set of booleans corresponding to
+// indices.
+type bitset []byte
+
+// reset initializes the bitset to the required size and clears it.
+func (b *bitset) reset(n int) {
+	requiredBytes := (n + 7) / 8
+	if cap(*b) < requiredBytes {
+		*b = make([]byte, requiredBytes)
+	} else {
+		*b = (*b)[:requiredBytes]
+	}
+	clear(*b)
+}
+
+// get checks if the given index is in range of the bitset and is set.
+func (b bitset) get(index int) bool {
+	idx, bit := index/8, index%8
+	return idx < len(b) && b[idx]&(1<<byte(bit)) != 0
+}
+
+// set sets the given index to true if it is in the range that the bitset can
+// represent.
+func (b bitset) set(index int) {
+	if idx, bit := index/8, index%8; idx < len(b) {
+		b[idx] |= 1 << byte(bit)
+	}
+}

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -77,10 +77,13 @@ type Decoder struct {
 	approximateBootTime  time.Time
 
 	// These fields are initialized and reset for each message.
-	snapshotMessage    snapshotMessage
-	dataItems          map[typeAndAddr]output.DataItem
-	currentlyEncoding  map[typeAndAddr]struct{}
-	skipIndiciesBuffer []byte
+	snapshotMessage   snapshotMessage
+	dataItems         map[typeAndAddr]output.DataItem
+	currentlyEncoding map[typeAndAddr]struct{}
+	// skippedArgumentExpressions is a bitset of the indices of the arguments
+	// that should be skipped during encoding because they encountered an
+	// evaluation during a previous attempt.
+	skippedArgumentExpressions bitset
 }
 
 // NewDecoder creates a new Decoder for the given program.
@@ -97,10 +100,11 @@ func NewDecoder(
 		typesByGoRuntimeType: make(map[uint32]ir.TypeID),
 		typeNameResolver:     typeNameResolver,
 		approximateBootTime:  approximateBootTime,
-		snapshotMessage:      snapshotMessage{},
-		dataItems:            make(map[typeAndAddr]output.DataItem),
-		currentlyEncoding:    make(map[typeAndAddr]struct{}),
-		skipIndiciesBuffer:   make([]byte, 1),
+
+		snapshotMessage:            snapshotMessage{},
+		dataItems:                  make(map[typeAndAddr]output.DataItem),
+		currentlyEncoding:          make(map[typeAndAddr]struct{}),
+		skippedArgumentExpressions: nil,
 	}
 	for _, probe := range program.Probes {
 		for _, event := range probe.Events {
@@ -288,13 +292,14 @@ func (s *snapshotMessage) init(
 	s.Debugger.Snapshot.Probe.ID = probe.GetID()
 	s.Debugger.Snapshot.Stack.frames = stackFrames
 
+	decoder.skippedArgumentExpressions.reset(len(rootType.Expressions))
 	s.Debugger.Snapshot.Captures.Entry.Arguments = argumentsData{
 		event:            event,
 		rootType:         rootType,
 		rootData:         s.rootData,
 		decoder:          decoder,
 		evaluationErrors: &s.Debugger.EvaluationErrors,
-		skipIndicies:     decoder.getSkipIndiciesBuffer(len(rootType.Expressions)),
+		skippedIndices:   &decoder.skippedArgumentExpressions,
 	}
 	return probe, nil
 }
@@ -312,20 +317,4 @@ func symbolicate(event Event, stackHash uint64, symbolicator symbol.Symbolicator
 		return nil, fmt.Errorf("error symbolicating stack: %w", err)
 	}
 	return stackFrames, nil
-}
-
-// getSkipIndiciesBuffer returns a zeroed byte slice of the required size,
-// reusing the internal buffer when possible to avoid allocations.
-func (d *Decoder) getSkipIndiciesBuffer(numExpressions int) []byte {
-	requiredBytes := (numExpressions + 7) / 8
-	if cap(d.skipIndiciesBuffer) < requiredBytes {
-		d.skipIndiciesBuffer = make([]byte, requiredBytes)
-	} else {
-		// Reuse existing buffer, just resize and clear
-		d.skipIndiciesBuffer = d.skipIndiciesBuffer[:requiredBytes]
-		for i := range d.skipIndiciesBuffer {
-			d.skipIndiciesBuffer[i] = 0
-		}
-	}
-	return d.skipIndiciesBuffer
 }

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -70,7 +70,7 @@ type argumentsData struct {
 	event            Event
 	decoder          *Decoder
 	evaluationErrors *[]string
-	skipIndicies     []byte
+	skippedIndices   *bitset
 }
 
 var ddDebuggerString = jsontext.String("dd_debugger")
@@ -81,36 +81,13 @@ func (ddDebuggerSource) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(ddDebuggerString)
 }
 
-// In the root data item, before the expressions, there is a bitset
-// which conveys if expression values are present in the data.
-// The rootType.PresenceBitsetSize conveys the size of the bitset in
-// bytes, and presence bits in the bitset correspond with index of
-// the expression in the root ir.
-func expressionIsPresent(bitset []byte, expressionIndex int) bool {
-	idx, bit := expressionIndex/8, expressionIndex%8
-	return idx < len(bitset) && bitset[idx]&(1<<byte(bit)) != 0
-}
-
-// Helper functions for skipIndicies bitset operations
-func isSkipped(bitset []byte, index int) bool {
-	idx, bit := index/8, index%8
-	return idx < len(bitset) && bitset[idx]&(1<<byte(bit)) != 0
-}
-
-func setSkipped(bitset []byte, index int) {
-	idx, bit := index/8, index%8
-	if idx < len(bitset) {
-		bitset[idx] |= 1 << byte(bit)
-	}
-}
-
 var errEvaluation = errors.New("evaluation error")
 
 // processExpression processes a single expression from the root type expressions
 func (ad *argumentsData) processExpression(
 	enc *jsontext.Encoder,
 	expr *ir.RootExpression,
-	presenceBitSet []byte,
+	presenceBitSet bitset,
 	expressionIndex int,
 ) error {
 	parameterType := expr.Expression.Type
@@ -124,7 +101,7 @@ func (ad *argumentsData) processExpression(
 	if err := writeTokens(enc, jsontext.String(expr.Name)); err != nil {
 		return err
 	}
-	if !expressionIsPresent(presenceBitSet, expressionIndex) && parameterSize != 0 {
+	if !presenceBitSet.get(expressionIndex) && parameterSize != 0 {
 		// Set not capture reason
 		if err := writeTokens(enc,
 			jsontext.BeginObject,
@@ -162,13 +139,13 @@ func (ad *argumentsData) MarshalJSONTo(enc *jsontext.Encoder) error {
 	// We iterate over the 'Expressions' of the EventRoot which contains
 	// metadata and raw bytes of the parameters of this function.
 	for i, expr := range ad.rootType.Expressions {
-		if isSkipped(ad.skipIndicies, i) {
+		if ad.skippedIndices.get(i) {
 			continue
 		}
 		if err := ad.processExpression(enc, expr, presenceBitSet, i); errors.Is(err, errEvaluation) {
 			// This expression resulted in an evaluation error, we mark it to be skipped
 			// and will try again
-			setSkipped(ad.skipIndicies, i)
+			ad.skippedIndices.set(i)
 			return err
 		} else if err != nil {
 			return err


### PR DESCRIPTION
I came here to fix the typos. It felt odd to not have the bitset abstraction encapsulated, so I fixed that while I was here.
