### PR TITLE
[FA] Fix merge-patch and delete previous fleet files (#40893)

### DIFF
--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -84,6 +84,9 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 	if err != nil {
 		return err
 	}
+
+	operations.FileOperations = append(buildOperationsFromLegacyInstaller(d.StablePath), operations.FileOperations...)
+
 	err = operations.Apply(d.ExperimentPath)
 	if err != nil {
 		return err
@@ -261,9 +264,16 @@ var (
 		"/conf.d/*.yaml",
 		"/conf.d/*.d/*.yaml",
 	}
+
+	legacyPathPrefix = filepath.Join("managed", "datadog-agent", "stable")
 )
 
 func configNameAllowed(file string) bool {
+	// Matching everything under the legacy /managed directory
+	if strings.HasPrefix(file, "/managed") {
+		return true
+	}
+
 	for _, allowedFile := range allowedConfigFiles {
 		match, err := filepath.Match(allowedFile, file)
 		if err != nil {
@@ -274,4 +284,104 @@ func configNameAllowed(file string) bool {
 		}
 	}
 	return false
+}
+
+func buildOperationsFromLegacyInstaller(rootPath string) []FileOperation {
+	var allOps []FileOperation
+
+	// /etc/datadog-agent/
+	realRootPath, err := filepath.EvalSymlinks(rootPath)
+	if err != nil {
+		return allOps
+	}
+
+	// Eval legacyPathPrefix symlink from rootPath
+	// /etc/datadog-agent/managed/datadog-agent/aaaa-bbbb-cccc
+	stableDirPath, err := filepath.EvalSymlinks(filepath.Join(realRootPath, legacyPathPrefix))
+	if err != nil {
+		return allOps
+	}
+
+	// managed/datadog-agent/aaaa-bbbb-cccc
+	managedDirSubPath, err := filepath.Rel(realRootPath, stableDirPath)
+	if err != nil {
+		return allOps
+	}
+
+	err = filepath.Walk(stableDirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		// Ignore application_monitoring.yaml as we need to keep it in the managed directory
+		if strings.HasSuffix(path, "application_monitoring.yaml") {
+			return nil
+		}
+
+		ops, err := buildOperationsFromLegacyConfigFile(path, realRootPath, managedDirSubPath)
+		if err != nil {
+			return err
+		}
+
+		allOps = append(allOps, ops...)
+		return nil
+	})
+	if err != nil {
+		return []FileOperation{}
+	}
+
+	return allOps
+}
+
+func buildOperationsFromLegacyConfigFile(fullFilePath, fullRootPath, managedDirSubPath string) ([]FileOperation, error) {
+	var ops []FileOperation
+
+	// Read the stable config file
+	stableDatadogYAML, err := os.ReadFile(fullFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ops, nil
+		}
+		return ops, err
+	}
+
+	// Since the config is YAML, we need to convert it to JSON
+	// 1. Parse the YAML in interface{}
+	// 2. Serialize the interface{} to JSON
+	var stableDatadogJSON interface{}
+	err = yaml.Unmarshal(stableDatadogYAML, &stableDatadogJSON)
+	if err != nil {
+		return ops, err
+	}
+	stableDatadogJSONBytes, err := json.Marshal(stableDatadogJSON)
+	if err != nil {
+		return ops, err
+	}
+
+	managedFilePath, err := filepath.Rel(fullRootPath, fullFilePath)
+	if err != nil {
+		return ops, err
+	}
+	fPath, err := filepath.Rel(managedDirSubPath, managedFilePath)
+	if err != nil {
+		return ops, err
+	}
+
+	// Add the merge patch operation
+	ops = append(ops, FileOperation{
+		FileOperationType: FileOperationType(FileOperationMergePatch),
+		FilePath:          "/" + strings.TrimPrefix(fPath, "/"),
+		Patch:             stableDatadogJSONBytes,
+	})
+
+	// Add the delete operation for the old file
+	ops = append(ops, FileOperation{
+		FileOperationType: FileOperationType(FileOperationDelete),
+		FilePath:          "/" + strings.TrimPrefix(managedFilePath, "/"),
+	})
+
+	return ops, nil
 }

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -8,6 +8,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -215,4 +216,123 @@ func TestOperationApply_NestedConfigFile(t *testing.T) {
 	assert.Equal(t, "newval", updatedMap["foo"])
 	assert.Equal(t, 1, updatedMap["bar"])
 	assert.Equal(t, 42, updatedMap["baz"])
+}
+
+func TestDirectories_GetState(t *testing.T) {
+	tmpDir := t.TempDir()
+	stablePath := filepath.Join(tmpDir, "stable")
+	experimentPath := filepath.Join(tmpDir, "experiment")
+
+	err := os.MkdirAll(stablePath, 0755)
+	assert.NoError(t, err)
+	err = os.MkdirAll(experimentPath, 0755)
+	assert.NoError(t, err)
+
+	dirs := &Directories{
+		StablePath:     stablePath,
+		ExperimentPath: experimentPath,
+	}
+
+	// Test with no deployment IDs
+	state, err := dirs.GetState()
+	assert.NoError(t, err)
+	assert.Equal(t, "", state.StableDeploymentID)
+	assert.Equal(t, "", state.ExperimentDeploymentID)
+
+	// Test with stable deployment ID only
+	err = os.WriteFile(filepath.Join(stablePath, deploymentIDFile), []byte("stable-123"), 0644)
+	assert.NoError(t, err)
+
+	state, err = dirs.GetState()
+	assert.NoError(t, err)
+	assert.Equal(t, "stable-123", state.StableDeploymentID)
+	assert.Equal(t, "", state.ExperimentDeploymentID)
+
+	// Test with both deployment IDs
+	err = os.WriteFile(filepath.Join(experimentPath, deploymentIDFile), []byte("experiment-456"), 0644)
+	assert.NoError(t, err)
+
+	state, err = dirs.GetState()
+	assert.NoError(t, err)
+	assert.Equal(t, "stable-123", state.StableDeploymentID)
+	assert.Equal(t, "experiment-456", state.ExperimentDeploymentID)
+
+	// Test with symlinked experiment (should clear experiment deployment ID)
+	err = os.Remove(filepath.Join(experimentPath, deploymentIDFile))
+	assert.NoError(t, err)
+	err = os.Symlink(filepath.Join(stablePath, deploymentIDFile), filepath.Join(experimentPath, deploymentIDFile))
+	assert.NoError(t, err)
+
+	state, err = dirs.GetState()
+	assert.NoError(t, err)
+	assert.Equal(t, "stable-123", state.StableDeploymentID)
+	assert.Equal(t, "", state.ExperimentDeploymentID)
+}
+
+func TestBuildOperationsFromLegacyConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	managedDir := filepath.Join(tmpDir, legacyPathPrefix)
+	err := os.MkdirAll(managedDir, 0755)
+	assert.NoError(t, err)
+
+	// Create a legacy config file
+	legacyConfig := []byte("{\"bar\":123,\"foo\":\"legacy_value\"}")
+	err = os.WriteFile(filepath.Join(managedDir, "datadog.yaml"), legacyConfig, 0644)
+	assert.NoError(t, err)
+
+	ops, err := buildOperationsFromLegacyConfigFile(filepath.Join(managedDir, "datadog.yaml"), tmpDir, legacyPathPrefix)
+	assert.NoError(t, err)
+	assert.Len(t, ops, 2)
+
+	// Check merge patch operation
+	assert.Equal(t, FileOperationMergePatch, ops[0].FileOperationType)
+	assert.Equal(t, "/datadog.yaml", ops[0].FilePath)
+	assert.Equal(t, string(legacyConfig), string(ops[0].Patch))
+
+	// Check delete operation
+	assert.Equal(t, FileOperationDelete, ops[1].FileOperationType)
+	assert.Equal(t, filepath.Join(legacyPathPrefix, "datadog.yaml"), strings.TrimPrefix(strings.TrimPrefix(ops[1].FilePath, "/"), "\\"))
+}
+
+func TestBuildOperationsFromLegacyInstaller(t *testing.T) {
+	tmpDir := t.TempDir()
+	managedDir := filepath.Join(tmpDir, legacyPathPrefix)
+	err := os.MkdirAll(managedDir, 0755)
+	assert.NoError(t, err)
+
+	// Create legacy config files
+	err = os.WriteFile(filepath.Join(managedDir, "datadog.yaml"), []byte("foo: legacy\n"), 0644)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(managedDir, "security-agent.yaml"), []byte("enabled: true\n"), 0644)
+	assert.NoError(t, err)
+
+	ops := buildOperationsFromLegacyInstaller(tmpDir)
+
+	// Should have 4 operations: 2 merge patches + 2 deletes
+	assert.Len(t, ops, 4)
+
+	// Check that we have operations for both files
+	filePaths := make(map[string]bool)
+	for _, op := range ops {
+		filePaths[strings.TrimPrefix(strings.TrimPrefix(op.FilePath, "/"), "\\")] = true
+	}
+	assert.True(t, filePaths["datadog.yaml"])
+	assert.True(t, filePaths["security-agent.yaml"])
+	assert.True(t, filePaths[filepath.Join("managed", "datadog-agent", "stable", "datadog.yaml")])
+	assert.True(t, filePaths[filepath.Join("managed", "datadog-agent", "stable", "security-agent.yaml")])
+}
+
+func TestBuildOperationsFromLegacyConfigFileKeepApplicationMonitoring(t *testing.T) {
+	tmpDir := t.TempDir()
+	managedDir := filepath.Join(tmpDir, legacyPathPrefix)
+	err := os.MkdirAll(managedDir, 0755)
+	assert.NoError(t, err)
+
+	// Create a legacy config file
+	legacyConfig := []byte("{\"bar\":123,\"foo\":\"legacy_value\"}")
+	err = os.WriteFile(filepath.Join(managedDir, "application_monitoring.yaml"), legacyConfig, 0644)
+	assert.NoError(t, err)
+
+	ops := buildOperationsFromLegacyInstaller(tmpDir)
+	assert.Len(t, ops, 0)
 }


### PR DESCRIPTION
### What does this PR do?

Merge-patch and delete previous fleet files.
If not done, this will keep a datadog config file in `managed` and prevent all config update from being successful

### Motivation

### Describe how you validated your changes

### Additional Notes

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
