### PR TITLE
[certs] Add config for TLS cert collection

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -264,6 +264,9 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_fentry"), false)
 
+	// TLS cert collection
+	cfg.BindEnvAndSetDefault(join(netNS, "enable_cert_collection"), false)
+
 	// windows config
 	cfg.BindEnvAndSetDefault(join(spNS, "windows.enable_monotonic_count"), false)
 

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -200,6 +200,9 @@ type Config struct {
 	// ExpectedTagsDuration is the duration for which we add host and container tags to our payloads, to handle the race
 	// in the backend for processing host/container tags and resolving them in our own pipelines.
 	ExpectedTagsDuration time.Duration
+
+	// EnableCertCollection enables the collection of TLS certificates via userspace probing
+	EnableCertCollection bool
 }
 
 // New creates a config for the network tracer
@@ -278,6 +281,8 @@ func New() *Config {
 		EnableFentry:   cfg.GetBool(sysconfig.FullKeyPath(netNS, "enable_fentry")),
 
 		ExpectedTagsDuration: cfg.GetDuration(sysconfig.FullKeyPath(spNS, "expected_tags_duration")),
+
+		EnableCertCollection: cfg.GetBool(sysconfig.FullKeyPath(netNS, "enable_cert_collection")),
 	}
 
 	if !c.CollectTCPv4Conns {

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -460,3 +460,28 @@ func TestExpectedTagsDuration(t *testing.T) {
 		assert.Equal(t, 30*time.Second, cfg.ExpectedTagsDuration)
 	})
 }
+
+func TestEnableCertCollection(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.Equal(t, false, cfg.EnableCertCollection)
+	})
+
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("network_config.enable_cert_collection", true)
+		cfg := New()
+
+		assert.Equal(t, true, cfg.EnableCertCollection)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_NETWORK_CONFIG_ENABLE_CERT_COLLECTION", "true")
+		cfg := New()
+
+		assert.Equal(t, true, cfg.EnableCertCollection)
+	})
+}


### PR DESCRIPTION
### What does this PR do?
This PR adds a config value, `network_config.enable_cert_collection`, to enable TLS cert collection (defaults to false)

### Motivation
Want to control the rollout of TLS cert collection.

### Describe how you validated your changes
New tests added:
```
go -tags linux,linux_bpf,npm,process,test,ec2,root -run ^TestEnableCertCollection$ github.com/DataDog/datadog-agent/pkg/network/config
```
