### PR TITLE
[tracer] Add verbose log level

### DIFF
--- a/pkg/network/ebpf/c/defs.h
+++ b/pkg/network/ebpf/c/defs.h
@@ -17,4 +17,15 @@ static __always_inline bool IS_ERR_OR_NULL(const void *ptr)
 #include <linux/err.h>
 #endif // COMPILE_CORE
 
+
+// verbose logs will trigger themselves in a loop when you are ssh'd in.
+// disable this if you want cleaner local debugging output
+#define LOG_VERBOSE
+
+#ifdef LOG_VERBOSE
+#define log_verbose(format, ...) log_debug(format, ##__VA_ARGS__)
+#else
+#define log_verbose(format, ...)
+#endif
+
 #endif

--- a/pkg/network/ebpf/c/protocols/classification/routing.h
+++ b/pkg/network/ebpf/c/protocols/classification/routing.h
@@ -2,6 +2,7 @@
 #define __PROTOCOL_ROUTING_H
 
 #include "ktypes.h"
+#include "defs.h"
 #include "protocols/classification/defs.h"
 #include "protocols/classification/stack-helpers.h"
 #include "protocols/classification/routing-helpers.h"
@@ -39,11 +40,11 @@ static __always_inline classification_prog_t __get_next_program(classification_c
 static __always_inline void classification_next_program(struct __sk_buff *skb, classification_context_t *classification_ctx) {
     classification_prog_t next_program = __get_next_program(classification_ctx);
     if (next_program == CLASSIFICATION_PROG_UNKNOWN || next_program == CLASSIFICATION_PROG_MAX) {
-        log_debug("classification tail-call: skb=%p tail-end", skb);
+        log_verbose("classification tail-call: skb=%p tail-end", skb);
         return;
     }
 
-    log_debug("classification tail-call: skb=%p from=%d to=%d", skb, classification_ctx->routing_current_program, next_program);
+    log_verbose("classification tail-call: skb=%p from=%d to=%d", skb, classification_ctx->routing_current_program, next_program);
     classification_ctx->routing_current_program = next_program;
     bpf_tail_call_compat(skb, &classification_progs, next_program);
 }

--- a/pkg/network/ebpf/c/tracer.c
+++ b/pkg/network/ebpf/c/tracer.c
@@ -8,6 +8,7 @@
 #include "bpf_endian.h"
 #include "bpf_metadata.h"
 #include "bpf_bypass.h"
+#include "defs.h"
 
 #ifdef COMPILE_PREBUILT
 #include "prebuilt/offsets.h"
@@ -60,13 +61,12 @@ int socket__classifier_grpc(struct __sk_buff *skb) {
 SEC("kprobe/tcp_sendmsg")
 int BPF_BYPASSABLE_KPROBE(kprobe__tcp_sendmsg) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("kprobe/tcp_sendmsg: pid_tgid: %llu", pid_tgid);
 #if defined(COMPILE_RUNTIME) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
     struct sock *skp = (struct sock *)PT_REGS_PARM2(ctx);
 #else
     struct sock *skp = (struct sock *)PT_REGS_PARM1(ctx);
 #endif
-    log_debug("kprobe/tcp_sendmsg: pid_tgid: %llu, sock: %p", pid_tgid, skp);
+    log_verbose("kprobe/tcp_sendmsg: pid_tgid: %llu, sock: %p", pid_tgid, skp);
     bpf_map_update_with_telemetry(tcp_sendmsg_args, &pid_tgid, &skp, BPF_ANY);
     return 0;
 }
@@ -75,7 +75,7 @@ int BPF_BYPASSABLE_KPROBE(kprobe__tcp_sendmsg) {
 SEC("kprobe/tcp_sendmsg")
 int BPF_BYPASSABLE_KPROBE(kprobe__tcp_sendmsg__pre_4_1_0) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("kprobe/tcp_sendmsg: pid_tgid: %llu", pid_tgid);
+    log_verbose("kprobe/tcp_sendmsg: pid_tgid: %llu", pid_tgid);
     struct sock *skp = (struct sock *)PT_REGS_PARM2(ctx);
     bpf_map_update_with_telemetry(tcp_sendmsg_args, &pid_tgid, &skp, BPF_ANY);
     return 0;
@@ -102,7 +102,7 @@ int BPF_BYPASSABLE_KRETPROBE(kretprobe__tcp_sendmsg, int sent) {
         return 0;
     }
 
-    log_debug("kretprobe/tcp_sendmsg: pid_tgid: %llu, sent: %d, sock: %p", pid_tgid, sent, skp);
+    log_verbose("kretprobe/tcp_sendmsg: pid_tgid: %llu, sent: %d, sock: %p", pid_tgid, sent, skp);
     conn_tuple_t t = {};
     if (!read_conn_tuple(&t, skp, pid_tgid, CONN_TYPE_TCP)) {
         return 0;
@@ -120,7 +120,7 @@ int BPF_BYPASSABLE_KRETPROBE(kretprobe__tcp_sendmsg, int sent) {
 SEC("kprobe/tcp_sendpage")
 int BPF_BYPASSABLE_KPROBE(kprobe__tcp_sendpage) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("kprobe/tcp_sendpage: pid_tgid: %llu", pid_tgid);
+    log_verbose("kprobe/tcp_sendpage: pid_tgid: %llu", pid_tgid);
     struct sock *skp = (struct sock *)PT_REGS_PARM1(ctx);
     bpf_map_update_with_telemetry(tcp_sendpage_args, &pid_tgid, &skp, BPF_ANY);
     return 0;
@@ -146,7 +146,7 @@ int BPF_BYPASSABLE_KRETPROBE(kretprobe__tcp_sendpage, int sent) {
         return 0;
     }
 
-    log_debug("kretprobe/tcp_sendpage: pid_tgid: %llu, sent: %d, sock: %p", pid_tgid, sent, skp);
+    log_verbose("kretprobe/tcp_sendpage: pid_tgid: %llu, sent: %d, sock: %p", pid_tgid, sent, skp);
     conn_tuple_t t = {};
     if (!read_conn_tuple(&t, skp, pid_tgid, CONN_TYPE_TCP)) {
         return 0;

--- a/pkg/network/ebpf/c/tracer/tcp_recv.h
+++ b/pkg/network/ebpf/c/tracer/tcp_recv.h
@@ -1,6 +1,7 @@
 #ifndef __TCP_RECV_H
 #define __TCP_RECV_H
 
+#include "defs.h"
 #include "bpf_helpers.h"
 #include "bpf_telemetry.h"
 #include "bpf_bypass.h"
@@ -48,7 +49,7 @@ int BPF_BYPASSABLE_KPROBE(kprobe__tcp_recvmsg__pre_5_19_0) {
 SEC("kprobe/tcp_recvmsg")
 int BPF_BYPASSABLE_KPROBE(kprobe__tcp_recvmsg__pre_4_1_0) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    log_debug("kprobe/tcp_recvmsg: pid_tgid: %llu", pid_tgid);
+    log_verbose("kprobe/tcp_recvmsg: pid_tgid: %llu", pid_tgid);
     int flags = (int)PT_REGS_PARM6(ctx);
     if (flags & MSG_PEEK) {
         return 0;


### PR DESCRIPTION
### What does this PR do?
This PR adds `log_verbose`, and uses it for certain common log lines. `log_verbose` is like `log_debug` but controlled by via `LOG_VERBOSE`. `log_verbose` is enabled by default, so the default behavior has not changed.

### Motivation
When ssh'd into the vagrant instance, it's difficult to read the tracer debug logs because it when you `cat /sys/kernel/tracing/trace_pipe` while ssh'd in, the logs trigger themselves in a very fast loop.

### Describe how you validated your changes
```
echo 1 | sudo tee /sys/kernel/debug/tracing/tracing_on
dda inv system-probe.build

# in tab 1:
BPF_DEBUG=true sudo -E ./bin/system-probe/system-probe

# in tab 2:
sudo cat /sys/kernel/tracing/trace_pipe
```
