### PR TITLE
[CWS] Make DNS resolution failues an event

### DIFF
--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -67,6 +67,7 @@ enum event_type
     EVENT_RAW_PACKET_ACTION,
     EVENT_CAPABILITIES,
     EVENT_MOVE_MOUNT,
+    FAILED_DNS,
     EVENT_MAX, // has to be the last one
 
     EVENT_ALL = 0xffffffff // used as a mask for all the events

--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -73,6 +73,11 @@ const (
 	RawPacketActionRuleID = "rawpacket_action"
 	// RawPacketActionRuleDesc is the rule description for raw packet action events
 	RawPacketActionRuleDesc = "RawPacket Action"
+
+	// FailedDNSRuleID is the rule ID for an event about a DNS packet that failed to get decoded
+	FailedDNSRuleID = "failed_dns"
+	// FailedDNSRuleDesc is the rule description for raw packet action events
+	FailedDNSRuleDesc = "Failed DNS"
 )
 
 // AgentContainerContext is like model.ContainerContext, but without event based resolvers
@@ -116,6 +121,7 @@ func AllCustomRuleIDs() []string {
 		BrokenProcessLineageErrorRuleID,
 		InternalCoreDumpRuleID,
 		SysCtlSnapshotRuleID,
+		FailedDNSRuleID,
 	}
 }
 

--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -43,6 +43,7 @@ var (
 		BrokenProcessLineageErrorRuleID: rate.Every(30 * time.Second),
 		EBPFLessHelloMessageRuleID:      rate.Inf, // No limit on hello message
 		InternalCoreDumpRuleID:          rate.Every(30 * time.Second),
+		FailedDNSRuleID:                 rate.Every(30 * time.Second),
 	}
 )
 

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -23,7 +23,149 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlexer.Lexer, out *EBPFLessHelloMsgEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlexer.Lexer, out *FailedDNSEvent) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "payload":
+			out.Payload = string(in.String())
+		case "date":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Timestamp).UnmarshalJSON(data))
+			}
+		case "service":
+			out.Service = string(in.String())
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.AgentContainerContext = nil
+			} else {
+				if out.AgentContainerContext == nil {
+					out.AgentContainerContext = new(events.AgentContainerContext)
+				}
+				easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in, out.AgentContainerContext)
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwriter.Writer, in FailedDNSEvent) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"payload\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Payload))
+	}
+	{
+		const prefix string = ",\"date\":"
+		out.RawString(prefix)
+		out.Raw((in.Timestamp).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"service\":"
+		out.RawString(prefix)
+		out.String(string(in.Service))
+	}
+	{
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		if in.AgentContainerContext == nil {
+			out.RawString("null")
+		} else {
+			easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out, *in.AgentContainerContext)
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v FailedDNSEvent) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *FailedDNSEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
+}
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in *jlexer.Lexer, out *events.AgentContainerContext) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ContainerID = containerutils.ContainerID(in.String())
+		case "created_at":
+			out.CreatedAt = uint64(in.Uint64())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jwriter.Writer, in events.AgentContainerContext) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ContainerID != "" {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.ContainerID))
+	}
+	{
+		const prefix string = ",\"created_at\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Uint64(uint64(in.CreatedAt))
+	}
+	out.RawByte('}')
+}
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *EBPFLessHelloMsgEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -95,7 +237,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwriter.Writer, in EBPFLessHelloMsgEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jwriter.Writer, in EBPFLessHelloMsgEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -163,67 +305,12 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EBPFLessHelloMsgEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EBPFLessHelloMsgEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
-}
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in *jlexer.Lexer, out *events.AgentContainerContext) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "id":
-			out.ContainerID = containerutils.ContainerID(in.String())
-		case "created_at":
-			out.CreatedAt = uint64(in.Uint64())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jwriter.Writer, in events.AgentContainerContext) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.ContainerID != "" {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.ContainerID))
-	}
-	{
-		const prefix string = ",\"created_at\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Uint64(uint64(in.CreatedAt))
-	}
-	out.RawByte('}')
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
 }
 func easyjsonF8f9ddd1Decode(in *jlexer.Lexer, out *struct {
 	ID             string `json:"id,omitempty"`
@@ -314,7 +401,7 @@ func easyjsonF8f9ddd1Encode(out *jwriter.Writer, in struct {
 	}
 	out.RawByte('}')
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *AbnormalEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jlexer.Lexer, out *AbnormalEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -371,7 +458,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jwriter.Writer, in AbnormalEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jwriter.Writer, in AbnormalEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -413,10 +500,10 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AbnormalEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AbnormalEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(l, v)
 }

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -191,6 +191,12 @@ func (m *EBPFMonitors) ProcessEvent(event *model.Event) {
 		return
 	}
 
+	if errors.Is(event.Error, model.ErrFailedDNSPacketDecoding) {
+		m.ebpfProbe.probe.DispatchCustomEvent(
+			NewFailedDNSEvent(m.ebpfProbe.GetAgentContainerContext(), events.FailedDNSRuleID, events.AbnormalPathRuleDesc, event),
+		)
+	}
+
 	var pathErr *path.ErrPathResolution
 	if errors.As(event.Error, &pathErr) {
 		m.ebpfProbe.probe.DispatchCustomEvent(

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -36,6 +36,7 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 		eval.EventType("dns"),
 		eval.EventType("exec"),
 		eval.EventType("exit"),
+		eval.EventType("failed_dns"),
 		eval.EventType("imds"),
 		eval.EventType("link"),
 		eval.EventType("load_module"),

--- a/pkg/security/secl/model/category.go
+++ b/pkg/security/secl/model/category.go
@@ -117,6 +117,7 @@ func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 		DNSEventType.String(),
 		FullDNSResponseEventType.String(),
 		ShortDNSResponseEventType.String(),
+		FailedDNSEventType.String(),
 		IMDSEventType.String(),
 		RawPacketFilterEventType.String(),
 		RawPacketActionEventType.String(),

--- a/pkg/security/secl/model/errors.go
+++ b/pkg/security/secl/model/errors.go
@@ -77,6 +77,9 @@ func (e *ErrProcessIncompleteLineage) Error() string {
 // ErrNoProcessContext defines an error for event without process context
 var ErrNoProcessContext = errors.New("process context not resolved")
 
+// ErrFailedDNSPacketDecoding defines a dns packet that failed to be decoded
+var ErrFailedDNSPacketDecoding = errors.New("dns packet couldn't be decoded")
+
 // ErrProcessBrokenLineage returned when a process lineage is broken
 type ErrProcessBrokenLineage struct {
 	Err error

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -137,6 +137,8 @@ const (
 	CapabilitiesEventType
 	// FileMoveMountEventType Move Mount even
 	FileMoveMountEventType
+	// FailedDNSEventType Failed DNS
+	FailedDNSEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -297,6 +299,8 @@ func (t EventType) String() string {
 		return "delete_key"
 	case ChangePermissionEventType:
 		return "change_permission"
+	case FailedDNSEventType:
+		return "failed_dns"
 	case LoginUIDWriteEventType:
 		return "login_uid_write"
 	case CgroupWriteEventType:

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -650,6 +650,7 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exit.Process)
 		_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, ev.Exit.Process)
 		_ = ev.FieldHandlers.ResolveProcessIsThread(ev, ev.Exit.Process)
+	case "failed_dns":
 	case "imds":
 	case "link":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Link.Source.FileFields)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -587,6 +587,11 @@ type DNSEvent struct {
 	Response *DNSResponse `field:"response,check:HasResponse"`
 }
 
+// FailedDNSEvent represents a DNS packet that was failed to be decoded (inbound or outbound)
+type FailedDNSEvent struct {
+	Payload []byte `field:"-"`
+}
+
 // DNSResponse represents a DNS response event
 type DNSResponse struct {
 	ResponseCode uint8 `field:"code"` // SECLDoc[code] Definition:`Response code of the DNS response according to RFC 1035` Constants:`DNS Responses`

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -142,6 +142,7 @@ type Event struct {
 	IMDS               IMDSEvent               `field:"imds" event:"imds"`                                 // [7.55] [Network] An IMDS event was captured
 	RawPacket          RawPacketEvent          `field:"packet" event:"packet"`                             // [7.60] [Network] A raw network packet was captured
 	NetworkFlowMonitor NetworkFlowMonitorEvent `field:"network_flow_monitor" event:"network_flow_monitor"` // [7.63] [Network] A network monitor event was sent
+	FailedDNS          FailedDNSEvent          `field:"failed_dns" event:"failed_dns"`                     // [7.7X] [Network] A DNS packet failed to be decoded
 
 	// on-demand events
 	OnDemand OnDemandEvent `field:"ondemand" event:"ondemand"`

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -137,6 +137,8 @@ const (
 	CapabilitiesEventType
 	// FileMoveMountEventType Move Mount even
 	FileMoveMountEventType
+	// FailedDNSEventType Failed DNS
+	FailedDNSEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -297,6 +299,8 @@ func (t EventType) String() string {
 		return "delete_key"
 	case ChangePermissionEventType:
 		return "change_permission"
+	case FailedDNSEventType:
+		return "failed_dns"
 	case LoginUIDWriteEventType:
 		return "login_uid_write"
 	case CgroupWriteEventType:

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -587,6 +587,11 @@ type DNSEvent struct {
 	Response *DNSResponse `field:"response,check:HasResponse"`
 }
 
+// FailedDNSEvent represents a DNS packet that was failed to be decoded (inbound or outbound)
+type FailedDNSEvent struct {
+	Payload []byte `field:"-"`
+}
+
 // DNSResponse represents a DNS response event
 type DNSResponse struct {
 	ResponseCode uint8 `field:"code"` // SECLDoc[code] Definition:`Response code of the DNS response according to RFC 1035` Constants:`DNS Responses`

--- a/pkg/security/tests/failed_dns_test.go
+++ b/pkg/security/tests/failed_dns_test.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+// Package tests holds tests related files
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/security/events"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+// Purpose of the test:
+// If any of the DNS packets fails to be decoded, creates the `failed_dns` event to indicate that it happened
+// The cases are:
+// - Request
+// - Full response
+// - Short response
+//
+// Notice: Not all invalid DNS packets emit an event, as they might get filtered in the kernel side before
+// getting to userspace (for example, an inbound packet with the request flag will get filtered before processing)
+
+func getPayloadBytes(customEvent *events.CustomEvent) (string, error) {
+	b, err := customEvent.MarshalJSON()
+	if err != nil {
+		return "", err
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		return "", err
+	}
+
+	var payloadB64 string
+	if err := json.Unmarshal(m["payload"], &payloadB64); err != nil {
+		return "", err
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", decoded), nil
+}
+
+func TestFailedDNSFullResponse(t *testing.T) {
+	SkipIfNotAvailable(t)
+	checkNetworkCompatibility(t)
+
+	ruleDefs := []*rules.RuleDefinition{{
+		ID:         "failed_dns_rule",
+		Expression: `dns.response.code != NXDOMAIN`,
+	}}
+
+	if testEnvironment != DockerEnvironment && !env.IsContainerized() {
+		if out, err := loadModule("veth"); err != nil {
+			t.Fatalf("couldn't load 'veth' module: %s,%v", string(out), err)
+		}
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("failed-dns-full-dns-response", func(t *testing.T) {
+		payload := "0000000000000000000000000800450000a41fbd400001115b567f0000357f0000010035d7140090fed7deadb0ef11111111111111111111111111706c6503636f6d0000010001c00c00010001000000ea0004600780c6c00c00010001000000ea000417c0e454c00c00010001000000ea000417d7008ac00c00010001000000ea000417d70088c00c00010001000000ea000417c0e450c00c00010001000000ea0004600780af000029ffd6"
+		err = test.GetCustomEventSent(t, func() error {
+			err = injectHexDump("lo", payload)
+			return nil
+		}, func(r *rules.Rule, customEvent *events.CustomEvent) bool {
+			if r.Rule.ID == "failed_dns" {
+				decodedStr, err := getPayloadBytes(customEvent)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, decodedStr, payload[len(payload)-len(decodedStr):])
+				return true
+			}
+			return false
+		}, 3*time.Second, model.CustomEventType, events.FailedDNSRuleID)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+func TestFailedDNSRequest(t *testing.T) {
+	SkipIfNotAvailable(t)
+	checkNetworkCompatibility(t)
+
+	ruleDefs := []*rules.RuleDefinition{{
+		ID:         "failed_dns_rule",
+		Expression: `dns.response.code != NXDOMAIN`,
+	}}
+
+	if testEnvironment != DockerEnvironment && !env.IsContainerized() {
+		if out, err := loadModule("veth"); err != nil {
+			t.Fatalf("couldn't load 'veth' module: %s,%v", string(out), err)
+		}
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("failed-dns-request", func(t *testing.T) {
+		payload := "00000000000000000000000008004500003c853c40004011b7727f0000017f000001b0e100350028fe3b7069636b207570207468652070686f6e6500776861616161617a61616161610a"
+		err = test.GetCustomEventSent(t, func() error {
+			err = injectHexDump("lo", payload)
+			return nil
+		}, func(r *rules.Rule, customEvent *events.CustomEvent) bool {
+			if r.Rule.ID == "failed_dns" {
+				decodedStr, err := getPayloadBytes(customEvent)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, "6970752068776161200070686f6e65", decodedStr)
+				return true
+			}
+			return false
+		}, 3*time.Second, model.CustomEventType, events.FailedDNSRuleID)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -567,6 +567,7 @@ def cws_go_generate(ctx, verbose=False):
             "./pkg/security/serializers/serializers_linux_easyjson.go",
         )
 
+    ctx.run("go generate ./pkg/security/probe/custom_events.go")
     ctx.run("go generate -tags=linux_bpf,cws_go_generate ./pkg/security/...")
 
     # synchronize the seclwin package from the secl package


### PR DESCRIPTION
### What does this PR do?

* We've spotted some events where non-DNS traffic on the DNS port is triggering error messages, but the error messages aren't enough to understand exactly where the problem is coming from: we can tell what the host is, but not the pod and container.
* In order to be better able to understand where this is coming from when this happens, and since this can indicate both an attempt to siphon data, an event was created.

### Motivation

* As above
 
### Describe how you validated your changes

* Integration tests and running locally to check if the event reached the backend

### Additional Notes

* This is a custom event and for this reason it isn´t possible to create SECL rules for that