### PR TITLE
dyninst/irgen: fix issues found in the wild

### DIFF
--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -3,151 +3,151 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a6046.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6006]
-	PrepareEventRoot 96 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6046]
+	PrepareEventRoot a7 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6046.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 66 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6050]
-	PrepareEventRoot 97 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6090]
+	PrepareEventRoot a8 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a6513.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ee 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5f 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6513]
-	PrepareEventRoot 92 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a6513.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6553]
+	PrepareEventRoot a3 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0x4a63ea.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@4a63ea]
-	PrepareEventRoot 95 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a63ea.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@4a5dce]
-	PrepareEventRoot 95 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a60ca.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@4a60ca]
-	PrepareEventRoot 8a 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a60ca.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@4a642a]
+	PrepareEventRoot a6 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a624a.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@4a5e0e]
+	PrepareEventRoot a6 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a610a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@4a610a]
+	PrepareEventRoot 9b 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a610a.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a624a]
-	PrepareEventRoot 8d 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a624a.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a628a]
+	PrepareEventRoot 9e 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63c0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 24 03 00 00 // ProcessType[[3]string]
+	Call 30 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a63c0]
-	PrepareEventRoot 90 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63c0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
+	PrepareEventRoot a1 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a61ca.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 4c 03 00 00 // ProcessType[[]int]
+	Call 70 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a61ca]
-	PrepareEventRoot 8c 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a61ca.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a620a]
+	PrepareEventRoot 9d 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a64aa.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e8 03 00 00 // ProcessType[map[string]int]
+	Call 59 04 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@4a64aa]
-	PrepareEventRoot 91 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64aa.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4a64ea]
+	PrepareEventRoot a2 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	Return 
-// 0x1a7: ProcessEvent[Probe[main.noArgs]@4a65ca]
-	PrepareEventRoot 93 00 00 00 00 00 00 00 
+// 0x1a7: ProcessEvent[Probe[main.noArgs]@4a660a]
+	PrepareEventRoot a4 00 00 00 00 00 00 00 
 	Return 
-// 0x1b1: ProcessExpression[Probe[main.stringArg]@0x4a614a.expr[0]]
+// 0x1b1: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	Return 
-// 0x1d3: ProcessEvent[Probe[main.stringArg]@4a614a]
-	PrepareEventRoot 8b 00 00 00 11 00 00 00 
-	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a614a.expr[0]]
+// 0x1d3: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot 9c 00 00 00 11 00 00 00 
+	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
-// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0x4a634a.expr[0]]
+// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 24 03 00 00 // ProcessType[[3]string]
+	Call 30 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x203: ProcessEvent[Probe[main.stringArrayArg]@4a634a]
-	PrepareEventRoot 8f 00 00 00 31 00 00 00 
-	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a634a.expr[0]]
+// 0x203: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
+	PrepareEventRoot a0 00 00 00 31 00 00 00 
+	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	Return 
-// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0x4a62ca.expr[0]]
+// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 66 03 00 00 // ProcessType[[]string]
+	Call 8a 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4a62ca]
-	PrepareEventRoot 8e 00 00 00 19 00 00 00 
-	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62ca.expr[0]]
+// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
+	PrepareEventRoot 9f 00 00 00 19 00 00 00 
+	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	Return 
-// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6636]
-	PrepareEventRoot 94 00 00 00 00 00 00 00 
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
+	PrepareEventRoot a5 00 00 00 00 00 00 00 
 	Return 
 // 0x254: ProcessType[*****int]
-	ProcessPointer 74 00 00 00 
+	ProcessPointer 79 00 00 00 
 	Return 
 // 0x25a: ProcessType[****int]
-	ProcessPointer 88 00 00 00 
+	ProcessPointer 99 00 00 00 
 	Return 
 // 0x260: ProcessType[***int]
-	ProcessPointer 75 00 00 00 
+	ProcessPointer 7a 00 00 00 
 	Return 
 // 0x266: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
@@ -158,210 +158,252 @@
 // 0x272: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x278: ProcessType[*bucket<string,int>]
+// 0x278: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 93 00 00 00 
+	Return 
+// 0x27e: ProcessType[*bucket<string,int>]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x27e: ProcessType[*bucket<string,main.bigStruct>]
+// 0x284: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 72 00 00 00 
 	Return 
-// 0x284: ProcessType[*error]
+// 0x28a: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 77 00 00 00 
+	Return 
+// 0x290: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x28a: ProcessType[*float32]
+// 0x296: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x290: ProcessType[*float64]
+// 0x29c: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x296: ProcessType[*int]
+// 0x2a2: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x29c: ProcessType[*int32]
+// 0x2a8: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x2a2: ProcessType[*int64]
+// 0x2ae: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x2a8: ProcessType[*main.bigStruct]
-	ProcessPointer 86 00 00 00 
+// 0x2b4: ProcessType[*main.bigStruct]
+	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x2ae: ProcessType[*runtime._defer]
+// 0x2ba: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x2b4: ProcessType[*runtime._panic]
+// 0x2c0: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x2ba: ProcessType[*runtime.cgoCallers]
+// 0x2c6: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x2c0: ProcessType[*runtime.coro]
+// 0x2cc: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2c6: ProcessType[*runtime.g]
+// 0x2d2: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x2cc: ProcessType[*runtime.m]
+// 0x2d8: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2d2: ProcessType[*runtime.mapextra]
+// 0x2de: ProcessType[*runtime.mapextra]
 	ProcessPointer 6d 00 00 00 
 	Return 
-// 0x2d8: ProcessType[*runtime.sudog]
+// 0x2e4: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2de: ProcessType[*runtime.timer]
+// 0x2ea: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x2e4: ProcessType[*runtime.traceBuf]
+// 0x2f0: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x2ea: ProcessType[*string]
+// 0x2f6: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2f0: ProcessType[*uint]
+// 0x2fc: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x2f6: ProcessType[*uint16]
+// 0x302: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2fc: ProcessType[*uint32]
+// 0x308: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x302: ProcessType[*uint64]
+// 0x30e: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x308: ProcessType[*uint8]
+// 0x314: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x30e: ProcessType[*uintptr]
+// 0x31a: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x314: ProcessType[[2]*runtime.traceBuf]
+// 0x320: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call e4 02 00 00 // ProcessType[*runtime.traceBuf]
+	Call f0 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x324: ProcessType[[3]string]
+// 0x330: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x334: ProcessType[[]bucket<string,int>.array]
+// 0x340: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a0 03 00 00 // ProcessType[bucket<string,int>]
+	Call d4 03 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x340: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x34c: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call b5 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call df 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x34c: ProcessType[[]int]
-	ProcessSlice 7c 00 00 00 08 00 00 00 
+// 0x358: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call f4 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x356: ProcessType[[]key<string>]
+// 0x364: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 09 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x370: ProcessType[[]int]
+	ProcessSlice 81 00 00 00 08 00 00 00 
+	Return 
+// 0x37a: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x366: ProcessType[[]string]
-	ProcessSlice 7e 00 00 00 10 00 00 00 
+// 0x38a: ProcessType[[]string]
+	ProcessSlice 83 00 00 00 10 00 00 00 
 	Return 
-// 0x370: ProcessType[[]string.array]
+// 0x394: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x37c: ProcessType[[]uint8]
-	ProcessSlice 78 00 00 00 01 00 00 00 
+// 0x3a0: ProcessType[[]uint8]
+	ProcessSlice 7d 00 00 00 01 00 00 00 
 	Return 
-// 0x386: ProcessType[[]uintptr]
-	ProcessSlice 7a 00 00 00 08 00 00 00 
+// 0x3aa: ProcessType[[]uintptr]
+	ProcessSlice 7f 00 00 00 08 00 00 00 
 	Return 
-// 0x390: ProcessType[[]val<main.bigStruct>]
+// 0x3b4: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call a8 02 00 00 // ProcessType[*main.bigStruct]
+	Call b4 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3a0: ProcessType[bucket<string,int>]
+// 0x3c4: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call 53 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x3d4: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 88 00 00 00 
+	Call 78 02 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x3df: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 56 03 00 00 // ProcessType[[]key<string>]
+	Call 7a 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 78 02 00 00 // ProcessType[*bucket<string,int>]
+	Call 7e 02 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x3b5: ProcessType[bucket<string,main.bigStruct>]
+// 0x3f4: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 56 03 00 00 // ProcessType[[]key<string>]
-	Call 90 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 7e 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 7a 03 00 00 // ProcessType[[]key<string>]
+	Call b4 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 84 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x3ca: ProcessType[error]
+// 0x409: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call c4 03 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8a 02 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x419: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3cc: ProcessType[hash<string,int>]
-	ProcessGoHmap 83 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x41b: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 98 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x3da: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 87 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x429: ProcessType[hash<string,int>]
+	ProcessGoHmap 88 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x3e8: ProcessType[map[string]int]
+// 0x437: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 8c 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x445: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 94 00 00 00 58 00 00 00 08 09 10 18 
+	Return 
+// 0x453: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 91 00 00 00 
+	Return 
+// 0x459: ProcessType[map[string]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x3ee: ProcessType[map[string]main.bigStruct]
+// 0x45f: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x3f4: ProcessType[runtime.g]
+// 0x465: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 75 00 00 00 
+	Return 
+// 0x46b: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call b4 02 00 00 // ProcessType[*runtime._panic]
+	Call c0 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call ae 02 00 00 // ProcessType[*runtime._defer]
+	Call ba 02 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call cc 02 00 00 // ProcessType[*runtime.m]
+	Call d8 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 7c 03 00 00 // ProcessType[[]uint8]
+	Call a0 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
 	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call d8 02 00 00 // ProcessType[*runtime.sudog]
+	Call e4 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 86 03 00 00 // ProcessType[[]uintptr]
+	Call aa 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call de 02 00 00 // ProcessType[*runtime.timer]
+	Call ea 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call c0 02 00 00 // ProcessType[*runtime.coro]
+	Call cc 02 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x44f: ProcessType[runtime.m]
-	Call c6 02 00 00 // ProcessType[*runtime.g]
+// 0x4c6: ProcessType[runtime.m]
+	Call d2 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call c6 02 00 00 // ProcessType[*runtime.g]
+	Call d2 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call c6 02 00 00 // ProcessType[*runtime.g]
+	Call d2 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call ba 02 00 00 // ProcessType[*runtime.cgoCallers]
+	Call c6 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call cc 02 00 00 // ProcessType[*runtime.m]
+	Call d8 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call af 04 00 00 // ProcessType[runtime.mLockProfile]
+	Call 26 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 86 03 00 00 // ProcessType[[]uintptr]
+	Call aa 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call cc 02 00 00 // ProcessType[*runtime.m]
+	Call d8 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 04 00 00 // ProcessType[runtime.mTraceState]
+	Call 31 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x4af: ProcessType[runtime.mLockProfile]
+// 0x526: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 86 03 00 00 // ProcessType[[]uintptr]
+	Call aa 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x4ba: ProcessType[runtime.mTraceState]
+// 0x531: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 14 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call cc 02 00 00 // ProcessType[*runtime.m]
+	Call 20 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call d8 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x4ca: ProcessType[string]
-	ProcessString 76 00 00 00 
+// 0x541: ProcessType[string]
+	ProcessString 7b 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -383,11 +425,11 @@ ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
 ID: 5 Len: 8 Enqueue: 626
-ID: 6 Len: 8 Enqueue: 776
+ID: 6 Len: 8 Enqueue: 788
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 782
+ID: 8 Len: 8 Enqueue: 794
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1226
+ID: 10 Len: 16 Enqueue: 1345
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -395,18 +437,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 970
+ID: 18 Len: 16 Enqueue: 1049
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 668
-ID: 21 Len: 8 Enqueue: 764
-ID: 22 Len: 432 Enqueue: 1012
+ID: 20 Len: 8 Enqueue: 680
+ID: 21 Len: 8 Enqueue: 776
+ID: 22 Len: 432 Enqueue: 1131
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 692
+ID: 24 Len: 8 Enqueue: 704
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 686
+ID: 26 Len: 8 Enqueue: 698
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 716
-ID: 29 Len: 1760 Enqueue: 1103
+ID: 28 Len: 8 Enqueue: 728
+ID: 29 Len: 1760 Enqueue: 1222
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -415,41 +457,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 892
+ID: 38 Len: 24 Enqueue: 928
 ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 728
+ID: 41 Len: 8 Enqueue: 740
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 902
-ID: 44 Len: 8 Enqueue: 734
+ID: 43 Len: 24 Enqueue: 938
+ID: 44 Len: 8 Enqueue: 746
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 704
+ID: 47 Len: 8 Enqueue: 716
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 710
+ID: 53 Len: 8 Enqueue: 722
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 698
+ID: 60 Len: 8 Enqueue: 710
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1199
+ID: 64 Len: 64 Enqueue: 1318
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1210
+ID: 69 Len: 32 Enqueue: 1329
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 788
-ID: 72 Len: 8 Enqueue: 740
+ID: 71 Len: 16 Enqueue: 800
+ID: 72 Len: 8 Enqueue: 752
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -465,67 +507,84 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 746
+ID: 88 Len: 8 Enqueue: 758
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 656
-ID: 92 Len: 8 Enqueue: 674
-ID: 93 Len: 8 Enqueue: 662
-ID: 94 Len: 8 Enqueue: 770
-ID: 95 Len: 8 Enqueue: 644
-ID: 96 Len: 8 Enqueue: 650
-ID: 97 Len: 8 Enqueue: 752
-ID: 98 Len: 8 Enqueue: 758
-ID: 99 Len: 24 Enqueue: 844
+ID: 91 Len: 8 Enqueue: 668
+ID: 92 Len: 8 Enqueue: 686
+ID: 93 Len: 8 Enqueue: 674
+ID: 94 Len: 8 Enqueue: 782
+ID: 95 Len: 8 Enqueue: 656
+ID: 96 Len: 8 Enqueue: 662
+ID: 97 Len: 8 Enqueue: 764
+ID: 98 Len: 8 Enqueue: 770
+ID: 99 Len: 24 Enqueue: 880
 ID: 100 Len: 24 Enqueue: 0
-ID: 101 Len: 24 Enqueue: 870
-ID: 102 Len: 48 Enqueue: 804
-ID: 103 Len: 8 Enqueue: 1000
+ID: 101 Len: 24 Enqueue: 906
+ID: 102 Len: 48 Enqueue: 816
+ID: 103 Len: 8 Enqueue: 1113
 ID: 104 Len: 8 Enqueue: 0
-ID: 105 Len: 48 Enqueue: 972
-ID: 106 Len: 8 Enqueue: 632
-ID: 107 Len: 208 Enqueue: 928
-ID: 108 Len: 8 Enqueue: 722
+ID: 105 Len: 48 Enqueue: 1065
+ID: 106 Len: 8 Enqueue: 638
+ID: 107 Len: 208 Enqueue: 991
+ID: 108 Len: 8 Enqueue: 734
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 8 Enqueue: 1006
+ID: 110 Len: 8 Enqueue: 1119
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 986
-ID: 113 Len: 8 Enqueue: 638
-ID: 114 Len: 208 Enqueue: 949
-ID: 115 Len: 8 Enqueue: 596
-ID: 116 Len: 8 Enqueue: 602
-ID: 117 Len: 8 Enqueue: 614
-ID: 118 Len: 1 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 1 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 0
+ID: 112 Len: 48 Enqueue: 1079
+ID: 113 Len: 8 Enqueue: 644
+ID: 114 Len: 208 Enqueue: 1012
+ID: 115 Len: 8 Enqueue: 1125
+ID: 116 Len: 8 Enqueue: 0
+ID: 117 Len: 48 Enqueue: 1093
+ID: 118 Len: 8 Enqueue: 650
+ID: 119 Len: 88 Enqueue: 1033
+ID: 120 Len: 8 Enqueue: 596
+ID: 121 Len: 8 Enqueue: 602
+ID: 122 Len: 8 Enqueue: 614
+ID: 123 Len: 1 Enqueue: 0
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 16 Enqueue: 880
+ID: 125 Len: 1 Enqueue: 0
+ID: 126 Len: 8 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 128 Enqueue: 854
-ID: 130 Len: 64 Enqueue: 0
-ID: 131 Len: 208 Enqueue: 820
-ID: 132 Len: 64 Enqueue: 912
-ID: 133 Len: 8 Enqueue: 680
-ID: 134 Len: 184 Enqueue: 0
-ID: 135 Len: 208 Enqueue: 832
-ID: 136 Len: 8 Enqueue: 608
-ID: 137 Len: 128 Enqueue: 0
-ID: 138 Len: 9 Enqueue: 0
-ID: 139 Len: 17 Enqueue: 0
-ID: 140 Len: 25 Enqueue: 0
-ID: 141 Len: 25 Enqueue: 0
-ID: 142 Len: 25 Enqueue: 0
-ID: 143 Len: 49 Enqueue: 0
-ID: 144 Len: 49 Enqueue: 0
-ID: 145 Len: 9 Enqueue: 0
-ID: 146 Len: 9 Enqueue: 0
-ID: 147 Len: 0 Enqueue: 0
-ID: 148 Len: 0 Enqueue: 0
-ID: 149 Len: 9 Enqueue: 0
-ID: 150 Len: 9 Enqueue: 0
-ID: 151 Len: 9 Enqueue: 0
+ID: 129 Len: 8 Enqueue: 0
+ID: 130 Len: 8 Enqueue: 0
+ID: 131 Len: 16 Enqueue: 916
+ID: 132 Len: 8 Enqueue: 0
+ID: 133 Len: 8 Enqueue: 0
+ID: 134 Len: 128 Enqueue: 890
+ID: 135 Len: 64 Enqueue: 0
+ID: 136 Len: 208 Enqueue: 844
+ID: 137 Len: 64 Enqueue: 948
+ID: 138 Len: 8 Enqueue: 692
+ID: 139 Len: 184 Enqueue: 0
+ID: 140 Len: 208 Enqueue: 856
+ID: 141 Len: 8 Enqueue: 0
+ID: 142 Len: 64 Enqueue: 964
+ID: 143 Len: 8 Enqueue: 1107
+ID: 144 Len: 8 Enqueue: 0
+ID: 145 Len: 48 Enqueue: 1051
+ID: 146 Len: 8 Enqueue: 632
+ID: 147 Len: 144 Enqueue: 980
+ID: 148 Len: 88 Enqueue: 868
+ID: 149 Len: 64 Enqueue: 0
+ID: 150 Len: 64 Enqueue: 0
+ID: 151 Len: 8 Enqueue: 0
+ID: 152 Len: 144 Enqueue: 832
+ID: 153 Len: 8 Enqueue: 608
+ID: 154 Len: 128 Enqueue: 0
+ID: 155 Len: 9 Enqueue: 0
+ID: 156 Len: 17 Enqueue: 0
+ID: 157 Len: 25 Enqueue: 0
+ID: 158 Len: 25 Enqueue: 0
+ID: 159 Len: 25 Enqueue: 0
+ID: 160 Len: 49 Enqueue: 0
+ID: 161 Len: 49 Enqueue: 0
+ID: 162 Len: 9 Enqueue: 0
+ID: 163 Len: 9 Enqueue: 0
+ID: 164 Len: 0 Enqueue: 0
+ID: 165 Len: 0 Enqueue: 0
+ID: 166 Len: 9 Enqueue: 0
+ID: 167 Len: 9 Enqueue: 0
+ID: 168 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,27 +7,27 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4a 02 00 00 // ProcessType[*****int]
+	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6006]
-	PrepareEventRoot 95 00 00 00 09 00 00 00 
+	PrepareEventRoot 96 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5c 02 00 00 // ProcessType[**int]
+	Call 66 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6050]
-	PrepareEventRoot 96 00 00 00 09 00 00 00 
+	PrepareEventRoot 97 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a6513.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e4 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ee 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6513]
 	PrepareEventRoot 92 00 00 00 09 00 00 00 
@@ -39,7 +39,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x97: ProcessEvent[Probe[main.inlined]@4a63ea]
-	PrepareEventRoot 94 00 00 00 09 00 00 00 
+	PrepareEventRoot 95 00 00 00 09 00 00 00 
 	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a63ea.expr[0]]
 	Return 
 // 0xa6: ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xb6: ProcessEvent[Probe[main.inlined]@4a5dce]
-	PrepareEventRoot 94 00 00 00 09 00 00 00 
+	PrepareEventRoot 95 00 00 00 09 00 00 00 
 	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
 	Return 
 // 0xc5: ProcessExpression[Probe[main.intArg]@0x4a60ca.expr[0]]
@@ -73,7 +73,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 1a 03 00 00 // ProcessType[[3]string]
+	Call 24 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a63c0]
 	PrepareEventRoot 90 00 00 00 31 00 00 00 
@@ -85,7 +85,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 42 03 00 00 // ProcessType[[]int]
+	Call 4c 03 00 00 // ProcessType[[]int]
 	Return 
 // 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a61ca]
 	PrepareEventRoot 8c 00 00 00 19 00 00 00 
@@ -95,7 +95,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call de 03 00 00 // ProcessType[map[string]int]
+	Call e8 03 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x198: ProcessEvent[Probe[main.mapArg]@4a64aa]
 	PrepareEventRoot 91 00 00 00 09 00 00 00 
@@ -109,7 +109,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	Return 
 // 0x1d3: ProcessEvent[Probe[main.stringArg]@4a614a]
 	PrepareEventRoot 8b 00 00 00 11 00 00 00 
@@ -119,7 +119,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 1a 03 00 00 // ProcessType[[3]string]
+	Call 24 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x203: ProcessEvent[Probe[main.stringArrayArg]@4a634a]
 	PrepareEventRoot 8f 00 00 00 31 00 00 00 
@@ -131,233 +131,236 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 5c 03 00 00 // ProcessType[[]string]
+	Call 66 03 00 00 // ProcessType[[]string]
 	Return 
 // 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4a62ca]
 	PrepareEventRoot 8e 00 00 00 19 00 00 00 
 	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62ca.expr[0]]
 	Return 
-// 0x24a: ProcessType[*****int]
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6636]
+	PrepareEventRoot 94 00 00 00 00 00 00 00 
+	Return 
+// 0x254: ProcessType[*****int]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x250: ProcessType[****int]
+// 0x25a: ProcessType[****int]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x256: ProcessType[***int]
+// 0x260: ProcessType[***int]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x25c: ProcessType[**int]
+// 0x266: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x262: ProcessType[*[]runtime.ancestorInfo]
+// 0x26c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x268: ProcessType[*bool]
+// 0x272: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x26e: ProcessType[*bucket<string,int>]
+// 0x278: ProcessType[*bucket<string,int>]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x274: ProcessType[*bucket<string,main.bigStruct>]
+// 0x27e: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 72 00 00 00 
 	Return 
-// 0x27a: ProcessType[*error]
+// 0x284: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x280: ProcessType[*float32]
+// 0x28a: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x286: ProcessType[*float64]
+// 0x290: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x28c: ProcessType[*int]
+// 0x296: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x292: ProcessType[*int32]
+// 0x29c: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x298: ProcessType[*int64]
+// 0x2a2: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x29e: ProcessType[*main.bigStruct]
+// 0x2a8: ProcessType[*main.bigStruct]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x2a4: ProcessType[*runtime._defer]
+// 0x2ae: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x2aa: ProcessType[*runtime._panic]
+// 0x2b4: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x2b0: ProcessType[*runtime.cgoCallers]
+// 0x2ba: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x2b6: ProcessType[*runtime.coro]
+// 0x2c0: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2bc: ProcessType[*runtime.g]
+// 0x2c6: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x2c2: ProcessType[*runtime.m]
+// 0x2cc: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2c8: ProcessType[*runtime.mapextra]
+// 0x2d2: ProcessType[*runtime.mapextra]
 	ProcessPointer 6d 00 00 00 
 	Return 
-// 0x2ce: ProcessType[*runtime.sudog]
+// 0x2d8: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2d4: ProcessType[*runtime.timer]
+// 0x2de: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x2da: ProcessType[*runtime.traceBuf]
+// 0x2e4: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x2e0: ProcessType[*string]
+// 0x2ea: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2e6: ProcessType[*uint]
+// 0x2f0: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x2ec: ProcessType[*uint16]
+// 0x2f6: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2f2: ProcessType[*uint32]
+// 0x2fc: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2f8: ProcessType[*uint64]
+// 0x302: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x2fe: ProcessType[*uint8]
+// 0x308: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x304: ProcessType[*uintptr]
+// 0x30e: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x30a: ProcessType[[2]*runtime.traceBuf]
+// 0x314: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call da 02 00 00 // ProcessType[*runtime.traceBuf]
+	Call e4 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x31a: ProcessType[[3]string]
+// 0x324: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x32a: ProcessType[[]bucket<string,int>.array]
+// 0x334: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 96 03 00 00 // ProcessType[bucket<string,int>]
+	Call a0 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x336: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x340: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call ab 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call b5 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x342: ProcessType[[]int]
+// 0x34c: ProcessType[[]int]
 	ProcessSlice 7c 00 00 00 08 00 00 00 
 	Return 
-// 0x34c: ProcessType[[]key<string>]
+// 0x356: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x35c: ProcessType[[]string]
+// 0x366: ProcessType[[]string]
 	ProcessSlice 7e 00 00 00 10 00 00 00 
 	Return 
-// 0x366: ProcessType[[]string.array]
+// 0x370: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x372: ProcessType[[]uint8]
+// 0x37c: ProcessType[[]uint8]
 	ProcessSlice 78 00 00 00 01 00 00 00 
 	Return 
-// 0x37c: ProcessType[[]uintptr]
+// 0x386: ProcessType[[]uintptr]
 	ProcessSlice 7a 00 00 00 08 00 00 00 
 	Return 
-// 0x386: ProcessType[[]val<main.bigStruct>]
+// 0x390: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 9e 02 00 00 // ProcessType[*main.bigStruct]
+	Call a8 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x396: ProcessType[bucket<string,int>]
+// 0x3a0: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4c 03 00 00 // ProcessType[[]key<string>]
+	Call 56 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 6e 02 00 00 // ProcessType[*bucket<string,int>]
+	Call 78 02 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x3ab: ProcessType[bucket<string,main.bigStruct>]
+// 0x3b5: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4c 03 00 00 // ProcessType[[]key<string>]
-	Call 86 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 74 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 56 03 00 00 // ProcessType[[]key<string>]
+	Call 90 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 7e 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x3c0: ProcessType[error]
+// 0x3ca: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3c2: ProcessType[hash<string,int>]
+// 0x3cc: ProcessType[hash<string,int>]
 	ProcessGoHmap 83 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x3d0: ProcessType[hash<string,main.bigStruct>]
+// 0x3da: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 87 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x3de: ProcessType[map[string]int]
+// 0x3e8: ProcessType[map[string]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x3e4: ProcessType[map[string]main.bigStruct]
+// 0x3ee: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x3ea: ProcessType[runtime.g]
+// 0x3f4: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call aa 02 00 00 // ProcessType[*runtime._panic]
+	Call b4 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a4 02 00 00 // ProcessType[*runtime._defer]
+	Call ae 02 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.m]
+	Call cc 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 72 03 00 00 // ProcessType[[]uint8]
+	Call 7c 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 62 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ce 02 00 00 // ProcessType[*runtime.sudog]
+	Call d8 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7c 03 00 00 // ProcessType[[]uintptr]
+	Call 86 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call d4 02 00 00 // ProcessType[*runtime.timer]
+	Call de 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.coro]
+	Call c0 02 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x445: ProcessType[runtime.m]
-	Call bc 02 00 00 // ProcessType[*runtime.g]
+// 0x44f: ProcessType[runtime.m]
+	Call c6 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call bc 02 00 00 // ProcessType[*runtime.g]
+	Call c6 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call bc 02 00 00 // ProcessType[*runtime.g]
+	Call c6 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ba 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.m]
+	Call cc 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call a5 04 00 00 // ProcessType[runtime.mLockProfile]
+	Call af 04 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 7c 03 00 00 // ProcessType[[]uintptr]
+	Call 86 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.m]
+	Call cc 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call b0 04 00 00 // ProcessType[runtime.mTraceState]
+	Call ba 04 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x4a5: ProcessType[runtime.mLockProfile]
+// 0x4af: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7c 03 00 00 // ProcessType[[]uintptr]
+	Call 86 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x4b0: ProcessType[runtime.mTraceState]
+// 0x4ba: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0a 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call c2 02 00 00 // ProcessType[*runtime.m]
+	Call 14 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call cc 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x4c0: ProcessType[string]
+// 0x4ca: ProcessType[string]
 	ProcessString 76 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -379,12 +382,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 616
-ID: 6 Len: 8 Enqueue: 766
+ID: 5 Len: 8 Enqueue: 626
+ID: 6 Len: 8 Enqueue: 776
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 772
+ID: 8 Len: 8 Enqueue: 782
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1216
+ID: 10 Len: 16 Enqueue: 1226
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -392,18 +395,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 960
+ID: 18 Len: 16 Enqueue: 970
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 658
-ID: 21 Len: 8 Enqueue: 754
-ID: 22 Len: 432 Enqueue: 1002
+ID: 20 Len: 8 Enqueue: 668
+ID: 21 Len: 8 Enqueue: 764
+ID: 22 Len: 432 Enqueue: 1012
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 682
+ID: 24 Len: 8 Enqueue: 692
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 676
+ID: 26 Len: 8 Enqueue: 686
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 706
-ID: 29 Len: 1760 Enqueue: 1093
+ID: 28 Len: 8 Enqueue: 716
+ID: 29 Len: 1760 Enqueue: 1103
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -412,41 +415,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 882
-ID: 39 Len: 8 Enqueue: 610
+ID: 38 Len: 24 Enqueue: 892
+ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 718
+ID: 41 Len: 8 Enqueue: 728
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 892
-ID: 44 Len: 8 Enqueue: 724
+ID: 43 Len: 24 Enqueue: 902
+ID: 44 Len: 8 Enqueue: 734
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 694
+ID: 47 Len: 8 Enqueue: 704
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 700
+ID: 53 Len: 8 Enqueue: 710
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 688
+ID: 60 Len: 8 Enqueue: 698
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1189
+ID: 64 Len: 64 Enqueue: 1199
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1200
+ID: 69 Len: 32 Enqueue: 1210
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 778
-ID: 72 Len: 8 Enqueue: 730
+ID: 71 Len: 16 Enqueue: 788
+ID: 72 Len: 8 Enqueue: 740
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -462,36 +465,36 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 736
+ID: 88 Len: 8 Enqueue: 746
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 646
-ID: 92 Len: 8 Enqueue: 664
-ID: 93 Len: 8 Enqueue: 652
-ID: 94 Len: 8 Enqueue: 760
-ID: 95 Len: 8 Enqueue: 634
-ID: 96 Len: 8 Enqueue: 640
-ID: 97 Len: 8 Enqueue: 742
-ID: 98 Len: 8 Enqueue: 748
-ID: 99 Len: 24 Enqueue: 834
+ID: 91 Len: 8 Enqueue: 656
+ID: 92 Len: 8 Enqueue: 674
+ID: 93 Len: 8 Enqueue: 662
+ID: 94 Len: 8 Enqueue: 770
+ID: 95 Len: 8 Enqueue: 644
+ID: 96 Len: 8 Enqueue: 650
+ID: 97 Len: 8 Enqueue: 752
+ID: 98 Len: 8 Enqueue: 758
+ID: 99 Len: 24 Enqueue: 844
 ID: 100 Len: 24 Enqueue: 0
-ID: 101 Len: 24 Enqueue: 860
-ID: 102 Len: 48 Enqueue: 794
-ID: 103 Len: 8 Enqueue: 990
+ID: 101 Len: 24 Enqueue: 870
+ID: 102 Len: 48 Enqueue: 804
+ID: 103 Len: 8 Enqueue: 1000
 ID: 104 Len: 8 Enqueue: 0
-ID: 105 Len: 48 Enqueue: 962
-ID: 106 Len: 8 Enqueue: 622
-ID: 107 Len: 208 Enqueue: 918
-ID: 108 Len: 8 Enqueue: 712
+ID: 105 Len: 48 Enqueue: 972
+ID: 106 Len: 8 Enqueue: 632
+ID: 107 Len: 208 Enqueue: 928
+ID: 108 Len: 8 Enqueue: 722
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 8 Enqueue: 996
+ID: 110 Len: 8 Enqueue: 1006
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 976
-ID: 113 Len: 8 Enqueue: 628
-ID: 114 Len: 208 Enqueue: 939
-ID: 115 Len: 8 Enqueue: 586
-ID: 116 Len: 8 Enqueue: 592
-ID: 117 Len: 8 Enqueue: 604
+ID: 112 Len: 48 Enqueue: 986
+ID: 113 Len: 8 Enqueue: 638
+ID: 114 Len: 208 Enqueue: 949
+ID: 115 Len: 8 Enqueue: 596
+ID: 116 Len: 8 Enqueue: 602
+ID: 117 Len: 8 Enqueue: 614
 ID: 118 Len: 1 Enqueue: 0
 ID: 119 Len: 8 Enqueue: 0
 ID: 120 Len: 1 Enqueue: 0
@@ -500,17 +503,17 @@ ID: 122 Len: 8 Enqueue: 0
 ID: 123 Len: 8 Enqueue: 0
 ID: 124 Len: 8 Enqueue: 0
 ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 16 Enqueue: 870
+ID: 126 Len: 16 Enqueue: 880
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 128 Enqueue: 844
+ID: 129 Len: 128 Enqueue: 854
 ID: 130 Len: 64 Enqueue: 0
-ID: 131 Len: 208 Enqueue: 810
-ID: 132 Len: 64 Enqueue: 902
-ID: 133 Len: 8 Enqueue: 670
+ID: 131 Len: 208 Enqueue: 820
+ID: 132 Len: 64 Enqueue: 912
+ID: 133 Len: 8 Enqueue: 680
 ID: 134 Len: 184 Enqueue: 0
-ID: 135 Len: 208 Enqueue: 822
-ID: 136 Len: 8 Enqueue: 598
+ID: 135 Len: 208 Enqueue: 832
+ID: 136 Len: 8 Enqueue: 608
 ID: 137 Len: 128 Enqueue: 0
 ID: 138 Len: 9 Enqueue: 0
 ID: 139 Len: 17 Enqueue: 0
@@ -522,6 +525,7 @@ ID: 144 Len: 49 Enqueue: 0
 ID: 145 Len: 9 Enqueue: 0
 ID: 146 Len: 9 Enqueue: 0
 ID: 147 Len: 0 Enqueue: 0
-ID: 148 Len: 9 Enqueue: 0
+ID: 148 Len: 0 Enqueue: 0
 ID: 149 Len: 9 Enqueue: 0
 ID: 150 Len: 9 Enqueue: 0
+ID: 151 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,27 +7,27 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4a 02 00 00 // ProcessType[*****int]
+	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8006]
-	PrepareEventRoot a2 00 00 00 09 00 00 00 
+	PrepareEventRoot a3 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5c 02 00 00 // ProcessType[**int]
+	Call 66 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8050]
-	PrepareEventRoot a3 00 00 00 09 00 00 00 
+	PrepareEventRoot a4 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a8513.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d6 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call e0 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a8513]
 	PrepareEventRoot 9f 00 00 00 09 00 00 00 
@@ -39,7 +39,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x97: ProcessEvent[Probe[main.inlined]@4a83ea]
-	PrepareEventRoot a1 00 00 00 09 00 00 00 
+	PrepareEventRoot a2 00 00 00 09 00 00 00 
 	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a83ea.expr[0]]
 	Return 
 // 0xa6: ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xb6: ProcessEvent[Probe[main.inlined]@4a7dce]
-	PrepareEventRoot a1 00 00 00 09 00 00 00 
+	PrepareEventRoot a2 00 00 00 09 00 00 00 
 	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
 	Return 
 // 0xc5: ProcessExpression[Probe[main.intArg]@0x4a80ca.expr[0]]
@@ -73,7 +73,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2a 03 00 00 // ProcessType[[3]string]
+	Call 34 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a83c0]
 	PrepareEventRoot 9d 00 00 00 31 00 00 00 
@@ -85,7 +85,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 52 03 00 00 // ProcessType[[]int]
+	Call 5c 03 00 00 // ProcessType[[]int]
 	Return 
 // 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a81ca]
 	PrepareEventRoot 99 00 00 00 19 00 00 00 
@@ -95,7 +95,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d0 03 00 00 // ProcessType[map[string]int]
+	Call da 03 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x198: ProcessEvent[Probe[main.mapArg]@4a84aa]
 	PrepareEventRoot 9e 00 00 00 09 00 00 00 
@@ -109,7 +109,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 08 05 00 00 // ProcessType[string]
+	Call 12 05 00 00 // ProcessType[string]
 	Return 
 // 0x1d3: ProcessEvent[Probe[main.stringArg]@4a814a]
 	PrepareEventRoot 98 00 00 00 11 00 00 00 
@@ -119,7 +119,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2a 03 00 00 // ProcessType[[3]string]
+	Call 34 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x203: ProcessEvent[Probe[main.stringArrayArg]@4a834a]
 	PrepareEventRoot 9c 00 00 00 31 00 00 00 
@@ -131,269 +131,272 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 74 03 00 00 // ProcessType[[]string]
+	Call 7e 03 00 00 // ProcessType[[]string]
 	Return 
 // 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4a82ca]
 	PrepareEventRoot 9b 00 00 00 19 00 00 00 
 	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a82ca.expr[0]]
 	Return 
-// 0x24a: ProcessType[*****int]
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8636]
+	PrepareEventRoot a1 00 00 00 00 00 00 00 
+	Return 
+// 0x254: ProcessType[*****int]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x250: ProcessType[****int]
+// 0x25a: ProcessType[****int]
 	ProcessPointer 95 00 00 00 
 	Return 
-// 0x256: ProcessType[***int]
+// 0x260: ProcessType[***int]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x25c: ProcessType[**int]
+// 0x266: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x262: ProcessType[*[]runtime.ancestorInfo]
+// 0x26c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x268: ProcessType[*bool]
+// 0x272: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x26e: ProcessType[*error]
+// 0x278: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x274: ProcessType[*float32]
+// 0x27e: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x27a: ProcessType[*float64]
+// 0x284: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x280: ProcessType[*int]
+// 0x28a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x286: ProcessType[*int32]
+// 0x290: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x28c: ProcessType[*int64]
+// 0x296: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x292: ProcessType[*main.bigStruct]
+// 0x29c: ProcessType[*main.bigStruct]
 	ProcessPointer 92 00 00 00 
 	Return 
-// 0x298: ProcessType[*runtime._defer]
+// 0x2a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x29e: ProcessType[*runtime._panic]
+// 0x2a8: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x2a4: ProcessType[*runtime.cgoCallers]
+// 0x2ae: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x2aa: ProcessType[*runtime.coro]
+// 0x2b4: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2b0: ProcessType[*runtime.g]
+// 0x2ba: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x2b6: ProcessType[*runtime.m]
+// 0x2c0: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2bc: ProcessType[*runtime.sudog]
+// 0x2c6: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2c2: ProcessType[*runtime.synctestGroup]
+// 0x2cc: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x2c8: ProcessType[*runtime.timer]
+// 0x2d2: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x2ce: ProcessType[*runtime.traceBuf]
+// 0x2d8: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x2d4: ProcessType[*string]
+// 0x2de: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x2da: ProcessType[*table<string,int>]
+// 0x2e4: ProcessType[*table<string,int>]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x2e0: ProcessType[*table<string,main.bigStruct>]
+// 0x2ea: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x2e6: ProcessType[*uint]
+// 0x2f0: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x2ec: ProcessType[*uint16]
+// 0x2f6: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2f2: ProcessType[*uint32]
+// 0x2fc: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2f8: ProcessType[*uint64]
+// 0x302: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x2fe: ProcessType[*uint8]
+// 0x308: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x304: ProcessType[*uintptr]
+// 0x30e: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x30a: ProcessType[[2]*runtime.traceBuf]
+// 0x314: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call ce 02 00 00 // ProcessType[*runtime.traceBuf]
+	Call d8 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x31a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x324: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 0a 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 14 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x32a: ProcessType[[3]string]
+// 0x334: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 08 05 00 00 // ProcessType[string]
+	Call 12 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x33a: ProcessType[[]*table<string,int>.array]
+// 0x344: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call da 02 00 00 // ProcessType[*table<string,int>]
+	Call e4 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x346: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x350: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call e0 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call ea 02 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x352: ProcessType[[]int]
+// 0x35c: ProcessType[[]int]
 	ProcessSlice 7f 00 00 00 08 00 00 00 
 	Return 
-// 0x35c: ProcessType[[]noalg.map.group[string]int.array]
+// 0x366: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call fc 03 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 06 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x368: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x372: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 07 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 11 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x374: ProcessType[[]string]
+// 0x37e: ProcessType[[]string]
 	ProcessSlice 81 00 00 00 10 00 00 00 
 	Return 
-// 0x37e: ProcessType[[]string.array]
+// 0x388: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 08 05 00 00 // ProcessType[string]
+	Call 12 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x38a: ProcessType[[]uint8]
+// 0x394: ProcessType[[]uint8]
 	ProcessSlice 7b 00 00 00 01 00 00 00 
 	Return 
-// 0x394: ProcessType[[]uintptr]
+// 0x39e: ProcessType[[]uintptr]
 	ProcessSlice 7d 00 00 00 08 00 00 00 
 	Return 
-// 0x39e: ProcessType[error]
+// 0x3a8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3a0: ProcessType[groupReference<string,int>]
+// 0x3aa: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 8a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3ac: ProcessType[groupReference<string,main.bigStruct>]
+// 0x3b6: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 94 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3b8: ProcessType[map<string,int>]
+// 0x3c2: ProcessType[map<string,int>]
 	ProcessGoSwissMap 89 00 00 00 86 00 00 00 10 18 
 	Return 
-// 0x3c4: ProcessType[map<string,main.bigStruct>]
+// 0x3ce: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 93 00 00 00 8e 00 00 00 10 18 
 	Return 
-// 0x3d0: ProcessType[map[string]int]
+// 0x3da: ProcessType[map[string]int]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x3d6: ProcessType[map[string]main.bigStruct]
+// 0x3e0: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x3dc: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x3e6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 12 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 1c 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ec: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x3f6: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 22 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 2c 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x3fc: ProcessType[noalg.map.group[string]int]
+// 0x406: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call ec 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call f6 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x407: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x411: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call dc 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call e6 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x412: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 08 05 00 00 // ProcessType[string]
+// 0x41c: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 12 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 92 02 00 00 // ProcessType[*main.bigStruct]
+	Call 9c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x422: ProcessType[noalg.struct { key string; elem int }]
-	Call 08 05 00 00 // ProcessType[string]
+// 0x42c: ProcessType[noalg.struct { key string; elem int }]
+	Call 12 05 00 00 // ProcessType[string]
 	Return 
-// 0x428: ProcessType[runtime.g]
+// 0x432: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 9e 02 00 00 // ProcessType[*runtime._panic]
+	Call a8 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 98 02 00 00 // ProcessType[*runtime._defer]
+	Call a2 02 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 8a 03 00 00 // ProcessType[[]uint8]
+	Call 94 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 62 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call bc 02 00 00 // ProcessType[*runtime.sudog]
+	Call c6 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 94 03 00 00 // ProcessType[[]uintptr]
+	Call 9e 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call c8 02 00 00 // ProcessType[*runtime.timer]
+	Call d2 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call aa 02 00 00 // ProcessType[*runtime.coro]
+	Call b4 02 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.synctestGroup]
+	Call cc 02 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x48d: ProcessType[runtime.m]
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+// 0x497: ProcessType[runtime.m]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 08 05 00 00 // ProcessType[string]
+	Call 12 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call a4 02 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ae 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ed 04 00 00 // ProcessType[runtime.mLockProfile]
+	Call f7 04 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 94 03 00 00 // ProcessType[[]uintptr]
+	Call 9e 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call f8 04 00 00 // ProcessType[runtime.mTraceState]
+	Call 02 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x4ed: ProcessType[runtime.mLockProfile]
+// 0x4f7: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 94 03 00 00 // ProcessType[[]uintptr]
+	Call 9e 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x4f8: ProcessType[runtime.mTraceState]
+// 0x502: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call 24 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x508: ProcessType[string]
+// 0x512: ProcessType[string]
 	ProcessString 79 00 00 00 
 	Return 
-// 0x50e: ProcessType[table<string,int>]
+// 0x518: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a0 03 00 00 // ProcessType[groupReference<string,int>]
+	Call aa 03 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x519: ProcessType[table<string,main.bigStruct>]
+// 0x523: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ac 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call b6 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -414,31 +417,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 766
+ID: 5 Len: 8 Enqueue: 776
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1288
+ID: 9 Len: 16 Enqueue: 1298
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 616
+ID: 11 Len: 8 Enqueue: 626
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 926
+ID: 13 Len: 16 Enqueue: 936
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 772
-ID: 20 Len: 8 Enqueue: 646
-ID: 21 Len: 8 Enqueue: 754
-ID: 22 Len: 440 Enqueue: 1064
+ID: 19 Len: 8 Enqueue: 782
+ID: 20 Len: 8 Enqueue: 656
+ID: 21 Len: 8 Enqueue: 764
+ID: 22 Len: 440 Enqueue: 1074
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 670
+ID: 24 Len: 8 Enqueue: 680
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 664
+ID: 26 Len: 8 Enqueue: 674
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 694
-ID: 29 Len: 1808 Enqueue: 1165
+ID: 28 Len: 8 Enqueue: 704
+ID: 29 Len: 1808 Enqueue: 1175
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -447,45 +450,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 906
-ID: 39 Len: 8 Enqueue: 610
+ID: 38 Len: 24 Enqueue: 916
+ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 700
+ID: 41 Len: 8 Enqueue: 710
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 916
-ID: 44 Len: 8 Enqueue: 712
+ID: 43 Len: 24 Enqueue: 926
+ID: 44 Len: 8 Enqueue: 722
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 682
+ID: 47 Len: 8 Enqueue: 692
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 706
+ID: 49 Len: 8 Enqueue: 716
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 688
+ID: 55 Len: 8 Enqueue: 698
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 676
+ID: 62 Len: 8 Enqueue: 686
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1261
+ID: 67 Len: 64 Enqueue: 1271
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1272
+ID: 72 Len: 56 Enqueue: 1282
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 794
-ID: 75 Len: 16 Enqueue: 778
-ID: 76 Len: 8 Enqueue: 718
+ID: 74 Len: 32 Enqueue: 804
+ID: 75 Len: 16 Enqueue: 788
+ID: 76 Len: 8 Enqueue: 728
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -502,34 +505,34 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 724
+ID: 93 Len: 8 Enqueue: 734
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 634
-ID: 97 Len: 8 Enqueue: 652
-ID: 98 Len: 8 Enqueue: 640
-ID: 99 Len: 8 Enqueue: 760
-ID: 100 Len: 8 Enqueue: 622
-ID: 101 Len: 8 Enqueue: 628
-ID: 102 Len: 8 Enqueue: 742
-ID: 103 Len: 8 Enqueue: 748
-ID: 104 Len: 24 Enqueue: 850
+ID: 96 Len: 8 Enqueue: 644
+ID: 97 Len: 8 Enqueue: 662
+ID: 98 Len: 8 Enqueue: 650
+ID: 99 Len: 8 Enqueue: 770
+ID: 100 Len: 8 Enqueue: 632
+ID: 101 Len: 8 Enqueue: 638
+ID: 102 Len: 8 Enqueue: 752
+ID: 103 Len: 8 Enqueue: 758
+ID: 104 Len: 24 Enqueue: 860
 ID: 105 Len: 24 Enqueue: 0
-ID: 106 Len: 24 Enqueue: 884
-ID: 107 Len: 48 Enqueue: 810
-ID: 108 Len: 8 Enqueue: 976
+ID: 106 Len: 24 Enqueue: 894
+ID: 107 Len: 48 Enqueue: 820
+ID: 108 Len: 8 Enqueue: 986
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 48 Enqueue: 952
+ID: 110 Len: 48 Enqueue: 962
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 8 Enqueue: 730
-ID: 113 Len: 8 Enqueue: 982
+ID: 112 Len: 8 Enqueue: 740
+ID: 113 Len: 8 Enqueue: 992
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 48 Enqueue: 964
+ID: 115 Len: 48 Enqueue: 974
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 8 Enqueue: 736
-ID: 118 Len: 8 Enqueue: 586
-ID: 119 Len: 8 Enqueue: 592
-ID: 120 Len: 8 Enqueue: 604
+ID: 117 Len: 8 Enqueue: 746
+ID: 118 Len: 8 Enqueue: 596
+ID: 119 Len: 8 Enqueue: 602
+ID: 120 Len: 8 Enqueue: 614
 ID: 121 Len: 1 Enqueue: 0
 ID: 122 Len: 8 Enqueue: 0
 ID: 123 Len: 1 Enqueue: 0
@@ -538,27 +541,27 @@ ID: 125 Len: 8 Enqueue: 0
 ID: 126 Len: 8 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 16 Enqueue: 894
+ID: 129 Len: 16 Enqueue: 904
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 32 Enqueue: 1294
-ID: 132 Len: 16 Enqueue: 928
+ID: 131 Len: 32 Enqueue: 1304
+ID: 132 Len: 16 Enqueue: 938
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 200 Enqueue: 1020
-ID: 135 Len: 192 Enqueue: 1004
-ID: 136 Len: 24 Enqueue: 1058
-ID: 137 Len: 8 Enqueue: 826
-ID: 138 Len: 200 Enqueue: 860
-ID: 139 Len: 32 Enqueue: 1305
-ID: 140 Len: 16 Enqueue: 940
+ID: 134 Len: 200 Enqueue: 1030
+ID: 135 Len: 192 Enqueue: 1014
+ID: 136 Len: 24 Enqueue: 1068
+ID: 137 Len: 8 Enqueue: 836
+ID: 138 Len: 200 Enqueue: 870
+ID: 139 Len: 32 Enqueue: 1315
+ID: 140 Len: 16 Enqueue: 950
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 200 Enqueue: 1031
-ID: 143 Len: 192 Enqueue: 988
-ID: 144 Len: 24 Enqueue: 1042
-ID: 145 Len: 8 Enqueue: 658
+ID: 142 Len: 200 Enqueue: 1041
+ID: 143 Len: 192 Enqueue: 998
+ID: 144 Len: 24 Enqueue: 1052
+ID: 145 Len: 8 Enqueue: 668
 ID: 146 Len: 184 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 838
-ID: 148 Len: 200 Enqueue: 872
-ID: 149 Len: 8 Enqueue: 598
+ID: 147 Len: 8 Enqueue: 848
+ID: 148 Len: 200 Enqueue: 882
+ID: 149 Len: 8 Enqueue: 608
 ID: 150 Len: 128 Enqueue: 0
 ID: 151 Len: 9 Enqueue: 0
 ID: 152 Len: 17 Enqueue: 0
@@ -570,6 +573,7 @@ ID: 157 Len: 49 Enqueue: 0
 ID: 158 Len: 9 Enqueue: 0
 ID: 159 Len: 9 Enqueue: 0
 ID: 160 Len: 0 Enqueue: 0
-ID: 161 Len: 9 Enqueue: 0
+ID: 161 Len: 0 Enqueue: 0
 ID: 162 Len: 9 Enqueue: 0
 ID: 163 Len: 9 Enqueue: 0
+ID: 164 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -3,151 +3,151 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a8046.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8006]
-	PrepareEventRoot a3 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8046]
+	PrepareEventRoot be 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8046.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8090.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 66 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8050]
-	PrepareEventRoot a4 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8090]
+	PrepareEventRoot bf 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8090.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a8513.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e0 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 46 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a8513]
-	PrepareEventRoot 9f 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a8513.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a8553]
+	PrepareEventRoot ba 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0x4a83ea.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@4a83ea]
-	PrepareEventRoot a2 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a83ea.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@4a7dce]
-	PrepareEventRoot a2 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a80ca.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@4a80ca]
-	PrepareEventRoot 97 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a80ca.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@4a842a]
+	PrepareEventRoot bd 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a824a.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@4a7e0e]
+	PrepareEventRoot bd 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a810a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@4a810a]
+	PrepareEventRoot b2 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a810a.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a828a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a824a]
-	PrepareEventRoot 9a 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a824a.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a828a]
+	PrepareEventRoot b5 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a828a.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83c0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 34 03 00 00 // ProcessType[[3]string]
+	Call 40 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a83c0]
-	PrepareEventRoot 9d 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83c0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8400]
+	PrepareEventRoot b8 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a81ca.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 5c 03 00 00 // ProcessType[[]int]
+	Call 80 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a81ca]
-	PrepareEventRoot 99 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a81ca.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a820a]
+	PrepareEventRoot b4 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a84aa.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call da 03 00 00 // ProcessType[map[string]int]
+	Call 40 04 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@4a84aa]
-	PrepareEventRoot 9e 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84aa.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4a84ea]
+	PrepareEventRoot b9 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	Return 
-// 0x1a7: ProcessEvent[Probe[main.noArgs]@4a85ca]
-	PrepareEventRoot a0 00 00 00 00 00 00 00 
+// 0x1a7: ProcessEvent[Probe[main.noArgs]@4a860a]
+	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x1b1: ProcessExpression[Probe[main.stringArg]@0x4a814a.expr[0]]
+// 0x1b1: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 12 05 00 00 // ProcessType[string]
+	Call a4 05 00 00 // ProcessType[string]
 	Return 
-// 0x1d3: ProcessEvent[Probe[main.stringArg]@4a814a]
-	PrepareEventRoot 98 00 00 00 11 00 00 00 
-	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a814a.expr[0]]
+// 0x1d3: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot b3 00 00 00 11 00 00 00 
+	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	Return 
-// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0x4a834a.expr[0]]
+// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 34 03 00 00 // ProcessType[[3]string]
+	Call 40 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x203: ProcessEvent[Probe[main.stringArrayArg]@4a834a]
-	PrepareEventRoot 9c 00 00 00 31 00 00 00 
-	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a834a.expr[0]]
+// 0x203: ProcessEvent[Probe[main.stringArrayArg]@4a838a]
+	PrepareEventRoot b7 00 00 00 31 00 00 00 
+	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
 	Return 
-// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0x4a82ca.expr[0]]
+// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 7e 03 00 00 // ProcessType[[]string]
+	Call ae 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4a82ca]
-	PrepareEventRoot 9b 00 00 00 19 00 00 00 
-	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a82ca.expr[0]]
+// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4a830a]
+	PrepareEventRoot b6 00 00 00 19 00 00 00 
+	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	Return 
-// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8636]
-	PrepareEventRoot a1 00 00 00 00 00 00 00 
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
 // 0x254: ProcessType[*****int]
-	ProcessPointer 77 00 00 00 
+	ProcessPointer 7c 00 00 00 
 	Return 
 // 0x25a: ProcessType[****int]
-	ProcessPointer 95 00 00 00 
+	ProcessPointer b0 00 00 00 
 	Return 
 // 0x260: ProcessType[***int]
-	ProcessPointer 78 00 00 00 
+	ProcessPointer 7d 00 00 00 
 	Return 
 // 0x266: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
@@ -177,7 +177,7 @@
 	ProcessPointer 0c 00 00 00 
 	Return 
 // 0x29c: ProcessType[*main.bigStruct]
-	ProcessPointer 92 00 00 00 
+	ProcessPointer 97 00 00 00 
 	Return 
 // 0x2a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
@@ -212,130 +212,182 @@
 // 0x2de: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x2e4: ProcessType[*table<string,int>]
-	ProcessPointer 83 00 00 00 
+// 0x2e4: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer a7 00 00 00 
 	Return 
-// 0x2ea: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 8b 00 00 00 
+// 0x2ea: ProcessType[*table<string,int>]
+	ProcessPointer 88 00 00 00 
 	Return 
-// 0x2f0: ProcessType[*uint]
+// 0x2f0: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 90 00 00 00 
+	Return 
+// 0x2f6: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 9a 00 00 00 
+	Return 
+// 0x2fc: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x2f6: ProcessType[*uint16]
+// 0x302: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2fc: ProcessType[*uint32]
+// 0x308: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x302: ProcessType[*uint64]
+// 0x30e: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x308: ProcessType[*uint8]
+// 0x314: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x30e: ProcessType[*uintptr]
+// 0x31a: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x314: ProcessType[[2]*runtime.traceBuf]
+// 0x320: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
 	Call d8 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x324: ProcessType[[2][2]*runtime.traceBuf]
+// 0x330: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 14 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 20 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x334: ProcessType[[3]string]
+// 0x340: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 12 05 00 00 // ProcessType[string]
+	Call a4 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x344: ProcessType[[]*table<string,int>.array]
+// 0x350: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e4 02 00 00 // ProcessType[*table<string,int>]
+	Call e4 02 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x350: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x35c: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call ea 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call ea 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x35c: ProcessType[[]int]
-	ProcessSlice 7f 00 00 00 08 00 00 00 
-	Return 
-// 0x366: ProcessType[[]noalg.map.group[string]int.array]
+// 0x368: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 06 04 00 00 // ProcessType[noalg.map.group[string]int]
+	Call f0 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x374: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call f6 02 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x380: ProcessType[[]int]
+	ProcessSlice 84 00 00 00 08 00 00 00 
+	Return 
+// 0x38a: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 82 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x372: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x396: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 11 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 8d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x37e: ProcessType[[]string]
-	ProcessSlice 81 00 00 00 10 00 00 00 
-	Return 
-// 0x388: ProcessType[[]string.array]
+// 0x3a2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 12 05 00 00 // ProcessType[string]
+	Call 98 04 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x3ae: ProcessType[[]string]
+	ProcessSlice 86 00 00 00 10 00 00 00 
+	Return 
+// 0x3b8: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call a4 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x394: ProcessType[[]uint8]
-	ProcessSlice 7b 00 00 00 01 00 00 00 
+// 0x3c4: ProcessType[[]uint8]
+	ProcessSlice 80 00 00 00 01 00 00 00 
 	Return 
-// 0x39e: ProcessType[[]uintptr]
-	ProcessSlice 7d 00 00 00 08 00 00 00 
+// 0x3ce: ProcessType[[]uintptr]
+	ProcessSlice 82 00 00 00 08 00 00 00 
 	Return 
-// 0x3a8: ProcessType[error]
+// 0x3d8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3aa: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 8a 00 00 00 c8 00 00 00 00 08 
+// 0x3da: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x3b6: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 94 00 00 00 c8 00 00 00 00 08 
+// 0x3e6: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 8f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3c2: ProcessType[map<string,int>]
-	ProcessGoSwissMap 89 00 00 00 86 00 00 00 10 18 
+// 0x3f2: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3ce: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 93 00 00 00 8e 00 00 00 10 18 
+// 0x3fe: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups a6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x3da: ProcessType[map[string]int]
+// 0x40a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap ae 00 00 00 aa 00 00 00 10 18 
+	Return 
+// 0x416: ProcessType[map<string,int>]
+	ProcessGoSwissMap 8e 00 00 00 8b 00 00 00 10 18 
+	Return 
+// 0x422: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 98 00 00 00 93 00 00 00 10 18 
+	Return 
+// 0x42e: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap a5 00 00 00 9d 00 00 00 10 18 
+	Return 
+// 0x43a: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer a2 00 00 00 
+	Return 
+// 0x440: ProcessType[map[string]int]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x3e0: ProcessType[map[string]main.bigStruct]
+// 0x446: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x3e6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x44c: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 78 00 00 00 
+	Return 
+// 0x452: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 1c 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a3 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f6: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x462: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 2c 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call b3 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x406: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call f6 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x472: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call b9 04 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x411: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x482: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call e6 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 62 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x41c: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 12 05 00 00 // ProcessType[string]
+// 0x48d: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call 52 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x498: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	IncrementOutputOffset 08 00 00 00 
+	Call 72 04 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Return 
+// 0x4a3: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a4 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
 	Call 9c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x42c: ProcessType[noalg.struct { key string; elem int }]
-	Call 12 05 00 00 // ProcessType[string]
+// 0x4b3: ProcessType[noalg.struct { key string; elem int }]
+	Call a4 05 00 00 // ProcessType[string]
 	Return 
-// 0x432: ProcessType[runtime.g]
+// 0x4b9: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	IncrementOutputOffset 08 00 00 00 
+	Call 3a 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x4c4: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
 	Call a8 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
@@ -343,13 +395,13 @@
 	IncrementOutputOffset 08 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 94 03 00 00 // ProcessType[[]uint8]
+	Call c4 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
 	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
 	Call c6 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9e 03 00 00 // ProcessType[[]uintptr]
+	Call ce 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
 	Call d2 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
@@ -357,46 +409,54 @@
 	IncrementOutputOffset 08 00 00 00 
 	Call cc 02 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x497: ProcessType[runtime.m]
+// 0x529: ProcessType[runtime.m]
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 12 05 00 00 // ProcessType[string]
+	Call a4 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
 	Call ae 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call f7 04 00 00 // ProcessType[runtime.mLockProfile]
+	Call 89 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 9e 03 00 00 // ProcessType[[]uintptr]
+	Call ce 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 05 00 00 // ProcessType[runtime.mTraceState]
+	Call 94 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x4f7: ProcessType[runtime.mLockProfile]
+// 0x589: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9e 03 00 00 // ProcessType[[]uintptr]
+	Call ce 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x502: ProcessType[runtime.mTraceState]
+// 0x594: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 24 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 30 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x512: ProcessType[string]
-	ProcessString 79 00 00 00 
+// 0x5a4: ProcessType[string]
+	ProcessString 7e 00 00 00 
 	Return 
-// 0x518: ProcessType[table<string,int>]
+// 0x5aa: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call aa 03 00 00 // ProcessType[groupReference<string,int>]
+	Call da 03 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x523: ProcessType[table<string,main.bigStruct>]
+// 0x5b5: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call b6 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call e6 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x5c0: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call f2 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x5cb: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call fe 03 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -417,31 +477,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 776
+ID: 5 Len: 8 Enqueue: 788
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1298
+ID: 9 Len: 16 Enqueue: 1444
 ID: 10 Len: 4 Enqueue: 0
 ID: 11 Len: 8 Enqueue: 626
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 936
+ID: 13 Len: 16 Enqueue: 984
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 782
+ID: 19 Len: 8 Enqueue: 794
 ID: 20 Len: 8 Enqueue: 656
-ID: 21 Len: 8 Enqueue: 764
-ID: 22 Len: 440 Enqueue: 1074
+ID: 21 Len: 8 Enqueue: 776
+ID: 22 Len: 440 Enqueue: 1220
 ID: 23 Len: 16 Enqueue: 0
 ID: 24 Len: 8 Enqueue: 680
 ID: 25 Len: 8 Enqueue: 0
 ID: 26 Len: 8 Enqueue: 674
 ID: 27 Len: 8 Enqueue: 0
 ID: 28 Len: 8 Enqueue: 704
-ID: 29 Len: 1808 Enqueue: 1175
+ID: 29 Len: 1808 Enqueue: 1321
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -450,12 +510,12 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 916
+ID: 38 Len: 24 Enqueue: 964
 ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
 ID: 41 Len: 8 Enqueue: 710
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 926
+ID: 43 Len: 24 Enqueue: 974
 ID: 44 Len: 8 Enqueue: 722
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
@@ -479,15 +539,15 @@ ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1271
+ID: 67 Len: 64 Enqueue: 1417
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1282
+ID: 72 Len: 56 Enqueue: 1428
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 804
-ID: 75 Len: 16 Enqueue: 788
+ID: 74 Len: 32 Enqueue: 816
+ID: 75 Len: 16 Enqueue: 800
 ID: 76 Len: 8 Enqueue: 728
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
@@ -511,69 +571,96 @@ ID: 95 Len: 16 Enqueue: 0
 ID: 96 Len: 8 Enqueue: 644
 ID: 97 Len: 8 Enqueue: 662
 ID: 98 Len: 8 Enqueue: 650
-ID: 99 Len: 8 Enqueue: 770
+ID: 99 Len: 8 Enqueue: 782
 ID: 100 Len: 8 Enqueue: 632
 ID: 101 Len: 8 Enqueue: 638
-ID: 102 Len: 8 Enqueue: 752
-ID: 103 Len: 8 Enqueue: 758
-ID: 104 Len: 24 Enqueue: 860
+ID: 102 Len: 8 Enqueue: 764
+ID: 103 Len: 8 Enqueue: 770
+ID: 104 Len: 24 Enqueue: 896
 ID: 105 Len: 24 Enqueue: 0
-ID: 106 Len: 24 Enqueue: 894
-ID: 107 Len: 48 Enqueue: 820
-ID: 108 Len: 8 Enqueue: 986
+ID: 106 Len: 24 Enqueue: 942
+ID: 107 Len: 48 Enqueue: 832
+ID: 108 Len: 8 Enqueue: 1088
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 48 Enqueue: 962
+ID: 110 Len: 48 Enqueue: 1046
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 8 Enqueue: 740
-ID: 113 Len: 8 Enqueue: 992
+ID: 112 Len: 8 Enqueue: 746
+ID: 113 Len: 8 Enqueue: 1094
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 48 Enqueue: 974
+ID: 115 Len: 48 Enqueue: 1058
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 8 Enqueue: 746
-ID: 118 Len: 8 Enqueue: 596
-ID: 119 Len: 8 Enqueue: 602
-ID: 120 Len: 8 Enqueue: 614
-ID: 121 Len: 1 Enqueue: 0
-ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 1 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 0
+ID: 117 Len: 8 Enqueue: 752
+ID: 118 Len: 8 Enqueue: 1100
+ID: 119 Len: 8 Enqueue: 0
+ID: 120 Len: 48 Enqueue: 1070
+ID: 121 Len: 8 Enqueue: 0
+ID: 122 Len: 8 Enqueue: 758
+ID: 123 Len: 8 Enqueue: 596
+ID: 124 Len: 8 Enqueue: 602
+ID: 125 Len: 8 Enqueue: 614
+ID: 126 Len: 1 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 16 Enqueue: 904
+ID: 128 Len: 1 Enqueue: 0
+ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 32 Enqueue: 1304
-ID: 132 Len: 16 Enqueue: 938
+ID: 131 Len: 8 Enqueue: 0
+ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 200 Enqueue: 1030
-ID: 135 Len: 192 Enqueue: 1014
-ID: 136 Len: 24 Enqueue: 1068
-ID: 137 Len: 8 Enqueue: 836
-ID: 138 Len: 200 Enqueue: 870
-ID: 139 Len: 32 Enqueue: 1315
-ID: 140 Len: 16 Enqueue: 950
-ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 200 Enqueue: 1041
-ID: 143 Len: 192 Enqueue: 998
-ID: 144 Len: 24 Enqueue: 1052
-ID: 145 Len: 8 Enqueue: 668
-ID: 146 Len: 184 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 848
-ID: 148 Len: 200 Enqueue: 882
-ID: 149 Len: 8 Enqueue: 608
-ID: 150 Len: 128 Enqueue: 0
-ID: 151 Len: 9 Enqueue: 0
-ID: 152 Len: 17 Enqueue: 0
-ID: 153 Len: 25 Enqueue: 0
-ID: 154 Len: 25 Enqueue: 0
-ID: 155 Len: 25 Enqueue: 0
-ID: 156 Len: 49 Enqueue: 0
-ID: 157 Len: 49 Enqueue: 0
-ID: 158 Len: 9 Enqueue: 0
-ID: 159 Len: 9 Enqueue: 0
-ID: 160 Len: 0 Enqueue: 0
-ID: 161 Len: 0 Enqueue: 0
-ID: 162 Len: 9 Enqueue: 0
-ID: 163 Len: 9 Enqueue: 0
-ID: 164 Len: 9 Enqueue: 0
+ID: 134 Len: 16 Enqueue: 952
+ID: 135 Len: 8 Enqueue: 0
+ID: 136 Len: 32 Enqueue: 1461
+ID: 137 Len: 16 Enqueue: 998
+ID: 138 Len: 8 Enqueue: 0
+ID: 139 Len: 200 Enqueue: 1154
+ID: 140 Len: 192 Enqueue: 1122
+ID: 141 Len: 24 Enqueue: 1203
+ID: 142 Len: 8 Enqueue: 860
+ID: 143 Len: 200 Enqueue: 906
+ID: 144 Len: 32 Enqueue: 1472
+ID: 145 Len: 16 Enqueue: 1010
+ID: 146 Len: 8 Enqueue: 0
+ID: 147 Len: 200 Enqueue: 1165
+ID: 148 Len: 192 Enqueue: 1106
+ID: 149 Len: 24 Enqueue: 1187
+ID: 150 Len: 8 Enqueue: 668
+ID: 151 Len: 184 Enqueue: 0
+ID: 152 Len: 8 Enqueue: 872
+ID: 153 Len: 200 Enqueue: 918
+ID: 154 Len: 32 Enqueue: 1483
+ID: 155 Len: 16 Enqueue: 1022
+ID: 156 Len: 8 Enqueue: 0
+ID: 157 Len: 136 Enqueue: 1176
+ID: 158 Len: 128 Enqueue: 1138
+ID: 159 Len: 16 Enqueue: 1209
+ID: 160 Len: 8 Enqueue: 1082
+ID: 161 Len: 8 Enqueue: 0
+ID: 162 Len: 48 Enqueue: 1034
+ID: 163 Len: 8 Enqueue: 0
+ID: 164 Len: 8 Enqueue: 740
+ID: 165 Len: 8 Enqueue: 884
+ID: 166 Len: 136 Enqueue: 930
+ID: 167 Len: 32 Enqueue: 1450
+ID: 168 Len: 16 Enqueue: 986
+ID: 169 Len: 8 Enqueue: 0
+ID: 170 Len: 136 Enqueue: 0
+ID: 171 Len: 128 Enqueue: 0
+ID: 172 Len: 16 Enqueue: 0
+ID: 173 Len: 8 Enqueue: 0
+ID: 174 Len: 8 Enqueue: 848
+ID: 175 Len: 136 Enqueue: 0
+ID: 176 Len: 8 Enqueue: 608
+ID: 177 Len: 128 Enqueue: 0
+ID: 178 Len: 9 Enqueue: 0
+ID: 179 Len: 17 Enqueue: 0
+ID: 180 Len: 25 Enqueue: 0
+ID: 181 Len: 25 Enqueue: 0
+ID: 182 Len: 25 Enqueue: 0
+ID: 183 Len: 49 Enqueue: 0
+ID: 184 Len: 49 Enqueue: 0
+ID: 185 Len: 9 Enqueue: 0
+ID: 186 Len: 9 Enqueue: 0
+ID: 187 Len: 0 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
+ID: 189 Len: 9 Enqueue: 0
+ID: 190 Len: 9 Enqueue: 0
+ID: 191 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -3,151 +3,151 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4ae646.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae606]
-	PrepareEventRoot a8 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae646]
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae646.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae690.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 66 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae650]
-	PrepareEventRoot a9 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae690]
+	PrepareEventRoot c4 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae690.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4aeb13.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call fc 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 62 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeb13]
-	PrepareEventRoot a4 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4aeb13.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeb53]
+	PrepareEventRoot bf 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0x4ae9ea.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@4ae9ea]
-	PrepareEventRoot a7 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae9ea.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@4ae3ce]
-	PrepareEventRoot a7 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0x4ae6ca.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@4ae6ca]
-	PrepareEventRoot 9c 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4ae6ca.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@4aea2a]
+	PrepareEventRoot c2 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4ae84a.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@4ae40e]
+	PrepareEventRoot c2 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4ae70a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@4ae70a]
+	PrepareEventRoot b7 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4ae70a.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4ae88a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@4ae84a]
-	PrepareEventRoot 9f 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae84a.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4ae88a]
+	PrepareEventRoot ba 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae88a.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4ae9c0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 3a 03 00 00 // ProcessType[[3]string]
+	Call 46 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4ae9c0]
-	PrepareEventRoot a2 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4ae9c0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4aea00]
+	PrepareEventRoot bd 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4ae7ca.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 78 03 00 00 // ProcessType[[]int]
+	Call 9c 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4ae7ca]
-	PrepareEventRoot 9e 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae7ca.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4ae80a]
+	PrepareEventRoot b9 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4aeaaa.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f6 03 00 00 // ProcessType[map[string]int]
+	Call 5c 04 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@4aeaaa]
-	PrepareEventRoot a3 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaaa.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4aeaea]
+	PrepareEventRoot be 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	Return 
-// 0x1a7: ProcessEvent[Probe[main.noArgs]@4aebca]
-	PrepareEventRoot a5 00 00 00 00 00 00 00 
+// 0x1a7: ProcessEvent[Probe[main.noArgs]@4aec0a]
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x1b1: ProcessExpression[Probe[main.stringArg]@0x4ae74a.expr[0]]
+// 0x1b1: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 38 05 00 00 // ProcessType[string]
+	Call ca 05 00 00 // ProcessType[string]
 	Return 
-// 0x1d3: ProcessEvent[Probe[main.stringArg]@4ae74a]
-	PrepareEventRoot 9d 00 00 00 11 00 00 00 
-	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae74a.expr[0]]
+// 0x1d3: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot b8 00 00 00 11 00 00 00 
+	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	Return 
-// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0x4ae94a.expr[0]]
+// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 3a 03 00 00 // ProcessType[[3]string]
+	Call 46 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x203: ProcessEvent[Probe[main.stringArrayArg]@4ae94a]
-	PrepareEventRoot a1 00 00 00 31 00 00 00 
-	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae94a.expr[0]]
+// 0x203: ProcessEvent[Probe[main.stringArrayArg]@4ae98a]
+	PrepareEventRoot bc 00 00 00 31 00 00 00 
+	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
 	Return 
-// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0x4ae8ca.expr[0]]
+// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 9a 03 00 00 // ProcessType[[]string]
+	Call ca 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4ae8ca]
-	PrepareEventRoot a0 00 00 00 19 00 00 00 
-	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae8ca.expr[0]]
+// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4ae90a]
+	PrepareEventRoot bb 00 00 00 19 00 00 00 
+	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	Return 
-// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec36]
-	PrepareEventRoot a6 00 00 00 00 00 00 00 
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
 // 0x254: ProcessType[*****int]
-	ProcessPointer 79 00 00 00 
+	ProcessPointer 7e 00 00 00 
 	Return 
 // 0x25a: ProcessType[****int]
-	ProcessPointer 9a 00 00 00 
+	ProcessPointer b5 00 00 00 
 	Return 
 // 0x260: ProcessType[***int]
-	ProcessPointer 7a 00 00 00 
+	ProcessPointer 7f 00 00 00 
 	Return 
 // 0x266: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
@@ -177,7 +177,7 @@
 	ProcessPointer 0c 00 00 00 
 	Return 
 // 0x29c: ProcessType[*main.bigStruct]
-	ProcessPointer 97 00 00 00 
+	ProcessPointer 9c 00 00 00 
 	Return 
 // 0x2a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
@@ -198,7 +198,7 @@
 	ProcessPointer 1d 00 00 00 
 	Return 
 // 0x2c6: ProcessType[*runtime.p]
-	ProcessPointer 81 00 00 00 
+	ProcessPointer 86 00 00 00 
 	Return 
 // 0x2cc: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
@@ -215,138 +215,190 @@
 // 0x2e4: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x2ea: ProcessType[*table<string,int>]
-	ProcessPointer 88 00 00 00 
+// 0x2ea: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer ac 00 00 00 
 	Return 
-// 0x2f0: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 90 00 00 00 
+// 0x2f0: ProcessType[*table<string,int>]
+	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x2f6: ProcessType[*uint]
+// 0x2f6: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 95 00 00 00 
+	Return 
+// 0x2fc: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 9f 00 00 00 
+	Return 
+// 0x302: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x2fc: ProcessType[*uint16]
+// 0x308: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x302: ProcessType[*uint32]
+// 0x30e: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x308: ProcessType[*uint64]
+// 0x314: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x30e: ProcessType[*uint8]
+// 0x31a: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x314: ProcessType[*uintptr]
+// 0x320: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x31a: ProcessType[[2]*runtime.traceBuf]
+// 0x326: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
 	Call de 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x32a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x336: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 1a 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 26 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x33a: ProcessType[[3]string]
+// 0x346: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 38 05 00 00 // ProcessType[string]
+	Call ca 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x34a: ProcessType[[]*runtime.p]
-	ProcessSlice 82 00 00 00 08 00 00 00 
+// 0x356: ProcessType[[]*runtime.p]
+	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x354: ProcessType[[]*runtime.p.array]
+// 0x360: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
 	Call c6 02 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x360: ProcessType[[]*table<string,int>.array]
+// 0x36c: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ea 02 00 00 // ProcessType[*table<string,int>]
+	Call ea 02 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x378: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f0 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f0 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x378: ProcessType[[]int]
-	ProcessSlice 84 00 00 00 08 00 00 00 
-	Return 
-// 0x382: ProcessType[[]noalg.map.group[string]int.array]
+// 0x384: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 22 04 00 00 // ProcessType[noalg.map.group[string]int]
+	Call f6 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x390: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call fc 02 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x39c: ProcessType[[]int]
+	ProcessSlice 89 00 00 00 08 00 00 00 
+	Return 
+// 0x3a6: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 9e 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x38e: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x3b2: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 2d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call a9 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x39a: ProcessType[[]string]
-	ProcessSlice 86 00 00 00 10 00 00 00 
-	Return 
-// 0x3a4: ProcessType[[]string.array]
+// 0x3be: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 38 05 00 00 // ProcessType[string]
+	Call b4 04 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x3ca: ProcessType[[]string]
+	ProcessSlice 8b 00 00 00 10 00 00 00 
+	Return 
+// 0x3d4: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call ca 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3b0: ProcessType[[]uint8]
-	ProcessSlice 7d 00 00 00 01 00 00 00 
+// 0x3e0: ProcessType[[]uint8]
+	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x3ba: ProcessType[[]uintptr]
-	ProcessSlice 7f 00 00 00 08 00 00 00 
+// 0x3ea: ProcessType[[]uintptr]
+	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[error]
+// 0x3f4: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3c6: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 8f 00 00 00 c8 00 00 00 00 08 
+// 0x3f6: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x3d2: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
+// 0x402: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 94 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3de: ProcessType[map<string,int>]
-	ProcessGoSwissMap 8e 00 00 00 8b 00 00 00 10 18 
+// 0x40e: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 9e 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3ea: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 98 00 00 00 93 00 00 00 10 18 
+// 0x41a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups ab 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x3f6: ProcessType[map[string]int]
+// 0x426: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap b3 00 00 00 af 00 00 00 10 18 
+	Return 
+// 0x432: ProcessType[map<string,int>]
+	ProcessGoSwissMap 93 00 00 00 90 00 00 00 10 18 
+	Return 
+// 0x43e: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 9d 00 00 00 98 00 00 00 10 18 
+	Return 
+// 0x44a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap aa 00 00 00 a2 00 00 00 10 18 
+	Return 
+// 0x456: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer a7 00 00 00 
+	Return 
+// 0x45c: ProcessType[map[string]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x3fc: ProcessType[map[string]main.bigStruct]
+// 0x462: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x402: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x468: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 7a 00 00 00 
+	Return 
+// 0x46e: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 38 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call bf 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x412: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x47e: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 48 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call cf 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x422: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call 12 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x48e: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call d5 04 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x42d: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x49e: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 7e 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x438: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 38 05 00 00 // ProcessType[string]
+// 0x4a9: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6e 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x4b4: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	IncrementOutputOffset 08 00 00 00 
+	Call 8e 04 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Return 
+// 0x4bf: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call ca 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
 	Call 9c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x448: ProcessType[noalg.struct { key string; elem int }]
-	Call 38 05 00 00 // ProcessType[string]
+// 0x4cf: ProcessType[noalg.struct { key string; elem int }]
+	Call ca 05 00 00 // ProcessType[string]
 	Return 
-// 0x44e: ProcessType[runtime.g]
+// 0x4d5: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	IncrementOutputOffset 08 00 00 00 
+	Call 56 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x4e0: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
 	Call a8 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
@@ -354,13 +406,13 @@
 	IncrementOutputOffset 08 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call b0 03 00 00 // ProcessType[[]uint8]
+	Call e0 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
 	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
 	Call cc 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 03 00 00 // ProcessType[[]uintptr]
+	Call ea 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
 	Call d8 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
@@ -368,48 +420,56 @@
 	IncrementOutputOffset 08 00 00 00 
 	Call d2 02 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x4b3: ProcessType[runtime.m]
+// 0x545: ProcessType[runtime.m]
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 38 05 00 00 // ProcessType[string]
+	Call ca 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 4a 03 00 00 // ProcessType[[]*runtime.p]
+	Call 56 03 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
 	Call ae 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 1d 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call af 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call ba 03 00 00 // ProcessType[[]uintptr]
+	Call ea 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 28 05 00 00 // ProcessType[runtime.mTraceState]
+	Call ba 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x51d: ProcessType[runtime.mLockProfile]
+// 0x5af: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 03 00 00 // ProcessType[[]uintptr]
+	Call ea 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x528: ProcessType[runtime.mTraceState]
+// 0x5ba: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 36 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x538: ProcessType[string]
-	ProcessString 7b 00 00 00 
+// 0x5ca: ProcessType[string]
+	ProcessString 80 00 00 00 
 	Return 
-// 0x53e: ProcessType[table<string,int>]
+// 0x5d0: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call c6 03 00 00 // ProcessType[groupReference<string,int>]
+	Call f6 03 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x549: ProcessType[table<string,main.bigStruct>]
+// 0x5db: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call d2 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 02 04 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x5e6: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 0e 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x5f1: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 1a 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -430,31 +490,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 782
+ID: 5 Len: 8 Enqueue: 794
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1336
+ID: 9 Len: 16 Enqueue: 1482
 ID: 10 Len: 4 Enqueue: 0
 ID: 11 Len: 8 Enqueue: 626
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 964
+ID: 13 Len: 16 Enqueue: 1012
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 788
+ID: 19 Len: 8 Enqueue: 800
 ID: 20 Len: 8 Enqueue: 656
-ID: 21 Len: 8 Enqueue: 770
-ID: 22 Len: 440 Enqueue: 1102
+ID: 21 Len: 8 Enqueue: 782
+ID: 22 Len: 440 Enqueue: 1248
 ID: 23 Len: 16 Enqueue: 0
 ID: 24 Len: 8 Enqueue: 680
 ID: 25 Len: 8 Enqueue: 0
 ID: 26 Len: 8 Enqueue: 674
 ID: 27 Len: 8 Enqueue: 0
 ID: 28 Len: 8 Enqueue: 704
-ID: 29 Len: 1816 Enqueue: 1203
+ID: 29 Len: 1816 Enqueue: 1349
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -463,12 +523,12 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 944
+ID: 38 Len: 24 Enqueue: 992
 ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
 ID: 41 Len: 8 Enqueue: 716
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 954
+ID: 43 Len: 24 Enqueue: 1002
 ID: 44 Len: 8 Enqueue: 728
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
@@ -487,7 +547,7 @@ ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 842
+ID: 62 Len: 24 Enqueue: 854
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 710
 ID: 65 Len: 8 Enqueue: 686
@@ -495,15 +555,15 @@ ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1309
+ID: 70 Len: 56 Enqueue: 1455
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1320
+ID: 75 Len: 56 Enqueue: 1466
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 810
-ID: 78 Len: 16 Enqueue: 794
+ID: 77 Len: 32 Enqueue: 822
+ID: 78 Len: 16 Enqueue: 806
 ID: 79 Len: 8 Enqueue: 734
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
@@ -526,72 +586,99 @@ ID: 97 Len: 16 Enqueue: 0
 ID: 98 Len: 8 Enqueue: 644
 ID: 99 Len: 8 Enqueue: 650
 ID: 100 Len: 8 Enqueue: 662
-ID: 101 Len: 8 Enqueue: 776
+ID: 101 Len: 8 Enqueue: 788
 ID: 102 Len: 8 Enqueue: 632
 ID: 103 Len: 8 Enqueue: 638
-ID: 104 Len: 8 Enqueue: 758
-ID: 105 Len: 8 Enqueue: 764
-ID: 106 Len: 24 Enqueue: 888
+ID: 104 Len: 8 Enqueue: 770
+ID: 105 Len: 8 Enqueue: 776
+ID: 106 Len: 24 Enqueue: 924
 ID: 107 Len: 24 Enqueue: 0
-ID: 108 Len: 24 Enqueue: 922
-ID: 109 Len: 48 Enqueue: 826
-ID: 110 Len: 8 Enqueue: 1014
+ID: 108 Len: 24 Enqueue: 970
+ID: 109 Len: 48 Enqueue: 838
+ID: 110 Len: 8 Enqueue: 1116
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 990
+ID: 112 Len: 48 Enqueue: 1074
 ID: 113 Len: 8 Enqueue: 0
-ID: 114 Len: 8 Enqueue: 746
-ID: 115 Len: 8 Enqueue: 1020
+ID: 114 Len: 8 Enqueue: 752
+ID: 115 Len: 8 Enqueue: 1122
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1002
+ID: 117 Len: 48 Enqueue: 1086
 ID: 118 Len: 8 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 752
-ID: 120 Len: 8 Enqueue: 596
-ID: 121 Len: 8 Enqueue: 602
-ID: 122 Len: 8 Enqueue: 614
-ID: 123 Len: 1 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 1 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 0
+ID: 119 Len: 8 Enqueue: 758
+ID: 120 Len: 8 Enqueue: 1128
+ID: 121 Len: 8 Enqueue: 0
+ID: 122 Len: 48 Enqueue: 1098
+ID: 123 Len: 8 Enqueue: 0
+ID: 124 Len: 8 Enqueue: 764
+ID: 125 Len: 8 Enqueue: 596
+ID: 126 Len: 8 Enqueue: 602
+ID: 127 Len: 8 Enqueue: 614
+ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
-ID: 130 Len: 8 Enqueue: 852
+ID: 130 Len: 1 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 16 Enqueue: 932
-ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 32 Enqueue: 1342
-ID: 137 Len: 16 Enqueue: 966
+ID: 134 Len: 8 Enqueue: 0
+ID: 135 Len: 8 Enqueue: 864
+ID: 136 Len: 8 Enqueue: 0
+ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 200 Enqueue: 1058
-ID: 140 Len: 192 Enqueue: 1042
-ID: 141 Len: 24 Enqueue: 1096
-ID: 142 Len: 8 Enqueue: 864
-ID: 143 Len: 200 Enqueue: 898
-ID: 144 Len: 32 Enqueue: 1353
-ID: 145 Len: 16 Enqueue: 978
-ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 200 Enqueue: 1069
-ID: 148 Len: 192 Enqueue: 1026
-ID: 149 Len: 24 Enqueue: 1080
-ID: 150 Len: 8 Enqueue: 668
-ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 8 Enqueue: 876
-ID: 153 Len: 200 Enqueue: 910
-ID: 154 Len: 8 Enqueue: 608
-ID: 155 Len: 128 Enqueue: 0
-ID: 156 Len: 9 Enqueue: 0
-ID: 157 Len: 17 Enqueue: 0
-ID: 158 Len: 25 Enqueue: 0
-ID: 159 Len: 25 Enqueue: 0
-ID: 160 Len: 25 Enqueue: 0
-ID: 161 Len: 49 Enqueue: 0
-ID: 162 Len: 49 Enqueue: 0
-ID: 163 Len: 9 Enqueue: 0
-ID: 164 Len: 9 Enqueue: 0
-ID: 165 Len: 0 Enqueue: 0
-ID: 166 Len: 0 Enqueue: 0
-ID: 167 Len: 9 Enqueue: 0
-ID: 168 Len: 9 Enqueue: 0
-ID: 169 Len: 9 Enqueue: 0
+ID: 139 Len: 16 Enqueue: 980
+ID: 140 Len: 8 Enqueue: 0
+ID: 141 Len: 32 Enqueue: 1499
+ID: 142 Len: 16 Enqueue: 1026
+ID: 143 Len: 8 Enqueue: 0
+ID: 144 Len: 200 Enqueue: 1182
+ID: 145 Len: 192 Enqueue: 1150
+ID: 146 Len: 24 Enqueue: 1231
+ID: 147 Len: 8 Enqueue: 888
+ID: 148 Len: 200 Enqueue: 934
+ID: 149 Len: 32 Enqueue: 1510
+ID: 150 Len: 16 Enqueue: 1038
+ID: 151 Len: 8 Enqueue: 0
+ID: 152 Len: 200 Enqueue: 1193
+ID: 153 Len: 192 Enqueue: 1134
+ID: 154 Len: 24 Enqueue: 1215
+ID: 155 Len: 8 Enqueue: 668
+ID: 156 Len: 184 Enqueue: 0
+ID: 157 Len: 8 Enqueue: 900
+ID: 158 Len: 200 Enqueue: 946
+ID: 159 Len: 32 Enqueue: 1521
+ID: 160 Len: 16 Enqueue: 1050
+ID: 161 Len: 8 Enqueue: 0
+ID: 162 Len: 136 Enqueue: 1204
+ID: 163 Len: 128 Enqueue: 1166
+ID: 164 Len: 16 Enqueue: 1237
+ID: 165 Len: 8 Enqueue: 1110
+ID: 166 Len: 8 Enqueue: 0
+ID: 167 Len: 48 Enqueue: 1062
+ID: 168 Len: 8 Enqueue: 0
+ID: 169 Len: 8 Enqueue: 746
+ID: 170 Len: 8 Enqueue: 912
+ID: 171 Len: 136 Enqueue: 958
+ID: 172 Len: 32 Enqueue: 1488
+ID: 173 Len: 16 Enqueue: 1014
+ID: 174 Len: 8 Enqueue: 0
+ID: 175 Len: 136 Enqueue: 0
+ID: 176 Len: 128 Enqueue: 0
+ID: 177 Len: 16 Enqueue: 0
+ID: 178 Len: 8 Enqueue: 0
+ID: 179 Len: 8 Enqueue: 876
+ID: 180 Len: 136 Enqueue: 0
+ID: 181 Len: 8 Enqueue: 608
+ID: 182 Len: 128 Enqueue: 0
+ID: 183 Len: 9 Enqueue: 0
+ID: 184 Len: 17 Enqueue: 0
+ID: 185 Len: 25 Enqueue: 0
+ID: 186 Len: 25 Enqueue: 0
+ID: 187 Len: 25 Enqueue: 0
+ID: 188 Len: 49 Enqueue: 0
+ID: 189 Len: 49 Enqueue: 0
+ID: 190 Len: 9 Enqueue: 0
+ID: 191 Len: 9 Enqueue: 0
+ID: 192 Len: 0 Enqueue: 0
+ID: 193 Len: 0 Enqueue: 0
+ID: 194 Len: 9 Enqueue: 0
+ID: 195 Len: 9 Enqueue: 0
+ID: 196 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,27 +7,27 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4a 02 00 00 // ProcessType[*****int]
+	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae606]
-	PrepareEventRoot a7 00 00 00 09 00 00 00 
+	PrepareEventRoot a8 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5c 02 00 00 // ProcessType[**int]
+	Call 66 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae650]
-	PrepareEventRoot a8 00 00 00 09 00 00 00 
+	PrepareEventRoot a9 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4aeb13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f2 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call fc 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeb13]
 	PrepareEventRoot a4 00 00 00 09 00 00 00 
@@ -39,7 +39,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x97: ProcessEvent[Probe[main.inlined]@4ae9ea]
-	PrepareEventRoot a6 00 00 00 09 00 00 00 
+	PrepareEventRoot a7 00 00 00 09 00 00 00 
 	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae9ea.expr[0]]
 	Return 
 // 0xa6: ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xb6: ProcessEvent[Probe[main.inlined]@4ae3ce]
-	PrepareEventRoot a6 00 00 00 09 00 00 00 
+	PrepareEventRoot a7 00 00 00 09 00 00 00 
 	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
 	Return 
 // 0xc5: ProcessExpression[Probe[main.intArg]@0x4ae6ca.expr[0]]
@@ -73,7 +73,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 30 03 00 00 // ProcessType[[3]string]
+	Call 3a 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4ae9c0]
 	PrepareEventRoot a2 00 00 00 31 00 00 00 
@@ -85,7 +85,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 6e 03 00 00 // ProcessType[[]int]
+	Call 78 03 00 00 // ProcessType[[]int]
 	Return 
 // 0x16e: ProcessEvent[Probe[main.intSliceArg]@4ae7ca]
 	PrepareEventRoot 9e 00 00 00 19 00 00 00 
@@ -95,7 +95,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ec 03 00 00 // ProcessType[map[string]int]
+	Call f6 03 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x198: ProcessEvent[Probe[main.mapArg]@4aeaaa]
 	PrepareEventRoot a3 00 00 00 09 00 00 00 
@@ -109,7 +109,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 2e 05 00 00 // ProcessType[string]
+	Call 38 05 00 00 // ProcessType[string]
 	Return 
 // 0x1d3: ProcessEvent[Probe[main.stringArg]@4ae74a]
 	PrepareEventRoot 9d 00 00 00 11 00 00 00 
@@ -119,7 +119,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 30 03 00 00 // ProcessType[[3]string]
+	Call 3a 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x203: ProcessEvent[Probe[main.stringArrayArg]@4ae94a]
 	PrepareEventRoot a1 00 00 00 31 00 00 00 
@@ -131,282 +131,285 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 90 03 00 00 // ProcessType[[]string]
+	Call 9a 03 00 00 // ProcessType[[]string]
 	Return 
 // 0x23b: ProcessEvent[Probe[main.stringSliceArg]@4ae8ca]
 	PrepareEventRoot a0 00 00 00 19 00 00 00 
 	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae8ca.expr[0]]
 	Return 
-// 0x24a: ProcessType[*****int]
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec36]
+	PrepareEventRoot a6 00 00 00 00 00 00 00 
+	Return 
+// 0x254: ProcessType[*****int]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x250: ProcessType[****int]
+// 0x25a: ProcessType[****int]
 	ProcessPointer 9a 00 00 00 
 	Return 
-// 0x256: ProcessType[***int]
+// 0x260: ProcessType[***int]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x25c: ProcessType[**int]
+// 0x266: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x262: ProcessType[*[]runtime.ancestorInfo]
+// 0x26c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x268: ProcessType[*bool]
+// 0x272: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x26e: ProcessType[*error]
+// 0x278: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x274: ProcessType[*float32]
+// 0x27e: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x27a: ProcessType[*float64]
+// 0x284: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x280: ProcessType[*int]
+// 0x28a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x286: ProcessType[*int32]
+// 0x290: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x28c: ProcessType[*int64]
+// 0x296: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x292: ProcessType[*main.bigStruct]
+// 0x29c: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x298: ProcessType[*runtime._defer]
+// 0x2a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x29e: ProcessType[*runtime._panic]
+// 0x2a8: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x2a4: ProcessType[*runtime.cgoCallers]
+// 0x2ae: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x2aa: ProcessType[*runtime.coro]
+// 0x2b4: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2b0: ProcessType[*runtime.g]
+// 0x2ba: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x2b6: ProcessType[*runtime.m]
+// 0x2c0: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2bc: ProcessType[*runtime.p]
+// 0x2c6: ProcessType[*runtime.p]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x2c2: ProcessType[*runtime.sudog]
+// 0x2cc: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2c8: ProcessType[*runtime.synctestBubble]
+// 0x2d2: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x2ce: ProcessType[*runtime.timer]
+// 0x2d8: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x2d4: ProcessType[*runtime.traceBuf]
+// 0x2de: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x2da: ProcessType[*string]
+// 0x2e4: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x2e0: ProcessType[*table<string,int>]
+// 0x2ea: ProcessType[*table<string,int>]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x2e6: ProcessType[*table<string,main.bigStruct>]
+// 0x2f0: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x2ec: ProcessType[*uint]
+// 0x2f6: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x2f2: ProcessType[*uint16]
+// 0x2fc: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2f8: ProcessType[*uint32]
+// 0x302: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2fe: ProcessType[*uint64]
+// 0x308: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x304: ProcessType[*uint8]
+// 0x30e: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x30a: ProcessType[*uintptr]
+// 0x314: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x310: ProcessType[[2]*runtime.traceBuf]
+// 0x31a: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call d4 02 00 00 // ProcessType[*runtime.traceBuf]
+	Call de 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x320: ProcessType[[2][2]*runtime.traceBuf]
+// 0x32a: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 10 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 1a 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x330: ProcessType[[3]string]
+// 0x33a: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 2e 05 00 00 // ProcessType[string]
+	Call 38 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x340: ProcessType[[]*runtime.p]
+// 0x34a: ProcessType[[]*runtime.p]
 	ProcessSlice 82 00 00 00 08 00 00 00 
 	Return 
-// 0x34a: ProcessType[[]*runtime.p.array]
+// 0x354: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call bc 02 00 00 // ProcessType[*runtime.p]
+	Call c6 02 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x356: ProcessType[[]*table<string,int>.array]
+// 0x360: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call e0 02 00 00 // ProcessType[*table<string,int>]
+	Call ea 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x362: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x36c: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call e6 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f0 02 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36e: ProcessType[[]int]
+// 0x378: ProcessType[[]int]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x378: ProcessType[[]noalg.map.group[string]int.array]
+// 0x382: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 18 04 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 22 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x384: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x38e: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 23 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 2d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x390: ProcessType[[]string]
+// 0x39a: ProcessType[[]string]
 	ProcessSlice 86 00 00 00 10 00 00 00 
 	Return 
-// 0x39a: ProcessType[[]string.array]
+// 0x3a4: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 2e 05 00 00 // ProcessType[string]
+	Call 38 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3a6: ProcessType[[]uint8]
+// 0x3b0: ProcessType[[]uint8]
 	ProcessSlice 7d 00 00 00 01 00 00 00 
 	Return 
-// 0x3b0: ProcessType[[]uintptr]
+// 0x3ba: ProcessType[[]uintptr]
 	ProcessSlice 7f 00 00 00 08 00 00 00 
 	Return 
-// 0x3ba: ProcessType[error]
+// 0x3c4: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3bc: ProcessType[groupReference<string,int>]
+// 0x3c6: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 8f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3c8: ProcessType[groupReference<string,main.bigStruct>]
+// 0x3d2: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3d4: ProcessType[map<string,int>]
+// 0x3de: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8e 00 00 00 8b 00 00 00 10 18 
 	Return 
-// 0x3e0: ProcessType[map<string,main.bigStruct>]
+// 0x3ea: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 98 00 00 00 93 00 00 00 10 18 
 	Return 
-// 0x3ec: ProcessType[map[string]int]
+// 0x3f6: ProcessType[map[string]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x3f2: ProcessType[map[string]main.bigStruct]
+// 0x3fc: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x3f8: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x402: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 2e 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 38 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x408: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x412: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 3e 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 48 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x418: ProcessType[noalg.map.group[string]int]
+// 0x422: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 08 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 12 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x423: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x42d: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call f8 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 02 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x42e: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 2e 05 00 00 // ProcessType[string]
+// 0x438: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 38 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 92 02 00 00 // ProcessType[*main.bigStruct]
+	Call 9c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x43e: ProcessType[noalg.struct { key string; elem int }]
-	Call 2e 05 00 00 // ProcessType[string]
+// 0x448: ProcessType[noalg.struct { key string; elem int }]
+	Call 38 05 00 00 // ProcessType[string]
 	Return 
-// 0x444: ProcessType[runtime.g]
+// 0x44e: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 9e 02 00 00 // ProcessType[*runtime._panic]
+	Call a8 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 98 02 00 00 // ProcessType[*runtime._defer]
+	Call a2 02 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call a6 03 00 00 // ProcessType[[]uint8]
+	Call b0 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 62 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.sudog]
+	Call cc 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call b0 03 00 00 // ProcessType[[]uintptr]
+	Call ba 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call ce 02 00 00 // ProcessType[*runtime.timer]
+	Call d8 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call aa 02 00 00 // ProcessType[*runtime.coro]
+	Call b4 02 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call c8 02 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d2 02 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x4a9: ProcessType[runtime.m]
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+// 0x4b3: ProcessType[runtime.m]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 2e 05 00 00 // ProcessType[string]
+	Call 38 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 40 03 00 00 // ProcessType[[]*runtime.p]
+	Call 4a 03 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call a4 02 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ae 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 13 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call 1d 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call b0 03 00 00 // ProcessType[[]uintptr]
+	Call ba 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1e 05 00 00 // ProcessType[runtime.mTraceState]
+	Call 28 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x513: ProcessType[runtime.mLockProfile]
+// 0x51d: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call b0 03 00 00 // ProcessType[[]uintptr]
+	Call ba 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x51e: ProcessType[runtime.mTraceState]
+// 0x528: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 20 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call 2a 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x52e: ProcessType[string]
+// 0x538: ProcessType[string]
 	ProcessString 7b 00 00 00 
 	Return 
-// 0x534: ProcessType[table<string,int>]
+// 0x53e: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call bc 03 00 00 // ProcessType[groupReference<string,int>]
+	Call c6 03 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x53f: ProcessType[table<string,main.bigStruct>]
+// 0x549: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call c8 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call d2 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -427,31 +430,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 772
+ID: 5 Len: 8 Enqueue: 782
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1326
+ID: 9 Len: 16 Enqueue: 1336
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 616
+ID: 11 Len: 8 Enqueue: 626
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 954
+ID: 13 Len: 16 Enqueue: 964
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 778
-ID: 20 Len: 8 Enqueue: 646
-ID: 21 Len: 8 Enqueue: 760
-ID: 22 Len: 440 Enqueue: 1092
+ID: 19 Len: 8 Enqueue: 788
+ID: 20 Len: 8 Enqueue: 656
+ID: 21 Len: 8 Enqueue: 770
+ID: 22 Len: 440 Enqueue: 1102
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 670
+ID: 24 Len: 8 Enqueue: 680
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 664
+ID: 26 Len: 8 Enqueue: 674
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 694
-ID: 29 Len: 1816 Enqueue: 1193
+ID: 28 Len: 8 Enqueue: 704
+ID: 29 Len: 1816 Enqueue: 1203
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -460,48 +463,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 934
-ID: 39 Len: 8 Enqueue: 610
+ID: 38 Len: 24 Enqueue: 944
+ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 706
+ID: 41 Len: 8 Enqueue: 716
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 944
-ID: 44 Len: 8 Enqueue: 718
+ID: 43 Len: 24 Enqueue: 954
+ID: 44 Len: 8 Enqueue: 728
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 682
+ID: 47 Len: 8 Enqueue: 692
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 712
+ID: 49 Len: 8 Enqueue: 722
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 688
+ID: 55 Len: 8 Enqueue: 698
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 832
+ID: 62 Len: 24 Enqueue: 842
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 700
-ID: 65 Len: 8 Enqueue: 676
+ID: 64 Len: 8 Enqueue: 710
+ID: 65 Len: 8 Enqueue: 686
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1299
+ID: 70 Len: 56 Enqueue: 1309
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1310
+ID: 75 Len: 56 Enqueue: 1320
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 800
-ID: 78 Len: 16 Enqueue: 784
-ID: 79 Len: 8 Enqueue: 724
+ID: 77 Len: 32 Enqueue: 810
+ID: 78 Len: 16 Enqueue: 794
+ID: 79 Len: 8 Enqueue: 734
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -517,34 +520,34 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 730
+ID: 95 Len: 8 Enqueue: 740
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 634
-ID: 99 Len: 8 Enqueue: 640
-ID: 100 Len: 8 Enqueue: 652
-ID: 101 Len: 8 Enqueue: 766
-ID: 102 Len: 8 Enqueue: 622
-ID: 103 Len: 8 Enqueue: 628
-ID: 104 Len: 8 Enqueue: 748
-ID: 105 Len: 8 Enqueue: 754
-ID: 106 Len: 24 Enqueue: 878
+ID: 98 Len: 8 Enqueue: 644
+ID: 99 Len: 8 Enqueue: 650
+ID: 100 Len: 8 Enqueue: 662
+ID: 101 Len: 8 Enqueue: 776
+ID: 102 Len: 8 Enqueue: 632
+ID: 103 Len: 8 Enqueue: 638
+ID: 104 Len: 8 Enqueue: 758
+ID: 105 Len: 8 Enqueue: 764
+ID: 106 Len: 24 Enqueue: 888
 ID: 107 Len: 24 Enqueue: 0
-ID: 108 Len: 24 Enqueue: 912
-ID: 109 Len: 48 Enqueue: 816
-ID: 110 Len: 8 Enqueue: 1004
+ID: 108 Len: 24 Enqueue: 922
+ID: 109 Len: 48 Enqueue: 826
+ID: 110 Len: 8 Enqueue: 1014
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 980
+ID: 112 Len: 48 Enqueue: 990
 ID: 113 Len: 8 Enqueue: 0
-ID: 114 Len: 8 Enqueue: 736
-ID: 115 Len: 8 Enqueue: 1010
+ID: 114 Len: 8 Enqueue: 746
+ID: 115 Len: 8 Enqueue: 1020
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 992
+ID: 117 Len: 48 Enqueue: 1002
 ID: 118 Len: 8 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 742
-ID: 120 Len: 8 Enqueue: 586
-ID: 121 Len: 8 Enqueue: 592
-ID: 122 Len: 8 Enqueue: 604
+ID: 119 Len: 8 Enqueue: 752
+ID: 120 Len: 8 Enqueue: 596
+ID: 121 Len: 8 Enqueue: 602
+ID: 122 Len: 8 Enqueue: 614
 ID: 123 Len: 1 Enqueue: 0
 ID: 124 Len: 8 Enqueue: 0
 ID: 125 Len: 1 Enqueue: 0
@@ -552,31 +555,31 @@ ID: 126 Len: 8 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
-ID: 130 Len: 8 Enqueue: 842
+ID: 130 Len: 8 Enqueue: 852
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 16 Enqueue: 922
+ID: 134 Len: 16 Enqueue: 932
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 32 Enqueue: 1332
-ID: 137 Len: 16 Enqueue: 956
+ID: 136 Len: 32 Enqueue: 1342
+ID: 137 Len: 16 Enqueue: 966
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 200 Enqueue: 1048
-ID: 140 Len: 192 Enqueue: 1032
-ID: 141 Len: 24 Enqueue: 1086
-ID: 142 Len: 8 Enqueue: 854
-ID: 143 Len: 200 Enqueue: 888
-ID: 144 Len: 32 Enqueue: 1343
-ID: 145 Len: 16 Enqueue: 968
+ID: 139 Len: 200 Enqueue: 1058
+ID: 140 Len: 192 Enqueue: 1042
+ID: 141 Len: 24 Enqueue: 1096
+ID: 142 Len: 8 Enqueue: 864
+ID: 143 Len: 200 Enqueue: 898
+ID: 144 Len: 32 Enqueue: 1353
+ID: 145 Len: 16 Enqueue: 978
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 200 Enqueue: 1059
-ID: 148 Len: 192 Enqueue: 1016
-ID: 149 Len: 24 Enqueue: 1070
-ID: 150 Len: 8 Enqueue: 658
+ID: 147 Len: 200 Enqueue: 1069
+ID: 148 Len: 192 Enqueue: 1026
+ID: 149 Len: 24 Enqueue: 1080
+ID: 150 Len: 8 Enqueue: 668
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 8 Enqueue: 866
-ID: 153 Len: 200 Enqueue: 900
-ID: 154 Len: 8 Enqueue: 598
+ID: 152 Len: 8 Enqueue: 876
+ID: 153 Len: 200 Enqueue: 910
+ID: 154 Len: 8 Enqueue: 608
 ID: 155 Len: 128 Enqueue: 0
 ID: 156 Len: 9 Enqueue: 0
 ID: 157 Len: 17 Enqueue: 0
@@ -588,6 +591,7 @@ ID: 162 Len: 49 Enqueue: 0
 ID: 163 Len: 9 Enqueue: 0
 ID: 164 Len: 9 Enqueue: 0
 ID: 165 Len: 0 Enqueue: 0
-ID: 166 Len: 9 Enqueue: 0
+ID: 166 Len: 0 Enqueue: 0
 ID: 167 Len: 9 Enqueue: 0
 ID: 168 Len: 9 Enqueue: 0
+ID: 169 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,27 +7,27 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4a 02 00 00 // ProcessType[*****int]
+	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5338]
-	PrepareEventRoot 96 00 00 00 09 00 00 00 
+	PrepareEventRoot 97 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5c 02 00 00 // ProcessType[**int]
+	Call 66 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5370]
-	PrepareEventRoot 97 00 00 00 09 00 00 00 
+	PrepareEventRoot 98 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e4 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ee 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b5820]
 	PrepareEventRoot 93 00 00 00 09 00 00 00 
@@ -39,7 +39,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x97: ProcessEvent[Probe[main.inlined]@b56ec]
-	PrepareEventRoot 95 00 00 00 09 00 00 00 
+	PrepareEventRoot 96 00 00 00 09 00 00 00 
 	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
 	Return 
 // 0xa6: ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xb6: ProcessEvent[Probe[main.inlined]@b514c]
-	PrepareEventRoot 95 00 00 00 09 00 00 00 
+	PrepareEventRoot 96 00 00 00 09 00 00 00 
 	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
 	Return 
 // 0xc5: ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
@@ -73,7 +73,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 1a 03 00 00 // ProcessType[[3]string]
+	Call 24 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b56d0]
 	PrepareEventRoot 91 00 00 00 31 00 00 00 
@@ -85,7 +85,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 42 03 00 00 // ProcessType[[]int]
+	Call 4c 03 00 00 // ProcessType[[]int]
 	Return 
 // 0x16e: ProcessEvent[Probe[main.intSliceArg]@b54bc]
 	PrepareEventRoot 8d 00 00 00 19 00 00 00 
@@ -95,7 +95,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call de 03 00 00 // ProcessType[map[string]int]
+	Call e8 03 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x198: ProcessEvent[Probe[main.mapArg]@b57ac]
 	PrepareEventRoot 92 00 00 00 09 00 00 00 
@@ -109,7 +109,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	Return 
 // 0x1d3: ProcessEvent[Probe[main.stringArg]@b543c]
 	PrepareEventRoot 8c 00 00 00 11 00 00 00 
@@ -119,7 +119,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 1a 03 00 00 // ProcessType[[3]string]
+	Call 24 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x203: ProcessEvent[Probe[main.stringArrayArg]@b565c]
 	PrepareEventRoot 90 00 00 00 31 00 00 00 
@@ -131,233 +131,236 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 5c 03 00 00 // ProcessType[[]string]
+	Call 66 03 00 00 // ProcessType[[]string]
 	Return 
 // 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b55cc]
 	PrepareEventRoot 8f 00 00 00 19 00 00 00 
 	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
 	Return 
-// 0x24a: ProcessType[*****int]
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5950]
+	PrepareEventRoot 95 00 00 00 00 00 00 00 
+	Return 
+// 0x254: ProcessType[*****int]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x250: ProcessType[****int]
+// 0x25a: ProcessType[****int]
 	ProcessPointer 89 00 00 00 
 	Return 
-// 0x256: ProcessType[***int]
+// 0x260: ProcessType[***int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x25c: ProcessType[**int]
+// 0x266: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x262: ProcessType[*[]runtime.ancestorInfo]
+// 0x26c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x268: ProcessType[*bool]
+// 0x272: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x26e: ProcessType[*bucket<string,int>]
+// 0x278: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x274: ProcessType[*bucket<string,main.bigStruct>]
+// 0x27e: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x27a: ProcessType[*error]
+// 0x284: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x280: ProcessType[*float32]
+// 0x28a: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x286: ProcessType[*float64]
+// 0x290: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x28c: ProcessType[*int]
+// 0x296: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x292: ProcessType[*int32]
+// 0x29c: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x298: ProcessType[*int64]
+// 0x2a2: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x29e: ProcessType[*main.bigStruct]
+// 0x2a8: ProcessType[*main.bigStruct]
 	ProcessPointer 87 00 00 00 
 	Return 
-// 0x2a4: ProcessType[*runtime._defer]
+// 0x2ae: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x2aa: ProcessType[*runtime._panic]
+// 0x2b4: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x2b0: ProcessType[*runtime.cgoCallers]
+// 0x2ba: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x2b6: ProcessType[*runtime.coro]
+// 0x2c0: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2bc: ProcessType[*runtime.g]
+// 0x2c6: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x2c2: ProcessType[*runtime.m]
+// 0x2cc: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2c8: ProcessType[*runtime.mapextra]
+// 0x2d2: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x2ce: ProcessType[*runtime.sudog]
+// 0x2d8: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2d4: ProcessType[*runtime.timer]
+// 0x2de: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x2da: ProcessType[*runtime.traceBuf]
+// 0x2e4: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x2e0: ProcessType[*string]
+// 0x2ea: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2e6: ProcessType[*uint]
+// 0x2f0: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x2ec: ProcessType[*uint16]
+// 0x2f6: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2f2: ProcessType[*uint32]
+// 0x2fc: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2f8: ProcessType[*uint64]
+// 0x302: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x2fe: ProcessType[*uint8]
+// 0x308: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x304: ProcessType[*uintptr]
+// 0x30e: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x30a: ProcessType[[2]*runtime.traceBuf]
+// 0x314: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call da 02 00 00 // ProcessType[*runtime.traceBuf]
+	Call e4 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x31a: ProcessType[[3]string]
+// 0x324: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x32a: ProcessType[[]bucket<string,int>.array]
+// 0x334: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 96 03 00 00 // ProcessType[bucket<string,int>]
+	Call a0 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x336: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x340: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call ab 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call b5 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x342: ProcessType[[]int]
+// 0x34c: ProcessType[[]int]
 	ProcessSlice 7d 00 00 00 08 00 00 00 
 	Return 
-// 0x34c: ProcessType[[]key<string>]
+// 0x356: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x35c: ProcessType[[]string]
+// 0x366: ProcessType[[]string]
 	ProcessSlice 7f 00 00 00 10 00 00 00 
 	Return 
-// 0x366: ProcessType[[]string.array]
+// 0x370: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x372: ProcessType[[]uint8]
+// 0x37c: ProcessType[[]uint8]
 	ProcessSlice 79 00 00 00 01 00 00 00 
 	Return 
-// 0x37c: ProcessType[[]uintptr]
+// 0x386: ProcessType[[]uintptr]
 	ProcessSlice 7b 00 00 00 08 00 00 00 
 	Return 
-// 0x386: ProcessType[[]val<main.bigStruct>]
+// 0x390: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 9e 02 00 00 // ProcessType[*main.bigStruct]
+	Call a8 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x396: ProcessType[bucket<string,int>]
+// 0x3a0: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4c 03 00 00 // ProcessType[[]key<string>]
+	Call 56 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 6e 02 00 00 // ProcessType[*bucket<string,int>]
+	Call 78 02 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x3ab: ProcessType[bucket<string,main.bigStruct>]
+// 0x3b5: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4c 03 00 00 // ProcessType[[]key<string>]
-	Call 86 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 74 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 56 03 00 00 // ProcessType[[]key<string>]
+	Call 90 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 7e 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x3c0: ProcessType[error]
+// 0x3ca: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3c2: ProcessType[hash<string,int>]
+// 0x3cc: ProcessType[hash<string,int>]
 	ProcessGoHmap 84 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x3d0: ProcessType[hash<string,main.bigStruct>]
+// 0x3da: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 88 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x3de: ProcessType[map[string]int]
+// 0x3e8: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x3e4: ProcessType[map[string]main.bigStruct]
+// 0x3ee: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x3ea: ProcessType[runtime.g]
+// 0x3f4: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call aa 02 00 00 // ProcessType[*runtime._panic]
+	Call b4 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a4 02 00 00 // ProcessType[*runtime._defer]
+	Call ae 02 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.m]
+	Call cc 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 72 03 00 00 // ProcessType[[]uint8]
+	Call 7c 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 62 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ce 02 00 00 // ProcessType[*runtime.sudog]
+	Call d8 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7c 03 00 00 // ProcessType[[]uintptr]
+	Call 86 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call d4 02 00 00 // ProcessType[*runtime.timer]
+	Call de 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.coro]
+	Call c0 02 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x445: ProcessType[runtime.m]
-	Call bc 02 00 00 // ProcessType[*runtime.g]
+// 0x44f: ProcessType[runtime.m]
+	Call c6 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call bc 02 00 00 // ProcessType[*runtime.g]
+	Call c6 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call bc 02 00 00 // ProcessType[*runtime.g]
+	Call c6 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call c0 04 00 00 // ProcessType[string]
+	Call ca 04 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ba 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.m]
+	Call cc 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call a5 04 00 00 // ProcessType[runtime.mLockProfile]
+	Call af 04 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 7c 03 00 00 // ProcessType[[]uintptr]
+	Call 86 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.m]
+	Call cc 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call b0 04 00 00 // ProcessType[runtime.mTraceState]
+	Call ba 04 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x4a5: ProcessType[runtime.mLockProfile]
+// 0x4af: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7c 03 00 00 // ProcessType[[]uintptr]
+	Call 86 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x4b0: ProcessType[runtime.mTraceState]
+// 0x4ba: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0a 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call c2 02 00 00 // ProcessType[*runtime.m]
+	Call 14 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call cc 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x4c0: ProcessType[string]
+// 0x4ca: ProcessType[string]
 	ProcessString 77 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -379,12 +382,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 616
-ID: 6 Len: 8 Enqueue: 766
+ID: 5 Len: 8 Enqueue: 626
+ID: 6 Len: 8 Enqueue: 776
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 772
+ID: 8 Len: 8 Enqueue: 782
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1216
+ID: 10 Len: 16 Enqueue: 1226
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -392,18 +395,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 960
+ID: 18 Len: 16 Enqueue: 970
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 658
-ID: 21 Len: 8 Enqueue: 754
-ID: 22 Len: 432 Enqueue: 1002
+ID: 20 Len: 8 Enqueue: 668
+ID: 21 Len: 8 Enqueue: 764
+ID: 22 Len: 432 Enqueue: 1012
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 682
+ID: 24 Len: 8 Enqueue: 692
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 676
+ID: 26 Len: 8 Enqueue: 686
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 706
-ID: 29 Len: 1760 Enqueue: 1093
+ID: 28 Len: 8 Enqueue: 716
+ID: 29 Len: 1760 Enqueue: 1103
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -412,41 +415,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 882
-ID: 39 Len: 8 Enqueue: 610
+ID: 38 Len: 24 Enqueue: 892
+ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 718
+ID: 41 Len: 8 Enqueue: 728
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 892
-ID: 44 Len: 8 Enqueue: 724
+ID: 43 Len: 24 Enqueue: 902
+ID: 44 Len: 8 Enqueue: 734
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 694
+ID: 47 Len: 8 Enqueue: 704
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 700
+ID: 53 Len: 8 Enqueue: 710
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 688
+ID: 60 Len: 8 Enqueue: 698
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1189
+ID: 64 Len: 64 Enqueue: 1199
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1200
+ID: 69 Len: 32 Enqueue: 1210
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 778
-ID: 72 Len: 8 Enqueue: 730
+ID: 71 Len: 16 Enqueue: 788
+ID: 72 Len: 8 Enqueue: 740
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -462,37 +465,37 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 736
+ID: 88 Len: 8 Enqueue: 746
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 646
-ID: 93 Len: 8 Enqueue: 664
-ID: 94 Len: 8 Enqueue: 652
-ID: 95 Len: 8 Enqueue: 760
-ID: 96 Len: 8 Enqueue: 634
-ID: 97 Len: 8 Enqueue: 640
-ID: 98 Len: 8 Enqueue: 742
-ID: 99 Len: 8 Enqueue: 748
-ID: 100 Len: 24 Enqueue: 834
+ID: 92 Len: 8 Enqueue: 656
+ID: 93 Len: 8 Enqueue: 674
+ID: 94 Len: 8 Enqueue: 662
+ID: 95 Len: 8 Enqueue: 770
+ID: 96 Len: 8 Enqueue: 644
+ID: 97 Len: 8 Enqueue: 650
+ID: 98 Len: 8 Enqueue: 752
+ID: 99 Len: 8 Enqueue: 758
+ID: 100 Len: 24 Enqueue: 844
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 860
-ID: 103 Len: 48 Enqueue: 794
-ID: 104 Len: 8 Enqueue: 990
+ID: 102 Len: 24 Enqueue: 870
+ID: 103 Len: 48 Enqueue: 804
+ID: 104 Len: 8 Enqueue: 1000
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 962
-ID: 107 Len: 8 Enqueue: 622
-ID: 108 Len: 208 Enqueue: 918
-ID: 109 Len: 8 Enqueue: 712
+ID: 106 Len: 48 Enqueue: 972
+ID: 107 Len: 8 Enqueue: 632
+ID: 108 Len: 208 Enqueue: 928
+ID: 109 Len: 8 Enqueue: 722
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 996
+ID: 111 Len: 8 Enqueue: 1006
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 976
-ID: 114 Len: 8 Enqueue: 628
-ID: 115 Len: 208 Enqueue: 939
-ID: 116 Len: 8 Enqueue: 586
-ID: 117 Len: 8 Enqueue: 592
-ID: 118 Len: 8 Enqueue: 604
+ID: 113 Len: 48 Enqueue: 986
+ID: 114 Len: 8 Enqueue: 638
+ID: 115 Len: 208 Enqueue: 949
+ID: 116 Len: 8 Enqueue: 596
+ID: 117 Len: 8 Enqueue: 602
+ID: 118 Len: 8 Enqueue: 614
 ID: 119 Len: 1 Enqueue: 0
 ID: 120 Len: 8 Enqueue: 0
 ID: 121 Len: 1 Enqueue: 0
@@ -501,17 +504,17 @@ ID: 123 Len: 8 Enqueue: 0
 ID: 124 Len: 8 Enqueue: 0
 ID: 125 Len: 8 Enqueue: 0
 ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 16 Enqueue: 870
+ID: 127 Len: 16 Enqueue: 880
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
-ID: 130 Len: 128 Enqueue: 844
+ID: 130 Len: 128 Enqueue: 854
 ID: 131 Len: 64 Enqueue: 0
-ID: 132 Len: 208 Enqueue: 810
-ID: 133 Len: 64 Enqueue: 902
-ID: 134 Len: 8 Enqueue: 670
+ID: 132 Len: 208 Enqueue: 820
+ID: 133 Len: 64 Enqueue: 912
+ID: 134 Len: 8 Enqueue: 680
 ID: 135 Len: 184 Enqueue: 0
-ID: 136 Len: 208 Enqueue: 822
-ID: 137 Len: 8 Enqueue: 598
+ID: 136 Len: 208 Enqueue: 832
+ID: 137 Len: 8 Enqueue: 608
 ID: 138 Len: 128 Enqueue: 0
 ID: 139 Len: 9 Enqueue: 0
 ID: 140 Len: 17 Enqueue: 0
@@ -523,6 +526,7 @@ ID: 145 Len: 49 Enqueue: 0
 ID: 146 Len: 9 Enqueue: 0
 ID: 147 Len: 9 Enqueue: 0
 ID: 148 Len: 0 Enqueue: 0
-ID: 149 Len: 9 Enqueue: 0
+ID: 149 Len: 0 Enqueue: 0
 ID: 150 Len: 9 Enqueue: 0
 ID: 151 Len: 9 Enqueue: 0
+ID: 152 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -3,151 +3,151 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5388.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5338]
-	PrepareEventRoot 97 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5388]
+	PrepareEventRoot a8 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5388.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 66 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5370]
-	PrepareEventRoot 98 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b53c0]
+	PrepareEventRoot a9 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5870.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ee 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5f 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@b5820]
-	PrepareEventRoot 93 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b5870]
+	PrepareEventRoot a4 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5870.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@b56ec]
-	PrepareEventRoot 96 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@b514c]
-	PrepareEventRoot 96 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb573c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@b53cc]
-	PrepareEventRoot 8b 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@b573c]
+	PrepareEventRoot a7 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb573c.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@b519c]
+	PrepareEventRoot a7 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb541c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@b541c]
+	PrepareEventRoot 9c 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb541c.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb559c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@b554c]
-	PrepareEventRoot 8e 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b559c]
+	PrepareEventRoot 9f 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb559c.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 24 03 00 00 // ProcessType[[3]string]
+	Call 30 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b56d0]
-	PrepareEventRoot 91 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
+	PrepareEventRoot a2 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb550c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 4c 03 00 00 // ProcessType[[]int]
+	Call 70 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b54bc]
-	PrepareEventRoot 8d 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b550c]
+	PrepareEventRoot 9e 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb550c.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb57fc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e8 03 00 00 // ProcessType[map[string]int]
+	Call 59 04 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@b57ac]
-	PrepareEventRoot 92 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b57fc]
+	PrepareEventRoot a3 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57fc.expr[0]]
 	Return 
-// 0x1a7: ProcessEvent[Probe[main.noArgs]@b58dc]
-	PrepareEventRoot 94 00 00 00 00 00 00 00 
+// 0x1a7: ProcessEvent[Probe[main.noArgs]@b592c]
+	PrepareEventRoot a5 00 00 00 00 00 00 00 
 	Return 
-// 0x1b1: ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
+// 0x1b1: ProcessExpression[Probe[main.stringArg]@0xb548c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	Return 
-// 0x1d3: ProcessEvent[Probe[main.stringArg]@b543c]
-	PrepareEventRoot 8c 00 00 00 11 00 00 00 
-	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
+// 0x1d3: ProcessEvent[Probe[main.stringArg]@b548c]
+	PrepareEventRoot 9d 00 00 00 11 00 00 00 
+	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb548c.expr[0]]
 	Return 
-// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
+// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0xb56ac.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 24 03 00 00 // ProcessType[[3]string]
+	Call 30 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x203: ProcessEvent[Probe[main.stringArrayArg]@b565c]
-	PrepareEventRoot 90 00 00 00 31 00 00 00 
-	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
+// 0x203: ProcessEvent[Probe[main.stringArrayArg]@b56ac]
+	PrepareEventRoot a1 00 00 00 31 00 00 00 
+	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb56ac.expr[0]]
 	Return 
-// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
+// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0xb561c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 66 03 00 00 // ProcessType[[]string]
+	Call 8a 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b55cc]
-	PrepareEventRoot 8f 00 00 00 19 00 00 00 
-	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
+// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b561c]
+	PrepareEventRoot a0 00 00 00 19 00 00 00 
+	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb561c.expr[0]]
 	Return 
-// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5950]
-	PrepareEventRoot 95 00 00 00 00 00 00 00 
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59a0]
+	PrepareEventRoot a6 00 00 00 00 00 00 00 
 	Return 
 // 0x254: ProcessType[*****int]
-	ProcessPointer 75 00 00 00 
+	ProcessPointer 7a 00 00 00 
 	Return 
 // 0x25a: ProcessType[****int]
-	ProcessPointer 89 00 00 00 
+	ProcessPointer 9a 00 00 00 
 	Return 
 // 0x260: ProcessType[***int]
-	ProcessPointer 76 00 00 00 
+	ProcessPointer 7b 00 00 00 
 	Return 
 // 0x266: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
@@ -158,210 +158,252 @@
 // 0x272: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x278: ProcessType[*bucket<string,int>]
+// 0x278: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 94 00 00 00 
+	Return 
+// 0x27e: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x27e: ProcessType[*bucket<string,main.bigStruct>]
+// 0x284: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x284: ProcessType[*error]
+// 0x28a: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 78 00 00 00 
+	Return 
+// 0x290: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x28a: ProcessType[*float32]
+// 0x296: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x290: ProcessType[*float64]
+// 0x29c: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x296: ProcessType[*int]
+// 0x2a2: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x29c: ProcessType[*int32]
+// 0x2a8: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x2a2: ProcessType[*int64]
+// 0x2ae: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x2a8: ProcessType[*main.bigStruct]
-	ProcessPointer 87 00 00 00 
+// 0x2b4: ProcessType[*main.bigStruct]
+	ProcessPointer 8c 00 00 00 
 	Return 
-// 0x2ae: ProcessType[*runtime._defer]
+// 0x2ba: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x2b4: ProcessType[*runtime._panic]
+// 0x2c0: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x2ba: ProcessType[*runtime.cgoCallers]
+// 0x2c6: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x2c0: ProcessType[*runtime.coro]
+// 0x2cc: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2c6: ProcessType[*runtime.g]
+// 0x2d2: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x2cc: ProcessType[*runtime.m]
+// 0x2d8: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2d2: ProcessType[*runtime.mapextra]
+// 0x2de: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x2d8: ProcessType[*runtime.sudog]
+// 0x2e4: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2de: ProcessType[*runtime.timer]
+// 0x2ea: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x2e4: ProcessType[*runtime.traceBuf]
+// 0x2f0: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x2ea: ProcessType[*string]
+// 0x2f6: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2f0: ProcessType[*uint]
+// 0x2fc: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x2f6: ProcessType[*uint16]
+// 0x302: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2fc: ProcessType[*uint32]
+// 0x308: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x302: ProcessType[*uint64]
+// 0x30e: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x308: ProcessType[*uint8]
+// 0x314: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x30e: ProcessType[*uintptr]
+// 0x31a: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x314: ProcessType[[2]*runtime.traceBuf]
+// 0x320: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call e4 02 00 00 // ProcessType[*runtime.traceBuf]
+	Call f0 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x324: ProcessType[[3]string]
+// 0x330: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x334: ProcessType[[]bucket<string,int>.array]
+// 0x340: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a0 03 00 00 // ProcessType[bucket<string,int>]
+	Call d4 03 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x340: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x34c: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call b5 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call df 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x34c: ProcessType[[]int]
-	ProcessSlice 7d 00 00 00 08 00 00 00 
+// 0x358: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call f4 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x356: ProcessType[[]key<string>]
+// 0x364: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 09 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x370: ProcessType[[]int]
+	ProcessSlice 82 00 00 00 08 00 00 00 
+	Return 
+// 0x37a: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x366: ProcessType[[]string]
-	ProcessSlice 7f 00 00 00 10 00 00 00 
+// 0x38a: ProcessType[[]string]
+	ProcessSlice 84 00 00 00 10 00 00 00 
 	Return 
-// 0x370: ProcessType[[]string.array]
+// 0x394: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x37c: ProcessType[[]uint8]
-	ProcessSlice 79 00 00 00 01 00 00 00 
+// 0x3a0: ProcessType[[]uint8]
+	ProcessSlice 7e 00 00 00 01 00 00 00 
 	Return 
-// 0x386: ProcessType[[]uintptr]
-	ProcessSlice 7b 00 00 00 08 00 00 00 
+// 0x3aa: ProcessType[[]uintptr]
+	ProcessSlice 80 00 00 00 08 00 00 00 
 	Return 
-// 0x390: ProcessType[[]val<main.bigStruct>]
+// 0x3b4: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call a8 02 00 00 // ProcessType[*main.bigStruct]
+	Call b4 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3a0: ProcessType[bucket<string,int>]
+// 0x3c4: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call 53 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x3d4: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 88 00 00 00 
+	Call 78 02 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x3df: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 56 03 00 00 // ProcessType[[]key<string>]
+	Call 7a 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 78 02 00 00 // ProcessType[*bucket<string,int>]
+	Call 7e 02 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x3b5: ProcessType[bucket<string,main.bigStruct>]
+// 0x3f4: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 56 03 00 00 // ProcessType[[]key<string>]
-	Call 90 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 7e 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 7a 03 00 00 // ProcessType[[]key<string>]
+	Call b4 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 84 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x3ca: ProcessType[error]
+// 0x409: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call c4 03 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8a 02 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x419: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3cc: ProcessType[hash<string,int>]
-	ProcessGoHmap 84 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x41b: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 99 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x3da: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 88 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x429: ProcessType[hash<string,int>]
+	ProcessGoHmap 89 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x3e8: ProcessType[map[string]int]
+// 0x437: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 8d 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x445: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 95 00 00 00 58 00 00 00 08 09 10 18 
+	Return 
+// 0x453: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 92 00 00 00 
+	Return 
+// 0x459: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x3ee: ProcessType[map[string]main.bigStruct]
+// 0x45f: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x3f4: ProcessType[runtime.g]
+// 0x465: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 76 00 00 00 
+	Return 
+// 0x46b: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call b4 02 00 00 // ProcessType[*runtime._panic]
+	Call c0 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call ae 02 00 00 // ProcessType[*runtime._defer]
+	Call ba 02 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call cc 02 00 00 // ProcessType[*runtime.m]
+	Call d8 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 7c 03 00 00 // ProcessType[[]uint8]
+	Call a0 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
 	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call d8 02 00 00 // ProcessType[*runtime.sudog]
+	Call e4 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 86 03 00 00 // ProcessType[[]uintptr]
+	Call aa 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call de 02 00 00 // ProcessType[*runtime.timer]
+	Call ea 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call c0 02 00 00 // ProcessType[*runtime.coro]
+	Call cc 02 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x44f: ProcessType[runtime.m]
-	Call c6 02 00 00 // ProcessType[*runtime.g]
+// 0x4c6: ProcessType[runtime.m]
+	Call d2 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call c6 02 00 00 // ProcessType[*runtime.g]
+	Call d2 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call c6 02 00 00 // ProcessType[*runtime.g]
+	Call d2 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call ca 04 00 00 // ProcessType[string]
+	Call 41 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call ba 02 00 00 // ProcessType[*runtime.cgoCallers]
+	Call c6 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call cc 02 00 00 // ProcessType[*runtime.m]
+	Call d8 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call af 04 00 00 // ProcessType[runtime.mLockProfile]
+	Call 26 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 86 03 00 00 // ProcessType[[]uintptr]
+	Call aa 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call cc 02 00 00 // ProcessType[*runtime.m]
+	Call d8 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 04 00 00 // ProcessType[runtime.mTraceState]
+	Call 31 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x4af: ProcessType[runtime.mLockProfile]
+// 0x526: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 86 03 00 00 // ProcessType[[]uintptr]
+	Call aa 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x4ba: ProcessType[runtime.mTraceState]
+// 0x531: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 14 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call cc 02 00 00 // ProcessType[*runtime.m]
+	Call 20 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call d8 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x4ca: ProcessType[string]
-	ProcessString 77 00 00 00 
+// 0x541: ProcessType[string]
+	ProcessString 7c 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -383,11 +425,11 @@ ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
 ID: 5 Len: 8 Enqueue: 626
-ID: 6 Len: 8 Enqueue: 776
+ID: 6 Len: 8 Enqueue: 788
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 782
+ID: 8 Len: 8 Enqueue: 794
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1226
+ID: 10 Len: 16 Enqueue: 1345
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -395,18 +437,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 970
+ID: 18 Len: 16 Enqueue: 1049
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 668
-ID: 21 Len: 8 Enqueue: 764
-ID: 22 Len: 432 Enqueue: 1012
+ID: 20 Len: 8 Enqueue: 680
+ID: 21 Len: 8 Enqueue: 776
+ID: 22 Len: 432 Enqueue: 1131
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 692
+ID: 24 Len: 8 Enqueue: 704
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 686
+ID: 26 Len: 8 Enqueue: 698
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 716
-ID: 29 Len: 1760 Enqueue: 1103
+ID: 28 Len: 8 Enqueue: 728
+ID: 29 Len: 1760 Enqueue: 1222
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -415,41 +457,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 892
+ID: 38 Len: 24 Enqueue: 928
 ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 728
+ID: 41 Len: 8 Enqueue: 740
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 902
-ID: 44 Len: 8 Enqueue: 734
+ID: 43 Len: 24 Enqueue: 938
+ID: 44 Len: 8 Enqueue: 746
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 704
+ID: 47 Len: 8 Enqueue: 716
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 710
+ID: 53 Len: 8 Enqueue: 722
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 698
+ID: 60 Len: 8 Enqueue: 710
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1199
+ID: 64 Len: 64 Enqueue: 1318
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1210
+ID: 69 Len: 32 Enqueue: 1329
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 788
-ID: 72 Len: 8 Enqueue: 740
+ID: 71 Len: 16 Enqueue: 800
+ID: 72 Len: 8 Enqueue: 752
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -465,68 +507,85 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 746
+ID: 88 Len: 8 Enqueue: 758
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 656
-ID: 93 Len: 8 Enqueue: 674
-ID: 94 Len: 8 Enqueue: 662
-ID: 95 Len: 8 Enqueue: 770
-ID: 96 Len: 8 Enqueue: 644
-ID: 97 Len: 8 Enqueue: 650
-ID: 98 Len: 8 Enqueue: 752
-ID: 99 Len: 8 Enqueue: 758
-ID: 100 Len: 24 Enqueue: 844
+ID: 92 Len: 8 Enqueue: 668
+ID: 93 Len: 8 Enqueue: 686
+ID: 94 Len: 8 Enqueue: 674
+ID: 95 Len: 8 Enqueue: 782
+ID: 96 Len: 8 Enqueue: 656
+ID: 97 Len: 8 Enqueue: 662
+ID: 98 Len: 8 Enqueue: 764
+ID: 99 Len: 8 Enqueue: 770
+ID: 100 Len: 24 Enqueue: 880
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 870
-ID: 103 Len: 48 Enqueue: 804
-ID: 104 Len: 8 Enqueue: 1000
+ID: 102 Len: 24 Enqueue: 906
+ID: 103 Len: 48 Enqueue: 816
+ID: 104 Len: 8 Enqueue: 1113
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 972
-ID: 107 Len: 8 Enqueue: 632
-ID: 108 Len: 208 Enqueue: 928
-ID: 109 Len: 8 Enqueue: 722
+ID: 106 Len: 48 Enqueue: 1065
+ID: 107 Len: 8 Enqueue: 638
+ID: 108 Len: 208 Enqueue: 991
+ID: 109 Len: 8 Enqueue: 734
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 1006
+ID: 111 Len: 8 Enqueue: 1119
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 986
-ID: 114 Len: 8 Enqueue: 638
-ID: 115 Len: 208 Enqueue: 949
-ID: 116 Len: 8 Enqueue: 596
-ID: 117 Len: 8 Enqueue: 602
-ID: 118 Len: 8 Enqueue: 614
-ID: 119 Len: 1 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 0
-ID: 121 Len: 1 Enqueue: 0
-ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 0
+ID: 113 Len: 48 Enqueue: 1079
+ID: 114 Len: 8 Enqueue: 644
+ID: 115 Len: 208 Enqueue: 1012
+ID: 116 Len: 8 Enqueue: 1125
+ID: 117 Len: 8 Enqueue: 0
+ID: 118 Len: 48 Enqueue: 1093
+ID: 119 Len: 8 Enqueue: 650
+ID: 120 Len: 88 Enqueue: 1033
+ID: 121 Len: 8 Enqueue: 596
+ID: 122 Len: 8 Enqueue: 602
+ID: 123 Len: 8 Enqueue: 614
+ID: 124 Len: 1 Enqueue: 0
 ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 16 Enqueue: 880
+ID: 126 Len: 1 Enqueue: 0
+ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
-ID: 130 Len: 128 Enqueue: 854
-ID: 131 Len: 64 Enqueue: 0
-ID: 132 Len: 208 Enqueue: 820
-ID: 133 Len: 64 Enqueue: 912
-ID: 134 Len: 8 Enqueue: 680
-ID: 135 Len: 184 Enqueue: 0
-ID: 136 Len: 208 Enqueue: 832
-ID: 137 Len: 8 Enqueue: 608
-ID: 138 Len: 128 Enqueue: 0
-ID: 139 Len: 9 Enqueue: 0
-ID: 140 Len: 17 Enqueue: 0
-ID: 141 Len: 25 Enqueue: 0
-ID: 142 Len: 25 Enqueue: 0
-ID: 143 Len: 25 Enqueue: 0
-ID: 144 Len: 49 Enqueue: 0
-ID: 145 Len: 49 Enqueue: 0
-ID: 146 Len: 9 Enqueue: 0
-ID: 147 Len: 9 Enqueue: 0
-ID: 148 Len: 0 Enqueue: 0
-ID: 149 Len: 0 Enqueue: 0
-ID: 150 Len: 9 Enqueue: 0
-ID: 151 Len: 9 Enqueue: 0
-ID: 152 Len: 9 Enqueue: 0
+ID: 130 Len: 8 Enqueue: 0
+ID: 131 Len: 8 Enqueue: 0
+ID: 132 Len: 16 Enqueue: 916
+ID: 133 Len: 8 Enqueue: 0
+ID: 134 Len: 8 Enqueue: 0
+ID: 135 Len: 128 Enqueue: 890
+ID: 136 Len: 64 Enqueue: 0
+ID: 137 Len: 208 Enqueue: 844
+ID: 138 Len: 64 Enqueue: 948
+ID: 139 Len: 8 Enqueue: 692
+ID: 140 Len: 184 Enqueue: 0
+ID: 141 Len: 208 Enqueue: 856
+ID: 142 Len: 8 Enqueue: 0
+ID: 143 Len: 64 Enqueue: 964
+ID: 144 Len: 8 Enqueue: 1107
+ID: 145 Len: 8 Enqueue: 0
+ID: 146 Len: 48 Enqueue: 1051
+ID: 147 Len: 8 Enqueue: 632
+ID: 148 Len: 144 Enqueue: 980
+ID: 149 Len: 88 Enqueue: 868
+ID: 150 Len: 64 Enqueue: 0
+ID: 151 Len: 64 Enqueue: 0
+ID: 152 Len: 8 Enqueue: 0
+ID: 153 Len: 144 Enqueue: 832
+ID: 154 Len: 8 Enqueue: 608
+ID: 155 Len: 128 Enqueue: 0
+ID: 156 Len: 9 Enqueue: 0
+ID: 157 Len: 17 Enqueue: 0
+ID: 158 Len: 25 Enqueue: 0
+ID: 159 Len: 25 Enqueue: 0
+ID: 160 Len: 25 Enqueue: 0
+ID: 161 Len: 49 Enqueue: 0
+ID: 162 Len: 49 Enqueue: 0
+ID: 163 Len: 9 Enqueue: 0
+ID: 164 Len: 9 Enqueue: 0
+ID: 165 Len: 0 Enqueue: 0
+ID: 166 Len: 0 Enqueue: 0
+ID: 167 Len: 9 Enqueue: 0
+ID: 168 Len: 9 Enqueue: 0
+ID: 169 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,40 +7,40 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4a 02 00 00 // ProcessType[*****int]
+	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b51cc]
-	PrepareEventRoot a3 00 00 00 09 00 00 00 
+	PrepareEventRoot a4 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5c 02 00 00 // ProcessType[**int]
+	Call 66 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5204]
-	PrepareEventRoot a4 00 00 00 09 00 00 00 
+	PrepareEventRoot a5 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb56a0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d6 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call e0 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@b5690]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b56a0]
 	PrepareEventRoot a0 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb56a0.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb556c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@b555c]
-	PrepareEventRoot a2 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@b556c]
+	PrepareEventRoot a3 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb556c.expr[0]]
 	Return 
 // 0xa6: ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
 	ExprPrepare 
@@ -48,352 +48,355 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xb6: ProcessEvent[Probe[main.inlined]@b4fec]
-	PrepareEventRoot a2 00 00 00 09 00 00 00 
+	PrepareEventRoot a3 00 00 00 09 00 00 00 
 	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
 	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb526c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@b525c]
+// 0xdb: ProcessEvent[Probe[main.intArg]@b526c]
 	PrepareEventRoot 98 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb526c.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb53dc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@b53cc]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b53dc]
 	PrepareEventRoot 9b 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb53dc.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5550.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2a 03 00 00 // ProcessType[[3]string]
+	Call 34 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5540]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5550]
 	PrepareEventRoot 9e 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5550.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb535c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 52 03 00 00 // ProcessType[[]int]
+	Call 5c 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b534c]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b535c]
 	PrepareEventRoot 9a 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb535c.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb562c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d0 03 00 00 // ProcessType[map[string]int]
+	Call da 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@b561c]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b562c]
 	PrepareEventRoot 9f 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb562c.expr[0]]
 	Return 
-// 0x1a7: ProcessEvent[Probe[main.noArgs]@b574c]
+// 0x1a7: ProcessEvent[Probe[main.noArgs]@b575c]
 	PrepareEventRoot a1 00 00 00 00 00 00 00 
 	Return 
-// 0x1b1: ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
+// 0x1b1: ProcessExpression[Probe[main.stringArg]@0xb52dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 08 05 00 00 // ProcessType[string]
+	Call 12 05 00 00 // ProcessType[string]
 	Return 
-// 0x1d3: ProcessEvent[Probe[main.stringArg]@b52cc]
+// 0x1d3: ProcessEvent[Probe[main.stringArg]@b52dc]
 	PrepareEventRoot 99 00 00 00 11 00 00 00 
-	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
+	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb52dc.expr[0]]
 	Return 
-// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
+// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0xb54dc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2a 03 00 00 // ProcessType[[3]string]
+	Call 34 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x203: ProcessEvent[Probe[main.stringArrayArg]@b54cc]
+// 0x203: ProcessEvent[Probe[main.stringArrayArg]@b54dc]
 	PrepareEventRoot 9d 00 00 00 31 00 00 00 
-	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
+	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb54dc.expr[0]]
 	Return 
-// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
+// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0xb545c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 74 03 00 00 // ProcessType[[]string]
+	Call 7e 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b544c]
+// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b545c]
 	PrepareEventRoot 9c 00 00 00 19 00 00 00 
-	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
+	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb545c.expr[0]]
 	Return 
-// 0x24a: ProcessType[*****int]
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b57d0]
+	PrepareEventRoot a2 00 00 00 00 00 00 00 
+	Return 
+// 0x254: ProcessType[*****int]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x250: ProcessType[****int]
+// 0x25a: ProcessType[****int]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x256: ProcessType[***int]
+// 0x260: ProcessType[***int]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x25c: ProcessType[**int]
+// 0x266: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x262: ProcessType[*[]runtime.ancestorInfo]
+// 0x26c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x268: ProcessType[*bool]
+// 0x272: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x26e: ProcessType[*error]
+// 0x278: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x274: ProcessType[*float32]
+// 0x27e: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x27a: ProcessType[*float64]
+// 0x284: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x280: ProcessType[*int]
+// 0x28a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x286: ProcessType[*int32]
+// 0x290: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x28c: ProcessType[*int64]
+// 0x296: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x292: ProcessType[*main.bigStruct]
+// 0x29c: ProcessType[*main.bigStruct]
 	ProcessPointer 93 00 00 00 
 	Return 
-// 0x298: ProcessType[*runtime._defer]
+// 0x2a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x29e: ProcessType[*runtime._panic]
+// 0x2a8: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x2a4: ProcessType[*runtime.cgoCallers]
+// 0x2ae: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x2aa: ProcessType[*runtime.coro]
+// 0x2b4: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2b0: ProcessType[*runtime.g]
+// 0x2ba: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x2b6: ProcessType[*runtime.m]
+// 0x2c0: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2bc: ProcessType[*runtime.sudog]
+// 0x2c6: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2c2: ProcessType[*runtime.synctestGroup]
+// 0x2cc: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x2c8: ProcessType[*runtime.timer]
+// 0x2d2: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x2ce: ProcessType[*runtime.traceBuf]
+// 0x2d8: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x2d4: ProcessType[*string]
+// 0x2de: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x2da: ProcessType[*table<string,int>]
+// 0x2e4: ProcessType[*table<string,int>]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x2e0: ProcessType[*table<string,main.bigStruct>]
+// 0x2ea: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 8c 00 00 00 
 	Return 
-// 0x2e6: ProcessType[*uint]
+// 0x2f0: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2ec: ProcessType[*uint16]
+// 0x2f6: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2f2: ProcessType[*uint32]
+// 0x2fc: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2f8: ProcessType[*uint64]
+// 0x302: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x2fe: ProcessType[*uint8]
+// 0x308: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x304: ProcessType[*uintptr]
+// 0x30e: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x30a: ProcessType[[2]*runtime.traceBuf]
+// 0x314: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call ce 02 00 00 // ProcessType[*runtime.traceBuf]
+	Call d8 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x31a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x324: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 0a 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 14 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x32a: ProcessType[[3]string]
+// 0x334: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 08 05 00 00 // ProcessType[string]
+	Call 12 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x33a: ProcessType[[]*table<string,int>.array]
+// 0x344: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call da 02 00 00 // ProcessType[*table<string,int>]
+	Call e4 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x346: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x350: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call e0 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call ea 02 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x352: ProcessType[[]int]
+// 0x35c: ProcessType[[]int]
 	ProcessSlice 80 00 00 00 08 00 00 00 
 	Return 
-// 0x35c: ProcessType[[]noalg.map.group[string]int.array]
+// 0x366: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call fc 03 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 06 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x368: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x372: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 07 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 11 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x374: ProcessType[[]string]
+// 0x37e: ProcessType[[]string]
 	ProcessSlice 82 00 00 00 10 00 00 00 
 	Return 
-// 0x37e: ProcessType[[]string.array]
+// 0x388: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 08 05 00 00 // ProcessType[string]
+	Call 12 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x38a: ProcessType[[]uint8]
+// 0x394: ProcessType[[]uint8]
 	ProcessSlice 7c 00 00 00 01 00 00 00 
 	Return 
-// 0x394: ProcessType[[]uintptr]
+// 0x39e: ProcessType[[]uintptr]
 	ProcessSlice 7e 00 00 00 08 00 00 00 
 	Return 
-// 0x39e: ProcessType[error]
+// 0x3a8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3a0: ProcessType[groupReference<string,int>]
+// 0x3aa: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 8b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3ac: ProcessType[groupReference<string,main.bigStruct>]
+// 0x3b6: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 95 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3b8: ProcessType[map<string,int>]
+// 0x3c2: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8a 00 00 00 87 00 00 00 10 18 
 	Return 
-// 0x3c4: ProcessType[map<string,main.bigStruct>]
+// 0x3ce: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 94 00 00 00 8f 00 00 00 10 18 
 	Return 
-// 0x3d0: ProcessType[map[string]int]
+// 0x3da: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x3d6: ProcessType[map[string]main.bigStruct]
+// 0x3e0: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x3dc: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x3e6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 12 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 1c 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ec: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x3f6: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 22 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 2c 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x3fc: ProcessType[noalg.map.group[string]int]
+// 0x406: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call ec 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call f6 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x407: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x411: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call dc 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call e6 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x412: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 08 05 00 00 // ProcessType[string]
+// 0x41c: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 12 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 92 02 00 00 // ProcessType[*main.bigStruct]
+	Call 9c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x422: ProcessType[noalg.struct { key string; elem int }]
-	Call 08 05 00 00 // ProcessType[string]
+// 0x42c: ProcessType[noalg.struct { key string; elem int }]
+	Call 12 05 00 00 // ProcessType[string]
 	Return 
-// 0x428: ProcessType[runtime.g]
+// 0x432: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 9e 02 00 00 // ProcessType[*runtime._panic]
+	Call a8 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 98 02 00 00 // ProcessType[*runtime._defer]
+	Call a2 02 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 8a 03 00 00 // ProcessType[[]uint8]
+	Call 94 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 62 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call bc 02 00 00 // ProcessType[*runtime.sudog]
+	Call c6 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 94 03 00 00 // ProcessType[[]uintptr]
+	Call 9e 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call c8 02 00 00 // ProcessType[*runtime.timer]
+	Call d2 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call aa 02 00 00 // ProcessType[*runtime.coro]
+	Call b4 02 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.synctestGroup]
+	Call cc 02 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x48d: ProcessType[runtime.m]
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+// 0x497: ProcessType[runtime.m]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 08 05 00 00 // ProcessType[string]
+	Call 12 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call a4 02 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ae 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ed 04 00 00 // ProcessType[runtime.mLockProfile]
+	Call f7 04 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 94 03 00 00 // ProcessType[[]uintptr]
+	Call 9e 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call f8 04 00 00 // ProcessType[runtime.mTraceState]
+	Call 02 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x4ed: ProcessType[runtime.mLockProfile]
+// 0x4f7: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 94 03 00 00 // ProcessType[[]uintptr]
+	Call 9e 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x4f8: ProcessType[runtime.mTraceState]
+// 0x502: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call 24 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x508: ProcessType[string]
+// 0x512: ProcessType[string]
 	ProcessString 7a 00 00 00 
 	Return 
-// 0x50e: ProcessType[table<string,int>]
+// 0x518: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a0 03 00 00 // ProcessType[groupReference<string,int>]
+	Call aa 03 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x519: ProcessType[table<string,main.bigStruct>]
+// 0x523: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ac 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call b6 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -414,31 +417,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 766
+ID: 5 Len: 8 Enqueue: 776
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1288
+ID: 9 Len: 16 Enqueue: 1298
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 616
+ID: 11 Len: 8 Enqueue: 626
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 926
+ID: 14 Len: 16 Enqueue: 936
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 772
-ID: 20 Len: 8 Enqueue: 646
-ID: 21 Len: 8 Enqueue: 754
-ID: 22 Len: 440 Enqueue: 1064
+ID: 19 Len: 8 Enqueue: 782
+ID: 20 Len: 8 Enqueue: 656
+ID: 21 Len: 8 Enqueue: 764
+ID: 22 Len: 440 Enqueue: 1074
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 670
+ID: 24 Len: 8 Enqueue: 680
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 664
+ID: 26 Len: 8 Enqueue: 674
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 694
-ID: 29 Len: 1808 Enqueue: 1165
+ID: 28 Len: 8 Enqueue: 704
+ID: 29 Len: 1808 Enqueue: 1175
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -447,45 +450,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 906
-ID: 39 Len: 8 Enqueue: 610
+ID: 38 Len: 24 Enqueue: 916
+ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 700
+ID: 41 Len: 8 Enqueue: 710
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 916
-ID: 44 Len: 8 Enqueue: 712
+ID: 43 Len: 24 Enqueue: 926
+ID: 44 Len: 8 Enqueue: 722
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 682
+ID: 47 Len: 8 Enqueue: 692
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 706
+ID: 49 Len: 8 Enqueue: 716
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 688
+ID: 55 Len: 8 Enqueue: 698
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 676
+ID: 62 Len: 8 Enqueue: 686
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1261
+ID: 67 Len: 64 Enqueue: 1271
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1272
+ID: 72 Len: 56 Enqueue: 1282
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 794
-ID: 75 Len: 16 Enqueue: 778
-ID: 76 Len: 8 Enqueue: 718
+ID: 74 Len: 32 Enqueue: 804
+ID: 75 Len: 16 Enqueue: 788
+ID: 76 Len: 8 Enqueue: 728
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -502,35 +505,35 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 724
+ID: 93 Len: 8 Enqueue: 734
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 634
-ID: 98 Len: 8 Enqueue: 652
-ID: 99 Len: 8 Enqueue: 640
-ID: 100 Len: 8 Enqueue: 760
-ID: 101 Len: 8 Enqueue: 622
-ID: 102 Len: 8 Enqueue: 628
-ID: 103 Len: 8 Enqueue: 742
-ID: 104 Len: 8 Enqueue: 748
-ID: 105 Len: 24 Enqueue: 850
+ID: 97 Len: 8 Enqueue: 644
+ID: 98 Len: 8 Enqueue: 662
+ID: 99 Len: 8 Enqueue: 650
+ID: 100 Len: 8 Enqueue: 770
+ID: 101 Len: 8 Enqueue: 632
+ID: 102 Len: 8 Enqueue: 638
+ID: 103 Len: 8 Enqueue: 752
+ID: 104 Len: 8 Enqueue: 758
+ID: 105 Len: 24 Enqueue: 860
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 884
-ID: 108 Len: 48 Enqueue: 810
-ID: 109 Len: 8 Enqueue: 976
+ID: 107 Len: 24 Enqueue: 894
+ID: 108 Len: 48 Enqueue: 820
+ID: 109 Len: 8 Enqueue: 986
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 952
+ID: 111 Len: 48 Enqueue: 962
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 730
-ID: 114 Len: 8 Enqueue: 982
+ID: 113 Len: 8 Enqueue: 740
+ID: 114 Len: 8 Enqueue: 992
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 964
+ID: 116 Len: 48 Enqueue: 974
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 736
-ID: 119 Len: 8 Enqueue: 586
-ID: 120 Len: 8 Enqueue: 592
-ID: 121 Len: 8 Enqueue: 604
+ID: 118 Len: 8 Enqueue: 746
+ID: 119 Len: 8 Enqueue: 596
+ID: 120 Len: 8 Enqueue: 602
+ID: 121 Len: 8 Enqueue: 614
 ID: 122 Len: 1 Enqueue: 0
 ID: 123 Len: 8 Enqueue: 0
 ID: 124 Len: 1 Enqueue: 0
@@ -539,27 +542,27 @@ ID: 126 Len: 8 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
-ID: 130 Len: 16 Enqueue: 894
+ID: 130 Len: 16 Enqueue: 904
 ID: 131 Len: 8 Enqueue: 0
-ID: 132 Len: 32 Enqueue: 1294
-ID: 133 Len: 16 Enqueue: 928
+ID: 132 Len: 32 Enqueue: 1304
+ID: 133 Len: 16 Enqueue: 938
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 200 Enqueue: 1020
-ID: 136 Len: 192 Enqueue: 1004
-ID: 137 Len: 24 Enqueue: 1058
-ID: 138 Len: 8 Enqueue: 826
-ID: 139 Len: 200 Enqueue: 860
-ID: 140 Len: 32 Enqueue: 1305
-ID: 141 Len: 16 Enqueue: 940
+ID: 135 Len: 200 Enqueue: 1030
+ID: 136 Len: 192 Enqueue: 1014
+ID: 137 Len: 24 Enqueue: 1068
+ID: 138 Len: 8 Enqueue: 836
+ID: 139 Len: 200 Enqueue: 870
+ID: 140 Len: 32 Enqueue: 1315
+ID: 141 Len: 16 Enqueue: 950
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 200 Enqueue: 1031
-ID: 144 Len: 192 Enqueue: 988
-ID: 145 Len: 24 Enqueue: 1042
-ID: 146 Len: 8 Enqueue: 658
+ID: 143 Len: 200 Enqueue: 1041
+ID: 144 Len: 192 Enqueue: 998
+ID: 145 Len: 24 Enqueue: 1052
+ID: 146 Len: 8 Enqueue: 668
 ID: 147 Len: 184 Enqueue: 0
-ID: 148 Len: 8 Enqueue: 838
-ID: 149 Len: 200 Enqueue: 872
-ID: 150 Len: 8 Enqueue: 598
+ID: 148 Len: 8 Enqueue: 848
+ID: 149 Len: 200 Enqueue: 882
+ID: 150 Len: 8 Enqueue: 608
 ID: 151 Len: 128 Enqueue: 0
 ID: 152 Len: 9 Enqueue: 0
 ID: 153 Len: 17 Enqueue: 0
@@ -571,6 +574,7 @@ ID: 158 Len: 49 Enqueue: 0
 ID: 159 Len: 9 Enqueue: 0
 ID: 160 Len: 9 Enqueue: 0
 ID: 161 Len: 0 Enqueue: 0
-ID: 162 Len: 9 Enqueue: 0
+ID: 162 Len: 0 Enqueue: 0
 ID: 163 Len: 9 Enqueue: 0
 ID: 164 Len: 9 Enqueue: 0
+ID: 165 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -3,151 +3,151 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb520c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b51cc]
-	PrepareEventRoot a4 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b520c]
+	PrepareEventRoot bf 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb520c.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5244.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 66 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5204]
-	PrepareEventRoot a5 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5244]
+	PrepareEventRoot c0 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5244.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb56a0.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb56e0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e0 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 46 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@b56a0]
-	PrepareEventRoot a0 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb56a0.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b56e0]
+	PrepareEventRoot bb 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb56e0.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0xb556c.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@b556c]
-	PrepareEventRoot a3 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb556c.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@b4fec]
-	PrepareEventRoot a3 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0xb526c.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb55ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@b526c]
-	PrepareEventRoot 98 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb526c.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@b55ac]
+	PrepareEventRoot be 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb55ac.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb53dc.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@b502c]
+	PrepareEventRoot be 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb52ac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@b52ac]
+	PrepareEventRoot b3 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb52ac.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb541c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@b53dc]
-	PrepareEventRoot 9b 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb53dc.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b541c]
+	PrepareEventRoot b6 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb541c.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5550.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 34 03 00 00 // ProcessType[[3]string]
+	Call 40 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5550]
-	PrepareEventRoot 9e 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5550.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5590]
+	PrepareEventRoot b9 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb535c.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb539c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 5c 03 00 00 // ProcessType[[]int]
+	Call 80 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b535c]
-	PrepareEventRoot 9a 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb535c.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b539c]
+	PrepareEventRoot b5 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb539c.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb562c.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb566c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call da 03 00 00 // ProcessType[map[string]int]
+	Call 40 04 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@b562c]
-	PrepareEventRoot 9f 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb562c.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b566c]
+	PrepareEventRoot ba 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb566c.expr[0]]
 	Return 
-// 0x1a7: ProcessEvent[Probe[main.noArgs]@b575c]
-	PrepareEventRoot a1 00 00 00 00 00 00 00 
+// 0x1a7: ProcessEvent[Probe[main.noArgs]@b579c]
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x1b1: ProcessExpression[Probe[main.stringArg]@0xb52dc.expr[0]]
+// 0x1b1: ProcessExpression[Probe[main.stringArg]@0xb531c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 12 05 00 00 // ProcessType[string]
+	Call a4 05 00 00 // ProcessType[string]
 	Return 
-// 0x1d3: ProcessEvent[Probe[main.stringArg]@b52dc]
-	PrepareEventRoot 99 00 00 00 11 00 00 00 
-	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb52dc.expr[0]]
+// 0x1d3: ProcessEvent[Probe[main.stringArg]@b531c]
+	PrepareEventRoot b4 00 00 00 11 00 00 00 
+	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb531c.expr[0]]
 	Return 
-// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0xb54dc.expr[0]]
+// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0xb551c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 34 03 00 00 // ProcessType[[3]string]
+	Call 40 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x203: ProcessEvent[Probe[main.stringArrayArg]@b54dc]
-	PrepareEventRoot 9d 00 00 00 31 00 00 00 
-	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb54dc.expr[0]]
+// 0x203: ProcessEvent[Probe[main.stringArrayArg]@b551c]
+	PrepareEventRoot b8 00 00 00 31 00 00 00 
+	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb551c.expr[0]]
 	Return 
-// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0xb545c.expr[0]]
+// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0xb549c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 7e 03 00 00 // ProcessType[[]string]
+	Call ae 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b545c]
-	PrepareEventRoot 9c 00 00 00 19 00 00 00 
-	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb545c.expr[0]]
+// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b549c]
+	PrepareEventRoot b7 00 00 00 19 00 00 00 
+	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb549c.expr[0]]
 	Return 
-// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b57d0]
-	PrepareEventRoot a2 00 00 00 00 00 00 00 
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5810]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
 // 0x254: ProcessType[*****int]
-	ProcessPointer 78 00 00 00 
+	ProcessPointer 7d 00 00 00 
 	Return 
 // 0x25a: ProcessType[****int]
-	ProcessPointer 96 00 00 00 
+	ProcessPointer b1 00 00 00 
 	Return 
 // 0x260: ProcessType[***int]
-	ProcessPointer 79 00 00 00 
+	ProcessPointer 7e 00 00 00 
 	Return 
 // 0x266: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
@@ -177,7 +177,7 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x29c: ProcessType[*main.bigStruct]
-	ProcessPointer 93 00 00 00 
+	ProcessPointer 98 00 00 00 
 	Return 
 // 0x2a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
@@ -212,130 +212,182 @@
 // 0x2de: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x2e4: ProcessType[*table<string,int>]
-	ProcessPointer 84 00 00 00 
+// 0x2e4: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer a8 00 00 00 
 	Return 
-// 0x2ea: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 8c 00 00 00 
+// 0x2ea: ProcessType[*table<string,int>]
+	ProcessPointer 89 00 00 00 
 	Return 
-// 0x2f0: ProcessType[*uint]
+// 0x2f0: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 91 00 00 00 
+	Return 
+// 0x2f6: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 9b 00 00 00 
+	Return 
+// 0x2fc: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2f6: ProcessType[*uint16]
+// 0x302: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2fc: ProcessType[*uint32]
+// 0x308: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x302: ProcessType[*uint64]
+// 0x30e: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x308: ProcessType[*uint8]
+// 0x314: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x30e: ProcessType[*uintptr]
+// 0x31a: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x314: ProcessType[[2]*runtime.traceBuf]
+// 0x320: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
 	Call d8 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x324: ProcessType[[2][2]*runtime.traceBuf]
+// 0x330: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 14 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 20 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x334: ProcessType[[3]string]
+// 0x340: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 12 05 00 00 // ProcessType[string]
+	Call a4 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x344: ProcessType[[]*table<string,int>.array]
+// 0x350: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e4 02 00 00 // ProcessType[*table<string,int>]
+	Call e4 02 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x350: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x35c: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call ea 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call ea 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x35c: ProcessType[[]int]
-	ProcessSlice 80 00 00 00 08 00 00 00 
-	Return 
-// 0x366: ProcessType[[]noalg.map.group[string]int.array]
+// 0x368: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 06 04 00 00 // ProcessType[noalg.map.group[string]int]
+	Call f0 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x374: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call f6 02 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x380: ProcessType[[]int]
+	ProcessSlice 85 00 00 00 08 00 00 00 
+	Return 
+// 0x38a: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 82 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x372: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x396: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 11 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 8d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x37e: ProcessType[[]string]
-	ProcessSlice 82 00 00 00 10 00 00 00 
-	Return 
-// 0x388: ProcessType[[]string.array]
+// 0x3a2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 12 05 00 00 // ProcessType[string]
+	Call 98 04 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x3ae: ProcessType[[]string]
+	ProcessSlice 87 00 00 00 10 00 00 00 
+	Return 
+// 0x3b8: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call a4 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x394: ProcessType[[]uint8]
-	ProcessSlice 7c 00 00 00 01 00 00 00 
+// 0x3c4: ProcessType[[]uint8]
+	ProcessSlice 81 00 00 00 01 00 00 00 
 	Return 
-// 0x39e: ProcessType[[]uintptr]
-	ProcessSlice 7e 00 00 00 08 00 00 00 
+// 0x3ce: ProcessType[[]uintptr]
+	ProcessSlice 83 00 00 00 08 00 00 00 
 	Return 
-// 0x3a8: ProcessType[error]
+// 0x3d8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3aa: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 8b 00 00 00 c8 00 00 00 00 08 
+// 0x3da: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x3b6: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 95 00 00 00 c8 00 00 00 00 08 
+// 0x3e6: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 90 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3c2: ProcessType[map<string,int>]
-	ProcessGoSwissMap 8a 00 00 00 87 00 00 00 10 18 
+// 0x3f2: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3ce: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 94 00 00 00 8f 00 00 00 10 18 
+// 0x3fe: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups a7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x3da: ProcessType[map[string]int]
+// 0x40a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap af 00 00 00 ab 00 00 00 10 18 
+	Return 
+// 0x416: ProcessType[map<string,int>]
+	ProcessGoSwissMap 8f 00 00 00 8c 00 00 00 10 18 
+	Return 
+// 0x422: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 99 00 00 00 94 00 00 00 10 18 
+	Return 
+// 0x42e: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap a6 00 00 00 9e 00 00 00 10 18 
+	Return 
+// 0x43a: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer a3 00 00 00 
+	Return 
+// 0x440: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x3e0: ProcessType[map[string]main.bigStruct]
+// 0x446: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x3e6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x44c: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 79 00 00 00 
+	Return 
+// 0x452: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 1c 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a3 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f6: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x462: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 2c 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call b3 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x406: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call f6 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x472: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call b9 04 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x411: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x482: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call e6 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 62 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x41c: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 12 05 00 00 // ProcessType[string]
+// 0x48d: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call 52 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x498: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	IncrementOutputOffset 08 00 00 00 
+	Call 72 04 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Return 
+// 0x4a3: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a4 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
 	Call 9c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x42c: ProcessType[noalg.struct { key string; elem int }]
-	Call 12 05 00 00 // ProcessType[string]
+// 0x4b3: ProcessType[noalg.struct { key string; elem int }]
+	Call a4 05 00 00 // ProcessType[string]
 	Return 
-// 0x432: ProcessType[runtime.g]
+// 0x4b9: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	IncrementOutputOffset 08 00 00 00 
+	Call 3a 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x4c4: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
 	Call a8 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
@@ -343,13 +395,13 @@
 	IncrementOutputOffset 08 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 94 03 00 00 // ProcessType[[]uint8]
+	Call c4 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
 	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
 	Call c6 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9e 03 00 00 // ProcessType[[]uintptr]
+	Call ce 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
 	Call d2 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
@@ -357,46 +409,54 @@
 	IncrementOutputOffset 08 00 00 00 
 	Call cc 02 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x497: ProcessType[runtime.m]
+// 0x529: ProcessType[runtime.m]
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 12 05 00 00 // ProcessType[string]
+	Call a4 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
 	Call ae 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call f7 04 00 00 // ProcessType[runtime.mLockProfile]
+	Call 89 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 9e 03 00 00 // ProcessType[[]uintptr]
+	Call ce 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 05 00 00 // ProcessType[runtime.mTraceState]
+	Call 94 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x4f7: ProcessType[runtime.mLockProfile]
+// 0x589: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9e 03 00 00 // ProcessType[[]uintptr]
+	Call ce 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x502: ProcessType[runtime.mTraceState]
+// 0x594: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 24 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 30 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x512: ProcessType[string]
-	ProcessString 7a 00 00 00 
+// 0x5a4: ProcessType[string]
+	ProcessString 7f 00 00 00 
 	Return 
-// 0x518: ProcessType[table<string,int>]
+// 0x5aa: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call aa 03 00 00 // ProcessType[groupReference<string,int>]
+	Call da 03 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x523: ProcessType[table<string,main.bigStruct>]
+// 0x5b5: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call b6 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call e6 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x5c0: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call f2 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x5cb: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call fe 03 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -417,31 +477,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 776
+ID: 5 Len: 8 Enqueue: 788
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1298
+ID: 9 Len: 16 Enqueue: 1444
 ID: 10 Len: 8 Enqueue: 0
 ID: 11 Len: 8 Enqueue: 626
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 936
+ID: 14 Len: 16 Enqueue: 984
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 782
+ID: 19 Len: 8 Enqueue: 794
 ID: 20 Len: 8 Enqueue: 656
-ID: 21 Len: 8 Enqueue: 764
-ID: 22 Len: 440 Enqueue: 1074
+ID: 21 Len: 8 Enqueue: 776
+ID: 22 Len: 440 Enqueue: 1220
 ID: 23 Len: 16 Enqueue: 0
 ID: 24 Len: 8 Enqueue: 680
 ID: 25 Len: 8 Enqueue: 0
 ID: 26 Len: 8 Enqueue: 674
 ID: 27 Len: 8 Enqueue: 0
 ID: 28 Len: 8 Enqueue: 704
-ID: 29 Len: 1808 Enqueue: 1175
+ID: 29 Len: 1808 Enqueue: 1321
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -450,12 +510,12 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 916
+ID: 38 Len: 24 Enqueue: 964
 ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
 ID: 41 Len: 8 Enqueue: 710
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 926
+ID: 43 Len: 24 Enqueue: 974
 ID: 44 Len: 8 Enqueue: 722
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
@@ -479,15 +539,15 @@ ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1271
+ID: 67 Len: 64 Enqueue: 1417
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1282
+ID: 72 Len: 56 Enqueue: 1428
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 804
-ID: 75 Len: 16 Enqueue: 788
+ID: 74 Len: 32 Enqueue: 816
+ID: 75 Len: 16 Enqueue: 800
 ID: 76 Len: 8 Enqueue: 728
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
@@ -512,69 +572,96 @@ ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 644
 ID: 98 Len: 8 Enqueue: 662
 ID: 99 Len: 8 Enqueue: 650
-ID: 100 Len: 8 Enqueue: 770
+ID: 100 Len: 8 Enqueue: 782
 ID: 101 Len: 8 Enqueue: 632
 ID: 102 Len: 8 Enqueue: 638
-ID: 103 Len: 8 Enqueue: 752
-ID: 104 Len: 8 Enqueue: 758
-ID: 105 Len: 24 Enqueue: 860
+ID: 103 Len: 8 Enqueue: 764
+ID: 104 Len: 8 Enqueue: 770
+ID: 105 Len: 24 Enqueue: 896
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 894
-ID: 108 Len: 48 Enqueue: 820
-ID: 109 Len: 8 Enqueue: 986
+ID: 107 Len: 24 Enqueue: 942
+ID: 108 Len: 48 Enqueue: 832
+ID: 109 Len: 8 Enqueue: 1088
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 962
+ID: 111 Len: 48 Enqueue: 1046
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 740
-ID: 114 Len: 8 Enqueue: 992
+ID: 113 Len: 8 Enqueue: 746
+ID: 114 Len: 8 Enqueue: 1094
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 974
+ID: 116 Len: 48 Enqueue: 1058
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 746
-ID: 119 Len: 8 Enqueue: 596
-ID: 120 Len: 8 Enqueue: 602
-ID: 121 Len: 8 Enqueue: 614
-ID: 122 Len: 1 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 1 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 8 Enqueue: 0
+ID: 118 Len: 8 Enqueue: 752
+ID: 119 Len: 8 Enqueue: 1100
+ID: 120 Len: 8 Enqueue: 0
+ID: 121 Len: 48 Enqueue: 1070
+ID: 122 Len: 8 Enqueue: 0
+ID: 123 Len: 8 Enqueue: 758
+ID: 124 Len: 8 Enqueue: 596
+ID: 125 Len: 8 Enqueue: 602
+ID: 126 Len: 8 Enqueue: 614
+ID: 127 Len: 1 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 0
-ID: 130 Len: 16 Enqueue: 904
+ID: 129 Len: 1 Enqueue: 0
+ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
-ID: 132 Len: 32 Enqueue: 1304
-ID: 133 Len: 16 Enqueue: 938
+ID: 132 Len: 8 Enqueue: 0
+ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 200 Enqueue: 1030
-ID: 136 Len: 192 Enqueue: 1014
-ID: 137 Len: 24 Enqueue: 1068
-ID: 138 Len: 8 Enqueue: 836
-ID: 139 Len: 200 Enqueue: 870
-ID: 140 Len: 32 Enqueue: 1315
-ID: 141 Len: 16 Enqueue: 950
-ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 200 Enqueue: 1041
-ID: 144 Len: 192 Enqueue: 998
-ID: 145 Len: 24 Enqueue: 1052
-ID: 146 Len: 8 Enqueue: 668
-ID: 147 Len: 184 Enqueue: 0
-ID: 148 Len: 8 Enqueue: 848
-ID: 149 Len: 200 Enqueue: 882
-ID: 150 Len: 8 Enqueue: 608
-ID: 151 Len: 128 Enqueue: 0
-ID: 152 Len: 9 Enqueue: 0
-ID: 153 Len: 17 Enqueue: 0
-ID: 154 Len: 25 Enqueue: 0
-ID: 155 Len: 25 Enqueue: 0
-ID: 156 Len: 25 Enqueue: 0
-ID: 157 Len: 49 Enqueue: 0
-ID: 158 Len: 49 Enqueue: 0
-ID: 159 Len: 9 Enqueue: 0
-ID: 160 Len: 9 Enqueue: 0
-ID: 161 Len: 0 Enqueue: 0
-ID: 162 Len: 0 Enqueue: 0
-ID: 163 Len: 9 Enqueue: 0
-ID: 164 Len: 9 Enqueue: 0
-ID: 165 Len: 9 Enqueue: 0
+ID: 135 Len: 16 Enqueue: 952
+ID: 136 Len: 8 Enqueue: 0
+ID: 137 Len: 32 Enqueue: 1461
+ID: 138 Len: 16 Enqueue: 998
+ID: 139 Len: 8 Enqueue: 0
+ID: 140 Len: 200 Enqueue: 1154
+ID: 141 Len: 192 Enqueue: 1122
+ID: 142 Len: 24 Enqueue: 1203
+ID: 143 Len: 8 Enqueue: 860
+ID: 144 Len: 200 Enqueue: 906
+ID: 145 Len: 32 Enqueue: 1472
+ID: 146 Len: 16 Enqueue: 1010
+ID: 147 Len: 8 Enqueue: 0
+ID: 148 Len: 200 Enqueue: 1165
+ID: 149 Len: 192 Enqueue: 1106
+ID: 150 Len: 24 Enqueue: 1187
+ID: 151 Len: 8 Enqueue: 668
+ID: 152 Len: 184 Enqueue: 0
+ID: 153 Len: 8 Enqueue: 872
+ID: 154 Len: 200 Enqueue: 918
+ID: 155 Len: 32 Enqueue: 1483
+ID: 156 Len: 16 Enqueue: 1022
+ID: 157 Len: 8 Enqueue: 0
+ID: 158 Len: 136 Enqueue: 1176
+ID: 159 Len: 128 Enqueue: 1138
+ID: 160 Len: 16 Enqueue: 1209
+ID: 161 Len: 8 Enqueue: 1082
+ID: 162 Len: 8 Enqueue: 0
+ID: 163 Len: 48 Enqueue: 1034
+ID: 164 Len: 8 Enqueue: 0
+ID: 165 Len: 8 Enqueue: 740
+ID: 166 Len: 8 Enqueue: 884
+ID: 167 Len: 136 Enqueue: 930
+ID: 168 Len: 32 Enqueue: 1450
+ID: 169 Len: 16 Enqueue: 986
+ID: 170 Len: 8 Enqueue: 0
+ID: 171 Len: 136 Enqueue: 0
+ID: 172 Len: 128 Enqueue: 0
+ID: 173 Len: 16 Enqueue: 0
+ID: 174 Len: 8 Enqueue: 0
+ID: 175 Len: 8 Enqueue: 848
+ID: 176 Len: 136 Enqueue: 0
+ID: 177 Len: 8 Enqueue: 608
+ID: 178 Len: 128 Enqueue: 0
+ID: 179 Len: 9 Enqueue: 0
+ID: 180 Len: 17 Enqueue: 0
+ID: 181 Len: 25 Enqueue: 0
+ID: 182 Len: 25 Enqueue: 0
+ID: 183 Len: 25 Enqueue: 0
+ID: 184 Len: 49 Enqueue: 0
+ID: 185 Len: 49 Enqueue: 0
+ID: 186 Len: 9 Enqueue: 0
+ID: 187 Len: 9 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
+ID: 189 Len: 0 Enqueue: 0
+ID: 190 Len: 9 Enqueue: 0
+ID: 191 Len: 9 Enqueue: 0
+ID: 192 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,27 +7,27 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4a 02 00 00 // ProcessType[*****int]
+	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7d60]
-	PrepareEventRoot a8 00 00 00 09 00 00 00 
+	PrepareEventRoot a9 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5c 02 00 00 // ProcessType[**int]
+	Call 66 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7d94]
-	PrepareEventRoot a9 00 00 00 09 00 00 00 
+	PrepareEventRoot aa 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f2 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call fc 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b81f0]
 	PrepareEventRoot a5 00 00 00 09 00 00 00 
@@ -39,7 +39,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x97: ProcessEvent[Probe[main.inlined]@b80bc]
-	PrepareEventRoot a7 00 00 00 09 00 00 00 
+	PrepareEventRoot a8 00 00 00 09 00 00 00 
 	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
 	Return 
 // 0xa6: ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xb6: ProcessEvent[Probe[main.inlined]@b7b88]
-	PrepareEventRoot a7 00 00 00 09 00 00 00 
+	PrepareEventRoot a8 00 00 00 09 00 00 00 
 	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
 	Return 
 // 0xc5: ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
@@ -73,7 +73,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 30 03 00 00 // ProcessType[[3]string]
+	Call 3a 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80a0]
 	PrepareEventRoot a3 00 00 00 31 00 00 00 
@@ -85,7 +85,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 6e 03 00 00 // ProcessType[[]int]
+	Call 78 03 00 00 // ProcessType[[]int]
 	Return 
 // 0x16e: ProcessEvent[Probe[main.intSliceArg]@b7ecc]
 	PrepareEventRoot 9f 00 00 00 19 00 00 00 
@@ -95,7 +95,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ec 03 00 00 // ProcessType[map[string]int]
+	Call f6 03 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x198: ProcessEvent[Probe[main.mapArg]@b817c]
 	PrepareEventRoot a4 00 00 00 09 00 00 00 
@@ -109,7 +109,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 2e 05 00 00 // ProcessType[string]
+	Call 38 05 00 00 // ProcessType[string]
 	Return 
 // 0x1d3: ProcessEvent[Probe[main.stringArg]@b7e5c]
 	PrepareEventRoot 9e 00 00 00 11 00 00 00 
@@ -119,7 +119,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 30 03 00 00 // ProcessType[[3]string]
+	Call 3a 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x203: ProcessEvent[Probe[main.stringArrayArg]@b803c]
 	PrepareEventRoot a2 00 00 00 31 00 00 00 
@@ -131,282 +131,285 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 90 03 00 00 // ProcessType[[]string]
+	Call 9a 03 00 00 // ProcessType[[]string]
 	Return 
 // 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b7fbc]
 	PrepareEventRoot a1 00 00 00 19 00 00 00 
 	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
 	Return 
-// 0x24a: ProcessType[*****int]
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8310]
+	PrepareEventRoot a7 00 00 00 00 00 00 00 
+	Return 
+// 0x254: ProcessType[*****int]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x250: ProcessType[****int]
+// 0x25a: ProcessType[****int]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x256: ProcessType[***int]
+// 0x260: ProcessType[***int]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x25c: ProcessType[**int]
+// 0x266: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x262: ProcessType[*[]runtime.ancestorInfo]
+// 0x26c: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x268: ProcessType[*bool]
+// 0x272: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x26e: ProcessType[*error]
+// 0x278: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x274: ProcessType[*float32]
+// 0x27e: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x27a: ProcessType[*float64]
+// 0x284: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x280: ProcessType[*int]
+// 0x28a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x286: ProcessType[*int32]
+// 0x290: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x28c: ProcessType[*int64]
+// 0x296: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x292: ProcessType[*main.bigStruct]
+// 0x29c: ProcessType[*main.bigStruct]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x298: ProcessType[*runtime._defer]
+// 0x2a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x29e: ProcessType[*runtime._panic]
+// 0x2a8: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x2a4: ProcessType[*runtime.cgoCallers]
+// 0x2ae: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x2aa: ProcessType[*runtime.coro]
+// 0x2b4: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2b0: ProcessType[*runtime.g]
+// 0x2ba: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x2b6: ProcessType[*runtime.m]
+// 0x2c0: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2bc: ProcessType[*runtime.p]
+// 0x2c6: ProcessType[*runtime.p]
 	ProcessPointer 82 00 00 00 
 	Return 
-// 0x2c2: ProcessType[*runtime.sudog]
+// 0x2cc: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2c8: ProcessType[*runtime.synctestBubble]
+// 0x2d2: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x2ce: ProcessType[*runtime.timer]
+// 0x2d8: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x2d4: ProcessType[*runtime.traceBuf]
+// 0x2de: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x2da: ProcessType[*string]
+// 0x2e4: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x2e0: ProcessType[*table<string,int>]
+// 0x2ea: ProcessType[*table<string,int>]
 	ProcessPointer 89 00 00 00 
 	Return 
-// 0x2e6: ProcessType[*table<string,main.bigStruct>]
+// 0x2f0: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x2ec: ProcessType[*uint]
+// 0x2f6: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2f2: ProcessType[*uint16]
+// 0x2fc: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2f8: ProcessType[*uint32]
+// 0x302: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2fe: ProcessType[*uint64]
+// 0x308: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x304: ProcessType[*uint8]
+// 0x30e: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x30a: ProcessType[*uintptr]
+// 0x314: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x310: ProcessType[[2]*runtime.traceBuf]
+// 0x31a: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call d4 02 00 00 // ProcessType[*runtime.traceBuf]
+	Call de 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x320: ProcessType[[2][2]*runtime.traceBuf]
+// 0x32a: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 10 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 1a 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x330: ProcessType[[3]string]
+// 0x33a: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 2e 05 00 00 // ProcessType[string]
+	Call 38 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x340: ProcessType[[]*runtime.p]
+// 0x34a: ProcessType[[]*runtime.p]
 	ProcessSlice 83 00 00 00 08 00 00 00 
 	Return 
-// 0x34a: ProcessType[[]*runtime.p.array]
+// 0x354: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call bc 02 00 00 // ProcessType[*runtime.p]
+	Call c6 02 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x356: ProcessType[[]*table<string,int>.array]
+// 0x360: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call e0 02 00 00 // ProcessType[*table<string,int>]
+	Call ea 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x362: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x36c: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call e6 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f0 02 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36e: ProcessType[[]int]
+// 0x378: ProcessType[[]int]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x378: ProcessType[[]noalg.map.group[string]int.array]
+// 0x382: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 18 04 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 22 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x384: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x38e: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 23 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 2d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x390: ProcessType[[]string]
+// 0x39a: ProcessType[[]string]
 	ProcessSlice 87 00 00 00 10 00 00 00 
 	Return 
-// 0x39a: ProcessType[[]string.array]
+// 0x3a4: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 2e 05 00 00 // ProcessType[string]
+	Call 38 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3a6: ProcessType[[]uint8]
+// 0x3b0: ProcessType[[]uint8]
 	ProcessSlice 7e 00 00 00 01 00 00 00 
 	Return 
-// 0x3b0: ProcessType[[]uintptr]
+// 0x3ba: ProcessType[[]uintptr]
 	ProcessSlice 80 00 00 00 08 00 00 00 
 	Return 
-// 0x3ba: ProcessType[error]
+// 0x3c4: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3bc: ProcessType[groupReference<string,int>]
+// 0x3c6: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 90 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3c8: ProcessType[groupReference<string,main.bigStruct>]
+// 0x3d2: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3d4: ProcessType[map<string,int>]
+// 0x3de: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8f 00 00 00 8c 00 00 00 10 18 
 	Return 
-// 0x3e0: ProcessType[map<string,main.bigStruct>]
+// 0x3ea: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 99 00 00 00 94 00 00 00 10 18 
 	Return 
-// 0x3ec: ProcessType[map[string]int]
+// 0x3f6: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x3f2: ProcessType[map[string]main.bigStruct]
+// 0x3fc: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x3f8: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x402: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 2e 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 38 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x408: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x412: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 3e 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 48 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x418: ProcessType[noalg.map.group[string]int]
+// 0x422: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 08 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 12 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x423: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x42d: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call f8 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 02 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x42e: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 2e 05 00 00 // ProcessType[string]
+// 0x438: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 38 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 92 02 00 00 // ProcessType[*main.bigStruct]
+	Call 9c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x43e: ProcessType[noalg.struct { key string; elem int }]
-	Call 2e 05 00 00 // ProcessType[string]
+// 0x448: ProcessType[noalg.struct { key string; elem int }]
+	Call 38 05 00 00 // ProcessType[string]
 	Return 
-// 0x444: ProcessType[runtime.g]
+// 0x44e: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 9e 02 00 00 // ProcessType[*runtime._panic]
+	Call a8 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 98 02 00 00 // ProcessType[*runtime._defer]
+	Call a2 02 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call a6 03 00 00 // ProcessType[[]uint8]
+	Call b0 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 62 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call c2 02 00 00 // ProcessType[*runtime.sudog]
+	Call cc 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call b0 03 00 00 // ProcessType[[]uintptr]
+	Call ba 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call ce 02 00 00 // ProcessType[*runtime.timer]
+	Call d8 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call aa 02 00 00 // ProcessType[*runtime.coro]
+	Call b4 02 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call c8 02 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d2 02 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x4a9: ProcessType[runtime.m]
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+// 0x4b3: ProcessType[runtime.m]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call b0 02 00 00 // ProcessType[*runtime.g]
+	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 2e 05 00 00 // ProcessType[string]
+	Call 38 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 40 03 00 00 // ProcessType[[]*runtime.p]
+	Call 4a 03 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call a4 02 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ae 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 13 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call 1d 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call b0 03 00 00 // ProcessType[[]uintptr]
+	Call ba 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1e 05 00 00 // ProcessType[runtime.mTraceState]
+	Call 28 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x513: ProcessType[runtime.mLockProfile]
+// 0x51d: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call b0 03 00 00 // ProcessType[[]uintptr]
+	Call ba 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x51e: ProcessType[runtime.mTraceState]
+// 0x528: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 20 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b6 02 00 00 // ProcessType[*runtime.m]
+	Call 2a 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c0 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x52e: ProcessType[string]
+// 0x538: ProcessType[string]
 	ProcessString 7c 00 00 00 
 	Return 
-// 0x534: ProcessType[table<string,int>]
+// 0x53e: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call bc 03 00 00 // ProcessType[groupReference<string,int>]
+	Call c6 03 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x53f: ProcessType[table<string,main.bigStruct>]
+// 0x549: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call c8 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call d2 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -427,31 +430,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 772
+ID: 5 Len: 8 Enqueue: 782
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1326
+ID: 9 Len: 16 Enqueue: 1336
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 616
+ID: 11 Len: 8 Enqueue: 626
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 954
+ID: 14 Len: 16 Enqueue: 964
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 778
-ID: 20 Len: 8 Enqueue: 646
-ID: 21 Len: 8 Enqueue: 760
-ID: 22 Len: 440 Enqueue: 1092
+ID: 19 Len: 8 Enqueue: 788
+ID: 20 Len: 8 Enqueue: 656
+ID: 21 Len: 8 Enqueue: 770
+ID: 22 Len: 440 Enqueue: 1102
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 670
+ID: 24 Len: 8 Enqueue: 680
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 664
+ID: 26 Len: 8 Enqueue: 674
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 694
-ID: 29 Len: 1816 Enqueue: 1193
+ID: 28 Len: 8 Enqueue: 704
+ID: 29 Len: 1816 Enqueue: 1203
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -460,48 +463,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 934
-ID: 39 Len: 8 Enqueue: 610
+ID: 38 Len: 24 Enqueue: 944
+ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 706
+ID: 41 Len: 8 Enqueue: 716
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 944
-ID: 44 Len: 8 Enqueue: 718
+ID: 43 Len: 24 Enqueue: 954
+ID: 44 Len: 8 Enqueue: 728
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 682
+ID: 47 Len: 8 Enqueue: 692
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 712
+ID: 49 Len: 8 Enqueue: 722
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 688
+ID: 55 Len: 8 Enqueue: 698
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 832
+ID: 62 Len: 24 Enqueue: 842
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 700
-ID: 65 Len: 8 Enqueue: 676
+ID: 64 Len: 8 Enqueue: 710
+ID: 65 Len: 8 Enqueue: 686
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1299
+ID: 70 Len: 56 Enqueue: 1309
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1310
+ID: 75 Len: 56 Enqueue: 1320
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 800
-ID: 78 Len: 16 Enqueue: 784
-ID: 79 Len: 8 Enqueue: 724
+ID: 77 Len: 32 Enqueue: 810
+ID: 78 Len: 16 Enqueue: 794
+ID: 79 Len: 8 Enqueue: 734
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -517,35 +520,35 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 730
+ID: 95 Len: 8 Enqueue: 740
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 634
-ID: 100 Len: 8 Enqueue: 640
-ID: 101 Len: 8 Enqueue: 766
-ID: 102 Len: 8 Enqueue: 652
-ID: 103 Len: 8 Enqueue: 622
-ID: 104 Len: 8 Enqueue: 628
-ID: 105 Len: 8 Enqueue: 748
-ID: 106 Len: 8 Enqueue: 754
-ID: 107 Len: 24 Enqueue: 878
+ID: 99 Len: 8 Enqueue: 644
+ID: 100 Len: 8 Enqueue: 650
+ID: 101 Len: 8 Enqueue: 776
+ID: 102 Len: 8 Enqueue: 662
+ID: 103 Len: 8 Enqueue: 632
+ID: 104 Len: 8 Enqueue: 638
+ID: 105 Len: 8 Enqueue: 758
+ID: 106 Len: 8 Enqueue: 764
+ID: 107 Len: 24 Enqueue: 888
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 912
-ID: 110 Len: 48 Enqueue: 816
-ID: 111 Len: 8 Enqueue: 1004
+ID: 109 Len: 24 Enqueue: 922
+ID: 110 Len: 48 Enqueue: 826
+ID: 111 Len: 8 Enqueue: 1014
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 980
+ID: 113 Len: 48 Enqueue: 990
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 736
-ID: 116 Len: 8 Enqueue: 1010
+ID: 115 Len: 8 Enqueue: 746
+ID: 116 Len: 8 Enqueue: 1020
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 992
+ID: 118 Len: 48 Enqueue: 1002
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 742
-ID: 121 Len: 8 Enqueue: 586
-ID: 122 Len: 8 Enqueue: 592
-ID: 123 Len: 8 Enqueue: 604
+ID: 120 Len: 8 Enqueue: 752
+ID: 121 Len: 8 Enqueue: 596
+ID: 122 Len: 8 Enqueue: 602
+ID: 123 Len: 8 Enqueue: 614
 ID: 124 Len: 1 Enqueue: 0
 ID: 125 Len: 8 Enqueue: 0
 ID: 126 Len: 1 Enqueue: 0
@@ -553,31 +556,31 @@ ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 842
+ID: 131 Len: 8 Enqueue: 852
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 16 Enqueue: 922
+ID: 135 Len: 16 Enqueue: 932
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 32 Enqueue: 1332
-ID: 138 Len: 16 Enqueue: 956
+ID: 137 Len: 32 Enqueue: 1342
+ID: 138 Len: 16 Enqueue: 966
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 200 Enqueue: 1048
-ID: 141 Len: 192 Enqueue: 1032
-ID: 142 Len: 24 Enqueue: 1086
-ID: 143 Len: 8 Enqueue: 854
-ID: 144 Len: 200 Enqueue: 888
-ID: 145 Len: 32 Enqueue: 1343
-ID: 146 Len: 16 Enqueue: 968
+ID: 140 Len: 200 Enqueue: 1058
+ID: 141 Len: 192 Enqueue: 1042
+ID: 142 Len: 24 Enqueue: 1096
+ID: 143 Len: 8 Enqueue: 864
+ID: 144 Len: 200 Enqueue: 898
+ID: 145 Len: 32 Enqueue: 1353
+ID: 146 Len: 16 Enqueue: 978
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 1059
-ID: 149 Len: 192 Enqueue: 1016
-ID: 150 Len: 24 Enqueue: 1070
-ID: 151 Len: 8 Enqueue: 658
+ID: 148 Len: 200 Enqueue: 1069
+ID: 149 Len: 192 Enqueue: 1026
+ID: 150 Len: 24 Enqueue: 1080
+ID: 151 Len: 8 Enqueue: 668
 ID: 152 Len: 184 Enqueue: 0
-ID: 153 Len: 8 Enqueue: 866
-ID: 154 Len: 200 Enqueue: 900
-ID: 155 Len: 8 Enqueue: 598
+ID: 153 Len: 8 Enqueue: 876
+ID: 154 Len: 200 Enqueue: 910
+ID: 155 Len: 8 Enqueue: 608
 ID: 156 Len: 128 Enqueue: 0
 ID: 157 Len: 9 Enqueue: 0
 ID: 158 Len: 17 Enqueue: 0
@@ -589,6 +592,7 @@ ID: 163 Len: 49 Enqueue: 0
 ID: 164 Len: 9 Enqueue: 0
 ID: 165 Len: 9 Enqueue: 0
 ID: 166 Len: 0 Enqueue: 0
-ID: 167 Len: 9 Enqueue: 0
+ID: 167 Len: 0 Enqueue: 0
 ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 9 Enqueue: 0
+ID: 170 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -3,151 +3,151 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb7da0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 54 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7d60]
-	PrepareEventRoot a9 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7da0]
+	PrepareEventRoot c4 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7da0.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7dd4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 66 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7d94]
-	PrepareEventRoot aa 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7dd4]
+	PrepareEventRoot c5 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7dd4.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb8230.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call fc 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 62 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@b81f0]
-	PrepareEventRoot a5 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b8230]
+	PrepareEventRoot c0 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8230.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@b80bc]
-	PrepareEventRoot a8 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@b7b88]
-	PrepareEventRoot a8 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb80fc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@b7dec]
-	PrepareEventRoot 9d 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@b80fc]
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb80fc.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb7f4c.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@b7bc8]
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb7e2c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@b7e2c]
+	PrepareEventRoot b8 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb7e2c.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb7f8c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@b7f4c]
-	PrepareEventRoot a0 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f4c.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b7f8c]
+	PrepareEventRoot bb 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f8c.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 3a 03 00 00 // ProcessType[[3]string]
+	Call 46 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80a0]
-	PrepareEventRoot a3 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80a0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80e0]
+	PrepareEventRoot be 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb7ecc.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb7f0c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 78 03 00 00 // ProcessType[[]int]
+	Call 9c 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b7ecc]
-	PrepareEventRoot 9f 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7ecc.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b7f0c]
+	PrepareEventRoot ba 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7f0c.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb817c.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb81bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f6 03 00 00 // ProcessType[map[string]int]
+	Call 5c 04 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@b817c]
-	PrepareEventRoot a4 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb817c.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b81bc]
+	PrepareEventRoot bf 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb81bc.expr[0]]
 	Return 
-// 0x1a7: ProcessEvent[Probe[main.noArgs]@b829c]
-	PrepareEventRoot a6 00 00 00 00 00 00 00 
+// 0x1a7: ProcessEvent[Probe[main.noArgs]@b82dc]
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1b1: ProcessExpression[Probe[main.stringArg]@0xb7e5c.expr[0]]
+// 0x1b1: ProcessExpression[Probe[main.stringArg]@0xb7e9c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 38 05 00 00 // ProcessType[string]
+	Call ca 05 00 00 // ProcessType[string]
 	Return 
-// 0x1d3: ProcessEvent[Probe[main.stringArg]@b7e5c]
-	PrepareEventRoot 9e 00 00 00 11 00 00 00 
-	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7e5c.expr[0]]
+// 0x1d3: ProcessEvent[Probe[main.stringArg]@b7e9c]
+	PrepareEventRoot b9 00 00 00 11 00 00 00 
+	Call b1 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7e9c.expr[0]]
 	Return 
-// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0xb803c.expr[0]]
+// 0x1e2: ProcessExpression[Probe[main.stringArrayArg]@0xb807c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 3a 03 00 00 // ProcessType[[3]string]
+	Call 46 03 00 00 // ProcessType[[3]string]
 	Return 
-// 0x203: ProcessEvent[Probe[main.stringArrayArg]@b803c]
-	PrepareEventRoot a2 00 00 00 31 00 00 00 
-	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb803c.expr[0]]
+// 0x203: ProcessEvent[Probe[main.stringArrayArg]@b807c]
+	PrepareEventRoot bd 00 00 00 31 00 00 00 
+	Call e2 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb807c.expr[0]]
 	Return 
-// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
+// 0x212: ProcessExpression[Probe[main.stringSliceArg]@0xb7ffc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 9a 03 00 00 // ProcessType[[]string]
+	Call ca 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b7fbc]
-	PrepareEventRoot a1 00 00 00 19 00 00 00 
-	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
+// 0x23b: ProcessEvent[Probe[main.stringSliceArg]@b7ffc]
+	PrepareEventRoot bc 00 00 00 19 00 00 00 
+	Call 12 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7ffc.expr[0]]
 	Return 
-// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8310]
-	PrepareEventRoot a7 00 00 00 00 00 00 00 
+// 0x24a: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8350]
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
 // 0x254: ProcessType[*****int]
-	ProcessPointer 7a 00 00 00 
+	ProcessPointer 7f 00 00 00 
 	Return 
 // 0x25a: ProcessType[****int]
-	ProcessPointer 9b 00 00 00 
+	ProcessPointer b6 00 00 00 
 	Return 
 // 0x260: ProcessType[***int]
-	ProcessPointer 7b 00 00 00 
+	ProcessPointer 80 00 00 00 
 	Return 
 // 0x266: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
@@ -177,7 +177,7 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x29c: ProcessType[*main.bigStruct]
-	ProcessPointer 98 00 00 00 
+	ProcessPointer 9d 00 00 00 
 	Return 
 // 0x2a2: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
@@ -198,7 +198,7 @@
 	ProcessPointer 1d 00 00 00 
 	Return 
 // 0x2c6: ProcessType[*runtime.p]
-	ProcessPointer 82 00 00 00 
+	ProcessPointer 87 00 00 00 
 	Return 
 // 0x2cc: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
@@ -215,138 +215,190 @@
 // 0x2e4: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x2ea: ProcessType[*table<string,int>]
-	ProcessPointer 89 00 00 00 
+// 0x2ea: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer ad 00 00 00 
 	Return 
-// 0x2f0: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 91 00 00 00 
+// 0x2f0: ProcessType[*table<string,int>]
+	ProcessPointer 8e 00 00 00 
 	Return 
-// 0x2f6: ProcessType[*uint]
+// 0x2f6: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 96 00 00 00 
+	Return 
+// 0x2fc: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer a0 00 00 00 
+	Return 
+// 0x302: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2fc: ProcessType[*uint16]
+// 0x308: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x302: ProcessType[*uint32]
+// 0x30e: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x308: ProcessType[*uint64]
+// 0x314: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x30e: ProcessType[*uint8]
+// 0x31a: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x314: ProcessType[*uintptr]
+// 0x320: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x31a: ProcessType[[2]*runtime.traceBuf]
+// 0x326: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
 	Call de 02 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x32a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x336: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 1a 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 26 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x33a: ProcessType[[3]string]
+// 0x346: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 38 05 00 00 // ProcessType[string]
+	Call ca 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x34a: ProcessType[[]*runtime.p]
-	ProcessSlice 83 00 00 00 08 00 00 00 
+// 0x356: ProcessType[[]*runtime.p]
+	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x354: ProcessType[[]*runtime.p.array]
+// 0x360: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
 	Call c6 02 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x360: ProcessType[[]*table<string,int>.array]
+// 0x36c: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ea 02 00 00 // ProcessType[*table<string,int>]
+	Call ea 02 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x378: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f0 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f0 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x378: ProcessType[[]int]
-	ProcessSlice 85 00 00 00 08 00 00 00 
-	Return 
-// 0x382: ProcessType[[]noalg.map.group[string]int.array]
+// 0x384: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 22 04 00 00 // ProcessType[noalg.map.group[string]int]
+	Call f6 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x390: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call fc 02 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x39c: ProcessType[[]int]
+	ProcessSlice 8a 00 00 00 08 00 00 00 
+	Return 
+// 0x3a6: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 9e 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x38e: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x3b2: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 2d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call a9 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x39a: ProcessType[[]string]
-	ProcessSlice 87 00 00 00 10 00 00 00 
-	Return 
-// 0x3a4: ProcessType[[]string.array]
+// 0x3be: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 38 05 00 00 // ProcessType[string]
+	Call b4 04 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x3ca: ProcessType[[]string]
+	ProcessSlice 8c 00 00 00 10 00 00 00 
+	Return 
+// 0x3d4: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call ca 05 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3b0: ProcessType[[]uint8]
-	ProcessSlice 7e 00 00 00 01 00 00 00 
+// 0x3e0: ProcessType[[]uint8]
+	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x3ba: ProcessType[[]uintptr]
-	ProcessSlice 80 00 00 00 08 00 00 00 
+// 0x3ea: ProcessType[[]uintptr]
+	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[error]
+// 0x3f4: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x3c6: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 90 00 00 00 c8 00 00 00 00 08 
+// 0x3f6: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b5 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x3d2: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
+// 0x402: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 95 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3de: ProcessType[map<string,int>]
-	ProcessGoSwissMap 8f 00 00 00 8c 00 00 00 10 18 
+// 0x40e: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 9f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3ea: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 99 00 00 00 94 00 00 00 10 18 
+// 0x41a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups ac 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x3f6: ProcessType[map[string]int]
+// 0x426: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap b4 00 00 00 b0 00 00 00 10 18 
+	Return 
+// 0x432: ProcessType[map<string,int>]
+	ProcessGoSwissMap 94 00 00 00 91 00 00 00 10 18 
+	Return 
+// 0x43e: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 9e 00 00 00 99 00 00 00 10 18 
+	Return 
+// 0x44a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap ab 00 00 00 a3 00 00 00 10 18 
+	Return 
+// 0x456: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer a8 00 00 00 
+	Return 
+// 0x45c: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x3fc: ProcessType[map[string]main.bigStruct]
+// 0x462: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x402: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x468: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 7b 00 00 00 
+	Return 
+// 0x46e: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 38 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call bf 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x412: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x47e: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 48 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call cf 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x422: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call 12 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x48e: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call d5 04 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x42d: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x49e: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 7e 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x438: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 38 05 00 00 // ProcessType[string]
+// 0x4a9: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6e 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x4b4: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	IncrementOutputOffset 08 00 00 00 
+	Call 8e 04 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Return 
+// 0x4bf: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call ca 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
 	Call 9c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x448: ProcessType[noalg.struct { key string; elem int }]
-	Call 38 05 00 00 // ProcessType[string]
+// 0x4cf: ProcessType[noalg.struct { key string; elem int }]
+	Call ca 05 00 00 // ProcessType[string]
 	Return 
-// 0x44e: ProcessType[runtime.g]
+// 0x4d5: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	IncrementOutputOffset 08 00 00 00 
+	Call 56 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x4e0: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
 	Call a8 02 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
@@ -354,13 +406,13 @@
 	IncrementOutputOffset 08 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call b0 03 00 00 // ProcessType[[]uint8]
+	Call e0 03 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
 	Call 6c 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
 	Call cc 02 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 03 00 00 // ProcessType[[]uintptr]
+	Call ea 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
 	Call d8 02 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
@@ -368,48 +420,56 @@
 	IncrementOutputOffset 08 00 00 00 
 	Call d2 02 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x4b3: ProcessType[runtime.m]
+// 0x545: ProcessType[runtime.m]
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
 	Call ba 02 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 38 05 00 00 // ProcessType[string]
+	Call ca 05 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 4a 03 00 00 // ProcessType[[]*runtime.p]
+	Call 56 03 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
 	Call ae 02 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 1d 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call af 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call ba 03 00 00 // ProcessType[[]uintptr]
+	Call ea 03 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 28 05 00 00 // ProcessType[runtime.mTraceState]
+	Call ba 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x51d: ProcessType[runtime.mLockProfile]
+// 0x5af: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 03 00 00 // ProcessType[[]uintptr]
+	Call ea 03 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x528: ProcessType[runtime.mTraceState]
+// 0x5ba: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 36 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
 	Call c0 02 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x538: ProcessType[string]
-	ProcessString 7c 00 00 00 
+// 0x5ca: ProcessType[string]
+	ProcessString 81 00 00 00 
 	Return 
-// 0x53e: ProcessType[table<string,int>]
+// 0x5d0: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call c6 03 00 00 // ProcessType[groupReference<string,int>]
+	Call f6 03 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x549: ProcessType[table<string,main.bigStruct>]
+// 0x5db: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call d2 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 02 04 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x5e6: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 0e 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x5f1: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 1a 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -430,31 +490,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 782
+ID: 5 Len: 8 Enqueue: 794
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1336
+ID: 9 Len: 16 Enqueue: 1482
 ID: 10 Len: 8 Enqueue: 0
 ID: 11 Len: 8 Enqueue: 626
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 964
+ID: 14 Len: 16 Enqueue: 1012
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 788
+ID: 19 Len: 8 Enqueue: 800
 ID: 20 Len: 8 Enqueue: 656
-ID: 21 Len: 8 Enqueue: 770
-ID: 22 Len: 440 Enqueue: 1102
+ID: 21 Len: 8 Enqueue: 782
+ID: 22 Len: 440 Enqueue: 1248
 ID: 23 Len: 16 Enqueue: 0
 ID: 24 Len: 8 Enqueue: 680
 ID: 25 Len: 8 Enqueue: 0
 ID: 26 Len: 8 Enqueue: 674
 ID: 27 Len: 8 Enqueue: 0
 ID: 28 Len: 8 Enqueue: 704
-ID: 29 Len: 1816 Enqueue: 1203
+ID: 29 Len: 1816 Enqueue: 1349
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -463,12 +523,12 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 944
+ID: 38 Len: 24 Enqueue: 992
 ID: 39 Len: 8 Enqueue: 620
 ID: 40 Len: 8 Enqueue: 0
 ID: 41 Len: 8 Enqueue: 716
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 954
+ID: 43 Len: 24 Enqueue: 1002
 ID: 44 Len: 8 Enqueue: 728
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
@@ -487,7 +547,7 @@ ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 842
+ID: 62 Len: 24 Enqueue: 854
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 710
 ID: 65 Len: 8 Enqueue: 686
@@ -495,15 +555,15 @@ ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1309
+ID: 70 Len: 56 Enqueue: 1455
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1320
+ID: 75 Len: 56 Enqueue: 1466
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 810
-ID: 78 Len: 16 Enqueue: 794
+ID: 77 Len: 32 Enqueue: 822
+ID: 78 Len: 16 Enqueue: 806
 ID: 79 Len: 8 Enqueue: 734
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
@@ -526,73 +586,100 @@ ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
 ID: 99 Len: 8 Enqueue: 644
 ID: 100 Len: 8 Enqueue: 650
-ID: 101 Len: 8 Enqueue: 776
+ID: 101 Len: 8 Enqueue: 788
 ID: 102 Len: 8 Enqueue: 662
 ID: 103 Len: 8 Enqueue: 632
 ID: 104 Len: 8 Enqueue: 638
-ID: 105 Len: 8 Enqueue: 758
-ID: 106 Len: 8 Enqueue: 764
-ID: 107 Len: 24 Enqueue: 888
+ID: 105 Len: 8 Enqueue: 770
+ID: 106 Len: 8 Enqueue: 776
+ID: 107 Len: 24 Enqueue: 924
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 922
-ID: 110 Len: 48 Enqueue: 826
-ID: 111 Len: 8 Enqueue: 1014
+ID: 109 Len: 24 Enqueue: 970
+ID: 110 Len: 48 Enqueue: 838
+ID: 111 Len: 8 Enqueue: 1116
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 990
+ID: 113 Len: 48 Enqueue: 1074
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 746
-ID: 116 Len: 8 Enqueue: 1020
+ID: 115 Len: 8 Enqueue: 752
+ID: 116 Len: 8 Enqueue: 1122
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1002
+ID: 118 Len: 48 Enqueue: 1086
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 752
-ID: 121 Len: 8 Enqueue: 596
-ID: 122 Len: 8 Enqueue: 602
-ID: 123 Len: 8 Enqueue: 614
-ID: 124 Len: 1 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 1 Enqueue: 0
-ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 0
+ID: 120 Len: 8 Enqueue: 758
+ID: 121 Len: 8 Enqueue: 1128
+ID: 122 Len: 8 Enqueue: 0
+ID: 123 Len: 48 Enqueue: 1098
+ID: 124 Len: 8 Enqueue: 0
+ID: 125 Len: 8 Enqueue: 764
+ID: 126 Len: 8 Enqueue: 596
+ID: 127 Len: 8 Enqueue: 602
+ID: 128 Len: 8 Enqueue: 614
+ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 852
+ID: 131 Len: 1 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 16 Enqueue: 932
-ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 32 Enqueue: 1342
-ID: 138 Len: 16 Enqueue: 966
+ID: 135 Len: 8 Enqueue: 0
+ID: 136 Len: 8 Enqueue: 864
+ID: 137 Len: 8 Enqueue: 0
+ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 200 Enqueue: 1058
-ID: 141 Len: 192 Enqueue: 1042
-ID: 142 Len: 24 Enqueue: 1096
-ID: 143 Len: 8 Enqueue: 864
-ID: 144 Len: 200 Enqueue: 898
-ID: 145 Len: 32 Enqueue: 1353
-ID: 146 Len: 16 Enqueue: 978
-ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 1069
-ID: 149 Len: 192 Enqueue: 1026
-ID: 150 Len: 24 Enqueue: 1080
-ID: 151 Len: 8 Enqueue: 668
-ID: 152 Len: 184 Enqueue: 0
-ID: 153 Len: 8 Enqueue: 876
-ID: 154 Len: 200 Enqueue: 910
-ID: 155 Len: 8 Enqueue: 608
-ID: 156 Len: 128 Enqueue: 0
-ID: 157 Len: 9 Enqueue: 0
-ID: 158 Len: 17 Enqueue: 0
-ID: 159 Len: 25 Enqueue: 0
-ID: 160 Len: 25 Enqueue: 0
-ID: 161 Len: 25 Enqueue: 0
-ID: 162 Len: 49 Enqueue: 0
-ID: 163 Len: 49 Enqueue: 0
-ID: 164 Len: 9 Enqueue: 0
-ID: 165 Len: 9 Enqueue: 0
-ID: 166 Len: 0 Enqueue: 0
-ID: 167 Len: 0 Enqueue: 0
-ID: 168 Len: 9 Enqueue: 0
-ID: 169 Len: 9 Enqueue: 0
-ID: 170 Len: 9 Enqueue: 0
+ID: 140 Len: 16 Enqueue: 980
+ID: 141 Len: 8 Enqueue: 0
+ID: 142 Len: 32 Enqueue: 1499
+ID: 143 Len: 16 Enqueue: 1026
+ID: 144 Len: 8 Enqueue: 0
+ID: 145 Len: 200 Enqueue: 1182
+ID: 146 Len: 192 Enqueue: 1150
+ID: 147 Len: 24 Enqueue: 1231
+ID: 148 Len: 8 Enqueue: 888
+ID: 149 Len: 200 Enqueue: 934
+ID: 150 Len: 32 Enqueue: 1510
+ID: 151 Len: 16 Enqueue: 1038
+ID: 152 Len: 8 Enqueue: 0
+ID: 153 Len: 200 Enqueue: 1193
+ID: 154 Len: 192 Enqueue: 1134
+ID: 155 Len: 24 Enqueue: 1215
+ID: 156 Len: 8 Enqueue: 668
+ID: 157 Len: 184 Enqueue: 0
+ID: 158 Len: 8 Enqueue: 900
+ID: 159 Len: 200 Enqueue: 946
+ID: 160 Len: 32 Enqueue: 1521
+ID: 161 Len: 16 Enqueue: 1050
+ID: 162 Len: 8 Enqueue: 0
+ID: 163 Len: 136 Enqueue: 1204
+ID: 164 Len: 128 Enqueue: 1166
+ID: 165 Len: 16 Enqueue: 1237
+ID: 166 Len: 8 Enqueue: 1110
+ID: 167 Len: 8 Enqueue: 0
+ID: 168 Len: 48 Enqueue: 1062
+ID: 169 Len: 8 Enqueue: 0
+ID: 170 Len: 8 Enqueue: 746
+ID: 171 Len: 8 Enqueue: 912
+ID: 172 Len: 136 Enqueue: 958
+ID: 173 Len: 32 Enqueue: 1488
+ID: 174 Len: 16 Enqueue: 1014
+ID: 175 Len: 8 Enqueue: 0
+ID: 176 Len: 136 Enqueue: 0
+ID: 177 Len: 128 Enqueue: 0
+ID: 178 Len: 16 Enqueue: 0
+ID: 179 Len: 8 Enqueue: 0
+ID: 180 Len: 8 Enqueue: 876
+ID: 181 Len: 136 Enqueue: 0
+ID: 182 Len: 8 Enqueue: 608
+ID: 183 Len: 128 Enqueue: 0
+ID: 184 Len: 9 Enqueue: 0
+ID: 185 Len: 17 Enqueue: 0
+ID: 186 Len: 25 Enqueue: 0
+ID: 187 Len: 25 Enqueue: 0
+ID: 188 Len: 25 Enqueue: 0
+ID: 189 Len: 49 Enqueue: 0
+ID: 190 Len: 49 Enqueue: 0
+ID: 191 Len: 9 Enqueue: 0
+ID: 192 Len: 9 Enqueue: 0
+ID: 193 Len: 0 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 9 Enqueue: 0
+ID: 196 Len: 9 Enqueue: 0
+ID: 197 Len: 9 Enqueue: 0

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -1,116 +1,116 @@
-LocatePC: 0x4a60c0
+LocatePC: 0x4a6100
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
-LocatePC: 0x4a60f1
+LocatePC: 0x4a6131
 	fmt.Println@fmt/print.go:314
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
-LocatePC: 0x4a6140
+LocatePC: 0x4a6180
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-LocatePC: 0x4a6178
+LocatePC: 0x4a61b8
 	fmt.Println@fmt/print.go:314
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-LocatePC: 0x4a61c0
+LocatePC: 0x4a6200
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-LocatePC: 0x4a61fd
+LocatePC: 0x4a623d
 	fmt.Println@fmt/print.go:314
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-LocatePC: 0x4a6240
+LocatePC: 0x4a6280
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-LocatePC: 0x4a6273
+LocatePC: 0x4a62b3
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-LocatePC: 0x4a62c0
+LocatePC: 0x4a6300
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-LocatePC: 0x4a62fd
+LocatePC: 0x4a633d
 	fmt.Println@fmt/print.go:314
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-LocatePC: 0x4a6340
+LocatePC: 0x4a6380
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-LocatePC: 0x4a6373
+LocatePC: 0x4a63b3
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
-LocatePC: 0x4a63c0
+LocatePC: 0x4a6400
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4a63c0
+LocatePC: 0x4a6400
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4a64a0
+LocatePC: 0x4a64e0
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-LocatePC: 0x4a64cb
+LocatePC: 0x4a650b
 	fmt.Println@fmt/print.go:314
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-LocatePC: 0x4a6500
+LocatePC: 0x4a6540
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
-LocatePC: 0x4a655d
+LocatePC: 0x4a659d
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
-LocatePC: 0x4a65c0
+LocatePC: 0x4a6600
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0x4a65e9
+LocatePC: 0x4a6629
 	fmt.Println@fmt/print.go:314
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0x4a6620
+LocatePC: 0x4a6660
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
-LocatePC: 0x4a66cb
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0x4a63e0
+LocatePC: 0x4a6752
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+LocatePC: 0x4a6420
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
-LocatePC: 0x4a6411
+LocatePC: 0x4a6451
 	fmt.Println@fmt/print.go:314
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-LocatePC: 0x4a5dce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4a5df6
+LocatePC: 0x4a5e0e
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4a6006
+LocatePC: 0x4a5e36
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0x4a6046
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4a6025
+LocatePC: 0x4a6065
 	fmt.Println@fmt/print.go:314
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4a6050
+LocatePC: 0x4a6090
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0x4a606d
+LocatePC: 0x4a60ad
 	fmt.Println@fmt/print.go:314
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0x4a6050
+FunctionLines: 0x4a6090
 	fmt.Println
-		[0x4a5dfc, 0x4a5e1f) fmt.Println@fmt/print.go:314
-		[0x4a601d, 0x4a6045) fmt.Println@fmt/print.go:314
-		[0x4a6067, 0x4a608a) fmt.Println@fmt/print.go:314
+		[0x4a5e3c, 0x4a5e5f) fmt.Println@fmt/print.go:314
+		[0x4a605d, 0x4a6085) fmt.Println@fmt/print.go:314
+		[0x4a60a7, 0x4a60ca) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0x4a5c5d, 0x4a5c64) fmt.Scanln@fmt/scan.go:70
-		[0x4a5c65, 0x4a5c78) fmt.Scanln@fmt/scan.go:70
+		[0x4a5c9d, 0x4a5ca4) fmt.Scanln@fmt/scan.go:70
+		[0x4a5ca5, 0x4a5cb8) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4a6006, 0x4a601d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
+		[0x4a6046, 0x4a605d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0x4a6050, 0x4a6067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0x4a6090, 0x4a60a7) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0x4a5dce, 0x4a5dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0x4a5e0e, 0x4a5e3c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
-		[0x4a5c40, 0x4a5c5d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0x4a5c64, 0x4a5c65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0x4a5c78, 0x4a5c7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0x4a5c7d, 0x4a5cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0x4a5cbd, 0x4a5ccc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0x4a5ccc, 0x4a5cdd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0x4a5cdd, 0x4a5d0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0x4a5d0d, 0x4a5d2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0x4a5d2c, 0x4a5d7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0x4a5d7d, 0x4a5da5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0x4a5da5, 0x4a5dcd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0x4a5dcd, 0x4a5dce) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0x4a5e1f, 0x4a5e2b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0x4a5e2b, 0x4a5e67) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0x4a5e67, 0x4a5f05) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0x4a5f05, 0x4a5f20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0x4a5f20, 0x4a5f5b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0x4a5f5b, 0x4a5f95) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0x4a5f95, 0x4a5fd3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0x4a5fd3, 0x4a6005) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0x4a6005, 0x4a6006) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0x4a6045, 0x4a6050) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0x4a608a, 0x4a608f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4a608f, 0x4a6094) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0x4a6094, 0x4a609d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
-		[0x4a609d, 0x4a60aa) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a5c80, 0x4a5c9d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a5ca4, 0x4a5ca5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0x4a5cb8, 0x4a5cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0x4a5cbd, 0x4a5cfd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0x4a5cfd, 0x4a5d0c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0x4a5d0c, 0x4a5d1d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0x4a5d1d, 0x4a5d4d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0x4a5d4d, 0x4a5d6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0x4a5d6c, 0x4a5dbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0x4a5dbd, 0x4a5de5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0x4a5de5, 0x4a5e0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0x4a5e0d, 0x4a5e0e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0x4a5e5f, 0x4a5e6b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0x4a5e6b, 0x4a5ea7) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0x4a5ea7, 0x4a5f45) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0x4a5f45, 0x4a5f60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0x4a5f60, 0x4a5f9b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0x4a5f9b, 0x4a5fd5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0x4a5fd5, 0x4a6013) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0x4a6013, 0x4a6045) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0x4a6045, 0x4a6046) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0x4a6085, 0x4a6090) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0x4a60ca, 0x4a60cf) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0x4a60cf, 0x4a60d4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4a60d4, 0x4a60dd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0x4a60dd, 0x4a60ea) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -1,73 +1,77 @@
 LocatePC: 0x4a60c0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
 LocatePC: 0x4a60f1
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
 LocatePC: 0x4a6140
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
 LocatePC: 0x4a6178
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
 LocatePC: 0x4a61c0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
 LocatePC: 0x4a61fd
 	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
 LocatePC: 0x4a6240
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0x4a6273
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0x4a6273
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
 LocatePC: 0x4a62c0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
 LocatePC: 0x4a62fd
 	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
 LocatePC: 0x4a6340
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0x4a6373
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0x4a6373
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
 LocatePC: 0x4a63c0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0x4a63c0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0x4a64a0
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
 LocatePC: 0x4a64cb
 	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
 LocatePC: 0x4a6500
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
 LocatePC: 0x4a655d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
 LocatePC: 0x4a65c0
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:120
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
 LocatePC: 0x4a65e9
 	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+LocatePC: 0x4a6620
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0x4a66cb
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
 LocatePC: 0x4a63e0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 LocatePC: 0x4a6411
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 LocatePC: 0x4a5dce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4a5df6
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4a6006
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4a6025
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4a6050
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0x4a606d
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0x4a6050
 	fmt.Println
@@ -78,11 +82,11 @@ FunctionLines: 0x4a6050
 		[0x4a5c5d, 0x4a5c64) fmt.Scanln@fmt/scan.go:70
 		[0x4a5c65, 0x4a5c78) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4a6006, 0x4a601d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0x4a6006, 0x4a601d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0x4a6050, 0x4a6067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0x4a6050, 0x4a6067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0x4a5dce, 0x4a5dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+		[0x4a5dce, 0x4a5dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
 		[0x4a5c40, 0x4a5c5d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0x4a5c64, 0x4a5c65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -107,5 +111,6 @@ FunctionLines: 0x4a6050
 		[0x4a6005, 0x4a6006) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 		[0x4a6045, 0x4a6050) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 		[0x4a608a, 0x4a608f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4a608f, 0x4a6098) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0x4a6098, 0x4a60a5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a608f, 0x4a6094) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4a6094, 0x4a609d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0x4a609d, 0x4a60aa) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
@@ -1,116 +1,116 @@
-LocatePC: 0x4a80c0
+LocatePC: 0x4a8100
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
-LocatePC: 0x4a80f1
+LocatePC: 0x4a8131
 	fmt.Println@fmt/print.go:314
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
-LocatePC: 0x4a8140
+LocatePC: 0x4a8180
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-LocatePC: 0x4a8178
+LocatePC: 0x4a81b8
 	fmt.Println@fmt/print.go:314
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-LocatePC: 0x4a81c0
+LocatePC: 0x4a8200
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-LocatePC: 0x4a81fd
+LocatePC: 0x4a823d
 	fmt.Println@fmt/print.go:314
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-LocatePC: 0x4a8240
+LocatePC: 0x4a8280
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-LocatePC: 0x4a8273
+LocatePC: 0x4a82b3
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-LocatePC: 0x4a82c0
+LocatePC: 0x4a8300
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-LocatePC: 0x4a82fd
+LocatePC: 0x4a833d
 	fmt.Println@fmt/print.go:314
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-LocatePC: 0x4a8340
+LocatePC: 0x4a8380
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-LocatePC: 0x4a8373
+LocatePC: 0x4a83b3
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
-LocatePC: 0x4a83c0
+LocatePC: 0x4a8400
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4a83c0
+LocatePC: 0x4a8400
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4a84a0
+LocatePC: 0x4a84e0
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-LocatePC: 0x4a84cb
+LocatePC: 0x4a850b
 	fmt.Println@fmt/print.go:314
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-LocatePC: 0x4a8500
+LocatePC: 0x4a8540
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
-LocatePC: 0x4a855d
+LocatePC: 0x4a859d
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
-LocatePC: 0x4a85c0
+LocatePC: 0x4a8600
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0x4a85e9
+LocatePC: 0x4a8629
 	fmt.Println@fmt/print.go:314
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0x4a8620
+LocatePC: 0x4a8660
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
-LocatePC: 0x4a86d5
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0x4a83e0
+LocatePC: 0x4a8757
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+LocatePC: 0x4a8420
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
-LocatePC: 0x4a8411
+LocatePC: 0x4a8451
 	fmt.Println@fmt/print.go:314
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-LocatePC: 0x4a7dce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4a7df6
+LocatePC: 0x4a7e0e
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4a8006
+LocatePC: 0x4a7e36
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0x4a8046
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4a8025
+LocatePC: 0x4a8065
 	fmt.Println@fmt/print.go:314
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4a8050
+LocatePC: 0x4a8090
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0x4a806d
+LocatePC: 0x4a80ad
 	fmt.Println@fmt/print.go:314
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0x4a8050
+FunctionLines: 0x4a8090
 	fmt.Println
-		[0x4a7dfc, 0x4a7e1f) fmt.Println@fmt/print.go:314
-		[0x4a801d, 0x4a8045) fmt.Println@fmt/print.go:314
-		[0x4a8067, 0x4a808a) fmt.Println@fmt/print.go:314
+		[0x4a7e3c, 0x4a7e5f) fmt.Println@fmt/print.go:314
+		[0x4a805d, 0x4a8085) fmt.Println@fmt/print.go:314
+		[0x4a80a7, 0x4a80ca) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0x4a7c5d, 0x4a7c64) fmt.Scanln@fmt/scan.go:70
-		[0x4a7c65, 0x4a7c78) fmt.Scanln@fmt/scan.go:70
+		[0x4a7c9d, 0x4a7ca4) fmt.Scanln@fmt/scan.go:70
+		[0x4a7ca5, 0x4a7cb8) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4a8006, 0x4a801d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
+		[0x4a8046, 0x4a805d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0x4a8050, 0x4a8067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0x4a8090, 0x4a80a7) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0x4a7dce, 0x4a7dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0x4a7e0e, 0x4a7e3c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
-		[0x4a7c40, 0x4a7c5d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0x4a7c64, 0x4a7c65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0x4a7c78, 0x4a7c7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0x4a7c7d, 0x4a7cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0x4a7cbd, 0x4a7ccc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0x4a7ccc, 0x4a7cdd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0x4a7cdd, 0x4a7d0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0x4a7d0d, 0x4a7d2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0x4a7d2c, 0x4a7d7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0x4a7d7d, 0x4a7da5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0x4a7da5, 0x4a7dcd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0x4a7dcd, 0x4a7dce) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0x4a7e1f, 0x4a7e2b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0x4a7e2b, 0x4a7e67) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0x4a7e67, 0x4a7f05) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0x4a7f05, 0x4a7f20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0x4a7f20, 0x4a7f5b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0x4a7f5b, 0x4a7f95) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0x4a7f95, 0x4a7fd3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0x4a7fd3, 0x4a8005) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0x4a8005, 0x4a8006) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0x4a8045, 0x4a8050) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0x4a808a, 0x4a808f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4a808f, 0x4a8094) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0x4a8094, 0x4a809d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
-		[0x4a809d, 0x4a80aa) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a7c80, 0x4a7c9d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a7ca4, 0x4a7ca5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0x4a7cb8, 0x4a7cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0x4a7cbd, 0x4a7cfd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0x4a7cfd, 0x4a7d0c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0x4a7d0c, 0x4a7d1d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0x4a7d1d, 0x4a7d4d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0x4a7d4d, 0x4a7d6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0x4a7d6c, 0x4a7dbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0x4a7dbd, 0x4a7de5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0x4a7de5, 0x4a7e0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0x4a7e0d, 0x4a7e0e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0x4a7e5f, 0x4a7e6b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0x4a7e6b, 0x4a7ea7) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0x4a7ea7, 0x4a7f45) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0x4a7f45, 0x4a7f60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0x4a7f60, 0x4a7f9b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0x4a7f9b, 0x4a7fd5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0x4a7fd5, 0x4a8013) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0x4a8013, 0x4a8045) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0x4a8045, 0x4a8046) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0x4a8085, 0x4a8090) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0x4a80ca, 0x4a80cf) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0x4a80cf, 0x4a80d4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4a80d4, 0x4a80dd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0x4a80dd, 0x4a80ea) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
@@ -1,73 +1,77 @@
 LocatePC: 0x4a80c0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
 LocatePC: 0x4a80f1
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
 LocatePC: 0x4a8140
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
 LocatePC: 0x4a8178
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
 LocatePC: 0x4a81c0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
 LocatePC: 0x4a81fd
 	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
 LocatePC: 0x4a8240
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0x4a8273
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0x4a8273
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
 LocatePC: 0x4a82c0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
 LocatePC: 0x4a82fd
 	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
 LocatePC: 0x4a8340
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0x4a8373
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0x4a8373
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
 LocatePC: 0x4a83c0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0x4a83c0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0x4a84a0
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
 LocatePC: 0x4a84cb
 	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
 LocatePC: 0x4a8500
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
 LocatePC: 0x4a855d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
 LocatePC: 0x4a85c0
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:120
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
 LocatePC: 0x4a85e9
 	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+LocatePC: 0x4a8620
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0x4a86d5
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
 LocatePC: 0x4a83e0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 LocatePC: 0x4a8411
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 LocatePC: 0x4a7dce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4a7df6
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4a8006
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4a8025
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4a8050
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0x4a806d
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0x4a8050
 	fmt.Println
@@ -78,11 +82,11 @@ FunctionLines: 0x4a8050
 		[0x4a7c5d, 0x4a7c64) fmt.Scanln@fmt/scan.go:70
 		[0x4a7c65, 0x4a7c78) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4a8006, 0x4a801d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0x4a8006, 0x4a801d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0x4a8050, 0x4a8067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0x4a8050, 0x4a8067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0x4a7dce, 0x4a7dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+		[0x4a7dce, 0x4a7dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
 		[0x4a7c40, 0x4a7c5d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0x4a7c64, 0x4a7c65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -107,5 +111,6 @@ FunctionLines: 0x4a8050
 		[0x4a8005, 0x4a8006) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 		[0x4a8045, 0x4a8050) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 		[0x4a808a, 0x4a808f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4a808f, 0x4a8098) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0x4a8098, 0x4a80a5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a808f, 0x4a8094) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4a8094, 0x4a809d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0x4a809d, 0x4a80aa) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
@@ -1,74 +1,78 @@
 LocatePC: 0x4ae6c0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
 LocatePC: 0x4ae6f1
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
 LocatePC: 0x4ae740
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
 LocatePC: 0x4ae778
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
 LocatePC: 0x4ae7c0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
 LocatePC: 0x4ae7fd
 	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
 LocatePC: 0x4ae840
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0x4ae873
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0x4ae873
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
 LocatePC: 0x4ae8c0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
 LocatePC: 0x4ae8fd
 	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
 LocatePC: 0x4ae940
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0x4ae973
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0x4ae973
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
 LocatePC: 0x4ae9c0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0x4ae9c0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0x4aeaa0
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
 LocatePC: 0x4aeacb
 	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
 LocatePC: 0x4aeb00
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
 LocatePC: 0x4aeb5d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
 LocatePC: 0x4aebc0
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:120
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
 LocatePC: 0x4aebe9
 	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+LocatePC: 0x4aec20
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0x4aecd5
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
 LocatePC: 0x4ae9e0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 LocatePC: 0x4aea11
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 LocatePC: 0x4ae3ce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4ae3ee
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4ae606
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4ae625
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4ae650
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0x4ae66d
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0x4ae650
 	fmt.Println
@@ -79,11 +83,11 @@ FunctionLines: 0x4ae650
 		[0x4ae25d, 0x4ae264) fmt.Scanln@fmt/scan.go:70
 		[0x4ae265, 0x4ae278) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4ae606, 0x4ae61d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0x4ae606, 0x4ae61d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0x4ae650, 0x4ae667) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0x4ae650, 0x4ae667) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0x4ae3ce, 0x4ae3ec) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+		[0x4ae3ce, 0x4ae3ec) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
 		[0x4ae240, 0x4ae25d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0x4ae264, 0x4ae265) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -108,5 +112,6 @@ FunctionLines: 0x4ae650
 		[0x4ae605, 0x4ae606) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 		[0x4ae645, 0x4ae650) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 		[0x4ae68a, 0x4ae68f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4ae68f, 0x4ae698) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0x4ae698, 0x4ae6a5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4ae68f, 0x4ae694) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4ae694, 0x4ae69d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0x4ae69d, 0x4ae6aa) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
@@ -1,117 +1,117 @@
-LocatePC: 0x4ae6c0
+LocatePC: 0x4ae700
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
-LocatePC: 0x4ae6f1
+LocatePC: 0x4ae731
 	fmt.Println@fmt/print.go:314
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
-LocatePC: 0x4ae740
+LocatePC: 0x4ae780
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-LocatePC: 0x4ae778
+LocatePC: 0x4ae7b8
 	fmt.Println@fmt/print.go:314
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-LocatePC: 0x4ae7c0
+LocatePC: 0x4ae800
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-LocatePC: 0x4ae7fd
+LocatePC: 0x4ae83d
 	fmt.Println@fmt/print.go:314
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-LocatePC: 0x4ae840
+LocatePC: 0x4ae880
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-LocatePC: 0x4ae873
+LocatePC: 0x4ae8b3
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-LocatePC: 0x4ae8c0
+LocatePC: 0x4ae900
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-LocatePC: 0x4ae8fd
+LocatePC: 0x4ae93d
 	fmt.Println@fmt/print.go:314
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-LocatePC: 0x4ae940
+LocatePC: 0x4ae980
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-LocatePC: 0x4ae973
+LocatePC: 0x4ae9b3
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
-LocatePC: 0x4ae9c0
+LocatePC: 0x4aea00
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4ae9c0
+LocatePC: 0x4aea00
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4aeaa0
+LocatePC: 0x4aeae0
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-LocatePC: 0x4aeacb
+LocatePC: 0x4aeb0b
 	fmt.Println@fmt/print.go:314
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-LocatePC: 0x4aeb00
+LocatePC: 0x4aeb40
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
-LocatePC: 0x4aeb5d
+LocatePC: 0x4aeb9d
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
-LocatePC: 0x4aebc0
+LocatePC: 0x4aec00
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0x4aebe9
+LocatePC: 0x4aec29
 	fmt.Println@fmt/print.go:314
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0x4aec20
+LocatePC: 0x4aec60
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
-LocatePC: 0x4aecd5
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0x4ae9e0
+LocatePC: 0x4aed5b
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+LocatePC: 0x4aea20
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
-LocatePC: 0x4aea11
+LocatePC: 0x4aea51
 	fmt.Println@fmt/print.go:314
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-LocatePC: 0x4ae3ce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4ae3ee
-	fmt.Println@fmt/print.go:314
+LocatePC: 0x4ae40e
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4ae606
+LocatePC: 0x4ae42e
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0x4ae646
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4ae625
+LocatePC: 0x4ae665
 	fmt.Println@fmt/print.go:314
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4ae650
+LocatePC: 0x4ae690
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0x4ae66d
+LocatePC: 0x4ae6ad
 	fmt.Println@fmt/print.go:314
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0x4ae650
+FunctionLines: 0x4ae690
 	fmt.Println
-		[0x4ae3ec, 0x4ae40f) fmt.Println@fmt/print.go:314
-		[0x4ae61d, 0x4ae645) fmt.Println@fmt/print.go:314
-		[0x4ae667, 0x4ae68a) fmt.Println@fmt/print.go:314
+		[0x4ae42c, 0x4ae44f) fmt.Println@fmt/print.go:314
+		[0x4ae65d, 0x4ae685) fmt.Println@fmt/print.go:314
+		[0x4ae6a7, 0x4ae6ca) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0x4ae25d, 0x4ae264) fmt.Scanln@fmt/scan.go:70
-		[0x4ae265, 0x4ae278) fmt.Scanln@fmt/scan.go:70
+		[0x4ae29d, 0x4ae2a4) fmt.Scanln@fmt/scan.go:70
+		[0x4ae2a5, 0x4ae2b8) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4ae606, 0x4ae61d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
+		[0x4ae646, 0x4ae65d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0x4ae650, 0x4ae667) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0x4ae690, 0x4ae6a7) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0x4ae3ce, 0x4ae3ec) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0x4ae40e, 0x4ae42c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
-		[0x4ae240, 0x4ae25d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0x4ae264, 0x4ae265) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0x4ae278, 0x4ae27d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0x4ae27d, 0x4ae2bd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0x4ae2bd, 0x4ae2cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0x4ae2cc, 0x4ae2dd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0x4ae2dd, 0x4ae30d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0x4ae30d, 0x4ae32c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0x4ae32c, 0x4ae37d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0x4ae37d, 0x4ae3a5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0x4ae3a5, 0x4ae3cd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0x4ae3cd, 0x4ae3ce) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0x4ae40f, 0x4ae420) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0x4ae420, 0x4ae460) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0x4ae460, 0x4ae505) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0x4ae505, 0x4ae520) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0x4ae520, 0x4ae55b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0x4ae55b, 0x4ae595) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0x4ae595, 0x4ae5d3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0x4ae5d3, 0x4ae605) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0x4ae605, 0x4ae606) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0x4ae645, 0x4ae650) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0x4ae68a, 0x4ae68f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4ae68f, 0x4ae694) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0x4ae694, 0x4ae69d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
-		[0x4ae69d, 0x4ae6aa) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4ae280, 0x4ae29d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4ae2a4, 0x4ae2a5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0x4ae2b8, 0x4ae2bd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0x4ae2bd, 0x4ae2fd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0x4ae2fd, 0x4ae30c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0x4ae30c, 0x4ae31d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0x4ae31d, 0x4ae34d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0x4ae34d, 0x4ae36c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0x4ae36c, 0x4ae3bd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0x4ae3bd, 0x4ae3e5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0x4ae3e5, 0x4ae40d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0x4ae40d, 0x4ae40e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0x4ae44f, 0x4ae460) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0x4ae460, 0x4ae4a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0x4ae4a0, 0x4ae545) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0x4ae545, 0x4ae560) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0x4ae560, 0x4ae59b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0x4ae59b, 0x4ae5d5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0x4ae5d5, 0x4ae613) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0x4ae613, 0x4ae645) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0x4ae645, 0x4ae646) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0x4ae685, 0x4ae690) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0x4ae6ca, 0x4ae6cf) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0x4ae6cf, 0x4ae6d4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4ae6d4, 0x4ae6dd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0x4ae6dd, 0x4ae6ea) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -1,119 +1,119 @@
-LocatePC: 0xb53c0
+LocatePC: 0xb5410
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
-LocatePC: 0xb53f8
+LocatePC: 0xb5448
 	fmt.Println@fmt/print.go:314
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
-LocatePC: 0xb5430
+LocatePC: 0xb5480
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-LocatePC: 0xb5470
+LocatePC: 0xb54c0
 	fmt.Println@fmt/print.go:314
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-LocatePC: 0xb54b0
+LocatePC: 0xb5500
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-LocatePC: 0xb54f8
+LocatePC: 0xb5548
 	fmt.Println@fmt/print.go:314
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-LocatePC: 0xb5540
+LocatePC: 0xb5590
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-LocatePC: 0xb5580
+LocatePC: 0xb55d0
 	fmt.Println@fmt/print.go:314
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-LocatePC: 0xb55c0
+LocatePC: 0xb5610
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-LocatePC: 0xb5608
+LocatePC: 0xb5658
 	fmt.Println@fmt/print.go:314
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-LocatePC: 0xb5650
+LocatePC: 0xb56a0
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-LocatePC: 0xb5690
+LocatePC: 0xb56e0
 	fmt.Println@fmt/print.go:314
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
-LocatePC: 0xb56d0
+LocatePC: 0xb5720
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0xb56d8
+LocatePC: 0xb5728
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0xb57a0
+LocatePC: 0xb57f0
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-LocatePC: 0xb57d8
+LocatePC: 0xb5828
 	fmt.Println@fmt/print.go:314
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-LocatePC: 0xb5810
+LocatePC: 0xb5860
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
-LocatePC: 0xb5870
+LocatePC: 0xb58c0
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
-LocatePC: 0xb58d0
+LocatePC: 0xb5920
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0xb5908
+LocatePC: 0xb5958
 	fmt.Println@fmt/print.go:314
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0xb5940
+LocatePC: 0xb5990
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
-LocatePC: 0xb59e0
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0xb56e0
+LocatePC: 0xb5a68
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+LocatePC: 0xb5730
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
-LocatePC: 0xb5718
+LocatePC: 0xb5768
 	fmt.Println@fmt/print.go:314
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-LocatePC: 0xb514c
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb516c
-	fmt.Println@fmt/print.go:314
+LocatePC: 0xb519c
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb5338
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb5350
+LocatePC: 0xb51bc
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb5370
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0xb5388
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+LocatePC: 0xb53a0
+	fmt.Println@fmt/print.go:314
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+LocatePC: 0xb53c0
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+LocatePC: 0xb53d8
 	fmt.Println@fmt/print.go:314
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb5370
+FunctionLines: 0xb53c0
 	fmt.Println
-		[0xb5168, 0xb518c) fmt.Println@fmt/print.go:314
-		[0xb5348, 0xb5368) fmt.Println@fmt/print.go:314
-		[0xb5380, 0xb53a0) fmt.Println@fmt/print.go:314
+		[0xb51b8, 0xb51dc) fmt.Println@fmt/print.go:314
+		[0xb5398, 0xb53b8) fmt.Println@fmt/print.go:314
+		[0xb53d0, 0xb53f0) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0xb4fd0, 0xb4fd8) fmt.Scanln@fmt/scan.go:70
-		[0xb4fdc, 0xb4ff4) fmt.Scanln@fmt/scan.go:70
+		[0xb5020, 0xb5028) fmt.Scanln@fmt/scan.go:70
+		[0xb502c, 0xb5044) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb5338, 0xb5348) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
+		[0xb5388, 0xb5398) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0xb5370, 0xb5380) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0xb53c0, 0xb53d0) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0xb514c, 0xb5168) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0xb519c, 0xb51b8) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
-		[0xb4fb0, 0xb4fd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0xb4fd8, 0xb4fdc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0xb4ff4, 0xb4ff8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0xb4ff8, 0xb5028) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0xb5028, 0xb503c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0xb503c, 0xb504c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0xb504c, 0xb5078) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0xb5078, 0xb5094) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0xb5094, 0xb50e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0xb50e0, 0xb5114) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0xb5114, 0xb5148) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0xb5148, 0xb514c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb518c, 0xb5198) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb5198, 0xb51cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb51cc, 0xb5250) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb5250, 0xb5268) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb5268, 0xb529c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb529c, 0xb52d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb52d0, 0xb5304) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb5304, 0xb5334) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb5334, 0xb5338) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb5368, 0xb5370) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb53a0, 0xb53a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb53a4, 0xb53a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb53a8, 0xb53b4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
-		[0xb53b4, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb5000, 0xb5020) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb5028, 0xb502c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0xb5044, 0xb5048) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0xb5048, 0xb5078) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0xb5078, 0xb508c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0xb508c, 0xb509c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0xb509c, 0xb50c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0xb50c8, 0xb50e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0xb50e4, 0xb5130) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0xb5130, 0xb5164) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0xb5164, 0xb5198) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0xb5198, 0xb519c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0xb51dc, 0xb51e8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb51e8, 0xb521c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb521c, 0xb52a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb52a0, 0xb52b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb52b8, 0xb52ec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb52ec, 0xb5320) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb5320, 0xb5354) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb5354, 0xb5384) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb5384, 0xb5388) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb53b8, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb53f0, 0xb53f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb53f4, 0xb53f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb53f8, 0xb5404) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0xb5404, 0xb5410) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -1,76 +1,80 @@
 LocatePC: 0xb53c0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
 LocatePC: 0xb53f8
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
 LocatePC: 0xb5430
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
 LocatePC: 0xb5470
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
 LocatePC: 0xb54b0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
 LocatePC: 0xb54f8
 	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
 LocatePC: 0xb5540
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
 LocatePC: 0xb5580
 	fmt.Println@fmt/print.go:314
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
 LocatePC: 0xb55c0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
 LocatePC: 0xb5608
 	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
 LocatePC: 0xb5650
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
 LocatePC: 0xb5690
 	fmt.Println@fmt/print.go:314
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
 LocatePC: 0xb56d0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0xb56d8
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0xb57a0
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
 LocatePC: 0xb57d8
 	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
 LocatePC: 0xb5810
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
 LocatePC: 0xb5870
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
 LocatePC: 0xb58d0
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:120
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
 LocatePC: 0xb5908
 	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+LocatePC: 0xb5940
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0xb59e0
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
 LocatePC: 0xb56e0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 LocatePC: 0xb5718
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 LocatePC: 0xb514c
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0xb516c
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0xb5338
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0xb5350
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0xb5370
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0xb5388
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0xb5370
 	fmt.Println
@@ -81,11 +85,11 @@ FunctionLines: 0xb5370
 		[0xb4fd0, 0xb4fd8) fmt.Scanln@fmt/scan.go:70
 		[0xb4fdc, 0xb4ff4) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb5338, 0xb5348) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0xb5338, 0xb5348) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0xb5370, 0xb5380) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0xb5370, 0xb5380) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0xb514c, 0xb5168) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+		[0xb514c, 0xb5168) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
 		[0xb4fb0, 0xb4fd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0xb4fd8, 0xb4fdc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -110,5 +114,6 @@ FunctionLines: 0xb5370
 		[0xb5334, 0xb5338) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 		[0xb5368, 0xb5370) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 		[0xb53a0, 0xb53a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb53a4, 0xb53b0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb53b0, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb53a4, 0xb53a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb53a8, 0xb53b4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0xb53b4, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
@@ -1,76 +1,80 @@
-LocatePC: 0xb5250
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
-LocatePC: 0xb5288
-	fmt.Println@fmt/print.go:314
+LocatePC: 0xb5260
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
-LocatePC: 0xb52c0
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-LocatePC: 0xb5300
+LocatePC: 0xb5298
 	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
+LocatePC: 0xb52d0
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-LocatePC: 0xb5340
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-LocatePC: 0xb5380
+LocatePC: 0xb5310
 	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
+LocatePC: 0xb5350
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-LocatePC: 0xb53c0
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0xb5400
+LocatePC: 0xb5390
 	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
+LocatePC: 0xb53d0
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-LocatePC: 0xb5440
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-LocatePC: 0xb5480
+LocatePC: 0xb5410
 	fmt.Println@fmt/print.go:314
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
+LocatePC: 0xb5450
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-LocatePC: 0xb54c0
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0xb5500
+LocatePC: 0xb5490
 	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
+LocatePC: 0xb54d0
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-LocatePC: 0xb5540
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
-LocatePC: 0xb5548
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
-LocatePC: 0xb5610
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
-LocatePC: 0xb5648
+LocatePC: 0xb5510
 	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-LocatePC: 0xb5680
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
-LocatePC: 0xb56e0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
-LocatePC: 0xb5740
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:120
-LocatePC: 0xb5778
-	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
 LocatePC: 0xb5550
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
-LocatePC: 0xb5588
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
+LocatePC: 0xb5558
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
+LocatePC: 0xb5620
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+LocatePC: 0xb5658
 	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
+LocatePC: 0xb5690
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
+LocatePC: 0xb56f0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
+LocatePC: 0xb5750
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+LocatePC: 0xb5788
+	fmt.Println@fmt/print.go:314
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+LocatePC: 0xb57c0
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0xb5860
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+LocatePC: 0xb5560
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+LocatePC: 0xb5598
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 LocatePC: 0xb4fec
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0xb500a
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0xb51cc
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0xb51e4
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0xb5204
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0xb521c
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0xb5204
 	fmt.Println
@@ -81,11 +85,11 @@ FunctionLines: 0xb5204
 		[0xb4e70, 0xb4e78) fmt.Scanln@fmt/scan.go:70
 		[0xb4e7c, 0xb4e94) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb51cc, 0xb51dc) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0xb51cc, 0xb51dc) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0xb5204, 0xb5214) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0xb5204, 0xb5214) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0xb4fec, 0xb5008) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+		[0xb4fec, 0xb5008) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
 		[0xb4e50, 0xb4e70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0xb4e78, 0xb4e7c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -110,5 +114,6 @@ FunctionLines: 0xb5204
 		[0xb51c8, 0xb51cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 		[0xb51fc, 0xb5204) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 		[0xb5234, 0xb5238) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb5238, 0xb5244) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb5244, 0xb5250) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb5238, 0xb523c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb523c, 0xb5248) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0xb5248, 0xb5260) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
@@ -1,119 +1,119 @@
-LocatePC: 0xb5260
+LocatePC: 0xb52a0
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
-LocatePC: 0xb5298
+LocatePC: 0xb52d8
 	fmt.Println@fmt/print.go:314
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
-LocatePC: 0xb52d0
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
 LocatePC: 0xb5310
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+LocatePC: 0xb5350
 	fmt.Println@fmt/print.go:314
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-LocatePC: 0xb5350
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
 LocatePC: 0xb5390
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+LocatePC: 0xb53d0
 	fmt.Println@fmt/print.go:314
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-LocatePC: 0xb53d0
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
 LocatePC: 0xb5410
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0xb5450
 	fmt.Println@fmt/print.go:314
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-LocatePC: 0xb5450
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
 LocatePC: 0xb5490
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+LocatePC: 0xb54d0
 	fmt.Println@fmt/print.go:314
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-LocatePC: 0xb54d0
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
 LocatePC: 0xb5510
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0xb5550
 	fmt.Println@fmt/print.go:314
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
-LocatePC: 0xb5550
+LocatePC: 0xb5590
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0xb5558
+LocatePC: 0xb5598
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0xb5620
+LocatePC: 0xb5660
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-LocatePC: 0xb5658
+LocatePC: 0xb5698
 	fmt.Println@fmt/print.go:314
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-LocatePC: 0xb5690
+LocatePC: 0xb56d0
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
-LocatePC: 0xb56f0
+LocatePC: 0xb5730
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:109
-LocatePC: 0xb5750
+LocatePC: 0xb5790
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0xb5788
+LocatePC: 0xb57c8
 	fmt.Println@fmt/print.go:314
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0xb57c0
+LocatePC: 0xb5800
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
-LocatePC: 0xb5860
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0xb5560
+LocatePC: 0xb58e0
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+LocatePC: 0xb55a0
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
-LocatePC: 0xb5598
+LocatePC: 0xb55d8
 	fmt.Println@fmt/print.go:314
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-LocatePC: 0xb4fec
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb500a
-	fmt.Println@fmt/print.go:314
+LocatePC: 0xb502c
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb51cc
+LocatePC: 0xb504a
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0xb520c
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb51e4
+LocatePC: 0xb5224
 	fmt.Println@fmt/print.go:314
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb5204
+LocatePC: 0xb5244
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0xb521c
+LocatePC: 0xb525c
 	fmt.Println@fmt/print.go:314
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb5204
+FunctionLines: 0xb5244
 	fmt.Println
-		[0xb5008, 0xb5028) fmt.Println@fmt/print.go:314
-		[0xb51dc, 0xb51fc) fmt.Println@fmt/print.go:314
-		[0xb5214, 0xb5234) fmt.Println@fmt/print.go:314
+		[0xb5048, 0xb5068) fmt.Println@fmt/print.go:314
+		[0xb521c, 0xb523c) fmt.Println@fmt/print.go:314
+		[0xb5254, 0xb5274) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0xb4e70, 0xb4e78) fmt.Scanln@fmt/scan.go:70
-		[0xb4e7c, 0xb4e94) fmt.Scanln@fmt/scan.go:70
+		[0xb4eb0, 0xb4eb8) fmt.Scanln@fmt/scan.go:70
+		[0xb4ebc, 0xb4ed4) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb51cc, 0xb51dc) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
+		[0xb520c, 0xb521c) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0xb5204, 0xb5214) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0xb5244, 0xb5254) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0xb4fec, 0xb5008) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0xb502c, 0xb5048) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
-		[0xb4e50, 0xb4e70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0xb4e78, 0xb4e7c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0xb4e94, 0xb4e98) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0xb4e98, 0xb4ec8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0xb4ec8, 0xb4edc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0xb4edc, 0xb4eec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0xb4eec, 0xb4f18) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0xb4f18, 0xb4f34) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0xb4f34, 0xb4f80) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0xb4f80, 0xb4fb4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0xb4fb4, 0xb4fe8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0xb4fe8, 0xb4fec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb5028, 0xb5034) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb5034, 0xb5068) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb5068, 0xb50e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb50e4, 0xb50fc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb50fc, 0xb5130) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb5130, 0xb5164) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb5164, 0xb5198) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb5198, 0xb51c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb51c8, 0xb51cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb51fc, 0xb5204) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb5234, 0xb5238) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb5238, 0xb523c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb523c, 0xb5248) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
-		[0xb5248, 0xb5260) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb4e90, 0xb4eb0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb4eb8, 0xb4ebc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0xb4ed4, 0xb4ed8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0xb4ed8, 0xb4f08) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0xb4f08, 0xb4f1c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0xb4f1c, 0xb4f2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0xb4f2c, 0xb4f58) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0xb4f58, 0xb4f74) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0xb4f74, 0xb4fc0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0xb4fc0, 0xb4ff4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0xb4ff4, 0xb5028) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0xb5028, 0xb502c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0xb5068, 0xb5074) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb5074, 0xb50a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb50a8, 0xb5124) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb5124, 0xb513c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb513c, 0xb5170) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb5170, 0xb51a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb51a4, 0xb51d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb51d8, 0xb5208) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb5208, 0xb520c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb523c, 0xb5244) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb5274, 0xb5278) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb5278, 0xb527c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb527c, 0xb5288) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0xb5288, 0xb52a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
@@ -1,76 +1,80 @@
 LocatePC: 0xb7de0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
 LocatePC: 0xb7e18
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
 LocatePC: 0xb7e50
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
 LocatePC: 0xb7e88
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
 LocatePC: 0xb7ec0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
 LocatePC: 0xb7f00
 	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
 LocatePC: 0xb7f40
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
 LocatePC: 0xb7f78
 	fmt.Println@fmt/print.go:314
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
 LocatePC: 0xb7fb0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
 LocatePC: 0xb7ff0
 	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
 LocatePC: 0xb8030
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
 LocatePC: 0xb8068
 	fmt.Println@fmt/print.go:314
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
 LocatePC: 0xb80a0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0xb80a8
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
 LocatePC: 0xb8170
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
 LocatePC: 0xb81a8
 	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
 LocatePC: 0xb81e0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
-LocatePC: 0xb8238
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
+LocatePC: 0xb8238
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
 LocatePC: 0xb8290
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:120
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
 LocatePC: 0xb82c8
 	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+LocatePC: 0xb8300
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0xb83a0
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
 LocatePC: 0xb80b0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 LocatePC: 0xb80e8
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 LocatePC: 0xb7b88
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0xb7ba2
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0xb7d60
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0xb7d76
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0xb7d94
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0xb7daa
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0xb7d94
 	fmt.Println
@@ -81,11 +85,11 @@ FunctionLines: 0xb7d94
 		[0xb7a20, 0xb7a28) fmt.Scanln@fmt/scan.go:70
 		[0xb7a2c, 0xb7a44) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb7d60, 0xb7d6c) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0xb7d60, 0xb7d6c) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0xb7d94, 0xb7da0) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0xb7d94, 0xb7da0) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0xb7b88, 0xb7b9c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+		[0xb7b88, 0xb7b9c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
 		[0xb7a00, 0xb7a20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0xb7a28, 0xb7a2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -110,5 +114,6 @@ FunctionLines: 0xb7d94
 		[0xb7d5c, 0xb7d60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 		[0xb7d8c, 0xb7d94) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 		[0xb7dc0, 0xb7dc4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb7dc4, 0xb7dd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb7dd0, 0xb7de0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb7dc4, 0xb7dc8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb7dc8, 0xb7dd4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0xb7dd4, 0xb7de0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
@@ -1,119 +1,119 @@
-LocatePC: 0xb7de0
+LocatePC: 0xb7e20
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
-LocatePC: 0xb7e18
+LocatePC: 0xb7e58
 	fmt.Println@fmt/print.go:314
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:45
-LocatePC: 0xb7e50
+LocatePC: 0xb7e90
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-LocatePC: 0xb7e88
+LocatePC: 0xb7ec8
 	fmt.Println@fmt/print.go:314
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-LocatePC: 0xb7ec0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
 LocatePC: 0xb7f00
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+LocatePC: 0xb7f40
 	fmt.Println@fmt/print.go:314
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-LocatePC: 0xb7f40
+LocatePC: 0xb7f80
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-LocatePC: 0xb7f78
+LocatePC: 0xb7fb8
 	fmt.Println@fmt/print.go:314
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-LocatePC: 0xb7fb0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
 LocatePC: 0xb7ff0
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+LocatePC: 0xb8030
 	fmt.Println@fmt/print.go:314
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-LocatePC: 0xb8030
+LocatePC: 0xb8070
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-LocatePC: 0xb8068
+LocatePC: 0xb80a8
 	fmt.Println@fmt/print.go:314
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:70
-LocatePC: 0xb80a0
+LocatePC: 0xb80e0
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0xb80a8
+LocatePC: 0xb80e8
 	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0xb8170
+LocatePC: 0xb81b0
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-LocatePC: 0xb81a8
+LocatePC: 0xb81e8
 	fmt.Println@fmt/print.go:314
 	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-LocatePC: 0xb81e0
+LocatePC: 0xb8220
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
-LocatePC: 0xb8238
+LocatePC: 0xb8278
 	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
-LocatePC: 0xb8290
+LocatePC: 0xb82d0
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0xb82c8
+LocatePC: 0xb8308
 	fmt.Println@fmt/print.go:314
 	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0xb8300
+LocatePC: 0xb8340
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
-LocatePC: 0xb83a0
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0xb80b0
+LocatePC: 0xb8418
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+LocatePC: 0xb80f0
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
-LocatePC: 0xb80e8
+LocatePC: 0xb8128
 	fmt.Println@fmt/print.go:314
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-LocatePC: 0xb7b88
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb7ba2
-	fmt.Println@fmt/print.go:314
+LocatePC: 0xb7bc8
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb7d60
+LocatePC: 0xb7be2
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0xb7da0
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb7d76
+LocatePC: 0xb7db6
 	fmt.Println@fmt/print.go:314
 	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb7d94
+LocatePC: 0xb7dd4
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0xb7daa
+LocatePC: 0xb7dea
 	fmt.Println@fmt/print.go:314
 	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb7d94
+FunctionLines: 0xb7dd4
 	fmt.Println
-		[0xb7b9c, 0xb7bbc) fmt.Println@fmt/print.go:314
-		[0xb7d6c, 0xb7d8c) fmt.Println@fmt/print.go:314
-		[0xb7da0, 0xb7dc0) fmt.Println@fmt/print.go:314
+		[0xb7bdc, 0xb7bfc) fmt.Println@fmt/print.go:314
+		[0xb7dac, 0xb7dcc) fmt.Println@fmt/print.go:314
+		[0xb7de0, 0xb7e00) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0xb7a20, 0xb7a28) fmt.Scanln@fmt/scan.go:70
-		[0xb7a2c, 0xb7a44) fmt.Scanln@fmt/scan.go:70
+		[0xb7a60, 0xb7a68) fmt.Scanln@fmt/scan.go:70
+		[0xb7a6c, 0xb7a84) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb7d60, 0xb7d6c) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
+		[0xb7da0, 0xb7dac) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:113
 	main.PointerSmallChainArg
-		[0xb7d94, 0xb7da0) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0xb7dd4, 0xb7de0) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
 	main.inlined
-		[0xb7b88, 0xb7b9c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0xb7bc8, 0xb7bdc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
 	main.main
-		[0xb7a00, 0xb7a20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0xb7a28, 0xb7a2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0xb7a44, 0xb7a48) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0xb7a48, 0xb7a74) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0xb7a74, 0xb7a88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0xb7a88, 0xb7a98) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0xb7a98, 0xb7ac0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0xb7ac0, 0xb7adc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0xb7adc, 0xb7b1c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0xb7b1c, 0xb7b50) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0xb7b50, 0xb7b84) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0xb7b84, 0xb7b88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb7bbc, 0xb7bc8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb7bc8, 0xb7bfc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb7bfc, 0xb7c78) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb7c78, 0xb7c90) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb7c90, 0xb7cc4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb7cc4, 0xb7cf8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb7cf8, 0xb7d2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb7d2c, 0xb7d5c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb7d5c, 0xb7d60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb7d8c, 0xb7d94) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb7dc0, 0xb7dc4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb7dc4, 0xb7dc8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb7dc8, 0xb7dd4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
-		[0xb7dd4, 0xb7de0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb7a40, 0xb7a60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb7a68, 0xb7a6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0xb7a84, 0xb7a88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0xb7a88, 0xb7ab4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0xb7ab4, 0xb7ac8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0xb7ac8, 0xb7ad8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0xb7ad8, 0xb7b00) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0xb7b00, 0xb7b1c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0xb7b1c, 0xb7b5c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0xb7b5c, 0xb7b90) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0xb7b90, 0xb7bc4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0xb7bc4, 0xb7bc8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0xb7bfc, 0xb7c08) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb7c08, 0xb7c3c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb7c3c, 0xb7cb8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb7cb8, 0xb7cd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb7cd0, 0xb7d04) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb7d04, 0xb7d38) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb7d38, 0xb7d6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb7d6c, 0xb7d9c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb7d9c, 0xb7da0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb7dcc, 0xb7dd4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb7e00, 0xb7e04) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb7e04, 0xb7e08) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb7e08, 0xb7e14) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:41
+		[0xb7e14, 0xb7e20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,22 +1,22 @@
-- offset: "0x0000fb40"
+- offset: "0x0000fc80"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006020"
+  ptrToThis: "0x00006060"
   struct:
     fields:
     - name: a
       type: int
       offset: 0
-- offset: "0x0001b5a0"
+- offset: "0x0001b7a0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006060"
+  ptrToThis: "0x000060a0"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001afc0"
+- offset: "0x0000fb40"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006020"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001b5a0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00005ec0"
+  ptrToThis: "0x00006060"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,22 +1,22 @@
-- offset: "0x000112a0"
+- offset: "0x00011500"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006a00"
+  ptrToThis: "0x00006a20"
   struct:
     fields:
     - name: a
       type: int
       offset: 0
-- offset: "0x0001db40"
+- offset: "0x0001dea0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006a40"
+  ptrToThis: "0x00006a60"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001d3c0"
+- offset: "0x000112a0"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006a00"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001db40"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006940"
+  ptrToThis: "0x00006a40"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001e740"
+- offset: "0x00011cc0"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006d60"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001eec0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006ca0"
+  ptrToThis: "0x00006da0"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,22 +1,22 @@
-- offset: "0x00011cc0"
+- offset: "0x00011f40"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006d60"
+  ptrToThis: "0x00006da0"
   struct:
     fields:
     - name: a
       type: int
       offset: 0
-- offset: "0x0001eec0"
+- offset: "0x0001f240"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006da0"
+  ptrToThis: "0x00006de0"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,22 +1,22 @@
-- offset: "0x0000fac0"
+- offset: "0x0000fc00"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006000"
+  ptrToThis: "0x00006040"
   struct:
     fields:
     - name: a
       type: int
       offset: 0
-- offset: "0x0001b520"
+- offset: "0x0001b720"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006040"
+  ptrToThis: "0x00006080"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001af40"
+- offset: "0x0000fac0"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006000"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001b520"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00005ea0"
+  ptrToThis: "0x00006040"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,22 +1,22 @@
-- offset: "0x00011220"
+- offset: "0x00011480"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x000069e0"
+  ptrToThis: "0x00006a00"
   struct:
     fields:
     - name: a
       type: int
       offset: 0
-- offset: "0x0001dac0"
+- offset: "0x0001de20"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006a20"
+  ptrToThis: "0x00006a40"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001d340"
+- offset: "0x00011220"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x000069e0"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001dac0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006920"
+  ptrToThis: "0x00006a20"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001e6c0"
+- offset: "0x00011c40"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006d40"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001ee40"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006c80"
+  ptrToThis: "0x00006d80"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,22 +1,22 @@
-- offset: "0x00011c40"
+- offset: "0x00011ec0"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006d40"
+  ptrToThis: "0x00006d80"
   struct:
     fields:
     - name: a
       type: int
       offset: 0
-- offset: "0x0001ee40"
+- offset: "0x0001f1c0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006d80"
+  ptrToThis: "0x00006dc0"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 194 EventRootType Probe[main.HandleHTTP]
+          Type: 188 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 195 EventRootType Probe[main.LookAtTheRequest]
+          Type: 189 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -66,29 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 105 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0xd59848..0xd59881
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 107 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd59958..0xd5997a
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd5997a..0xd59a5c
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 109 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0xd597c0..0xd59a5c
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd59b20..0xd59be5]
@@ -114,20 +91,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 191
+      ID: 185
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []string.array
+      Pointee: 184 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 114
+      ID: 108
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 113 GoSliceDataType []uint8.array
+      Pointee: 107 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 116
+      ID: 110
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 115 GoSliceDataType []uintptr.array
+      Pointee: 109 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -136,29 +113,22 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 163
+      ID: 157
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 164 GoHMapBucketType bucket<string,[]string>
+      Pointee: 158 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 184
+      ID: 178
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 185 GoHMapBucketType bucket<string,string>
+      Pointee: 179 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 107
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.17632e+06
-      GoKind: 22
-      Pointee: 108 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 173
+      ID: 167
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 168 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -181,29 +151,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 105
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.187104e+06
-      GoKind: 22
-      Pointee: 106 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 117
+      ID: 111
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.396768e+06
       GoKind: 22
-      Pointee: 118 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 112 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 161
+      ID: 155
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 162 GoHMapHeaderType hash<string,[]string>
+      Pointee: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 176
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 183 GoHMapHeaderType hash<string,string>
+      Pointee: 177 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 93
       Name: '*int'
@@ -240,12 +203,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 171
+      ID: 165
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 172 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 166 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 103
       Name: '*net/http.Request'
@@ -254,40 +217,40 @@ Types:
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
-      ID: 176
+      ID: 170
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType net/http.Response
+      Pointee: 171 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 154
+      ID: 148
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.876224e+06
       GoKind: 22
-      Pointee: 155 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 149 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 179
+      ID: 173
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 180 UnresolvedPointeeType net/http.pattern
+      Pointee: 174 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 156
+      ID: 150
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.117184e+06
       GoKind: 22
-      Pointee: 157 UnresolvedPointeeType net/http.response
+      Pointee: 151 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 158
+      ID: 152
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 159 UnresolvedPointeeType net/url.URL
+      Pointee: 153 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -331,12 +294,12 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 165
+      ID: 159
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 379904
       GoKind: 22
-      Pointee: 166 UnresolvedPointeeType runtime.mapextra
+      Pointee: 160 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -366,115 +329,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 112
+      ID: 106
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 111 GoStringDataType string.str
+      Pointee: 105 GoStringDataType string.str
     - __kind: PointerType
-      ID: 123
+      ID: 117
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.532416e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 118 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 137
+      ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656736e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 119
+      ID: 113
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.532032e+06
       GoKind: 22
-      Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 114 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 129
+      ID: 123
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.655968e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 143
+      ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726624e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 131
+      ID: 125
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.65616e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 127
+      ID: 121
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.655776e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 139
+      ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.726176e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 147
+      ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.794496e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 141
+      ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.7264e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 119
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.532608e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 121
+      ID: 115
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.532224e+06
       GoKind: 22
-      Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 116 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 133
+      ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656352e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 145
+      ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726848e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656544e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -518,12 +481,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 175
+      ID: 169
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: EventRootType
-      ID: 194
+      ID: 188
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -547,7 +510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 195
+      ID: 189
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -652,7 +615,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 186
+      ID: 180
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -661,19 +624,19 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 183
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 164 GoHMapBucketType bucket<string,[]string>
+      Element: 158 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 187
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 185 GoHMapBucketType bucket<string,string>
+      Element: 179 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 187
+      ID: 181
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -684,7 +647,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 163
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -699,9 +662,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 190 GoSliceDataType []string.array
+      Data: 184 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 184
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -722,9 +685,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 113 GoSliceDataType []uint8.array
+      Data: 107 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 113
+      ID: 107
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -745,22 +708,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 115 GoSliceDataType []uintptr.array
+      Data: 109 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 115
+      ID: 109
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 188
+      ID: 182
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 169 GoSliceHeaderType []string
+      Element: 163 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 192
+      ID: 186
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -773,47 +736,43 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 164
+      ID: 158
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 180 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<string>
+          Type: 181 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 188 ArrayType []val<[]string>
+          Type: 182 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 163 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 169 GoSliceHeaderType []string
+      ValueType: 163 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 185
+      ID: 179
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 180 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<string>
+          Type: 181 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 192 ArrayType []val<string>
+          Type: 186 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 184 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: UnresolvedPointeeType
-      ID: 108
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 90
       Name: complex128
@@ -827,7 +786,7 @@ Types:
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 178
+      ID: 172
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215552e+06
@@ -839,23 +798,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 109
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.708256e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 110 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 110
-      Name: context.emptyCtx
-      GoRuntimeType: 1.43472e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 168
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -890,7 +834,7 @@ Types:
       GoRuntimeType: 455360
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 168
+      ID: 162
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
@@ -901,12 +845,8 @@ Types:
       ByteSize: 8
       GoRuntimeType: 798176
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 106
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 149
+      ID: 143
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.265696e+06
@@ -919,11 +859,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 118
+      ID: 112
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 162
+      ID: 156
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -944,20 +884,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 163 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 163 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 165 PointerType *runtime.mapextra
-      BucketType: 164 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 189 GoSliceDataType []bucket<string,[]string>.array
+          Type: 159 PointerType *runtime.mapextra
+      BucketType: 158 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 183
+      ID: 177
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -978,18 +918,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 184 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 184 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 165 PointerType *runtime.mapextra
-      BucketType: 185 GoHMapBucketType bucket<string,string>
-      BucketsType: 193 GoSliceDataType []bucket<string,string>.array
+          Type: 159 PointerType *runtime.mapextra
+      BucketType: 179 GoHMapBucketType bucket<string,string>
+      BucketsType: 187 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1120,7 +1060,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 167
+      ID: 161
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.092864e+06
@@ -1133,18 +1073,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 181
+      ID: 175
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 183 GoHMapHeaderType hash<string,string>
+      HeaderType: 177 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 172
+      ID: 166
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 146
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.006528e+06
@@ -1157,7 +1097,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 144
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.00512e+06
@@ -1170,14 +1110,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 160
+      ID: 154
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.963712e+06
       GoKind: 21
-      HeaderType: 162 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 147
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.005248e+06
@@ -1190,7 +1130,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 145
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.005504e+06
@@ -1214,7 +1154,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 158 PointerType *net/url.URL
+          Type: 152 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1226,19 +1166,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 160 GoMapType net/http.Header
+          Type: 154 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 167 GoInterfaceType io.ReadCloser
+          Type: 161 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 168 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 162 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 169 GoSliceHeaderType []string
+          Type: 163 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1247,16 +1187,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 170 GoMapType net/url.Values
+          Type: 164 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 170 GoMapType net/url.Values
+          Type: 164 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 171 PointerType *mime/multipart.Form
+          Type: 165 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 160 GoMapType net/http.Header
+          Type: 154 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1265,30 +1205,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 173 PointerType *crypto/tls.ConnectionState
+          Type: 167 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 175 GoChannelType <-chan struct {}
+          Type: 169 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 176 PointerType *net/http.Response
+          Type: 170 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 178 GoInterfaceType context.Context
+          Type: 172 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 179 PointerType *net/http.pattern
+          Type: 173 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 169 GoSliceHeaderType []string
+          Type: 163 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 181 GoMapType map[string]string
+          Type: 175 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 171
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1305,28 +1245,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 155
+      ID: 149
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 180
+      ID: 174
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 157
+      ID: 151
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 159
+      ID: 153
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 170
+      ID: 164
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.71184e+06
       GoKind: 21
-      HeaderType: 162 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1922,7 +1862,7 @@ Types:
           Offset: 24
           Type: 28 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 166
+      ID: 160
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -2056,18 +1996,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 112 PointerType *string.str
+          Type: 106 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 111 GoStringDataType string.str
+      Data: 105 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 111
+      ID: 105
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 124
+      ID: 118
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.855808e+06
@@ -2075,12 +2015,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 138
+      ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.931104e+06
@@ -2088,15 +2028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 120
+      ID: 114
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.855296e+06
@@ -2104,12 +2044,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 130
+      ID: 124
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.929952e+06
@@ -2117,15 +2057,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 144
+      ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999552e+06
@@ -2133,18 +2073,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 132
+      ID: 126
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.93024e+06
@@ -2152,15 +2092,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 128
+      ID: 122
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.929664e+06
@@ -2168,15 +2108,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 140
+      ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.998912e+06
@@ -2184,18 +2124,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 148
+      ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.058656e+06
@@ -2203,21 +2143,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 142
+      ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999232e+06
@@ -2225,18 +2165,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 120
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.856064e+06
@@ -2244,12 +2184,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 122
+      ID: 116
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.855552e+06
@@ -2257,12 +2197,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 134
+      ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.930528e+06
@@ -2270,15 +2210,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 146
+      ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999872e+06
@@ -2286,18 +2226,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.930816e+06
@@ -2305,13 +2245,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -2354,7 +2294,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543392
       GoKind: 26
-MaxTypeID: 195
+MaxTypeID: 189
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 207 EventRootType Probe[main.HandleHTTP]
+          Type: 201 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 208 EventRootType Probe[main.LookAtTheRequest]
+          Type: 202 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -66,29 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 110 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0xd313e8..0xd31421
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 112 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd314f7..0xd31512
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd31512..0xd315f9
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 114 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0xd31360..0xd315f9
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd316c0..0xd31785]
@@ -107,15 +84,15 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 168
+      ID: 162
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 169 PointerType *table<string,[]string>
+      Pointee: 163 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 181
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 188 PointerType *table<string,string>
+      Pointee: 182 PointerType *table<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -124,20 +101,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 198
+      ID: 192
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []string.array
+      Pointee: 191 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 119
+      ID: 113
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 118 GoSliceDataType []uint8.array
+      Pointee: 112 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 121
+      ID: 115
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []uintptr.array
+      Pointee: 114 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -146,19 +123,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 112
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.316768e+06
-      GoKind: 22
-      Pointee: 113 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 176
+      ID: 170
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -181,19 +151,12 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 110
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.32752e+06
-      GoKind: 22
-      Pointee: 111 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 122
+      ID: 116
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.577632e+06
       GoKind: 22
-      Pointee: 123 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 117 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 98
       Name: '*int'
@@ -230,22 +193,22 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 166
+      ID: 160
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 167 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 185
+      ID: 179
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 186 GoSwissMapHeaderType map<string,string>
+      Pointee: 180 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 174
+      ID: 168
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 175 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 108
       Name: '*net/http.Request'
@@ -254,50 +217,50 @@ Types:
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
-      ID: 179
+      ID: 173
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 180 UnresolvedPointeeType net/http.Response
+      Pointee: 174 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 159
+      ID: 153
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.045344e+06
       GoKind: 22
-      Pointee: 160 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 182
+      ID: 176
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 183 UnresolvedPointeeType net/http.pattern
+      Pointee: 177 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 161
+      ID: 155
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.254144e+06
       GoKind: 22
-      Pointee: 162 UnresolvedPointeeType net/http.response
+      Pointee: 156 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 163
+      ID: 157
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 164 UnresolvedPointeeType net/url.URL
+      Pointee: 158 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 191
+      ID: 185
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 192 StructureType noalg.map.group[string][]string
+      Pointee: 186 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 201
+      ID: 195
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 202 StructureType noalg.map.group[string]string
+      Pointee: 196 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -376,125 +339,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 117
+      ID: 111
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 116 GoStringDataType string.str
+      Pointee: 110 GoStringDataType string.str
     - __kind: PointerType
-      ID: 128
+      ID: 122
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.716704e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 123 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 142
+      ID: 136
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774624e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 124
+      ID: 118
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.71632e+06
       GoKind: 22
-      Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 119 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 134
+      ID: 128
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773856e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 148
+      ID: 142
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845888e+06
       GoKind: 22
-      Pointee: 149 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 136
+      ID: 130
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774048e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 132
+      ID: 126
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.773664e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 144
+      ID: 138
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.84544e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 152
+      ID: 146
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.918112e+06
       GoKind: 22
-      Pointee: 153 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 146
+      ID: 140
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845664e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 130
+      ID: 124
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.716896e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 120
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.716512e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 121 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 138
+      ID: 132
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.77424e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 150
+      ID: 144
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.846112e+06
       GoKind: 22
-      Pointee: 151 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 140
+      ID: 134
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774432e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 169
+      ID: 163
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 189 StructureType table<string,[]string>
+      Pointee: 183 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 188
+      ID: 182
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 199 StructureType table<string,string>
+      Pointee: 193 StructureType table<string,string>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -538,12 +501,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 178
+      ID: 172
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: EventRootType
-      ID: 207
+      ID: 201
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -567,7 +530,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 208
+      ID: 202
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -688,35 +651,35 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 189
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 169 PointerType *table<string,[]string>
+      Element: 163 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 199
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 188 PointerType *table<string,string>
+      Element: 182 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 190
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 192 StructureType noalg.map.group[string][]string
+      Element: 186 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 200
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: slice
       ByteSize: 264
-      Element: 202 StructureType noalg.map.group[string]string
+      Element: 196 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 166
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -731,9 +694,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 197 GoSliceDataType []string.array
+      Data: 191 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 191
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -754,9 +717,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 118 GoSliceDataType []uint8.array
+      Data: 112 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 112
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -777,9 +740,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 120 GoSliceDataType []uintptr.array
+      Data: 114 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 114
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -790,10 +753,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 591392
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 113
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 95
       Name: complex128
@@ -807,7 +766,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 181
+      ID: 175
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298688e+06
@@ -819,23 +778,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 114
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.827296e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 115 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 115
-      Name: context.emptyCtx
-      GoRuntimeType: 1.618752e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 171
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -870,7 +814,7 @@ Types:
       GoRuntimeType: 482080
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 171
+      ID: 165
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
@@ -881,12 +825,8 @@ Types:
       ByteSize: 8
       GoRuntimeType: 863936
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 111
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 154
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.440512e+06
@@ -899,37 +839,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 123
+      ID: 117
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 190
+      ID: 184
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 191 PointerType *noalg.map.group[string][]string
+          Type: 185 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 192 StructureType noalg.map.group[string][]string
-      GroupSliceType: 196 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 186 StructureType noalg.map.group[string][]string
+      GroupSliceType: 190 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 200
+      ID: 194
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 201 PointerType *noalg.map.group[string]string
+          Type: 195 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 202 StructureType noalg.map.group[string]string
-      GroupSliceType: 206 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 196 StructureType noalg.map.group[string]string
+      GroupSliceType: 200 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1060,7 +1000,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 170
+      ID: 164
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.130304e+06
@@ -1073,7 +1013,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 167
+      ID: 161
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1086,7 +1026,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 168 PointerType **table<string,[]string>
+          Type: 162 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1102,10 +1042,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 195 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 192 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 189 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 186 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 186
+      ID: 180
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1118,7 +1058,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 187 PointerType **table<string,string>
+          Type: 181 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1134,21 +1074,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 205 GoSliceDataType []*table<string,string>.array
-      GroupType: 202 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 199 GoSliceDataType []*table<string,string>.array
+      GroupType: 196 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 184
+      ID: 178
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.149376e+06
       GoKind: 21
-      HeaderType: 186 GoSwissMapHeaderType map<string,string>
+      HeaderType: 180 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 175
+      ID: 169
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 151
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.04576e+06
@@ -1161,7 +1101,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 149
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.044352e+06
@@ -1174,14 +1114,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 165
+      ID: 159
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.148192e+06
       GoKind: 21
-      HeaderType: 167 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 158
+      ID: 152
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.04448e+06
@@ -1194,7 +1134,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 150
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.044736e+06
@@ -1218,7 +1158,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 163 PointerType *net/url.URL
+          Type: 157 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1230,19 +1170,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 165 GoMapType net/http.Header
+          Type: 159 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 170 GoInterfaceType io.ReadCloser
+          Type: 164 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 171 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 172 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1251,16 +1191,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 173 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 173 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 174 PointerType *mime/multipart.Form
+          Type: 168 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 165 GoMapType net/http.Header
+          Type: 159 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1269,30 +1209,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 176 PointerType *crypto/tls.ConnectionState
+          Type: 170 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 178 GoChannelType <-chan struct {}
+          Type: 172 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 179 PointerType *net/http.Response
+          Type: 173 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 181 GoInterfaceType context.Context
+          Type: 175 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 182 PointerType *net/http.pattern
+          Type: 176 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 172 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 184 GoMapType map[string]string
+          Type: 178 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 180
+      ID: 174
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1309,48 +1249,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 160
+      ID: 154
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 183
+      ID: 177
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 162
+      ID: 156
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 164
+      ID: 158
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 173
+      ID: 167
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.9208e+06
       GoKind: 21
-      HeaderType: 167 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 193
+      ID: 187
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key string; elem []string }
+      Element: 188 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 203
+      ID: 197
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 204 StructureType noalg.struct { key string; elem string }
+      Element: 198 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 192
+      ID: 186
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -1361,9 +1301,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 187 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 202
+      ID: 196
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -1374,9 +1314,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 203 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 197 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 194
+      ID: 188
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -1387,9 +1327,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 172 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 204
+      ID: 198
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -2164,18 +2104,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 117 PointerType *string.str
+          Type: 111 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 116 GoStringDataType string.str
+      Data: 110 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 116
+      ID: 110
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 129
+      ID: 123
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.982976e+06
@@ -2183,12 +2123,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 143
+      ID: 137
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.06032e+06
@@ -2196,15 +2136,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 125
+      ID: 119
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.982464e+06
@@ -2212,12 +2152,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 135
+      ID: 129
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059168e+06
@@ -2225,15 +2165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 149
+      ID: 143
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129376e+06
@@ -2241,18 +2181,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 137
+      ID: 131
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059456e+06
@@ -2260,15 +2200,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 133
+      ID: 127
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.05888e+06
@@ -2276,15 +2216,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 145
+      ID: 139
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.128736e+06
@@ -2292,18 +2232,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 153
+      ID: 147
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.191008e+06
@@ -2311,21 +2251,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 147
+      ID: 141
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129056e+06
@@ -2333,18 +2273,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 131
+      ID: 125
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.983232e+06
@@ -2352,12 +2292,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 121
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.98272e+06
@@ -2365,12 +2305,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 139
+      ID: 133
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059744e+06
@@ -2378,15 +2318,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 151
+      ID: 145
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129696e+06
@@ -2394,18 +2334,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 141
+      ID: 135
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.060032e+06
@@ -2413,15 +2353,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 189
+      ID: 183
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2443,9 +2383,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 190 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 184 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 199
+      ID: 193
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2467,7 +2407,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 200 GoSwissMapGroupsType groupReference<string,string>
+          Type: 194 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -2510,7 +2450,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591456
       GoKind: 26
-MaxTypeID: 208
+MaxTypeID: 202
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 210 EventRootType Probe[main.HandleHTTP]
+          Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 211 EventRootType Probe[main.LookAtTheRequest]
+          Type: 207 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
 Subprograms:
@@ -66,22 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0xd363c8..0xd36401
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 114 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd364d7..0xd364f2
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd364f2..0xd365d9
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd366a0..0xd36765]
@@ -106,20 +90,20 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 171
+      ID: 167
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<string,[]string>
+      Pointee: 168 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 190
+      ID: 186
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 191 PointerType *table<string,string>
+      Pointee: 187 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 124
+      ID: 120
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 123 GoSliceDataType []*runtime.p.array
+      Pointee: 119 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -128,20 +112,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 201
+      ID: 197
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType []string.array
+      Pointee: 196 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 119
+      ID: 115
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 118 GoSliceDataType []uint8.array
+      Pointee: 114 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 121
+      ID: 117
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []uintptr.array
+      Pointee: 116 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -150,19 +134,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 114
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.321376e+06
-      GoKind: 22
-      Pointee: 115 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 179
+      ID: 175
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 180 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -185,19 +162,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 112
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.33264e+06
-      GoKind: 22
-      Pointee: 113 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 125
+      ID: 121
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.582816e+06
       GoKind: 22
-      Pointee: 126 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 122 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -234,22 +204,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 169
+      ID: 165
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 188
+      ID: 184
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 189 GoSwissMapHeaderType map<string,string>
+      Pointee: 185 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 177
+      ID: 173
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 178 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -258,50 +228,50 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 182
+      ID: 178
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.7584e+06
       GoKind: 22
-      Pointee: 183 UnresolvedPointeeType net/http.Response
+      Pointee: 179 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 162
+      ID: 158
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.053472e+06
       GoKind: 22
-      Pointee: 163 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 185
+      ID: 181
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642688e+06
       GoKind: 22
-      Pointee: 186 UnresolvedPointeeType net/http.pattern
+      Pointee: 182 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 164
+      ID: 160
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.27712e+06
       GoKind: 22
-      Pointee: 165 UnresolvedPointeeType net/http.response
+      Pointee: 161 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 166
+      ID: 162
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 167 UnresolvedPointeeType net/url.URL
+      Pointee: 163 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 194
+      ID: 190
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 195 StructureType noalg.map.group[string][]string
+      Pointee: 191 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 204
+      ID: 200
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 205 StructureType noalg.map.group[string]string
+      Pointee: 201 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -350,7 +320,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.055968e+06
       GoKind: 22
-      Pointee: 122 UnresolvedPointeeType runtime.p
+      Pointee: 118 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -387,125 +357,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 117
+      ID: 113
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 116 GoStringDataType string.str
+      Pointee: 112 GoStringDataType string.str
     - __kind: PointerType
-      ID: 131
+      ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.722368e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 145
+      ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781632e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 127
+      ID: 123
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.721984e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 137
+      ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.780864e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 151
+      ID: 147
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853888e+06
       GoKind: 22
-      Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 139
+      ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781056e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.780672e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 147
+      ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.85344e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 155
+      ID: 151
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.925792e+06
       GoKind: 22
-      Pointee: 156 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 149
+      ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853664e+06
       GoKind: 22
-      Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 133
+      ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.72256e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 125
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.722176e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 141
+      ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.781248e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 153
+      ID: 149
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.854112e+06
       GoKind: 22
-      Pointee: 154 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 143
+      ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.78144e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 172
+      ID: 168
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 192 StructureType table<string,[]string>
+      Pointee: 188 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 191
+      ID: 187
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 202 StructureType table<string,string>
+      Pointee: 198 StructureType table<string,string>
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -549,12 +519,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 181
+      ID: 177
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
     - __kind: EventRootType
-      ID: 210
+      ID: 206
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -578,7 +548,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 211
+      ID: 207
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -707,43 +677,43 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 123 GoSliceDataType []*runtime.p.array
+      Data: 119 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 119
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 194
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 172 PointerType *table<string,[]string>
+      Element: 168 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 204
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 191 PointerType *table<string,string>
+      Element: 187 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 195
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 195 StructureType noalg.map.group[string][]string
+      Element: 191 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 205
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: slice
       ByteSize: 264
-      Element: 205 StructureType noalg.map.group[string]string
+      Element: 201 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 171
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -758,9 +728,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 200 GoSliceDataType []string.array
+      Data: 196 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 196
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -781,9 +751,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 118 GoSliceDataType []uint8.array
+      Data: 114 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 114
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -804,9 +774,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 120 GoSliceDataType []uintptr.array
+      Data: 116 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 116
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -817,10 +787,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 595232
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 115
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 97
       Name: complex128
@@ -834,7 +800,7 @@ Types:
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 184
+      ID: 180
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.3032e+06
@@ -847,7 +813,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 180
+      ID: 176
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -882,7 +848,7 @@ Types:
       GoRuntimeType: 484960
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 174
+      ID: 170
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 705088
@@ -893,12 +859,8 @@ Types:
       ByteSize: 8
       GoRuntimeType: 867392
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 113
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 153
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.445024e+06
@@ -911,37 +873,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 126
+      ID: 122
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 193
+      ID: 189
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 194 PointerType *noalg.map.group[string][]string
+          Type: 190 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 195 StructureType noalg.map.group[string][]string
-      GroupSliceType: 199 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 191 StructureType noalg.map.group[string][]string
+      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 203
+      ID: 199
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 204 PointerType *noalg.map.group[string]string
+          Type: 200 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 205 StructureType noalg.map.group[string]string
-      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 201 StructureType noalg.map.group[string]string
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1072,7 +1034,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 173
+      ID: 169
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.135168e+06
@@ -1085,7 +1047,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 166
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1098,7 +1060,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<string,[]string>
+          Type: 167 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1117,10 +1079,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 198 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 195 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 191 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 189
+      ID: 185
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1133,7 +1095,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 190 PointerType **table<string,string>
+          Type: 186 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1152,21 +1114,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 208 GoSliceDataType []*table<string,string>.array
-      GroupType: 205 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
+      GroupType: 201 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 187
+      ID: 183
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.15424e+06
       GoKind: 21
-      HeaderType: 189 GoSwissMapHeaderType map<string,string>
+      HeaderType: 185 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 178
+      ID: 174
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 160
+      ID: 156
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.05008e+06
@@ -1179,7 +1141,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 158
+      ID: 154
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.048544e+06
@@ -1192,14 +1154,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 168
+      ID: 164
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.15504e+06
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 161
+      ID: 157
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.048672e+06
@@ -1212,7 +1174,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 159
+      ID: 155
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.048928e+06
@@ -1236,7 +1198,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 166 PointerType *net/url.URL
+          Type: 162 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1248,19 +1210,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 168 GoMapType net/http.Header
+          Type: 164 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 173 GoInterfaceType io.ReadCloser
+          Type: 169 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 174 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 175 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1269,16 +1231,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 176 GoMapType net/url.Values
+          Type: 172 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 176 GoMapType net/url.Values
+          Type: 172 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 177 PointerType *mime/multipart.Form
+          Type: 173 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 168 GoMapType net/http.Header
+          Type: 164 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1287,30 +1249,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 179 PointerType *crypto/tls.ConnectionState
+          Type: 175 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 181 GoChannelType <-chan struct {}
+          Type: 177 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 182 PointerType *net/http.Response
+          Type: 178 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 184 GoInterfaceType context.Context
+          Type: 180 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 185 PointerType *net/http.pattern
+          Type: 181 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 175 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 187 GoMapType map[string]string
+          Type: 183 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 183
+      ID: 179
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1327,48 +1289,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 163
+      ID: 159
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 186
+      ID: 182
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 165
+      ID: 161
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 167
+      ID: 163
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 176
+      ID: 172
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.92848e+06
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 196
+      ID: 192
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 197 StructureType noalg.struct { key string; elem []string }
+      Element: 193 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 206
+      ID: 202
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 207 StructureType noalg.struct { key string; elem string }
+      Element: 203 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 195
+      ID: 191
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -1379,9 +1341,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 196 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 205
+      ID: 201
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -1392,9 +1354,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 206 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 197
+      ID: 193
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -1405,9 +1367,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 175 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 207
+      ID: 203
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -2064,7 +2026,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 122
+      ID: 118
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -2189,18 +2151,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 117 PointerType *string.str
+          Type: 113 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 116 GoStringDataType string.str
+      Data: 112 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 116
+      ID: 112
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 132
+      ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.991456e+06
@@ -2208,12 +2170,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 146
+      ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.067584e+06
@@ -2221,15 +2183,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 128
+      ID: 124
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.990944e+06
@@ -2237,12 +2199,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 138
+      ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.066432e+06
@@ -2250,15 +2212,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 152
+      ID: 148
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.137312e+06
@@ -2266,18 +2228,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 140
+      ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.06672e+06
@@ -2285,15 +2247,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.066144e+06
@@ -2301,15 +2263,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 148
+      ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.136672e+06
@@ -2317,18 +2279,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 156
+      ID: 152
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.199296e+06
@@ -2336,21 +2298,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 150
+      ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136992e+06
@@ -2358,18 +2320,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 134
+      ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.991712e+06
@@ -2377,12 +2339,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 126
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.9912e+06
@@ -2390,12 +2352,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 142
+      ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.067008e+06
@@ -2403,15 +2365,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 154
+      ID: 150
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.137632e+06
@@ -2419,18 +2381,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 144
+      ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.067296e+06
@@ -2438,15 +2400,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 192
+      ID: 188
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2468,9 +2430,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 193 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 202
+      ID: 198
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2492,7 +2454,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 203 GoSwissMapGroupsType groupReference<string,string>
+          Type: 199 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -2535,7 +2497,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595296
       GoKind: 26
-MaxTypeID: 211
+MaxTypeID: 207
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18bb880", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 194 EventRootType Probe[main.HandleHTTP]
+          Type: 188 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff40", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 195 EventRootType Probe[main.LookAtTheRequest]
+          Type: 189 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e025c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -66,29 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 105 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0x8dffa8..0x8dffd8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 107 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x8e007c..0x8e0098
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8e0098..0x8e0170
-              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 109 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0x8dff30..0x8e0170
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8e0250..0x8e0310]
@@ -114,20 +91,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 191
+      ID: 185
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []string.array
+      Pointee: 184 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 114
+      ID: 108
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 113 GoSliceDataType []uint8.array
+      Pointee: 107 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 116
+      ID: 110
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 115 GoSliceDataType []uintptr.array
+      Pointee: 109 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -136,29 +113,22 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 163
+      ID: 157
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 164 GoHMapBucketType bucket<string,[]string>
+      Pointee: 158 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 184
+      ID: 178
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 185 GoHMapBucketType bucket<string,string>
+      Pointee: 179 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 107
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.176896e+06
-      GoKind: 22
-      Pointee: 108 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 173
+      ID: 167
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 168 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -181,29 +151,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 105
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.18768e+06
-      GoKind: 22
-      Pointee: 106 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 117
+      ID: 111
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.397152e+06
       GoKind: 22
-      Pointee: 118 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 112 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 161
+      ID: 155
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 162 GoHMapHeaderType hash<string,[]string>
+      Pointee: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 176
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 183 GoHMapHeaderType hash<string,string>
+      Pointee: 177 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 94
       Name: '*int'
@@ -240,12 +203,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 171
+      ID: 165
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 172 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 166 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 103
       Name: '*net/http.Request'
@@ -254,40 +217,40 @@ Types:
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
-      ID: 176
+      ID: 170
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType net/http.Response
+      Pointee: 171 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 154
+      ID: 148
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.8768e+06
       GoKind: 22
-      Pointee: 155 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 149 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 179
+      ID: 173
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 180 UnresolvedPointeeType net/http.pattern
+      Pointee: 174 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 156
+      ID: 150
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.11776e+06
       GoKind: 22
-      Pointee: 157 UnresolvedPointeeType net/http.response
+      Pointee: 151 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 158
+      ID: 152
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 159 UnresolvedPointeeType net/url.URL
+      Pointee: 153 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -331,12 +294,12 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 165
+      ID: 159
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 380000
       GoKind: 22
-      Pointee: 166 UnresolvedPointeeType runtime.mapextra
+      Pointee: 160 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -366,115 +329,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 112
+      ID: 106
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 111 GoStringDataType string.str
+      Pointee: 105 GoStringDataType string.str
     - __kind: PointerType
-      ID: 123
+      ID: 117
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.5328e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 118 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 137
+      ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.657312e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 119
+      ID: 113
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.532416e+06
       GoKind: 22
-      Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 114 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 129
+      ID: 123
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656544e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 143
+      ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.7272e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 131
+      ID: 125
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656736e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 127
+      ID: 121
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.656352e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 139
+      ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.726752e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 147
+      ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.795072e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 141
+      ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726976e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 119
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.532992e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 121
+      ID: 115
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.532608e+06
       GoKind: 22
-      Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 116 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 133
+      ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656928e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 145
+      ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.727424e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.65712e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -518,12 +481,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 175
+      ID: 169
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: EventRootType
-      ID: 194
+      ID: 188
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -547,7 +510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 195
+      ID: 189
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -652,7 +615,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 186
+      ID: 180
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -661,19 +624,19 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 183
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 164 GoHMapBucketType bucket<string,[]string>
+      Element: 158 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 187
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 185 GoHMapBucketType bucket<string,string>
+      Element: 179 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 187
+      ID: 181
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -684,7 +647,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 163
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -699,9 +662,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 190 GoSliceDataType []string.array
+      Data: 184 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 184
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -722,9 +685,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 113 GoSliceDataType []uint8.array
+      Data: 107 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 113
+      ID: 107
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -745,22 +708,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 115 GoSliceDataType []uintptr.array
+      Data: 109 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 115
+      ID: 109
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 188
+      ID: 182
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 169 GoSliceHeaderType []string
+      Element: 163 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 192
+      ID: 186
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -773,47 +736,43 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 164
+      ID: 158
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 180 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<string>
+          Type: 181 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 188 ArrayType []val<[]string>
+          Type: 182 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 163 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 169 GoSliceHeaderType []string
+      ValueType: 163 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 185
+      ID: 179
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 186 ArrayType [8]uint8
+          Type: 180 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 187 ArrayType []key<string>
+          Type: 181 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 192 ArrayType []val<string>
+          Type: 186 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 184 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: UnresolvedPointeeType
-      ID: 108
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 91
       Name: complex128
@@ -827,7 +786,7 @@ Types:
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 178
+      ID: 172
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215776e+06
@@ -839,23 +798,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 109
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.708832e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 110 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 110
-      Name: context.emptyCtx
-      GoRuntimeType: 1.435104e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 168
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -890,7 +834,7 @@ Types:
       GoRuntimeType: 455520
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 168
+      ID: 162
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
@@ -901,12 +845,8 @@ Types:
       ByteSize: 8
       GoRuntimeType: 798304
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 106
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 149
+      ID: 143
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.26592e+06
@@ -919,11 +859,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 118
+      ID: 112
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 162
+      ID: 156
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -944,20 +884,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 163 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 163 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 165 PointerType *runtime.mapextra
-      BucketType: 164 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 189 GoSliceDataType []bucket<string,[]string>.array
+          Type: 159 PointerType *runtime.mapextra
+      BucketType: 158 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 183
+      ID: 177
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -978,18 +918,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 184 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 184 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 165 PointerType *runtime.mapextra
-      BucketType: 185 GoHMapBucketType bucket<string,string>
-      BucketsType: 193 GoSliceDataType []bucket<string,string>.array
+          Type: 159 PointerType *runtime.mapextra
+      BucketType: 179 GoHMapBucketType bucket<string,string>
+      BucketsType: 187 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1120,7 +1060,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 167
+      ID: 161
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.093088e+06
@@ -1133,18 +1073,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 181
+      ID: 175
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 183 GoHMapHeaderType hash<string,string>
+      HeaderType: 177 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 172
+      ID: 166
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 146
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.006752e+06
@@ -1157,7 +1097,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 144
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.005344e+06
@@ -1170,14 +1110,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 160
+      ID: 154
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.964288e+06
       GoKind: 21
-      HeaderType: 162 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 147
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.005472e+06
@@ -1190,7 +1130,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 145
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.005728e+06
@@ -1214,7 +1154,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 158 PointerType *net/url.URL
+          Type: 152 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1226,19 +1166,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 160 GoMapType net/http.Header
+          Type: 154 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 167 GoInterfaceType io.ReadCloser
+          Type: 161 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 168 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 162 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 169 GoSliceHeaderType []string
+          Type: 163 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1247,16 +1187,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 170 GoMapType net/url.Values
+          Type: 164 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 170 GoMapType net/url.Values
+          Type: 164 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 171 PointerType *mime/multipart.Form
+          Type: 165 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 160 GoMapType net/http.Header
+          Type: 154 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1265,30 +1205,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 173 PointerType *crypto/tls.ConnectionState
+          Type: 167 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 175 GoChannelType <-chan struct {}
+          Type: 169 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 176 PointerType *net/http.Response
+          Type: 170 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 178 GoInterfaceType context.Context
+          Type: 172 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 179 PointerType *net/http.pattern
+          Type: 173 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 169 GoSliceHeaderType []string
+          Type: 163 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 181 GoMapType map[string]string
+          Type: 175 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 171
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1305,28 +1245,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 155
+      ID: 149
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 180
+      ID: 174
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 157
+      ID: 151
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 159
+      ID: 153
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 170
+      ID: 164
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.712416e+06
       GoKind: 21
-      HeaderType: 162 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1922,7 +1862,7 @@ Types:
           Offset: 24
           Type: 28 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 166
+      ID: 160
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -2056,18 +1996,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 112 PointerType *string.str
+          Type: 106 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 111 GoStringDataType string.str
+      Data: 105 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 111
+      ID: 105
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 124
+      ID: 118
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.856384e+06
@@ -2075,12 +2015,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 138
+      ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.93168e+06
@@ -2088,15 +2028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 120
+      ID: 114
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.855872e+06
@@ -2104,12 +2044,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 130
+      ID: 124
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.930528e+06
@@ -2117,15 +2057,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 144
+      ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.000128e+06
@@ -2133,18 +2073,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 132
+      ID: 126
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.930816e+06
@@ -2152,15 +2092,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 128
+      ID: 122
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.93024e+06
@@ -2168,15 +2108,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 140
+      ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.999488e+06
@@ -2184,18 +2124,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 148
+      ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.059232e+06
@@ -2203,21 +2143,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 142
+      ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999808e+06
@@ -2225,18 +2165,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 120
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.85664e+06
@@ -2244,12 +2184,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 122
+      ID: 116
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.856128e+06
@@ -2257,12 +2197,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 134
+      ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.931104e+06
@@ -2270,15 +2210,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 146
+      ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.000448e+06
@@ -2286,18 +2226,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 152 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.931392e+06
@@ -2305,13 +2245,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 149 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 151 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 153 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -2354,7 +2294,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543616
       GoKind: 26
-MaxTypeID: 195
+MaxTypeID: 189
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 207 EventRootType Probe[main.HandleHTTP]
+          Type: 201 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0ca0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 208 EventRootType Probe[main.LookAtTheRequest]
+          Type: 202 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0f9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -66,29 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 110 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0x8a0d08..0x8a0d38
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 112 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x8a0ddc..0x8a0df0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8a0df0..0x8a0ec0
-              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 114 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0x8a0c90..0x8a0ec0
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8a0f90..0x8a1040]
@@ -107,15 +84,15 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 168
+      ID: 162
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 169 PointerType *table<string,[]string>
+      Pointee: 163 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 181
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 188 PointerType *table<string,string>
+      Pointee: 182 PointerType *table<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -124,20 +101,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 198
+      ID: 192
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []string.array
+      Pointee: 191 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 119
+      ID: 113
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 118 GoSliceDataType []uint8.array
+      Pointee: 112 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 121
+      ID: 115
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []uintptr.array
+      Pointee: 114 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -146,19 +123,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 112
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.316032e+06
-      GoKind: 22
-      Pointee: 113 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 176
+      ID: 170
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -181,19 +151,12 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 110
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.326784e+06
-      GoKind: 22
-      Pointee: 111 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 122
+      ID: 116
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.57712e+06
       GoKind: 22
-      Pointee: 123 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 117 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -230,22 +193,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 166
+      ID: 160
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 167 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 185
+      ID: 179
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 186 GoSwissMapHeaderType map<string,string>
+      Pointee: 180 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 174
+      ID: 168
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 175 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 108
       Name: '*net/http.Request'
@@ -254,50 +217,50 @@ Types:
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
-      ID: 179
+      ID: 173
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 180 UnresolvedPointeeType net/http.Response
+      Pointee: 174 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 159
+      ID: 153
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.044608e+06
       GoKind: 22
-      Pointee: 160 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 182
+      ID: 176
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 183 UnresolvedPointeeType net/http.pattern
+      Pointee: 177 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 161
+      ID: 155
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.253408e+06
       GoKind: 22
-      Pointee: 162 UnresolvedPointeeType net/http.response
+      Pointee: 156 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 163
+      ID: 157
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 164 UnresolvedPointeeType net/url.URL
+      Pointee: 158 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 191
+      ID: 185
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 192 StructureType noalg.map.group[string][]string
+      Pointee: 186 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 201
+      ID: 195
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 202 StructureType noalg.map.group[string]string
+      Pointee: 196 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -376,125 +339,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 117
+      ID: 111
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 116 GoStringDataType string.str
+      Pointee: 110 GoStringDataType string.str
     - __kind: PointerType
-      ID: 128
+      ID: 122
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.716192e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 123 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 142
+      ID: 136
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774112e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 124
+      ID: 118
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.715808e+06
       GoKind: 22
-      Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 119 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 134
+      ID: 128
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773344e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 148
+      ID: 142
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845376e+06
       GoKind: 22
-      Pointee: 149 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 136
+      ID: 130
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.773536e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 132
+      ID: 126
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.773152e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 144
+      ID: 138
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.844928e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 152
+      ID: 146
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.917376e+06
       GoKind: 22
-      Pointee: 153 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 146
+      ID: 140
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845152e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 130
+      ID: 124
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.716384e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 120
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.716e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 121 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 138
+      ID: 132
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773728e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 150
+      ID: 144
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.8456e+06
       GoKind: 22
-      Pointee: 151 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 140
+      ID: 134
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.77392e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 169
+      ID: 163
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 189 StructureType table<string,[]string>
+      Pointee: 183 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 188
+      ID: 182
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 199 StructureType table<string,string>
+      Pointee: 193 StructureType table<string,string>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -538,12 +501,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 178
+      ID: 172
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: EventRootType
-      ID: 207
+      ID: 201
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -567,7 +530,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 208
+      ID: 202
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -688,35 +651,35 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 189
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 169 PointerType *table<string,[]string>
+      Element: 163 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 199
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 188 PointerType *table<string,string>
+      Element: 182 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 190
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 192 StructureType noalg.map.group[string][]string
+      Element: 186 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 200
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: slice
       ByteSize: 264
-      Element: 202 StructureType noalg.map.group[string]string
+      Element: 196 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 166
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -731,9 +694,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 197 GoSliceDataType []string.array
+      Data: 191 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 191
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -754,9 +717,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 118 GoSliceDataType []uint8.array
+      Data: 112 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 112
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -777,9 +740,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 120 GoSliceDataType []uintptr.array
+      Data: 114 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 114
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -790,10 +753,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 591200
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 113
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 96
       Name: complex128
@@ -807,7 +766,7 @@ Types:
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 181
+      ID: 175
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298016e+06
@@ -819,23 +778,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 114
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.826784e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 115 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 115
-      Name: context.emptyCtx
-      GoRuntimeType: 1.61824e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 171
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -870,7 +814,7 @@ Types:
       GoRuntimeType: 481952
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 171
+      ID: 165
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
@@ -881,12 +825,8 @@ Types:
       ByteSize: 8
       GoRuntimeType: 863360
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 111
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 154
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.43984e+06
@@ -899,37 +839,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 123
+      ID: 117
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 190
+      ID: 184
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 191 PointerType *noalg.map.group[string][]string
+          Type: 185 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 192 StructureType noalg.map.group[string][]string
-      GroupSliceType: 196 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 186 StructureType noalg.map.group[string][]string
+      GroupSliceType: 190 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 200
+      ID: 194
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 201 PointerType *noalg.map.group[string]string
+          Type: 195 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 202 StructureType noalg.map.group[string]string
-      GroupSliceType: 206 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 196 StructureType noalg.map.group[string]string
+      GroupSliceType: 200 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1060,7 +1000,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 170
+      ID: 164
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.129632e+06
@@ -1073,7 +1013,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 167
+      ID: 161
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1086,7 +1026,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 168 PointerType **table<string,[]string>
+          Type: 162 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1102,10 +1042,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 195 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 192 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 189 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 186 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 186
+      ID: 180
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1118,7 +1058,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 187 PointerType **table<string,string>
+          Type: 181 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1134,21 +1074,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 205 GoSliceDataType []*table<string,string>.array
-      GroupType: 202 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 199 GoSliceDataType []*table<string,string>.array
+      GroupType: 196 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 184
+      ID: 178
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.148704e+06
       GoKind: 21
-      HeaderType: 186 GoSwissMapHeaderType map<string,string>
+      HeaderType: 180 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 175
+      ID: 169
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 151
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.045088e+06
@@ -1161,7 +1101,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 149
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.04368e+06
@@ -1174,14 +1114,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 165
+      ID: 159
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.147456e+06
       GoKind: 21
-      HeaderType: 167 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 158
+      ID: 152
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.043808e+06
@@ -1194,7 +1134,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 150
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.044064e+06
@@ -1218,7 +1158,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 163 PointerType *net/url.URL
+          Type: 157 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1230,19 +1170,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 165 GoMapType net/http.Header
+          Type: 159 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 170 GoInterfaceType io.ReadCloser
+          Type: 164 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 171 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 172 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1251,16 +1191,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 173 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 173 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 174 PointerType *mime/multipart.Form
+          Type: 168 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 165 GoMapType net/http.Header
+          Type: 159 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1269,30 +1209,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 176 PointerType *crypto/tls.ConnectionState
+          Type: 170 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 178 GoChannelType <-chan struct {}
+          Type: 172 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 179 PointerType *net/http.Response
+          Type: 173 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 181 GoInterfaceType context.Context
+          Type: 175 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 182 PointerType *net/http.pattern
+          Type: 176 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 172 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 184 GoMapType map[string]string
+          Type: 178 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 180
+      ID: 174
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1309,48 +1249,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 160
+      ID: 154
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 183
+      ID: 177
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 162
+      ID: 156
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 164
+      ID: 158
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 173
+      ID: 167
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.920064e+06
       GoKind: 21
-      HeaderType: 167 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 193
+      ID: 187
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key string; elem []string }
+      Element: 188 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 203
+      ID: 197
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 204 StructureType noalg.struct { key string; elem string }
+      Element: 198 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 192
+      ID: 186
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -1361,9 +1301,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 187 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 202
+      ID: 196
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -1374,9 +1314,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 203 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 197 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 194
+      ID: 188
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -1387,9 +1327,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 172 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 204
+      ID: 198
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -2164,18 +2104,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 117 PointerType *string.str
+          Type: 111 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 116 GoStringDataType string.str
+      Data: 110 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 116
+      ID: 110
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 129
+      ID: 123
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.98224e+06
@@ -2183,12 +2123,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 143
+      ID: 137
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059584e+06
@@ -2196,15 +2136,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 125
+      ID: 119
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.981728e+06
@@ -2212,12 +2152,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 135
+      ID: 129
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.058432e+06
@@ -2225,15 +2165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 149
+      ID: 143
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12864e+06
@@ -2241,18 +2181,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 137
+      ID: 131
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.05872e+06
@@ -2260,15 +2200,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 133
+      ID: 127
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.058144e+06
@@ -2276,15 +2216,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 145
+      ID: 139
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.128e+06
@@ -2292,18 +2232,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 153
+      ID: 147
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.190272e+06
@@ -2311,21 +2251,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 147
+      ID: 141
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12832e+06
@@ -2333,18 +2273,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 131
+      ID: 125
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.982496e+06
@@ -2352,12 +2292,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 121
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.981984e+06
@@ -2365,12 +2305,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 139
+      ID: 133
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059008e+06
@@ -2378,15 +2318,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 151
+      ID: 145
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12896e+06
@@ -2394,18 +2334,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 157 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 141
+      ID: 135
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059296e+06
@@ -2413,15 +2353,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 154 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 156 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 189
+      ID: 183
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2443,9 +2383,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 190 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 184 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 199
+      ID: 193
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2467,7 +2407,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 200 GoSwissMapGroupsType groupReference<string,string>
+          Type: 194 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2510,7 +2450,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591264
       GoKind: 26
-MaxTypeID: 208
+MaxTypeID: 202
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 210 EventRootType Probe[main.HandleHTTP]
+          Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859980", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 211 EventRootType Probe[main.LookAtTheRequest]
+          Type: 207 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c5c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -66,22 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0x8599e4..0x859a14
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 114 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x859aa0..0x859ab8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x859ab8..0x859b80
-              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x859c50..0x859cf0]
@@ -106,20 +90,20 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 171
+      ID: 167
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<string,[]string>
+      Pointee: 168 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 190
+      ID: 186
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 191 PointerType *table<string,string>
+      Pointee: 187 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 124
+      ID: 120
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 123 GoSliceDataType []*runtime.p.array
+      Pointee: 119 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -128,20 +112,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 201
+      ID: 197
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType []string.array
+      Pointee: 196 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 119
+      ID: 115
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 118 GoSliceDataType []uint8.array
+      Pointee: 114 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 121
+      ID: 117
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []uintptr.array
+      Pointee: 116 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -150,19 +134,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 114
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.320608e+06
-      GoKind: 22
-      Pointee: 115 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 179
+      ID: 175
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 180 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -185,19 +162,12 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 112
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.331872e+06
-      GoKind: 22
-      Pointee: 113 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 125
+      ID: 121
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.582272e+06
       GoKind: 22
-      Pointee: 126 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 122 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -234,22 +204,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 169
+      ID: 165
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 188
+      ID: 184
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 189 GoSwissMapHeaderType map<string,string>
+      Pointee: 185 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 177
+      ID: 173
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 178 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -258,50 +228,50 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 182
+      ID: 178
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.757856e+06
       GoKind: 22
-      Pointee: 183 UnresolvedPointeeType net/http.Response
+      Pointee: 179 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 162
+      ID: 158
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.052704e+06
       GoKind: 22
-      Pointee: 163 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 185
+      ID: 181
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642144e+06
       GoKind: 22
-      Pointee: 186 UnresolvedPointeeType net/http.pattern
+      Pointee: 182 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 164
+      ID: 160
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.276352e+06
       GoKind: 22
-      Pointee: 165 UnresolvedPointeeType net/http.response
+      Pointee: 161 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 166
+      ID: 162
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 167 UnresolvedPointeeType net/url.URL
+      Pointee: 163 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 194
+      ID: 190
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 195 StructureType noalg.map.group[string][]string
+      Pointee: 191 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 204
+      ID: 200
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 205 StructureType noalg.map.group[string]string
+      Pointee: 201 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -350,7 +320,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.055264e+06
       GoKind: 22
-      Pointee: 122 UnresolvedPointeeType runtime.p
+      Pointee: 118 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -387,125 +357,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 117
+      ID: 113
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 116 GoStringDataType string.str
+      Pointee: 112 GoStringDataType string.str
     - __kind: PointerType
-      ID: 131
+      ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.721824e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 145
+      ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781088e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 127
+      ID: 123
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.72144e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 137
+      ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.78032e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 151
+      ID: 147
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853344e+06
       GoKind: 22
-      Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 139
+      ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.780512e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.780128e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 147
+      ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.852896e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 155
+      ID: 151
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.925024e+06
       GoKind: 22
-      Pointee: 156 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 149
+      ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.85312e+06
       GoKind: 22
-      Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 133
+      ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.722016e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 125
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.721632e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 141
+      ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.780704e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 153
+      ID: 149
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853568e+06
       GoKind: 22
-      Pointee: 154 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 143
+      ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.780896e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 172
+      ID: 168
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 192 StructureType table<string,[]string>
+      Pointee: 188 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 191
+      ID: 187
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 202 StructureType table<string,string>
+      Pointee: 198 StructureType table<string,string>
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -549,12 +519,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 181
+      ID: 177
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
     - __kind: EventRootType
-      ID: 210
+      ID: 206
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -578,7 +548,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 211
+      ID: 207
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -707,43 +677,43 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 123 GoSliceDataType []*runtime.p.array
+      Data: 119 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 119
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 194
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 172 PointerType *table<string,[]string>
+      Element: 168 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 204
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 191 PointerType *table<string,string>
+      Element: 187 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 195
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 195 StructureType noalg.map.group[string][]string
+      Element: 191 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 205
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: slice
       ByteSize: 264
-      Element: 205 StructureType noalg.map.group[string]string
+      Element: 201 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 171
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -758,9 +728,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 200 GoSliceDataType []string.array
+      Data: 196 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 196
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -781,9 +751,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 118 GoSliceDataType []uint8.array
+      Data: 114 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 114
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -804,9 +774,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 120 GoSliceDataType []uintptr.array
+      Data: 116 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 116
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -817,10 +787,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 595008
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 115
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 98
       Name: complex128
@@ -834,7 +800,7 @@ Types:
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 184
+      ID: 180
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.302496e+06
@@ -847,7 +813,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 180
+      ID: 176
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -882,7 +848,7 @@ Types:
       GoRuntimeType: 484800
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 174
+      ID: 170
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 704864
@@ -893,12 +859,8 @@ Types:
       ByteSize: 8
       GoRuntimeType: 866784
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 113
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 153
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.44432e+06
@@ -911,37 +873,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 126
+      ID: 122
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 193
+      ID: 189
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 194 PointerType *noalg.map.group[string][]string
+          Type: 190 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 195 StructureType noalg.map.group[string][]string
-      GroupSliceType: 199 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 191 StructureType noalg.map.group[string][]string
+      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 203
+      ID: 199
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 204 PointerType *noalg.map.group[string]string
+          Type: 200 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 205 StructureType noalg.map.group[string]string
-      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 201 StructureType noalg.map.group[string]string
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1072,7 +1034,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 173
+      ID: 169
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.134464e+06
@@ -1085,7 +1047,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 166
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1098,7 +1060,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<string,[]string>
+          Type: 167 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1117,10 +1079,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 198 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 195 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 191 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 189
+      ID: 185
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1133,7 +1095,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 190 PointerType **table<string,string>
+          Type: 186 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1152,21 +1114,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 208 GoSliceDataType []*table<string,string>.array
-      GroupType: 205 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
+      GroupType: 201 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 187
+      ID: 183
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.153536e+06
       GoKind: 21
-      HeaderType: 189 GoSwissMapHeaderType map<string,string>
+      HeaderType: 185 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 178
+      ID: 174
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 160
+      ID: 156
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.049376e+06
@@ -1179,7 +1141,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 158
+      ID: 154
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.04784e+06
@@ -1192,14 +1154,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 168
+      ID: 164
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.154272e+06
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 161
+      ID: 157
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.047968e+06
@@ -1212,7 +1174,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 159
+      ID: 155
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.048224e+06
@@ -1236,7 +1198,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 166 PointerType *net/url.URL
+          Type: 162 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1248,19 +1210,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 168 GoMapType net/http.Header
+          Type: 164 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 173 GoInterfaceType io.ReadCloser
+          Type: 169 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 174 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 175 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1269,16 +1231,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 176 GoMapType net/url.Values
+          Type: 172 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 176 GoMapType net/url.Values
+          Type: 172 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 177 PointerType *mime/multipart.Form
+          Type: 173 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 168 GoMapType net/http.Header
+          Type: 164 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1287,30 +1249,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 179 PointerType *crypto/tls.ConnectionState
+          Type: 175 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 181 GoChannelType <-chan struct {}
+          Type: 177 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 182 PointerType *net/http.Response
+          Type: 178 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 184 GoInterfaceType context.Context
+          Type: 180 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 185 PointerType *net/http.pattern
+          Type: 181 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 175 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 187 GoMapType map[string]string
+          Type: 183 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 183
+      ID: 179
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1327,48 +1289,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 163
+      ID: 159
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 186
+      ID: 182
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 165
+      ID: 161
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 167
+      ID: 163
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 176
+      ID: 172
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.927712e+06
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 196
+      ID: 192
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 197 StructureType noalg.struct { key string; elem []string }
+      Element: 193 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 206
+      ID: 202
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 207 StructureType noalg.struct { key string; elem string }
+      Element: 203 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 195
+      ID: 191
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -1379,9 +1341,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 196 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 205
+      ID: 201
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -1392,9 +1354,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 206 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 197
+      ID: 193
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -1405,9 +1367,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 175 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 207
+      ID: 203
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -2064,7 +2026,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 122
+      ID: 118
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -2189,18 +2151,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 117 PointerType *string.str
+          Type: 113 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 116 GoStringDataType string.str
+      Data: 112 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 116
+      ID: 112
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 132
+      ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.990688e+06
@@ -2208,12 +2170,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 146
+      ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.066816e+06
@@ -2221,15 +2183,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 128
+      ID: 124
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.990176e+06
@@ -2237,12 +2199,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 138
+      ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.065664e+06
@@ -2250,15 +2212,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 152
+      ID: 148
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136544e+06
@@ -2266,18 +2228,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 140
+      ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.065952e+06
@@ -2285,15 +2247,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.065376e+06
@@ -2301,15 +2263,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 148
+      ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.135904e+06
@@ -2317,18 +2279,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 156
+      ID: 152
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.198528e+06
@@ -2336,21 +2298,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 150
+      ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136224e+06
@@ -2358,18 +2320,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 134
+      ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.990944e+06
@@ -2377,12 +2339,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 126
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.990432e+06
@@ -2390,12 +2352,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 142
+      ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.06624e+06
@@ -2403,15 +2365,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 154
+      ID: 150
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136864e+06
@@ -2419,18 +2381,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 160 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 144
+      ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.066528e+06
@@ -2438,15 +2400,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 159 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 161 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 192
+      ID: 188
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2468,9 +2430,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 193 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 202
+      ID: 198
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2492,7 +2454,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 203 GoSwissMapGroupsType groupReference<string,string>
+          Type: 199 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2535,7 +2497,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595072
       GoKind: 26
-MaxTypeID: 211
+MaxTypeID: 207
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x139d860", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 193 EventRootType Probe[main.HandleHTTP]
+          Type: 188 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 194 EventRootType Probe[main.LookAtTheRequest]
+          Type: 189 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -66,45 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 105 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd28b8f..0xd28bb1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd28bb1..0xd28c90
-              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 107 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0xd28a68..0xd28a68
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xd28a68..0xd28aa8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd28aa8..0xd28aac
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 108 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0xd289e0..0xd28c90
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd28d60..0xd28e25]
@@ -130,20 +91,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 190
+      ID: 185
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []string.array
+      Pointee: 184 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 113
+      ID: 108
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uint8.array
+      Pointee: 107 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 115
+      ID: 110
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uintptr.array
+      Pointee: 109 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -152,29 +113,22 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 162
+      ID: 157
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 163 GoHMapBucketType bucket<string,[]string>
+      Pointee: 158 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 183
+      ID: 178
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 184 GoHMapBucketType bucket<string,string>
+      Pointee: 179 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 105
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.114976e+06
-      GoKind: 22
-      Pointee: 106 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 172
+      ID: 167
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 173 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 168 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -197,22 +151,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 116
+      ID: 111
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.361664e+06
       GoKind: 22
-      Pointee: 117 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 112 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 160
+      ID: 155
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 161 GoHMapHeaderType hash<string,[]string>
+      Pointee: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 176
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 182 GoHMapHeaderType hash<string,string>
+      Pointee: 177 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 93
       Name: '*int'
@@ -249,12 +203,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 170
+      ID: 165
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 166 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 103
       Name: '*net/http.Request'
@@ -263,40 +217,40 @@ Types:
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
-      ID: 175
+      ID: 170
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 176 UnresolvedPointeeType net/http.Response
+      Pointee: 171 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 153
+      ID: 148
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.832832e+06
       GoKind: 22
-      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 149 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 178
+      ID: 173
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType net/http.pattern
+      Pointee: 174 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 155
+      ID: 150
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.059008e+06
       GoKind: 22
-      Pointee: 156 UnresolvedPointeeType net/http.response
+      Pointee: 151 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 157
+      ID: 152
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 158 UnresolvedPointeeType net/url.URL
+      Pointee: 153 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -340,12 +294,12 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 164
+      ID: 159
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 165 UnresolvedPointeeType runtime.mapextra
+      Pointee: 160 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -375,115 +329,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 111
+      ID: 106
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 110 GoStringDataType string.str
+      Pointee: 105 GoStringDataType string.str
     - __kind: PointerType
-      ID: 122
+      ID: 117
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.495904e+06
       GoKind: 22
-      Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 118 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 136
+      ID: 131
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.61568e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 118
+      ID: 113
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.49552e+06
       GoKind: 22
-      Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 114 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 128
+      ID: 123
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.614912e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 142
+      ID: 137
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.684896e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 130
+      ID: 125
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615104e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 121
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.61472e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 122 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 138
+      ID: 133
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.684448e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 146
+      ID: 141
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.750176e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 140
+      ID: 135
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.684672e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 124
+      ID: 119
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.496096e+06
       GoKind: 22
-      Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 120 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 120
+      ID: 115
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.495712e+06
       GoKind: 22
-      Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 116 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 132
+      ID: 127
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.615296e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 144
+      ID: 139
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.68512e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 134
+      ID: 129
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615488e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -527,12 +481,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 174
+      ID: 169
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: EventRootType
-      ID: 193
+      ID: 188
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -556,7 +510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 194
+      ID: 189
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -661,7 +615,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 185
+      ID: 180
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -670,19 +624,19 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 183
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 163 GoHMapBucketType bucket<string,[]string>
+      Element: 158 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 187
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 184 GoHMapBucketType bucket<string,string>
+      Element: 179 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 186
+      ID: 181
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -693,7 +647,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 163
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -708,9 +662,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 189 GoSliceDataType []string.array
+      Data: 184 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 184
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -731,9 +685,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 112 GoSliceDataType []uint8.array
+      Data: 107 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 107
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -754,22 +708,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 114 GoSliceDataType []uintptr.array
+      Data: 109 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 109
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 187
+      ID: 182
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 168 GoSliceHeaderType []string
+      Element: 163 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 191
+      ID: 186
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -782,47 +736,43 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 163
+      ID: 158
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 180 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<string>
+          Type: 181 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 187 ArrayType []val<[]string>
+          Type: 182 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 162 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 168 GoSliceHeaderType []string
+      ValueType: 163 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 184
+      ID: 179
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 180 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<string>
+          Type: 181 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 191 ArrayType []val<string>
+          Type: 186 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 183 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: UnresolvedPointeeType
-      ID: 106
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 90
       Name: complex128
@@ -836,7 +786,7 @@ Types:
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 177
+      ID: 172
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187104e+06
@@ -848,23 +798,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 108
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.6672e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 109 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 109
-      Name: context.emptyCtx
-      GoRuntimeType: 1.399456e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 173
+      ID: 168
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -899,7 +834,7 @@ Types:
       GoRuntimeType: 451168
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 167
+      ID: 162
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
@@ -911,7 +846,7 @@ Types:
       GoRuntimeType: 785664
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 148
+      ID: 143
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.235648e+06
@@ -924,24 +859,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 117
+      ID: 112
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 107
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.295936e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 161
+      ID: 156
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -962,20 +884,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 162 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 162 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 164 PointerType *runtime.mapextra
-      BucketType: 163 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 188 GoSliceDataType []bucket<string,[]string>.array
+          Type: 159 PointerType *runtime.mapextra
+      BucketType: 158 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 182
+      ID: 177
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -996,18 +918,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 183 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 183 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 164 PointerType *runtime.mapextra
-      BucketType: 184 GoHMapBucketType bucket<string,string>
-      BucketsType: 192 GoSliceDataType []bucket<string,string>.array
+          Type: 159 PointerType *runtime.mapextra
+      BucketType: 179 GoHMapBucketType bucket<string,string>
+      BucketsType: 187 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1138,7 +1060,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 166
+      ID: 161
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067136e+06
@@ -1151,18 +1073,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 180
+      ID: 175
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 182 GoHMapHeaderType hash<string,string>
+      HeaderType: 177 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 166
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 146
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 983104
@@ -1175,7 +1097,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 149
+      ID: 144
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 981696
@@ -1188,14 +1110,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 159
+      ID: 154
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.91744e+06
       GoKind: 21
-      HeaderType: 161 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 147
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 981824
@@ -1208,7 +1130,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 145
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 982080
@@ -1232,7 +1154,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 157 PointerType *net/url.URL
+          Type: 152 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1244,19 +1166,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 159 GoMapType net/http.Header
+          Type: 154 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 166 GoInterfaceType io.ReadCloser
+          Type: 161 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 167 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 162 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 168 GoSliceHeaderType []string
+          Type: 163 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1265,16 +1187,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 169 GoMapType net/url.Values
+          Type: 164 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 169 GoMapType net/url.Values
+          Type: 164 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 170 PointerType *mime/multipart.Form
+          Type: 165 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 159 GoMapType net/http.Header
+          Type: 154 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1283,30 +1205,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 172 PointerType *crypto/tls.ConnectionState
+          Type: 167 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 174 GoChannelType <-chan struct {}
+          Type: 169 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 175 PointerType *net/http.Response
+          Type: 170 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 177 GoInterfaceType context.Context
+          Type: 172 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 178 PointerType *net/http.pattern
+          Type: 173 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 168 GoSliceHeaderType []string
+          Type: 163 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 180 GoMapType map[string]string
+          Type: 175 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 176
+      ID: 171
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1323,28 +1245,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 154
+      ID: 149
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 174
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 156
+      ID: 151
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 158
+      ID: 153
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 169
+      ID: 164
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.670784e+06
       GoKind: 21
-      HeaderType: 161 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1940,7 +1862,7 @@ Types:
           Offset: 24
           Type: 28 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 165
+      ID: 160
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -2074,18 +1996,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 111 PointerType *string.str
+          Type: 106 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 110 GoStringDataType string.str
+      Data: 105 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 110
+      ID: 105
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 123
+      ID: 118
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.810144e+06
@@ -2093,12 +2015,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 137
+      ID: 132
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885248e+06
@@ -2106,15 +2028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 119
+      ID: 114
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.809632e+06
@@ -2122,12 +2044,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 129
+      ID: 124
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.884096e+06
@@ -2135,15 +2057,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 143
+      ID: 138
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.9472e+06
@@ -2151,18 +2073,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 131
+      ID: 126
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.884384e+06
@@ -2170,15 +2092,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 122
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.883808e+06
@@ -2186,15 +2108,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 139
+      ID: 134
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.94656e+06
@@ -2202,18 +2124,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 147
+      ID: 142
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.005088e+06
@@ -2221,21 +2143,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 141
+      ID: 136
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.94688e+06
@@ -2243,18 +2165,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 125
+      ID: 120
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.8104e+06
@@ -2262,12 +2184,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 121
+      ID: 116
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.809888e+06
@@ -2275,12 +2197,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 133
+      ID: 128
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.884672e+06
@@ -2288,15 +2210,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 145
+      ID: 140
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.94752e+06
@@ -2304,18 +2226,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 135
+      ID: 130
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.88496e+06
@@ -2323,13 +2245,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -2372,7 +2294,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534656
       GoKind: 26
-MaxTypeID: 194
+MaxTypeID: 189
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 206 EventRootType Probe[main.HandleHTTP]
+          Type: 201 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 207 EventRootType Probe[main.LookAtTheRequest]
+          Type: 202 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -66,45 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 110 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xcfc7ee..0xcfc809
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcfc809..0xcfc8f0
-              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 112 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0xcfc6c8..0xcfc6c8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xcfc6c8..0xcfc708
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcfc708..0xcfc70c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 113 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0xcfc640..0xcfc8f0
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xcfc9c0..0xcfca85]
@@ -123,15 +84,15 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 167
+      ID: 162
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<string,[]string>
+      Pointee: 163 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 186
+      ID: 181
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 187 PointerType *table<string,string>
+      Pointee: 182 PointerType *table<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -140,20 +101,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 197
+      ID: 192
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []string.array
+      Pointee: 191 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 118
+      ID: 113
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 117 GoSliceDataType []uint8.array
+      Pointee: 112 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 120
+      ID: 115
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []uintptr.array
+      Pointee: 114 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -162,19 +123,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 110
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.245824e+06
-      GoKind: 22
-      Pointee: 111 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 175
+      ID: 170
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -197,12 +151,12 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 121
+      ID: 116
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.539904e+06
       GoKind: 22
-      Pointee: 122 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 117 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 98
       Name: '*int'
@@ -239,22 +193,22 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 160
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 184
+      ID: 179
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 185 GoSwissMapHeaderType map<string,string>
+      Pointee: 180 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 173
+      ID: 168
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 108
       Name: '*net/http.Request'
@@ -263,50 +217,50 @@ Types:
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
-      ID: 178
+      ID: 173
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType net/http.Response
+      Pointee: 174 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 158
+      ID: 153
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.99632e+06
       GoKind: 22
-      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 181
+      ID: 176
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 182 UnresolvedPointeeType net/http.pattern
+      Pointee: 177 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 160
+      ID: 155
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.189984e+06
       GoKind: 22
-      Pointee: 161 UnresolvedPointeeType net/http.response
+      Pointee: 156 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 162
+      ID: 157
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 163 UnresolvedPointeeType net/url.URL
+      Pointee: 158 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 190
+      ID: 185
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]string
+      Pointee: 186 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 200
+      ID: 195
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string]string
+      Pointee: 196 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -385,125 +339,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 116
+      ID: 111
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 115 GoStringDataType string.str
+      Pointee: 110 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 122
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.677056e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.729472e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 123
+      ID: 118
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.676672e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 133
+      ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.728704e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 147
+      ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.800096e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728896e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 131
+      ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.728512e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 143
+      ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.799648e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 151
+      ID: 146
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.869504e+06
       GoKind: 22
-      Pointee: 152 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 145
+      ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799872e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 124
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.677248e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 120
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.676864e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 137
+      ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.729088e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 149
+      ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.80032e+06
       GoKind: 22
-      Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 139
+      ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.72928e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 168
+      ID: 163
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 188 StructureType table<string,[]string>
+      Pointee: 183 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 182
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 198 StructureType table<string,string>
+      Pointee: 193 StructureType table<string,string>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -547,12 +501,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 177
+      ID: 172
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: EventRootType
-      ID: 206
+      ID: 201
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -576,7 +530,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 202
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -697,35 +651,35 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 189
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<string,[]string>
+      Element: 163 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 199
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 187 PointerType *table<string,string>
+      Element: 182 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 190
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 191 StructureType noalg.map.group[string][]string
+      Element: 186 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 200
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: slice
       ByteSize: 264
-      Element: 201 StructureType noalg.map.group[string]string
+      Element: 196 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 166
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -740,9 +694,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 196 GoSliceDataType []string.array
+      Data: 191 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 191
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -763,9 +717,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 117 GoSliceDataType []uint8.array
+      Data: 112 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 117
+      ID: 112
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -786,9 +740,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []uintptr.array
+      Data: 114 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 114
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -799,10 +753,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 580672
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 111
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 95
       Name: complex128
@@ -816,7 +766,7 @@ Types:
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 180
+      ID: 175
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.267616e+06
@@ -828,23 +778,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 113
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.781952e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 114 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 114
-      Name: context.emptyCtx
-      GoRuntimeType: 1.580704e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 176
+      ID: 171
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -879,7 +814,7 @@ Types:
       GoRuntimeType: 476896
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 170
+      ID: 165
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
@@ -891,7 +826,7 @@ Types:
       GoRuntimeType: 849568
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 148
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.40832e+06
@@ -904,50 +839,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 122
+      ID: 117
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 112
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.469568e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 184
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]string
+          Type: 185 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]string
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 186 StructureType noalg.map.group[string][]string
+      GroupSliceType: 190 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 194
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string]string
+          Type: 195 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 196 StructureType noalg.map.group[string]string
+      GroupSliceType: 200 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1078,7 +1000,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 169
+      ID: 164
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10128e+06
@@ -1091,7 +1013,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 161
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1104,7 +1026,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<string,[]string>
+          Type: 162 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1120,10 +1042,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 191 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 189 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 186 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 185
+      ID: 180
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1136,7 +1058,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 186 PointerType **table<string,string>
+          Type: 181 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1152,21 +1074,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
-      GroupType: 201 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 199 GoSliceDataType []*table<string,string>.array
+      GroupType: 196 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 183
+      ID: 178
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119712e+06
       GoKind: 21
-      HeaderType: 185 GoSwissMapHeaderType map<string,string>
+      HeaderType: 180 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 169
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 151
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.019104e+06
@@ -1179,7 +1101,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 154
+      ID: 149
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.017696e+06
@@ -1192,14 +1114,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 164
+      ID: 159
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.088128e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 152
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.017824e+06
@@ -1212,7 +1134,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 150
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.01808e+06
@@ -1236,7 +1158,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 162 PointerType *net/url.URL
+          Type: 157 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1248,19 +1170,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 164 GoMapType net/http.Header
+          Type: 159 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 169 GoInterfaceType io.ReadCloser
+          Type: 164 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 171 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1269,16 +1191,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 172 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 172 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 173 PointerType *mime/multipart.Form
+          Type: 168 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 164 GoMapType net/http.Header
+          Type: 159 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1287,30 +1209,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 175 PointerType *crypto/tls.ConnectionState
+          Type: 170 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 177 GoChannelType <-chan struct {}
+          Type: 172 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 178 PointerType *net/http.Response
+          Type: 173 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 180 GoInterfaceType context.Context
+          Type: 175 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 181 PointerType *net/http.pattern
+          Type: 176 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 171 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 183 GoMapType map[string]string
+          Type: 178 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 174
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1327,48 +1249,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 159
+      ID: 154
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 182
+      ID: 177
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 161
+      ID: 156
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 163
+      ID: 158
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 172
+      ID: 167
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.871296e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 192
+      ID: 187
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key string; elem []string }
+      Element: 188 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 202
+      ID: 197
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem string }
+      Element: 198 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 191
+      ID: 186
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -1379,9 +1301,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 187 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 201
+      ID: 196
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -1392,9 +1314,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 197 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 193
+      ID: 188
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -1405,9 +1327,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 171 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 203
+      ID: 198
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -2182,18 +2104,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 116 PointerType *string.str
+          Type: 111 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 115 GoStringDataType string.str
+      Data: 110 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 115
+      ID: 110
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 128
+      ID: 123
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.9328e+06
@@ -2201,12 +2123,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.010432e+06
@@ -2214,15 +2136,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 124
+      ID: 119
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.932288e+06
@@ -2230,12 +2152,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 134
+      ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.00928e+06
@@ -2243,15 +2165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 148
+      ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071712e+06
@@ -2259,18 +2181,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009568e+06
@@ -2278,15 +2200,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 132
+      ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.008992e+06
@@ -2294,15 +2216,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 144
+      ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.071072e+06
@@ -2310,18 +2232,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 152
+      ID: 147
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.131456e+06
@@ -2329,21 +2251,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 146
+      ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071392e+06
@@ -2351,18 +2273,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 125
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.933056e+06
@@ -2370,12 +2292,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 121
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.932544e+06
@@ -2383,12 +2305,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 138
+      ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.009856e+06
@@ -2396,15 +2318,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 150
+      ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.072032e+06
@@ -2412,18 +2334,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 140
+      ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.010144e+06
@@ -2431,15 +2353,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 188
+      ID: 183
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2461,9 +2383,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 184 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 198
+      ID: 193
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2485,7 +2407,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,string>
+          Type: 194 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -2528,7 +2450,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580736
       GoKind: 26
-MaxTypeID: 207
+MaxTypeID: 202
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 209 EventRootType Probe[main.HandleHTTP]
+          Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 210 EventRootType Probe[main.LookAtTheRequest]
+          Type: 207 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -66,38 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 112 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd0500e..0xd05029
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd05029..0xd05110
-              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 114 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0xd04ee8..0xd04ee8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xd04ee8..0xd04f28
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04f28..0xd04f2c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd051e0..0xd052a5]
@@ -122,20 +90,20 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 170
+      ID: 167
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 171 PointerType *table<string,[]string>
+      Pointee: 168 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 189
+      ID: 186
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 190 PointerType *table<string,string>
+      Pointee: 187 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 123
+      ID: 120
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 122 GoSliceDataType []*runtime.p.array
+      Pointee: 119 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -144,20 +112,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 200
+      ID: 197
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []string.array
+      Pointee: 196 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 118
+      ID: 115
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 117 GoSliceDataType []uint8.array
+      Pointee: 114 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 120
+      ID: 117
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []uintptr.array
+      Pointee: 116 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -166,19 +134,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 112
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.260704e+06
-      GoKind: 22
-      Pointee: 113 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 178
+      ID: 175
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -201,12 +162,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 124
+      ID: 121
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.550528e+06
       GoKind: 22
-      Pointee: 125 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 122 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -243,22 +204,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 168
+      ID: 165
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 169 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 184
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 188 GoSwissMapHeaderType map<string,string>
+      Pointee: 185 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 176
+      ID: 173
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -267,50 +228,50 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 181
+      ID: 178
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718816e+06
       GoKind: 22
-      Pointee: 182 UnresolvedPointeeType net/http.Response
+      Pointee: 179 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 161
+      ID: 158
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.010368e+06
       GoKind: 22
-      Pointee: 162 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 184
+      ID: 181
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608608e+06
       GoKind: 22
-      Pointee: 185 UnresolvedPointeeType net/http.pattern
+      Pointee: 182 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 163
+      ID: 160
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.218272e+06
       GoKind: 22
-      Pointee: 164 UnresolvedPointeeType net/http.response
+      Pointee: 161 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 165
+      ID: 162
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 166 UnresolvedPointeeType net/url.URL
+      Pointee: 163 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 193
+      ID: 190
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[string][]string
+      Pointee: 191 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 203
+      ID: 200
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[string]string
+      Pointee: 201 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -359,7 +320,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.03344e+06
       GoKind: 22
-      Pointee: 121 UnresolvedPointeeType runtime.p
+      Pointee: 118 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -396,125 +357,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 116
+      ID: 113
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 115 GoStringDataType string.str
+      Pointee: 112 GoStringDataType string.str
     - __kind: PointerType
-      ID: 130
+      ID: 127
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.68848e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 144
+      ID: 141
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.74224e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 123
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.688096e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 136
+      ID: 133
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741472e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 150
+      ID: 147
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.814048e+06
       GoKind: 22
-      Pointee: 151 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 138
+      ID: 135
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741664e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 134
+      ID: 131
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.74128e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 146
+      ID: 143
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.8136e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 154
+      ID: 151
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.882912e+06
       GoKind: 22
-      Pointee: 155 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 152 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 148
+      ID: 145
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813824e+06
       GoKind: 22
-      Pointee: 149 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 132
+      ID: 129
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.688672e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 128
+      ID: 125
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.688288e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 140
+      ID: 137
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741856e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 152
+      ID: 149
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.814272e+06
       GoKind: 22
-      Pointee: 153 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 142
+      ID: 139
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.742048e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 171
+      ID: 168
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 191 StructureType table<string,[]string>
+      Pointee: 188 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 190
+      ID: 187
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 201 StructureType table<string,string>
+      Pointee: 198 StructureType table<string,string>
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -558,12 +519,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 180
+      ID: 177
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
     - __kind: EventRootType
-      ID: 209
+      ID: 206
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -587,7 +548,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 210
+      ID: 207
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -716,43 +677,43 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 122 GoSliceDataType []*runtime.p.array
+      Data: 119 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 122
+      ID: 119
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 194
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 171 PointerType *table<string,[]string>
+      Element: 168 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 204
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 190 PointerType *table<string,string>
+      Element: 187 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 195
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 194 StructureType noalg.map.group[string][]string
+      Element: 191 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 205
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: slice
       ByteSize: 264
-      Element: 204 StructureType noalg.map.group[string]string
+      Element: 201 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 171
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -767,9 +728,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 199 GoSliceDataType []string.array
+      Data: 196 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 196
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -790,9 +751,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 117 GoSliceDataType []uint8.array
+      Data: 114 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 117
+      ID: 114
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -813,9 +774,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []uintptr.array
+      Data: 116 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 116
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -826,10 +787,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 585472
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 113
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 97
       Name: complex128
@@ -843,7 +800,7 @@ Types:
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 183
+      ID: 180
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276992e+06
@@ -856,7 +813,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 176
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -891,7 +848,7 @@ Types:
       GoRuntimeType: 480064
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 173
+      ID: 170
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693344
@@ -903,7 +860,7 @@ Types:
       GoRuntimeType: 855136
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 153
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.417952e+06
@@ -916,50 +873,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 125
+      ID: 122
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 114
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.479712e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 189
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[string][]string
+          Type: 190 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[string][]string
-      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 191 StructureType noalg.map.group[string][]string
+      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 199
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[string]string
+          Type: 200 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[string]string
-      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 201 StructureType noalg.map.group[string]string
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1090,7 +1034,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 172
+      ID: 169
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -1103,7 +1047,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 169
+      ID: 166
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1116,7 +1060,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 170 PointerType **table<string,[]string>
+          Type: 167 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1135,10 +1079,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 197 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 194 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 191 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 188
+      ID: 185
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1151,7 +1095,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 189 PointerType **table<string,string>
+          Type: 186 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1170,21 +1114,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 207 GoSliceDataType []*table<string,string>.array
-      GroupType: 204 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
+      GroupType: 201 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 186
+      ID: 183
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.129024e+06
       GoKind: 21
-      HeaderType: 188 GoSwissMapHeaderType map<string,string>
+      HeaderType: 185 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 174
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 159
+      ID: 156
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.027552e+06
@@ -1197,7 +1141,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 154
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.026016e+06
@@ -1210,14 +1154,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 167
+      ID: 164
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.101632e+06
       GoKind: 21
-      HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 160
+      ID: 157
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.026144e+06
@@ -1230,7 +1174,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 158
+      ID: 155
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.0264e+06
@@ -1254,7 +1198,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 165 PointerType *net/url.URL
+          Type: 162 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1266,19 +1210,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 167 GoMapType net/http.Header
+          Type: 164 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 172 GoInterfaceType io.ReadCloser
+          Type: 169 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 173 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 174 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1287,16 +1231,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 175 GoMapType net/url.Values
+          Type: 172 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 175 GoMapType net/url.Values
+          Type: 172 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 176 PointerType *mime/multipart.Form
+          Type: 173 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 167 GoMapType net/http.Header
+          Type: 164 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1305,30 +1249,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 178 PointerType *crypto/tls.ConnectionState
+          Type: 175 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 180 GoChannelType <-chan struct {}
+          Type: 177 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 181 PointerType *net/http.Response
+          Type: 178 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 183 GoInterfaceType context.Context
+          Type: 180 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 184 PointerType *net/http.pattern
+          Type: 181 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 174 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 186 GoMapType map[string]string
+          Type: 183 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 182
+      ID: 179
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1345,48 +1289,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 162
+      ID: 159
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 185
+      ID: 182
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 164
+      ID: 161
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 166
+      ID: 163
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 175
+      ID: 172
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.885152e+06
       GoKind: 21
-      HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 195
+      ID: 192
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 196 StructureType noalg.struct { key string; elem []string }
+      Element: 193 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 205
+      ID: 202
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key string; elem string }
+      Element: 203 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 194
+      ID: 191
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -1397,9 +1341,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 195 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 204
+      ID: 201
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -1410,9 +1354,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 196
+      ID: 193
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -1423,9 +1367,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 174 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 206
+      ID: 203
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -2082,7 +2026,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 121
+      ID: 118
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -2207,18 +2151,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 116 PointerType *string.str
+          Type: 113 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 115 GoStringDataType string.str
+      Data: 112 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 115
+      ID: 112
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 131
+      ID: 128
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.947456e+06
@@ -2226,12 +2170,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 145
+      ID: 142
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.023616e+06
@@ -2239,15 +2183,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 124
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.946944e+06
@@ -2255,12 +2199,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 137
+      ID: 134
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.022464e+06
@@ -2268,15 +2212,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 151
+      ID: 148
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085568e+06
@@ -2284,18 +2228,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 139
+      ID: 136
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.022752e+06
@@ -2303,15 +2247,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 135
+      ID: 132
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.022176e+06
@@ -2319,15 +2263,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 147
+      ID: 144
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.084928e+06
@@ -2335,18 +2279,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 155
+      ID: 152
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.1464e+06
@@ -2354,21 +2298,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 149
+      ID: 146
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085248e+06
@@ -2376,18 +2320,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 133
+      ID: 130
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.947712e+06
@@ -2395,12 +2339,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 129
+      ID: 126
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.9472e+06
@@ -2408,12 +2352,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 141
+      ID: 138
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.02304e+06
@@ -2421,15 +2365,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 153
+      ID: 150
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085888e+06
@@ -2437,18 +2381,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 143
+      ID: 140
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.023328e+06
@@ -2456,15 +2400,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 191
+      ID: 188
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2486,9 +2430,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 201
+      ID: 198
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2510,7 +2454,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<string,string>
+          Type: 199 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -2553,7 +2497,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585536
       GoKind: 26
-MaxTypeID: 210
+MaxTypeID: 207
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x182c9a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 193 EventRootType Probe[main.HandleHTTP]
+          Type: 188 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 194 EventRootType Probe[main.LookAtTheRequest]
+          Type: 189 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -66,45 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 105 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x8ad9b4..0x8ad9d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8ad9d0..0x8adab0
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 107 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0x8ad8d8..0x8ad8d8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x8ad8d8..0x8ad910
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8ad910..0x8ad914
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 108 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0x8ad860..0x8adab0
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8adb90..0x8adc50]
@@ -130,20 +91,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 190
+      ID: 185
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []string.array
+      Pointee: 184 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 113
+      ID: 108
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uint8.array
+      Pointee: 107 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 115
+      ID: 110
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uintptr.array
+      Pointee: 109 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -152,29 +113,22 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 162
+      ID: 157
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 163 GoHMapBucketType bucket<string,[]string>
+      Pointee: 158 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 183
+      ID: 178
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 184 GoHMapBucketType bucket<string,string>
+      Pointee: 179 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 105
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.11552e+06
-      GoKind: 22
-      Pointee: 106 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 172
+      ID: 167
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 173 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 168 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -197,22 +151,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 116
+      ID: 111
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.362016e+06
       GoKind: 22
-      Pointee: 117 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 112 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 160
+      ID: 155
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 161 GoHMapHeaderType hash<string,[]string>
+      Pointee: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 176
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 182 GoHMapHeaderType hash<string,string>
+      Pointee: 177 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 94
       Name: '*int'
@@ -249,12 +203,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 170
+      ID: 165
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 166 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 103
       Name: '*net/http.Request'
@@ -263,40 +217,40 @@ Types:
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
-      ID: 175
+      ID: 170
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 176 UnresolvedPointeeType net/http.Response
+      Pointee: 171 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 153
+      ID: 148
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.833376e+06
       GoKind: 22
-      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 149 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 178
+      ID: 173
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType net/http.pattern
+      Pointee: 174 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 155
+      ID: 150
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.059552e+06
       GoKind: 22
-      Pointee: 156 UnresolvedPointeeType net/http.response
+      Pointee: 151 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 157
+      ID: 152
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 158 UnresolvedPointeeType net/url.URL
+      Pointee: 153 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -340,12 +294,12 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 164
+      ID: 159
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 165 UnresolvedPointeeType runtime.mapextra
+      Pointee: 160 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -375,115 +329,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 111
+      ID: 106
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 110 GoStringDataType string.str
+      Pointee: 105 GoStringDataType string.str
     - __kind: PointerType
-      ID: 122
+      ID: 117
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.496256e+06
       GoKind: 22
-      Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 118 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 136
+      ID: 131
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.616224e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 118
+      ID: 113
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.495872e+06
       GoKind: 22
-      Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 114 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 128
+      ID: 123
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.615456e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 142
+      ID: 137
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.68544e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 130
+      ID: 125
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615648e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 121
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.615264e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 122 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 138
+      ID: 133
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.684992e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 146
+      ID: 141
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.75072e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 140
+      ID: 135
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.685216e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 124
+      ID: 119
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.496448e+06
       GoKind: 22
-      Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 120 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 120
+      ID: 115
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.496064e+06
       GoKind: 22
-      Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 116 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 132
+      ID: 127
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.61584e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 144
+      ID: 139
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.685664e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 134
+      ID: 129
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.616032e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -527,12 +481,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 174
+      ID: 169
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: EventRootType
-      ID: 193
+      ID: 188
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -556,7 +510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 194
+      ID: 189
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -661,7 +615,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 185
+      ID: 180
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -670,19 +624,19 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 183
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 163 GoHMapBucketType bucket<string,[]string>
+      Element: 158 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 187
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 184 GoHMapBucketType bucket<string,string>
+      Element: 179 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 186
+      ID: 181
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -693,7 +647,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 163
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -708,9 +662,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 189 GoSliceDataType []string.array
+      Data: 184 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 184
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -731,9 +685,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 112 GoSliceDataType []uint8.array
+      Data: 107 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 107
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -754,22 +708,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 114 GoSliceDataType []uintptr.array
+      Data: 109 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 109
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 187
+      ID: 182
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 168 GoSliceHeaderType []string
+      Element: 163 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 191
+      ID: 186
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -782,47 +736,43 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 163
+      ID: 158
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 180 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<string>
+          Type: 181 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 187 ArrayType []val<[]string>
+          Type: 182 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 162 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 168 GoSliceHeaderType []string
+      ValueType: 163 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 184
+      ID: 179
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 185 ArrayType [8]uint8
+          Type: 180 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 186 ArrayType []key<string>
+          Type: 181 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 191 ArrayType []val<string>
+          Type: 186 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 183 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: UnresolvedPointeeType
-      ID: 106
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 91
       Name: complex128
@@ -836,7 +786,7 @@ Types:
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 177
+      ID: 172
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187296e+06
@@ -848,23 +798,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 108
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.667744e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 109 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 109
-      Name: context.emptyCtx
-      GoRuntimeType: 1.399808e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 173
+      ID: 168
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -899,7 +834,7 @@ Types:
       GoRuntimeType: 451296
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 167
+      ID: 162
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
@@ -911,7 +846,7 @@ Types:
       GoRuntimeType: 785760
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 148
+      ID: 143
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.23584e+06
@@ -924,24 +859,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 117
+      ID: 112
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 107
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.296128e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 161
+      ID: 156
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -962,20 +884,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 162 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 162 PointerType *bucket<string,[]string>
+          Type: 157 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 164 PointerType *runtime.mapextra
-      BucketType: 163 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 188 GoSliceDataType []bucket<string,[]string>.array
+          Type: 159 PointerType *runtime.mapextra
+      BucketType: 158 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 182
+      ID: 177
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -996,18 +918,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 183 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 183 PointerType *bucket<string,string>
+          Type: 178 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 164 PointerType *runtime.mapextra
-      BucketType: 184 GoHMapBucketType bucket<string,string>
-      BucketsType: 192 GoSliceDataType []bucket<string,string>.array
+          Type: 159 PointerType *runtime.mapextra
+      BucketType: 179 GoHMapBucketType bucket<string,string>
+      BucketsType: 187 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1138,7 +1060,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 166
+      ID: 161
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067328e+06
@@ -1151,18 +1073,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 180
+      ID: 175
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 182 GoHMapHeaderType hash<string,string>
+      HeaderType: 177 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 166
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 146
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 983296
@@ -1175,7 +1097,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 149
+      ID: 144
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 981888
@@ -1188,14 +1110,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 159
+      ID: 154
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.917984e+06
       GoKind: 21
-      HeaderType: 161 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 147
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 982016
@@ -1208,7 +1130,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 145
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 982272
@@ -1232,7 +1154,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 157 PointerType *net/url.URL
+          Type: 152 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1244,19 +1166,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 159 GoMapType net/http.Header
+          Type: 154 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 166 GoInterfaceType io.ReadCloser
+          Type: 161 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 167 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 162 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 168 GoSliceHeaderType []string
+          Type: 163 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1265,16 +1187,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 169 GoMapType net/url.Values
+          Type: 164 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 169 GoMapType net/url.Values
+          Type: 164 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 170 PointerType *mime/multipart.Form
+          Type: 165 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 159 GoMapType net/http.Header
+          Type: 154 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1283,30 +1205,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 172 PointerType *crypto/tls.ConnectionState
+          Type: 167 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 174 GoChannelType <-chan struct {}
+          Type: 169 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 175 PointerType *net/http.Response
+          Type: 170 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 177 GoInterfaceType context.Context
+          Type: 172 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 178 PointerType *net/http.pattern
+          Type: 173 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 168 GoSliceHeaderType []string
+          Type: 163 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 180 GoMapType map[string]string
+          Type: 175 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 176
+      ID: 171
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1323,28 +1245,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 154
+      ID: 149
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 174
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 156
+      ID: 151
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 158
+      ID: 153
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 169
+      ID: 164
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.671328e+06
       GoKind: 21
-      HeaderType: 161 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1940,7 +1862,7 @@ Types:
           Offset: 24
           Type: 28 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 165
+      ID: 160
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -2074,18 +1996,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 111 PointerType *string.str
+          Type: 106 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 110 GoStringDataType string.str
+      Data: 105 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 110
+      ID: 105
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 123
+      ID: 118
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.810688e+06
@@ -2093,12 +2015,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 137
+      ID: 132
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885792e+06
@@ -2106,15 +2028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 119
+      ID: 114
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.810176e+06
@@ -2122,12 +2044,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 129
+      ID: 124
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.88464e+06
@@ -2135,15 +2057,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 143
+      ID: 138
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.947744e+06
@@ -2151,18 +2073,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 131
+      ID: 126
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.884928e+06
@@ -2170,15 +2092,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 122
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.884352e+06
@@ -2186,15 +2108,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 139
+      ID: 134
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.947104e+06
@@ -2202,18 +2124,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 147
+      ID: 142
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.005632e+06
@@ -2221,21 +2143,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 141
+      ID: 136
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.947424e+06
@@ -2243,18 +2165,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 144 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 125
+      ID: 120
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.810944e+06
@@ -2262,12 +2184,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 121
+      ID: 116
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.810432e+06
@@ -2275,12 +2197,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 133
+      ID: 128
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.885216e+06
@@ -2288,15 +2210,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 145
+      ID: 140
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.948064e+06
@@ -2304,18 +2226,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 146 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 135
+      ID: 130
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885504e+06
@@ -2323,13 +2245,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 145 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 147 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -2372,7 +2294,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534848
       GoKind: 26
-MaxTypeID: 194
+MaxTypeID: 189
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 206 EventRootType Probe[main.HandleHTTP]
+          Type: 201 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 207 EventRootType Probe[main.LookAtTheRequest]
+          Type: 202 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -66,45 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 110 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x86c254..0x86c268
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x86c268..0x86c340
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 112 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0x86c178..0x86c178
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x86c178..0x86c1b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x86c1b0..0x86c1b4
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 113 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0x86c100..0x86c340
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x86c410..0x86c4c0]
@@ -123,15 +84,15 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 167
+      ID: 162
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<string,[]string>
+      Pointee: 163 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 186
+      ID: 181
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 187 PointerType *table<string,string>
+      Pointee: 182 PointerType *table<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -140,20 +101,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 197
+      ID: 192
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []string.array
+      Pointee: 191 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 118
+      ID: 113
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 117 GoSliceDataType []uint8.array
+      Pointee: 112 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 120
+      ID: 115
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []uintptr.array
+      Pointee: 114 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -162,19 +123,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 110
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.245056e+06
-      GoKind: 22
-      Pointee: 111 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 175
+      ID: 170
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -197,12 +151,12 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 121
+      ID: 116
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.53936e+06
       GoKind: 22
-      Pointee: 122 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 117 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -239,22 +193,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 160
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 184
+      ID: 179
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 185 GoSwissMapHeaderType map<string,string>
+      Pointee: 180 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 173
+      ID: 168
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 108
       Name: '*net/http.Request'
@@ -263,50 +217,50 @@ Types:
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
-      ID: 178
+      ID: 173
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType net/http.Response
+      Pointee: 174 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 158
+      ID: 153
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.995552e+06
       GoKind: 22
-      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 181
+      ID: 176
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 182 UnresolvedPointeeType net/http.pattern
+      Pointee: 177 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 160
+      ID: 155
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.189216e+06
       GoKind: 22
-      Pointee: 161 UnresolvedPointeeType net/http.response
+      Pointee: 156 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 162
+      ID: 157
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 163 UnresolvedPointeeType net/url.URL
+      Pointee: 158 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 190
+      ID: 185
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]string
+      Pointee: 186 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 200
+      ID: 195
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string]string
+      Pointee: 196 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -385,125 +339,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 116
+      ID: 111
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 115 GoStringDataType string.str
+      Pointee: 110 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 122
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.676512e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728928e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 123
+      ID: 118
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.676128e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 133
+      ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.72816e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 147
+      ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799552e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728352e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 131
+      ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.727968e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 143
+      ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.799104e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 151
+      ID: 146
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.868736e+06
       GoKind: 22
-      Pointee: 152 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 145
+      ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799328e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 124
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.676704e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 120
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.67632e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 137
+      ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.728544e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 149
+      ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799776e+06
       GoKind: 22
-      Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 139
+      ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728736e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 168
+      ID: 163
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 188 StructureType table<string,[]string>
+      Pointee: 183 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 182
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 198 StructureType table<string,string>
+      Pointee: 193 StructureType table<string,string>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -547,12 +501,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 177
+      ID: 172
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: EventRootType
-      ID: 206
+      ID: 201
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -576,7 +530,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 202
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -697,35 +651,35 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 189
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<string,[]string>
+      Element: 163 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 199
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 187 PointerType *table<string,string>
+      Element: 182 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 190
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 191 StructureType noalg.map.group[string][]string
+      Element: 186 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 200
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: slice
       ByteSize: 264
-      Element: 201 StructureType noalg.map.group[string]string
+      Element: 196 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 166
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -740,9 +694,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 196 GoSliceDataType []string.array
+      Data: 191 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 191
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -763,9 +717,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 117 GoSliceDataType []uint8.array
+      Data: 112 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 117
+      ID: 112
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -786,9 +740,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []uintptr.array
+      Data: 114 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 114
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -799,10 +753,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 580448
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 111
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 96
       Name: complex128
@@ -816,7 +766,7 @@ Types:
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 180
+      ID: 175
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.266912e+06
@@ -828,23 +778,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 113
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.781408e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 114 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 114
-      Name: context.emptyCtx
-      GoRuntimeType: 1.58016e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 176
+      ID: 171
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -879,7 +814,7 @@ Types:
       GoRuntimeType: 476736
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 170
+      ID: 165
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
@@ -891,7 +826,7 @@ Types:
       GoRuntimeType: 848960
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 148
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.407616e+06
@@ -904,50 +839,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 122
+      ID: 117
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 112
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.468864e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 184
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]string
+          Type: 185 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]string
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 186 StructureType noalg.map.group[string][]string
+      GroupSliceType: 190 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 194
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string]string
+          Type: 195 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 196 StructureType noalg.map.group[string]string
+      GroupSliceType: 200 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1078,7 +1000,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 169
+      ID: 164
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.100576e+06
@@ -1091,7 +1013,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 161
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1104,7 +1026,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<string,[]string>
+          Type: 162 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1120,10 +1042,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 191 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 189 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 186 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 185
+      ID: 180
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1136,7 +1058,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 186 PointerType **table<string,string>
+          Type: 181 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1152,21 +1074,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
-      GroupType: 201 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 199 GoSliceDataType []*table<string,string>.array
+      GroupType: 196 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 183
+      ID: 178
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119008e+06
       GoKind: 21
-      HeaderType: 185 GoSwissMapHeaderType map<string,string>
+      HeaderType: 180 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 169
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 151
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.0184e+06
@@ -1179,7 +1101,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 154
+      ID: 149
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.016992e+06
@@ -1192,14 +1114,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 164
+      ID: 159
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.08736e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 152
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.01712e+06
@@ -1212,7 +1134,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 150
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.017376e+06
@@ -1236,7 +1158,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 162 PointerType *net/url.URL
+          Type: 157 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1248,19 +1170,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 164 GoMapType net/http.Header
+          Type: 159 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 169 GoInterfaceType io.ReadCloser
+          Type: 164 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 171 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1269,16 +1191,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 172 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 172 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 173 PointerType *mime/multipart.Form
+          Type: 168 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 164 GoMapType net/http.Header
+          Type: 159 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1287,30 +1209,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 175 PointerType *crypto/tls.ConnectionState
+          Type: 170 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 177 GoChannelType <-chan struct {}
+          Type: 172 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 178 PointerType *net/http.Response
+          Type: 173 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 180 GoInterfaceType context.Context
+          Type: 175 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 181 PointerType *net/http.pattern
+          Type: 176 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 171 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 183 GoMapType map[string]string
+          Type: 178 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 174
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1327,48 +1249,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 159
+      ID: 154
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 182
+      ID: 177
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 161
+      ID: 156
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 163
+      ID: 158
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 172
+      ID: 167
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.870528e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 192
+      ID: 187
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key string; elem []string }
+      Element: 188 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 202
+      ID: 197
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem string }
+      Element: 198 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 191
+      ID: 186
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -1379,9 +1301,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 187 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 201
+      ID: 196
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -1392,9 +1314,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 197 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 193
+      ID: 188
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -1405,9 +1327,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 171 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 203
+      ID: 198
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -2182,18 +2104,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 116 PointerType *string.str
+          Type: 111 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 115 GoStringDataType string.str
+      Data: 110 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 115
+      ID: 110
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 128
+      ID: 123
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.932032e+06
@@ -2201,12 +2123,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009664e+06
@@ -2214,15 +2136,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 124
+      ID: 119
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.93152e+06
@@ -2230,12 +2152,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 134
+      ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.008512e+06
@@ -2243,15 +2165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 148
+      ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.070944e+06
@@ -2259,18 +2181,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.0088e+06
@@ -2278,15 +2200,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 132
+      ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.008224e+06
@@ -2294,15 +2216,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 144
+      ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.070304e+06
@@ -2310,18 +2232,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 152
+      ID: 147
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.130688e+06
@@ -2329,21 +2251,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 146
+      ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.070624e+06
@@ -2351,18 +2273,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 149 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 125
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.932288e+06
@@ -2370,12 +2292,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 121
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.931776e+06
@@ -2383,12 +2305,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 138
+      ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.009088e+06
@@ -2396,15 +2318,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 150
+      ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071264e+06
@@ -2412,18 +2334,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 151 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 140
+      ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009376e+06
@@ -2431,15 +2353,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 150 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 152 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 188
+      ID: 183
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2461,9 +2383,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 184 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 198
+      ID: 193
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2485,7 +2407,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,string>
+          Type: 194 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2528,7 +2450,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580512
       GoKind: 26
-MaxTypeID: 207
+MaxTypeID: 202
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 209 EventRootType Probe[main.HandleHTTP]
+          Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b100", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 210 EventRootType Probe[main.LookAtTheRequest]
+          Type: 207 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b3fc", Frameless: true}]
           Condition: null
 Subprograms:
@@ -66,32 +66,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 112 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x82b23c..0x82b258
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x82b258..0x82b320
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 114 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0x82b164..0x82b164
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x82b164..0x82b1a4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x82b3f0..0x82b490]
@@ -116,20 +90,20 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 170
+      ID: 167
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 171 PointerType *table<string,[]string>
+      Pointee: 168 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 189
+      ID: 186
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 190 PointerType *table<string,string>
+      Pointee: 187 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 123
+      ID: 120
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 122 GoSliceDataType []*runtime.p.array
+      Pointee: 119 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -138,20 +112,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 200
+      ID: 197
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []string.array
+      Pointee: 196 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 118
+      ID: 115
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 117 GoSliceDataType []uint8.array
+      Pointee: 114 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 120
+      ID: 117
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []uintptr.array
+      Pointee: 116 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -160,19 +134,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 112
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.259936e+06
-      GoKind: 22
-      Pointee: 113 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 178
+      ID: 175
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -195,12 +162,12 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 124
+      ID: 121
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.549984e+06
       GoKind: 22
-      Pointee: 125 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 122 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -237,22 +204,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 168
+      ID: 165
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 169 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 184
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 188 GoSwissMapHeaderType map<string,string>
+      Pointee: 185 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 176
+      ID: 173
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -261,50 +228,50 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 181
+      ID: 178
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718272e+06
       GoKind: 22
-      Pointee: 182 UnresolvedPointeeType net/http.Response
+      Pointee: 179 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 161
+      ID: 158
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.0096e+06
       GoKind: 22
-      Pointee: 162 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 184
+      ID: 181
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608064e+06
       GoKind: 22
-      Pointee: 185 UnresolvedPointeeType net/http.pattern
+      Pointee: 182 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 163
+      ID: 160
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.217504e+06
       GoKind: 22
-      Pointee: 164 UnresolvedPointeeType net/http.response
+      Pointee: 161 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 165
+      ID: 162
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 166 UnresolvedPointeeType net/url.URL
+      Pointee: 163 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 193
+      ID: 190
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[string][]string
+      Pointee: 191 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 203
+      ID: 200
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[string]string
+      Pointee: 201 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -353,7 +320,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.032736e+06
       GoKind: 22
-      Pointee: 121 UnresolvedPointeeType runtime.p
+      Pointee: 118 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -390,125 +357,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 116
+      ID: 113
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 115 GoStringDataType string.str
+      Pointee: 112 GoStringDataType string.str
     - __kind: PointerType
-      ID: 130
+      ID: 127
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.687936e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 144
+      ID: 141
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741696e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 123
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.687552e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 136
+      ID: 133
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.740928e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 150
+      ID: 147
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813504e+06
       GoKind: 22
-      Pointee: 151 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 138
+      ID: 135
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.74112e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 134
+      ID: 131
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.740736e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 146
+      ID: 143
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.813056e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 154
+      ID: 151
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.882144e+06
       GoKind: 22
-      Pointee: 155 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 152 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 148
+      ID: 145
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.81328e+06
       GoKind: 22
-      Pointee: 149 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 132
+      ID: 129
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.688128e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 128
+      ID: 125
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.687744e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 140
+      ID: 137
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741312e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 152
+      ID: 149
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813728e+06
       GoKind: 22
-      Pointee: 153 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 142
+      ID: 139
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741504e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 171
+      ID: 168
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 191 StructureType table<string,[]string>
+      Pointee: 188 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 190
+      ID: 187
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 201 StructureType table<string,string>
+      Pointee: 198 StructureType table<string,string>
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -552,12 +519,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 180
+      ID: 177
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
     - __kind: EventRootType
-      ID: 209
+      ID: 206
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -581,7 +548,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 210
+      ID: 207
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -710,43 +677,43 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 122 GoSliceDataType []*runtime.p.array
+      Data: 119 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 122
+      ID: 119
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 194
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 171 PointerType *table<string,[]string>
+      Element: 168 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 204
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 190 PointerType *table<string,string>
+      Element: 187 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 195
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 194 StructureType noalg.map.group[string][]string
+      Element: 191 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 205
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: slice
       ByteSize: 264
-      Element: 204 StructureType noalg.map.group[string]string
+      Element: 201 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 171
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -761,9 +728,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 199 GoSliceDataType []string.array
+      Data: 196 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 196
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -784,9 +751,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 117 GoSliceDataType []uint8.array
+      Data: 114 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 117
+      ID: 114
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -807,9 +774,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []uintptr.array
+      Data: 116 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 116
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -820,10 +787,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 585248
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 113
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 98
       Name: complex128
@@ -837,7 +800,7 @@ Types:
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 183
+      ID: 180
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276288e+06
@@ -850,7 +813,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 176
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -885,7 +848,7 @@ Types:
       GoRuntimeType: 479904
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 173
+      ID: 170
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693216
@@ -897,7 +860,7 @@ Types:
       GoRuntimeType: 854528
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 153
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.417248e+06
@@ -910,50 +873,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 125
+      ID: 122
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 114
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.479008e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 189
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[string][]string
+          Type: 190 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[string][]string
-      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 191 StructureType noalg.map.group[string][]string
+      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 199
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[string]string
+          Type: 200 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[string]string
-      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 201 StructureType noalg.map.group[string]string
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1084,7 +1034,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 172
+      ID: 169
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -1097,7 +1047,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 169
+      ID: 166
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1110,7 +1060,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 170 PointerType **table<string,[]string>
+          Type: 167 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1129,10 +1079,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 197 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 194 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 191 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 188
+      ID: 185
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1145,7 +1095,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 189 PointerType **table<string,string>
+          Type: 186 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1164,21 +1114,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 207 GoSliceDataType []*table<string,string>.array
-      GroupType: 204 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
+      GroupType: 201 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 186
+      ID: 183
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.12832e+06
       GoKind: 21
-      HeaderType: 188 GoSwissMapHeaderType map<string,string>
+      HeaderType: 185 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 174
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 159
+      ID: 156
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.026848e+06
@@ -1191,7 +1141,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 154
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.025312e+06
@@ -1204,14 +1154,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 167
+      ID: 164
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.100864e+06
       GoKind: 21
-      HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 160
+      ID: 157
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.02544e+06
@@ -1224,7 +1174,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 158
+      ID: 155
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.025696e+06
@@ -1248,7 +1198,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 165 PointerType *net/url.URL
+          Type: 162 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1260,19 +1210,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 167 GoMapType net/http.Header
+          Type: 164 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 172 GoInterfaceType io.ReadCloser
+          Type: 169 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 173 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 174 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1281,16 +1231,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 175 GoMapType net/url.Values
+          Type: 172 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 175 GoMapType net/url.Values
+          Type: 172 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 176 PointerType *mime/multipart.Form
+          Type: 173 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 167 GoMapType net/http.Header
+          Type: 164 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1299,30 +1249,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 178 PointerType *crypto/tls.ConnectionState
+          Type: 175 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 180 GoChannelType <-chan struct {}
+          Type: 177 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 181 PointerType *net/http.Response
+          Type: 178 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 183 GoInterfaceType context.Context
+          Type: 180 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 184 PointerType *net/http.pattern
+          Type: 181 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 174 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 186 GoMapType map[string]string
+          Type: 183 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 182
+      ID: 179
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1339,48 +1289,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 162
+      ID: 159
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 185
+      ID: 182
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 164
+      ID: 161
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 166
+      ID: 163
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 175
+      ID: 172
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.884384e+06
       GoKind: 21
-      HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 195
+      ID: 192
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 196 StructureType noalg.struct { key string; elem []string }
+      Element: 193 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 205
+      ID: 202
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key string; elem string }
+      Element: 203 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 194
+      ID: 191
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -1391,9 +1341,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 195 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 204
+      ID: 201
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -1404,9 +1354,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 196
+      ID: 193
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -1417,9 +1367,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 174 GoSliceHeaderType []string
+          Type: 171 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 206
+      ID: 203
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -2076,7 +2026,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 121
+      ID: 118
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -2201,18 +2151,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 116 PointerType *string.str
+          Type: 113 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 115 GoStringDataType string.str
+      Data: 112 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 115
+      ID: 112
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 131
+      ID: 128
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.946688e+06
@@ -2220,12 +2170,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 145
+      ID: 142
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.022848e+06
@@ -2233,15 +2183,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 124
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.946176e+06
@@ -2249,12 +2199,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 137
+      ID: 134
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.021696e+06
@@ -2262,15 +2212,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 151
+      ID: 148
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.0848e+06
@@ -2278,18 +2228,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 139
+      ID: 136
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.021984e+06
@@ -2297,15 +2247,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 135
+      ID: 132
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.021408e+06
@@ -2313,15 +2263,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 147
+      ID: 144
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.08416e+06
@@ -2329,18 +2279,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 155
+      ID: 152
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.145632e+06
@@ -2348,21 +2298,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 149
+      ID: 146
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.08448e+06
@@ -2370,18 +2320,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Flusher
+          Type: 154 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 133
+      ID: 130
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.946944e+06
@@ -2389,12 +2339,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 129
+      ID: 126
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.946432e+06
@@ -2402,12 +2352,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 141
+      ID: 138
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.022272e+06
@@ -2415,15 +2365,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 153
+      ID: 150
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.08512e+06
@@ -2431,18 +2381,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 159 GoInterfaceType net/http.CloseNotifier
+          Type: 156 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 143
+      ID: 140
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.02256e+06
@@ -2450,15 +2400,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 158 GoInterfaceType net/http.Pusher
+          Type: 155 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 160 GoInterfaceType net/http.Hijacker
+          Type: 157 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 191
+      ID: 188
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2480,9 +2430,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 201
+      ID: 198
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2504,7 +2454,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<string,string>
+          Type: 199 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2547,7 +2497,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585312
       GoKind: 26
-MaxTypeID: 210
+MaxTypeID: 207
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x130d980", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -2343,15 +2343,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd045b6..0xd045c7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd045c7..0xd04665
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xd04680..0xd046e2]
@@ -2368,29 +2359,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xd04700..0xd0480e]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0475b..0xd04765
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd04765..0xd04780
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd04780..0xd04794
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd04756..0xd04760
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd04760..0xd04780
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd04780..0xd0478f
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xd04820..0xd04826]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -3464,20 +3464,20 @@ Types:
       ByteSize: 8
       Pointee: 129 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1032
+      ID: 1034
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1033 PointerType *main.deepSlice3
+      Pointee: 1035 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1051
+      ID: 1053
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1052 PointerType *main.deepSlice8
+      Pointee: 1054 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1057
+      ID: 1059
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1058 PointerType *main.deepSlice9
+      Pointee: 1060 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 144
       Name: '**main.stringType2'
@@ -3485,7 +3485,7 @@ Types:
       GoKind: 22
       Pointee: 145 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1028
+      ID: 1030
       Name: '**main.t'
       ByteSize: 8
       Pointee: 224 PointerType *main.t
@@ -3502,20 +3502,20 @@ Types:
       ByteSize: 8
       Pointee: 296 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1036
+      ID: 1038
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1035 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1037 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1055
+      ID: 1057
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1054 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1056 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1061
+      ID: 1063
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1060 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1062 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 294
       Name: '*[]*string.array'
@@ -3577,15 +3577,15 @@ Types:
       ByteSize: 8
       Pointee: 341 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 818 GoSliceDataType []float64.array
+      Pointee: 820 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1064
+      ID: 1066
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1063 GoSliceDataType []interface {}.array
+      Pointee: 1065 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 243
       Name: '*[]main.structWithCyclicSlices'
@@ -3597,10 +3597,10 @@ Types:
       ByteSize: 8
       Pointee: 345 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1091
+      ID: 372
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1090 GoSliceDataType []main.structWithMap.array
+      Pointee: 371 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 338
       Name: '*[]main.structWithNoStrings.array'
@@ -3644,66 +3644,66 @@ Types:
       ByteSize: 8
       Pointee: 291 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 944
+      ID: 946
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.848384e+06
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 947 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858336
       GoKind: 22
-      Pointee: 597 GoSliceHeaderType archive/tar.headerError
+      Pointee: 599 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 599
+      ID: 601
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 598 GoSliceDataType archive/tar.headerError.array
+      Pointee: 600 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 884
+      ID: 886
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.252928e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 887 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 832
+      ID: 834
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858528
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 835 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 834
+      ID: 836
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858624
       GoKind: 22
-      Pointee: 835 StructureType archive/zip.dirWriter
+      Pointee: 837 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.772672e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 934 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 860
+      ID: 862
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.016448e+06
       GoKind: 22
-      Pointee: 861 StructureType archive/zip.nopCloser
+      Pointee: 863 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 862
+      ID: 864
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.016704e+06
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 865 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3737,30 +3737,30 @@ Types:
       ByteSize: 8
       Pointee: 137 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1040
+      ID: 1042
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1041 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1043 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1068
+      ID: 1070
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1069 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1071 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1077
+      ID: 1079
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1078 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1080 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 160
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 161 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 1086
+      ID: 1088
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 1087 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1089 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 197
       Name: '*bucket<int,uint8>'
@@ -3777,10 +3777,10 @@ Types:
       ByteSize: 8
       Pointee: 176 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 788
+      ID: 790
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 789 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 791 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 170
       Name: '*bucket<string,int>'
@@ -3832,393 +3832,393 @@ Types:
       ByteSize: 8
       Pointee: 203 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 908
+      ID: 910
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.028864e+06
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType bufio.Reader
+      Pointee: 911 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 933
+      ID: 935
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.814112e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType bufio.Writer
+      Pointee: 936 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 980
+      ID: 982
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.121824e+06
       GoKind: 22
-      Pointee: 981 UnresolvedPointeeType bytes.Buffer
+      Pointee: 983 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 509
+      ID: 511
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 840960
       GoKind: 22
-      Pointee: 404 BaseType compress/flate.CorruptInputError
+      Pointee: 406 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 510
+      ID: 512
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 405 GoStringHeaderType compress/flate.InternalError
+      Pointee: 407 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 407
+      ID: 409
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 406 GoStringDataType compress/flate.InternalError.str
+      Pointee: 408 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 882
+      ID: 884
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.243168e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 885 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 828
+      ID: 830
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 829 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 831 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 904
+      ID: 906
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.599296e+06
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 907 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 740
+      ID: 742
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.1176e+06
       GoKind: 22
-      Pointee: 741 StructureType context.deadlineExceededError
+      Pointee: 743 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 589
+      ID: 591
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853248
       GoKind: 22
-      Pointee: 418 BaseType crypto/aes.KeySizeError
+      Pointee: 420 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853440
       GoKind: 22
-      Pointee: 419 BaseType crypto/des.KeySizeError
+      Pointee: 421 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 894
+      ID: 896
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.37344e+06
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 897 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 919
+      ID: 921
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.678304e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 922 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 591
+      ID: 593
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 420 BaseType crypto/rc4.KeySizeError
+      Pointee: 422 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 927
+      ID: 929
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.769856e+06
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 930 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.678752e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 924 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 923
+      ID: 925
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.6792e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 926 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 515
+      ID: 517
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842592
       GoKind: 22
-      Pointee: 408 BaseType crypto/tls.AlertError
+      Pointee: 410 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 680
+      ID: 682
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.004288e+06
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 683 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1006
+      ID: 1008
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.230944e+06
       GoKind: 22
-      Pointee: 1007 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1009 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 513
+      ID: 515
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842400
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 516 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 511
+      ID: 513
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842304
       GoKind: 22
-      Pointee: 512 StructureType crypto/tls.RecordHeaderError
+      Pointee: 514 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 679
+      ID: 681
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.002624e+06
       GoKind: 22
-      Pointee: 636 BaseType crypto/tls.alert
+      Pointee: 638 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 892
+      ID: 894
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.37056e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 895 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.449632e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 902 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 775
+      ID: 777
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.243488e+06
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 778 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 790
+      ID: 792
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.905536e+06
       GoKind: 22
-      Pointee: 791 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 793 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 585
+      ID: 587
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 586 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 588 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 579
+      ID: 581
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851712
       GoKind: 22
-      Pointee: 580 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 582 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 581
+      ID: 583
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 851808
       GoKind: 22
-      Pointee: 582 StructureType crypto/x509.HostnameError
+      Pointee: 584 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851616
       GoKind: 22
-      Pointee: 417 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 419 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 685
+      ID: 687
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010176e+06
       GoKind: 22
-      Pointee: 686 StructureType crypto/x509.SystemRootsError
+      Pointee: 688 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 587
+      ID: 589
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852288
       GoKind: 22
-      Pointee: 588 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 590 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 583
+      ID: 585
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852096
       GoKind: 22
-      Pointee: 584 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 586 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 600
+      ID: 602
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 858816
       GoKind: 22
-      Pointee: 601 StructureType encoding/asn1.StructuralError
+      Pointee: 603 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 604
+      ID: 606
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859008
       GoKind: 22
-      Pointee: 605 StructureType encoding/asn1.SyntaxError
+      Pointee: 607 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 858912
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 605 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 501
+      ID: 503
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839232
       GoKind: 22
-      Pointee: 402 BaseType encoding/base64.CorruptInputError
+      Pointee: 404 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 850
+      ID: 852
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 999424
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 853 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 504
+      ID: 506
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840096
       GoKind: 22
-      Pointee: 403 BaseType encoding/hex.InvalidByteError
+      Pointee: 405 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 472
+      ID: 474
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 833952
       GoKind: 22
-      Pointee: 473 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 475 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 671
+      ID: 673
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995072
       GoKind: 22
-      Pointee: 672 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 674 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 464
+      ID: 466
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833568
       GoKind: 22
-      Pointee: 465 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 467 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 470
+      ID: 472
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 471 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 473 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 468
+      ID: 470
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 833760
       GoKind: 22
-      Pointee: 469 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 471 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 466
+      ID: 468
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833664
       GoKind: 22
-      Pointee: 467 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 469 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 986
+      ID: 988
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.147392e+06
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 989 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 474
+      ID: 476
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834336
       GoKind: 22
-      Pointee: 475 StructureType encoding/json.jsonError
+      Pointee: 477 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 858
+      ID: 860
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.012992e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 861 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 573
+      ID: 575
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 576 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 571
+      ID: 573
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850560
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 574 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 575
+      ID: 577
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 414 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 416 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 416
+      ID: 418
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 415 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 417 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 579 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 964
+      ID: 966
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.017344e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 967 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -4227,19 +4227,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 442
+      ID: 444
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824256
       GoKind: 22
-      Pointee: 443 UnresolvedPointeeType errors.errorString
+      Pointee: 445 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 979712
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType errors.joinError
+      Pointee: 641 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 101
       Name: '*float32'
@@ -4255,806 +4255,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 974
+      ID: 976
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.11312e+06
       GoKind: 22
-      Pointee: 975 UnresolvedPointeeType fmt.pp
+      Pointee: 977 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 981504
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType fmt.wrapError
+      Pointee: 643 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 642
+      ID: 644
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 981632
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 645 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 502
+      ID: 504
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839616
       GoKind: 22
-      Pointee: 503 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 505 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 483
+      ID: 485
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 484 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 486 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 485
+      ID: 487
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 488 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 802
+      ID: 804
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836544
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 805 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 489
+      ID: 491
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 492 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 804
+      ID: 806
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 807 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 487
+      ID: 489
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 22
-      Pointee: 396 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 398 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 398
+      ID: 400
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 397 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 399 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 482
+      ID: 484
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836448
       GoKind: 22
-      Pointee: 393 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 395 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 395
+      ID: 397
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 394 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 396 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 488
+      ID: 490
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 22
-      Pointee: 399 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 401 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 401
+      ID: 403
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 400 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 402 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.12336e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 875 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 952
+      ID: 954
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.920544e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 955 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857280
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 597 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 749
+      ID: 751
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.126688e+06
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 752 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 982
+      ID: 984
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.12336e+06
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 985 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 522
+      ID: 524
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846144
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 525 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 529
+      ID: 531
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847200
       GoKind: 22
-      Pointee: 530 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 532 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 846912
       GoKind: 22
-      Pointee: 413 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 415 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 527
+      ID: 529
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 22
-      Pointee: 528 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 530 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 525
+      ID: 527
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 22
-      Pointee: 526 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 528 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 545
+      ID: 547
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849120
       GoKind: 22
-      Pointee: 546 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 548 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 549
+      ID: 551
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849312
       GoKind: 22
-      Pointee: 550 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 552 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 547
+      ID: 549
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849216
       GoKind: 22
-      Pointee: 548 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 550 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 543
+      ID: 545
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849024
       GoKind: 22
-      Pointee: 544 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 546 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 821
+      ID: 823
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 820 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 822 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 557
+      ID: 559
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 22
-      Pointee: 558 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 560 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 551
+      ID: 553
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849408
       GoKind: 22
-      Pointee: 552 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 554 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 555
+      ID: 557
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849600
       GoKind: 22
-      Pointee: 556 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 558 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 553
+      ID: 555
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 22
-      Pointee: 554 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 556 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 849792
       GoKind: 22
-      Pointee: 560 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 562 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 565
+      ID: 567
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850080
       GoKind: 22
-      Pointee: 566 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 568 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 567
+      ID: 569
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850176
       GoKind: 22
-      Pointee: 568 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 570 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 563
+      ID: 565
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 849984
       GoKind: 22
-      Pointee: 564 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 566 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 561
+      ID: 563
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 849888
       GoKind: 22
-      Pointee: 562 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 564 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 569
+      ID: 571
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850368
       GoKind: 22
-      Pointee: 570 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 572 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 491
+      ID: 493
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838272
       GoKind: 22
-      Pointee: 492 StructureType github.com/cihub/seelog.baseError
+      Pointee: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 911
+      ID: 913
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.675392e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 914 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 493
+      ID: 495
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838368
       GoKind: 22
-      Pointee: 494 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 496 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 890
+      ID: 892
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.36944e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 893 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 846
+      ID: 848
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 998400
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 849 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 880
+      ID: 882
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.241248e+06
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 883 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 497
+      ID: 499
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838560
       GoKind: 22
-      Pointee: 498 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 500 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 942
+      ID: 944
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.838592e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 945 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 957
+      ID: 959
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.992e+06
       GoKind: 22
-      Pointee: 954 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 956 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 956
+      ID: 958
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.991616e+06
       GoKind: 22
-      Pointee: 955 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 957 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 848
+      ID: 850
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 998528
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 851 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838464
       GoKind: 22
-      Pointee: 496 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 498 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838656
       GoKind: 22
-      Pointee: 500 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 502 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 915
+      ID: 917
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.67696e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 948
+      ID: 950
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.874464e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 951 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 950
+      ID: 952
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.905216e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 953 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.255328e+06
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 783 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 693
+      ID: 695
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.024384e+06
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 696 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 691
+      ID: 693
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024256e+06
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 694 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 695
+      ID: 697
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.028352e+06
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 698 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 697
+      ID: 699
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.02848e+06
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 700 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.47728e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 904 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 687
+      ID: 689
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.010944e+06
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 690 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 505
+      ID: 507
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840288
       GoKind: 22
-      Pointee: 506 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 508 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 998
+      ID: 1000
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.210048e+06
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1001 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 751
+      ID: 753
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.13488e+06
       GoKind: 22
-      Pointee: 752 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 754 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 724
+      ID: 726
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.11376e+06
       GoKind: 22
-      Pointee: 725 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 727 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 718
+      ID: 720
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.113376e+06
       GoKind: 22
-      Pointee: 719 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 721 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 657
+      ID: 659
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 988928
       GoKind: 22
-      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 730
+      ID: 732
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114144e+06
       GoKind: 22
-      Pointee: 731 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 733 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 988800
       GoKind: 22
-      Pointee: 635 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 637 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 722
+      ID: 724
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.113632e+06
       GoKind: 22
-      Pointee: 723 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 725 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 720
+      ID: 722
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.113504e+06
       GoKind: 22
-      Pointee: 721 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 723 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 728
+      ID: 730
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114016e+06
       GoKind: 22
-      Pointee: 729 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 731 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 726
+      ID: 728
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.113888e+06
       GoKind: 22
-      Pointee: 727 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 729 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1002
+      ID: 1004
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.221088e+06
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1005 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 734
+      ID: 736
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.114528e+06
       GoKind: 22
-      Pointee: 735 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 737 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 661
+      ID: 663
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989184
       GoKind: 22
-      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 659
+      ID: 661
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989056
       GoKind: 22
-      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 732
+      ID: 734
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 733 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 735 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 870912
       GoKind: 22
-      Pointee: 425 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 427 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 427
+      ID: 429
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 426 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 428 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 793
+      ID: 795
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.475744e+06
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 796 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 701
+      ID: 703
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.043328e+06
       GoKind: 22
-      Pointee: 702 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 704 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 878
+      ID: 880
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.173792e+06
       GoKind: 22
-      Pointee: 879 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 881 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 962
+      ID: 964
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.006976e+06
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 965 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 864
+      ID: 866
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.045632e+06
       GoKind: 22
-      Pointee: 865 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 867 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 617
+      ID: 619
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872160
       GoKind: 22
-      Pointee: 428 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 430 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 759
+      ID: 761
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.175456e+06
       GoKind: 22
-      Pointee: 760 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 762 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 620
+      ID: 622
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872448
       GoKind: 22
-      Pointee: 621 StructureType golang.org/x/net/http2.connError
+      Pointee: 623 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872352
       GoKind: 22
-      Pointee: 432 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 434 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 434
+      ID: 436
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 433 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 435 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 623
+      ID: 625
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872640
       GoKind: 22
-      Pointee: 438 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 440 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 440
+      ID: 442
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 439 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 441 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 622
+      ID: 624
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872544
       GoKind: 22
-      Pointee: 435 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 437 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 437
+      ID: 439
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 436 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 438 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 618
+      ID: 620
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872256
       GoKind: 22
-      Pointee: 429 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 431 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 431
+      ID: 433
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 430 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 432 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 960
+      ID: 962
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.005056e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 963 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 624
+      ID: 626
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872736
       GoKind: 22
-      Pointee: 625 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 627 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 872832
       GoKind: 22
-      Pointee: 441 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 443 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866304
       GoKind: 22
-      Pointee: 613 StructureType google.golang.org/grpc.dropError
+      Pointee: 615 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.172384e+06
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 760 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.262688e+06
       GoKind: 22
-      Pointee: 783 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 785 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 614
+      ID: 616
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869184
       GoKind: 22
-      Pointee: 615 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 617 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.68368e+06
       GoKind: 22
-      Pointee: 926 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 928 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 876
+      ID: 878
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.168928e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 879 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 699
+      ID: 701
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.037568e+06
       GoKind: 22
-      Pointee: 700 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 702 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 836
+      ID: 838
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869280
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 839 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855168
       GoKind: 22
-      Pointee: 593 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 595 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 689
+      ID: 691
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.0144e+06
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 692 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 755
+      ID: 757
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.14064e+06
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 758 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 753
+      ID: 755
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.140384e+06
       GoKind: 22
-      Pointee: 754 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 756 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 606
+      ID: 608
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 859872
       GoKind: 22
-      Pointee: 607 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 609 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 608
+      ID: 610
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 22
-      Pointee: 609 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 611 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 537
+      ID: 539
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 540 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 913
+      ID: 915
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.676064e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 916 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 215
       Name: '*hash<[4]int,[4]int>'
@@ -5081,30 +5081,30 @@ Types:
       ByteSize: 8
       Pointee: 135 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1038
+      ID: 1040
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1039 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1041 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1066
+      ID: 1068
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1067 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1069 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1075
+      ID: 1077
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1076 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1078 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 158
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 159 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 1084
+      ID: 1086
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 1085 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1087 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 195
       Name: '*hash<int,uint8>'
@@ -5121,10 +5121,10 @@ Types:
       ByteSize: 8
       Pointee: 174 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 787 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 789 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 168
       Name: '*hash<string,int>'
@@ -5176,12 +5176,12 @@ Types:
       ByteSize: 8
       Pointee: 201 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 627
+      ID: 629
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873600
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType html/template.Error
+      Pointee: 630 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 93
       Name: '*int'
@@ -5225,82 +5225,82 @@ Types:
       GoKind: 22
       Pointee: 148 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840672
       GoKind: 22
-      Pointee: 508 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 510 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 822
+      ID: 824
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 828864
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 825 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 716
+      ID: 718
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.112608e+06
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 719 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1004
+      ID: 1006
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.22576e+06
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1007 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 714
+      ID: 716
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.11248e+06
       GoKind: 22
-      Pointee: 715 StructureType internal/poll.errNetClosing
+      Pointee: 717 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 444
+      ID: 446
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828000
       GoKind: 22
-      Pointee: 445 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 447 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 868
+      ID: 870
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.103648e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType io.PipeWriter
+      Pointee: 871 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 866
+      ID: 868
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.103264e+06
       GoKind: 22
-      Pointee: 867 StructureType io.discard
+      Pointee: 869 StructureType io.discard
     - __kind: PointerType
-      ID: 840
+      ID: 842
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 979968
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType io.multiWriter
+      Pointee: 843 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 712
+      ID: 714
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112224e+06
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType io/fs.PathError
+      Pointee: 715 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 917
+      ID: 919
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.677184e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 920 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 301
       Name: '*main.deepMap2'
@@ -5309,12 +5309,12 @@ Types:
       GoKind: 22
       Pointee: 302 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1043
+      ID: 1045
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType main.deepMap3
+      Pointee: 1046 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 140
       Name: '*main.deepMap7'
@@ -5323,19 +5323,19 @@ Types:
       GoKind: 22
       Pointee: 141 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1071
+      ID: 1073
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 355904
       GoKind: 22
-      Pointee: 1072 StructureType main.deepMap8
+      Pointee: 1074 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1080
+      ID: 1082
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355840
       GoKind: 22
-      Pointee: 1081 StructureType main.deepMap9
+      Pointee: 1083 StructureType main.deepMap9
     - __kind: PointerType
       ID: 122
       Name: '*main.deepPtr2'
@@ -5344,12 +5344,12 @@ Types:
       GoKind: 22
       Pointee: 123 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1008
+      ID: 1010
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1011 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 124
       Name: '*main.deepPtr7'
@@ -5358,19 +5358,19 @@ Types:
       GoKind: 22
       Pointee: 125 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1046
+      ID: 1048
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356480
       GoKind: 22
-      Pointee: 1047 StructureType main.deepPtr8
+      Pointee: 1049 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1048
+      ID: 1050
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356416
       GoKind: 22
-      Pointee: 1049 StructureType main.deepPtr9
+      Pointee: 1051 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 129
       Name: '*main.deepSlice2'
@@ -5379,12 +5379,12 @@ Types:
       GoKind: 22
       Pointee: 295 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1033
+      ID: 1035
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357376
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1036 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 130
       Name: '*main.deepSlice7'
@@ -5393,19 +5393,19 @@ Types:
       GoKind: 22
       Pointee: 131 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1052
+      ID: 1054
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357056
       GoKind: 22
-      Pointee: 1053 StructureType main.deepSlice8
+      Pointee: 1055 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1058
+      ID: 1060
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 356992
       GoKind: 22
-      Pointee: 1059 StructureType main.deepSlice9
+      Pointee: 1061 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 286
       Name: '*main.emptyStruct'
@@ -5420,12 +5420,12 @@ Types:
       GoKind: 22
       Pointee: 151 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 823968
       GoKind: 22
-      Pointee: 1025 StructureType main.firstBehavior
+      Pointee: 1027 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 223
       Name: '*main.node'
@@ -5440,19 +5440,19 @@ Types:
       GoKind: 22
       Pointee: 238 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1026
+      ID: 1028
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824064
       GoKind: 22
-      Pointee: 1027 StructureType main.secondBehavior
+      Pointee: 1029 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1013
+      ID: 1015
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824160
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1016 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 142
       Name: '*main.stringType1'
@@ -5460,16 +5460,16 @@ Types:
       GoKind: 22
       Pointee: 143 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1011
+      ID: 1013
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1010 GoStringDataType main.stringType1.str
+      Pointee: 1012 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 145
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType main.stringType2
+      Pointee: 1014 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 241
       Name: '*main.structWithCyclicSlices'
@@ -5500,10 +5500,10 @@ Types:
       GoKind: 22
       Pointee: 225 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1030
+      ID: 1032
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1029 GoSliceDataType main.t.array
+      Pointee: 1031 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 236
       Name: '*main.threeStringStruct'
@@ -5517,554 +5517,554 @@ Types:
       GoKind: 22
       Pointee: 167 GoMapType map[string]int
     - __kind: PointerType
-      ID: 541
+      ID: 543
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848448
       GoKind: 22
-      Pointee: 542 StructureType math/big.ErrNaN
+      Pointee: 544 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 830
+      ID: 832
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843072
       GoKind: 22
-      Pointee: 831 StructureType mime/multipart.writerOnly·1
+      Pointee: 833 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 743
+      ID: 745
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.120928e+06
       GoKind: 22
-      Pointee: 744 UnresolvedPointeeType net.AddrError
+      Pointee: 746 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 769
+      ID: 771
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.239488e+06
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType net.DNSError
+      Pointee: 772 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 968
+      ID: 970
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.085792e+06
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType net.IPConn
+      Pointee: 971 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 767
+      ID: 769
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.239168e+06
       GoKind: 22
-      Pointee: 768 UnresolvedPointeeType net.OpError
+      Pointee: 770 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 745
+      ID: 747
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121056e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType net.ParseError
+      Pointee: 748 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 978
+      ID: 980
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.115168e+06
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType net.TCPConn
+      Pointee: 981 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 988
+      ID: 990
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.160128e+06
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType net.UDPConn
+      Pointee: 991 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 976
+      ID: 978
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.114656e+06
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType net.UnixConn
+      Pointee: 979 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 742
+      ID: 744
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.12016e+06
       GoKind: 22
-      Pointee: 705 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 707 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 706 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 708 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 673
+      ID: 675
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 995840
       GoKind: 22
-      Pointee: 674 StructureType net.canceledError
+      Pointee: 676 StructureType net.canceledError
     - __kind: PointerType
-      ID: 946
+      ID: 948
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.87216e+06
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType net.conn
+      Pointee: 949 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.716384e+06
       GoKind: 22
-      Pointee: 812 StructureType net.dialResult·1
+      Pointee: 814 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 990
+      ID: 992
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.164384e+06
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType net.netFD
+      Pointee: 993 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 476
+      ID: 478
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835296
       GoKind: 22
-      Pointee: 477 UnresolvedPointeeType net.notFoundError
+      Pointee: 479 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 478
+      ID: 480
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 835968
       GoKind: 22
-      Pointee: 479 StructureType net.result·2
+      Pointee: 481 StructureType net.result·2
     - __kind: PointerType
-      ID: 972
+      ID: 974
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.09968e+06
       GoKind: 22
-      Pointee: 973 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 975 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 970
+      ID: 972
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.0992e+06
       GoKind: 22
-      Pointee: 971 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 973 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.121696e+06
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType net.temporaryError
+      Pointee: 750 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 771
+      ID: 773
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.239648e+06
       GoKind: 22
-      Pointee: 772 UnresolvedPointeeType net.timeoutError
+      Pointee: 774 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 663
+      ID: 665
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 991616
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 666 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 824
+      ID: 826
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831168
       GoKind: 22
-      Pointee: 825 StructureType net/http.bufioFlushWriter
+      Pointee: 827 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 453
+      ID: 455
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 831840
       GoKind: 22
-      Pointee: 374 BaseType net/http.http2ConnectionError
+      Pointee: 376 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 454
+      ID: 456
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 831936
       GoKind: 22
-      Pointee: 455 StructureType net/http.http2GoAwayError
+      Pointee: 457 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 763
+      ID: 765
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.235328e+06
       GoKind: 22
-      Pointee: 764 StructureType net/http.http2StreamError
+      Pointee: 766 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 458
+      ID: 460
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832416
       GoKind: 22
-      Pointee: 459 StructureType net/http.http2connError
+      Pointee: 461 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 886
+      ID: 888
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.36608e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 889 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 457
+      ID: 459
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832320
       GoKind: 22
-      Pointee: 378 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 380 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 380
+      ID: 382
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 379 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 381 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 461
+      ID: 463
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832608
       GoKind: 22
-      Pointee: 384 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 386 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 386
+      ID: 388
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 385 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 387 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 460
+      ID: 462
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832512
       GoKind: 22
-      Pointee: 381 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 383 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 383
+      ID: 385
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 382 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 384 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 738
+      ID: 740
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.116704e+06
       GoKind: 22
-      Pointee: 739 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 741 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 669
+      ID: 671
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992256
       GoKind: 22
-      Pointee: 670 StructureType net/http.http2noCachedConnError
+      Pointee: 672 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 937
+      ID: 939
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.81616e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 940 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 456
+      ID: 458
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832224
       GoKind: 22
-      Pointee: 375 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 377 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 377
+      ID: 379
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 376 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 378 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 826
+      ID: 828
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832704
       GoKind: 22
-      Pointee: 827 StructureType net/http.http2stickyErrWriter
+      Pointee: 829 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 665
+      ID: 667
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 991872
       GoKind: 22
-      Pointee: 666 StructureType net/http.nothingWrittenError
+      Pointee: 668 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 888
+      ID: 890
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.030112e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType net/http.persistConn
+      Pointee: 891 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 844
+      ID: 846
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 991744
       GoKind: 22
-      Pointee: 845 StructureType net/http.persistConnWriter
+      Pointee: 847 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.11568e+06
       GoKind: 22
-      Pointee: 871 StructureType net/http.readWriteCloserBody
+      Pointee: 873 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 462
+      ID: 464
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 832800
       GoKind: 22
-      Pointee: 463 StructureType net/http.requestBodyReadError
+      Pointee: 465 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 765
+      ID: 767
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.236448e+06
       GoKind: 22
-      Pointee: 766 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 768 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 736
+      ID: 738
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.116576e+06
       GoKind: 22
-      Pointee: 737 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 739 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 667
+      ID: 669
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992000
       GoKind: 22
-      Pointee: 668 StructureType net/http.transportReadFromServerError
+      Pointee: 670 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 451
+      ID: 453
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831072
       GoKind: 22
-      Pointee: 452 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 454 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 939
+      ID: 941
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.817696e+06
       GoKind: 22
-      Pointee: 940 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 942 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 854
+      ID: 856
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.005312e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 857 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 533
+      ID: 535
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847392
       GoKind: 22
-      Pointee: 534 StructureType net/netip.parseAddrError
+      Pointee: 536 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 531
+      ID: 533
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847296
       GoKind: 22
-      Pointee: 532 StructureType net/netip.parsePrefixError
+      Pointee: 534 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 896
+      ID: 898
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.979776e+06
       GoKind: 22
-      Pointee: 897 UnresolvedPointeeType net/smtp.Client
+      Pointee: 899 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 856
+      ID: 858
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.010432e+06
       GoKind: 22
-      Pointee: 857 StructureType net/smtp.dataCloser
+      Pointee: 859 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 517
+      ID: 519
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843264
       GoKind: 22
-      Pointee: 518 UnresolvedPointeeType net/textproto.Error
+      Pointee: 520 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 516
+      ID: 518
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843168
       GoKind: 22
-      Pointee: 409 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 411 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 411
+      ID: 413
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 410 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 412 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 852
+      ID: 854
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.004672e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 855 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 773
+      ID: 775
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.239968e+06
       GoKind: 22
-      Pointee: 774 UnresolvedPointeeType net/url.Error
+      Pointee: 776 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 480
+      ID: 482
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836064
       GoKind: 22
-      Pointee: 387 GoStringHeaderType net/url.EscapeError
+      Pointee: 389 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 389
+      ID: 391
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 388 GoStringDataType net/url.EscapeError.str
+      Pointee: 390 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 481
+      ID: 483
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836160
       GoKind: 22
-      Pointee: 390 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 392 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 392
+      ID: 394
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 391 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 393 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 996
+      ID: 998
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.201632e+06
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType os.File
+      Pointee: 999 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 982784
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType os.LinkError
+      Pointee: 647 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 708
+      ID: 710
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105184e+06
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType os.SyscallError
+      Pointee: 711 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 994
+      ID: 996
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.198688e+06
       GoKind: 22
-      Pointee: 995 StructureType os.fileWithoutReadFrom
+      Pointee: 997 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 992
+      ID: 994
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.197952e+06
       GoKind: 22
-      Pointee: 993 StructureType os.fileWithoutWriteTo
+      Pointee: 995 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001344e+06
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType os/exec.Error
+      Pointee: 678 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 814
+      ID: 816
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.951744e+06
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 817 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.127712e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 877 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 677
+      ID: 679
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.001472e+06
       GoKind: 22
-      Pointee: 678 StructureType os/exec.wrappedError
+      Pointee: 680 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 611
+      ID: 613
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864384
       GoKind: 22
-      Pointee: 422 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 424 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 424
+      ID: 426
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 423 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 425 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 610
+      ID: 612
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864288
       GoKind: 22
-      Pointee: 421 BaseType os/user.UnknownUserIdError
+      Pointee: 423 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 446
+      ID: 448
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 828768
       GoKind: 22
-      Pointee: 447 UnresolvedPointeeType reflect.ValueError
+      Pointee: 449 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 539
+      ID: 541
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848064
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 542 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 647
+      ID: 649
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984320
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 650 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 652
+      ID: 654
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986240
       GoKind: 22
-      Pointee: 653 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 655 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -6080,12 +6080,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 649
+      ID: 651
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 984448
       GoKind: 22
-      Pointee: 650 StructureType runtime.boundsError
+      Pointee: 652 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
@@ -6101,24 +6101,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 710
+      ID: 712
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.11056e+06
       GoKind: 22
-      Pointee: 711 StructureType runtime.errorAddressString
+      Pointee: 713 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984064
       GoKind: 22
-      Pointee: 629 GoStringHeaderType runtime.errorString
+      Pointee: 631 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 631
+      ID: 633
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 630 GoStringDataType runtime.errorString.str
+      Pointee: 632 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
@@ -6141,17 +6141,17 @@ Types:
       GoKind: 22
       Pointee: 139 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 651
+      ID: 653
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 985984
       GoKind: 22
-      Pointee: 632 GoStringHeaderType runtime.plainError
+      Pointee: 634 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 634
+      ID: 636
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 633 GoStringDataType runtime.plainError.str
+      Pointee: 635 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -6174,12 +6174,12 @@ Types:
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 986496
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType strconv.NumError
+      Pointee: 657 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
@@ -6193,73 +6193,73 @@ Types:
       ByteSize: 8
       Pointee: 287 GoStringDataType string.str
     - __kind: PointerType
-      ID: 935
+      ID: 937
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.81488e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType strings.Builder
+      Pointee: 938 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 842
+      ID: 844
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 986624
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 845 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 838
+      ID: 840
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 839 StructureType struct { io.Writer }
+      Pointee: 841 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 762
+      ID: 764
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.234688e+06
       GoKind: 22
-      Pointee: 761 BaseType syscall.Errno
+      Pointee: 763 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 966
+      ID: 968
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.017728e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 969 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 703
+      ID: 705
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.047168e+06
       GoKind: 22
-      Pointee: 704 StructureType text/template.ExecError
+      Pointee: 706 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.4312e+06
       GoKind: 22
-      Pointee: 779 UnresolvedPointeeType time.Location
+      Pointee: 781 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 449
+      ID: 451
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829632
       GoKind: 22
-      Pointee: 450 UnresolvedPointeeType time.ParseError
+      Pointee: 452 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 448
+      ID: 450
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829536
       GoKind: 22
-      Pointee: 371 GoStringHeaderType time.fileSizeError
+      Pointee: 373 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 373
+      ID: 375
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 372 GoStringDataType time.fileSizeError.str
+      Pointee: 374 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -6303,54 +6303,54 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.771136e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 932 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 535
+      ID: 537
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847488
       GoKind: 22
-      Pointee: 536 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 538 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 958
+      ID: 960
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.994304e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 961 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 519
+      ID: 521
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843648
       GoKind: 22
-      Pointee: 520 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 522 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 521
+      ID: 523
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 843744
       GoKind: 22
-      Pointee: 412 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 414 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 682
+      ID: 684
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005056e+06
       GoKind: 22
-      Pointee: 683 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 685 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 684
+      ID: 686
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005184e+06
       GoKind: 22
-      Pointee: 637 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 639 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1191
       Name: Probe[main.stackC]
@@ -8449,7 +8449,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 806
+      ID: 808
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 624000
@@ -8508,7 +8508,7 @@ Types:
       ByteSize: 8
       Element: 129 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1031
+      ID: 1033
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446848
@@ -8516,22 +8516,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1032 PointerType **main.deepSlice3
+          Type: 1034 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1035 GoSliceDataType []*main.deepSlice3.array
+      Data: 1037 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1035
+      ID: 1037
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1033 PointerType *main.deepSlice3
+      Element: 1035 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1050
+      ID: 1052
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446528
@@ -8539,22 +8539,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1051 PointerType **main.deepSlice8
+          Type: 1053 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1054 GoSliceDataType []*main.deepSlice8.array
+      Data: 1056 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1054
+      ID: 1056
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1052 PointerType *main.deepSlice8
+      Element: 1054 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1056
+      ID: 1058
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446464
@@ -8562,20 +8562,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1057 PointerType **main.deepSlice9
+          Type: 1059 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1060 GoSliceDataType []*main.deepSlice9.array
+      Data: 1062 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1060
+      ID: 1062
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1058 PointerType *main.deepSlice9
+      Element: 1060 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 118
       Name: '[]*string'
@@ -8785,23 +8785,23 @@ Types:
       ByteSize: 144
       Element: 137 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1045
+      ID: 1047
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1041 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1043 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1073
+      ID: 1075
       Name: '[]bucket<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1069 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1071 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1082
+      ID: 1084
       Name: '[]bucket<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1078 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1080 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 305
       Name: '[]bucket<int,int>.array'
@@ -8809,11 +8809,11 @@ Types:
       ByteSize: 144
       Element: 161 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 1089
+      ID: 1091
       Name: '[]bucket<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 1087 GoHMapBucketType bucket<int,interface {}>
+      Element: 1089 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
       ID: 324
       Name: '[]bucket<int,uint8>.array'
@@ -8833,11 +8833,11 @@ Types:
       ByteSize: 336
       Element: 176 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 817
+      ID: 819
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 789 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 791 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 309
       Name: '[]bucket<string,int>.array'
@@ -8899,7 +8899,7 @@ Types:
       ByteSize: 32
       Element: 203 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 801
+      ID: 803
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454080
@@ -8914,15 +8914,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 818 GoSliceDataType []float64.array
+      Data: 820 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 818
+      ID: 820
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1062
+      ID: 1064
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454528
@@ -8937,9 +8937,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1063 GoSliceDataType []interface {}.array
+      Data: 1065 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1063
+      ID: 1065
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -9030,9 +9030,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1090 GoSliceDataType []main.structWithMap.array
+      Data: 371 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1090
+      ID: 371
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -9186,26 +9186,26 @@ Types:
       HasCount: true
       Element: 301 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1042
+      ID: 1044
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1043 PointerType *main.deepMap3
+      Element: 1045 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 1070
+      ID: 1072
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1071 PointerType *main.deepMap8
+      Element: 1073 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 1079
+      ID: 1081
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1080 PointerType *main.deepMap9
+      Element: 1082 PointerType *main.deepMap9
     - __kind: ArrayType
       ID: 314
       Name: '[]val<[2]int>'
@@ -9235,12 +9235,12 @@ Types:
       HasCount: true
       Element: 232 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 816
+      ID: 818
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 808 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 810 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
       ID: 304
       Name: '[]val<int>'
@@ -9249,7 +9249,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1088
+      ID: 1090
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
@@ -9319,11 +9319,11 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 947
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 597
+      ID: 599
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858432
@@ -9338,33 +9338,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 598 GoSliceDataType archive/tar.headerError.array
+      Data: 600 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 598
+      ID: 600
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 887
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 835
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 837
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.078272e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 934
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 861
+      ID: 863
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.37616e+06
@@ -9374,7 +9374,7 @@ Types:
           Offset: 0
           Type: 120 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 865
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9479,7 +9479,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 301 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1041
+      ID: 1043
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
@@ -9491,14 +9491,14 @@ Types:
           Type: 299 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1042 ArrayType []val<*main.deepMap3>
+          Type: 1044 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1040 PointerType *bucket<int,*main.deepMap3>
+          Type: 1042 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 1043 PointerType *main.deepMap3
+      ValueType: 1045 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 1069
+      ID: 1071
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
@@ -9510,14 +9510,14 @@ Types:
           Type: 299 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1070 ArrayType []val<*main.deepMap8>
+          Type: 1072 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 1068 PointerType *bucket<int,*main.deepMap8>
+          Type: 1070 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 1071 PointerType *main.deepMap8
+      ValueType: 1073 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 1078
+      ID: 1080
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
@@ -9529,12 +9529,12 @@ Types:
           Type: 299 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1079 ArrayType []val<*main.deepMap9>
+          Type: 1081 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 1077 PointerType *bucket<int,*main.deepMap9>
+          Type: 1079 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 1080 PointerType *main.deepMap9
+      ValueType: 1082 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 161
       Name: bucket<int,int>
@@ -9555,7 +9555,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 1087
+      ID: 1089
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
@@ -9567,10 +9567,10 @@ Types:
           Type: 299 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1088 ArrayType []val<interface {}>
+          Type: 1090 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 1086 PointerType *bucket<int,interface {}>
+          Type: 1088 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 148 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -9631,7 +9631,7 @@ Types:
       KeyType: 11 GoStringHeaderType string
       ValueType: 232 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 789
+      ID: 791
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
@@ -9643,12 +9643,12 @@ Types:
           Type: 306 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 816 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 818 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 788 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 790 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 808 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 810 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 171
       Name: bucket<string,int>
@@ -9840,15 +9840,15 @@ Types:
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 911
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 936
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 981
+      ID: 983
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9874,13 +9874,13 @@ Types:
       GoRuntimeType: 532064
       GoKind: 15
     - __kind: BaseType
-      ID: 404
+      ID: 406
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764544
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 405
+      ID: 407
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764640
@@ -9888,92 +9888,92 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 407 PointerType *compress/flate.InternalError.str
+          Type: 409 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 406 GoStringDataType compress/flate.InternalError.str
+      Data: 408 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 406
+      ID: 408
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 885
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 829
+      ID: 831
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 907
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 741
+      ID: 743
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296096e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 418
+      ID: 420
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767136
       GoKind: 2
     - __kind: BaseType
-      ID: 419
+      ID: 421
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767232
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 897
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 922
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 420
+      ID: 422
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767328
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 930
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 926
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 408
+      ID: 410
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765120
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 683
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1007
+      ID: 1009
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 516
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 512
+      ID: 514
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.60448e+06
@@ -9984,34 +9984,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 806 ArrayType [5]uint8
+          Type: 808 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 807 GoInterfaceType net.Conn
+          Type: 809 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 636
+      ID: 638
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951296
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 895
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 902
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 778
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 791
+      ID: 793
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 586
+      ID: 588
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.607552e+06
@@ -10019,21 +10019,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 790 PointerType *crypto/x509.Certificate
+          Type: 792 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 809 BaseType crypto/x509.InvalidReason
+          Type: 811 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 580
+      ID: 582
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.075584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 582
+      ID: 584
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.408512e+06
@@ -10041,24 +10041,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 790 PointerType *crypto/x509.Certificate
+          Type: 792 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 417
+      ID: 419
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 766752
       GoKind: 2
     - __kind: BaseType
-      ID: 809
+      ID: 811
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537568
       GoKind: 2
     - __kind: StructureType
-      ID: 686
+      ID: 688
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.37248e+06
@@ -10068,13 +10068,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 588
+      ID: 590
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.07584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 584
+      ID: 586
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.60736e+06
@@ -10082,15 +10082,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 790 PointerType *crypto/x509.Certificate
+          Type: 792 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 790 PointerType *crypto/x509.Certificate
+          Type: 792 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 601
+      ID: 603
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.253568e+06
@@ -10100,7 +10100,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 605
+      ID: 607
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.253728e+06
@@ -10110,55 +10110,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 605
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 402
+      ID: 404
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764160
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 853
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 403
+      ID: 405
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764352
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 473
+      ID: 475
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 672
+      ID: 674
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 465
+      ID: 467
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 471
+      ID: 473
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 469
+      ID: 471
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 467
+      ID: 469
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 989
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 475
+      ID: 477
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.238208e+06
@@ -10168,19 +10168,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 861
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 576
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 574
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 414
+      ID: 416
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766656
@@ -10188,22 +10188,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 416 PointerType *encoding/xml.UnmarshalError.str
+          Type: 418 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 415 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 417 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 415
+      ID: 417
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 579
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 967
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -10220,11 +10220,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 443
+      ID: 445
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 641
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -10240,15 +10240,15 @@ Types:
       GoRuntimeType: 532256
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 975
+      ID: 977
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 643
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 645
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -10264,11 +10264,11 @@ Types:
       GoRuntimeType: 777888
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 503
+      ID: 505
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 484
+      ID: 486
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.602752e+06
@@ -10276,7 +10276,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 799 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 801 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -10284,25 +10284,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 488
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 805
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 490
+      ID: 492
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 807
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 396
+      ID: 398
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763584
@@ -10310,18 +10310,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 398 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 400 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 397 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 399 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 397
+      ID: 399
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 799
+      ID: 801
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.073568e+06
@@ -10329,7 +10329,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 800 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 802 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -10344,7 +10344,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 801 GoSliceHeaderType []float64
+          Type: 803 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -10353,10 +10353,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 802 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 804 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 804 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 806 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 232 GoSliceHeaderType []string
@@ -10370,13 +10370,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 800
+      ID: 802
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534112
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 393
+      ID: 395
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763488
@@ -10384,18 +10384,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 395 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 397 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 394 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 396 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 394
+      ID: 396
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 399
+      ID: 401
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763680
@@ -10403,60 +10403,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 401 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 403 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 400 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 402 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 400
+      ID: 402
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 875
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 955
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 597
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 752
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 985
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 525
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 530
+      ID: 532
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.074816e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 413
+      ID: 415
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 765792
       GoKind: 2
     - __kind: StructureType
-      ID: 528
+      ID: 530
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.074688e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 526
+      ID: 528
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.406592e+06
@@ -10469,7 +10469,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 546
+      ID: 548
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.407392e+06
@@ -10482,7 +10482,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 550
+      ID: 552
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.606784e+06
@@ -10498,7 +10498,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 548
+      ID: 550
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.247968e+06
@@ -10508,7 +10508,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 544
+      ID: 546
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.247648e+06
@@ -10518,14 +10518,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 785
+      ID: 787
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135136e+06
       GoKind: 21
-      HeaderType: 787 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 789 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 808
+      ID: 810
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.008768e+06
@@ -10540,15 +10540,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 820 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 822 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 820
+      ID: 822
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 558
+      ID: 560
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.407712e+06
@@ -10556,12 +10556,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 785 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 787 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 785 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 787 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 552
+      ID: 554
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.248128e+06
@@ -10571,7 +10571,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 556
+      ID: 558
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.606976e+06
@@ -10582,12 +10582,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 808 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 810 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 808 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 810 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 554
+      ID: 556
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.407552e+06
@@ -10600,7 +10600,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 560
+      ID: 562
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.248288e+06
@@ -10608,9 +10608,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 777 StructureType time.Time
+          Type: 779 StructureType time.Time
     - __kind: StructureType
-      ID: 566
+      ID: 568
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.408032e+06
@@ -10623,7 +10623,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 568
+      ID: 570
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.248608e+06
@@ -10633,7 +10633,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 564
+      ID: 566
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.407872e+06
@@ -10646,7 +10646,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 562
+      ID: 564
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.248448e+06
@@ -10656,7 +10656,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 570
+      ID: 572
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.408192e+06
@@ -10669,7 +10669,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 492
+      ID: 494
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.240448e+06
@@ -10679,11 +10679,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 914
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 494
+      ID: 496
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.240608e+06
@@ -10691,21 +10691,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 492 StructureType github.com/cihub/seelog.baseError
+          Type: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 893
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 849
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 883
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 498
+      ID: 500
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.240928e+06
@@ -10713,13 +10713,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 492 StructureType github.com/cihub/seelog.baseError
+          Type: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 945
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 954
+      ID: 956
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.96784e+06
@@ -10727,12 +10727,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 942 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 944 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 955
+      ID: 957
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.991232e+06
@@ -10740,7 +10740,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 942 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 944 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -10748,11 +10748,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 851
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 496
+      ID: 498
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.240768e+06
@@ -10760,9 +10760,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 492 StructureType github.com/cihub/seelog.baseError
+          Type: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 500
+      ID: 502
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.241088e+06
@@ -10770,64 +10770,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 492 StructureType github.com/cihub/seelog.baseError
+          Type: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 918
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 951
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 953
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 783
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 696
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 694
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 698
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 700
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 690
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 506
+      ID: 508
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.242048e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1001
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 752
+      ID: 754
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 725
+      ID: 727
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.711456e+06
@@ -10843,11 +10843,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 719
+      ID: 721
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 658
+      ID: 660
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.509248e+06
@@ -10860,7 +10860,7 @@ Types:
           Offset: 1
           Type: 14 BaseType int8
     - __kind: StructureType
-      ID: 731
+      ID: 733
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.711904e+06
@@ -10876,13 +10876,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 635
+      ID: 637
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 948704
       GoKind: 8
     - __kind: StructureType
-      ID: 723
+      ID: 725
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.711232e+06
@@ -10898,13 +10898,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 810
+      ID: 812
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 761760
       GoKind: 8
     - __kind: StructureType
-      ID: 721
+      ID: 723
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.711008e+06
@@ -10912,15 +10912,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 810 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 812 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 810 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 812 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 729
+      ID: 731
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.6296e+06
@@ -10933,7 +10933,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 727
+      ID: 729
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.71168e+06
@@ -10949,11 +10949,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1005
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 735
+      ID: 737
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.43216e+06
@@ -10963,19 +10963,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 664
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.194976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 660
+      ID: 662
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.194848e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 733
+      ID: 735
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.629792e+06
@@ -10988,7 +10988,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 425
+      ID: 427
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769152
@@ -10996,22 +10996,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 427 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 429 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 426 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 428 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 426
+      ID: 428
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 796
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 704
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.265408e+06
@@ -11021,7 +11021,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 879
+      ID: 881
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.486112e+06
@@ -11029,13 +11029,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 903 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 905 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 965
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 903
+      ID: 905
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.085696e+06
@@ -11048,7 +11048,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 865
+      ID: 867
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.38096e+06
@@ -11058,19 +11058,19 @@ Types:
           Offset: 0
           Type: 120 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 428
+      ID: 430
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769728
       GoKind: 10
     - __kind: BaseType
-      ID: 792
+      ID: 794
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 961952
       GoKind: 10
     - __kind: StructureType
-      ID: 760
+      ID: 762
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.749984e+06
@@ -11081,12 +11081,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 792 BaseType golang.org/x/net/http2.ErrCode
+          Type: 794 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 621
+      ID: 623
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.415392e+06
@@ -11094,12 +11094,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 792 BaseType golang.org/x/net/http2.ErrCode
+          Type: 794 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 432
+      ID: 434
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769920
@@ -11107,18 +11107,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 434 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 436 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 433 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 435 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 433
+      ID: 435
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 438
+      ID: 440
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770112
@@ -11126,18 +11126,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 440 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 442 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 439 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 441 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 439
+      ID: 441
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 435
+      ID: 437
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770016
@@ -11145,18 +11145,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 437 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 439 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 436 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 438 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 436
+      ID: 438
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 429
+      ID: 431
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769824
@@ -11164,22 +11164,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 431 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 433 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 430 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 432 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 430
+      ID: 432
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 963
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 625
+      ID: 627
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.266048e+06
@@ -11189,13 +11189,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 441
+      ID: 443
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770208
       GoKind: 2
     - __kind: StructureType
-      ID: 613
+      ID: 615
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.261088e+06
@@ -11205,11 +11205,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 760
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 783
+      ID: 785
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.775744e+06
@@ -11225,7 +11225,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 615
+      ID: 617
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.414912e+06
@@ -11238,7 +11238,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 926
+      ID: 928
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.829216e+06
@@ -11246,16 +11246,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 807 GoInterfaceType net.Conn
+          Type: 809 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 941 GoInterfaceType io.Reader
+          Type: 943 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 879
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 700
+      ID: 702
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.37856e+06
@@ -11265,29 +11265,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 839
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 593
+      ID: 595
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 692
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 758
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 754
+      ID: 756
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.325696e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 607
+      ID: 609
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.254368e+06
@@ -11297,7 +11297,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 609
+      ID: 611
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.254528e+06
@@ -11307,11 +11307,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 540
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 916
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -11485,7 +11485,7 @@ Types:
       BucketType: 137 GoHMapBucketType bucket<int,*main.deepMap2>
       BucketsType: 303 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1039
+      ID: 1041
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -11506,20 +11506,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1040 PointerType *bucket<int,*main.deepMap3>
+          Type: 1042 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1040 PointerType *bucket<int,*main.deepMap3>
+          Type: 1042 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 1041 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1045 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1043 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1047 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 1067
+      ID: 1069
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -11540,20 +11540,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1068 PointerType *bucket<int,*main.deepMap8>
+          Type: 1070 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 1068 PointerType *bucket<int,*main.deepMap8>
+          Type: 1070 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 1069 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 1073 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1071 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1075 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 1076
+      ID: 1078
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -11574,18 +11574,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1077 PointerType *bucket<int,*main.deepMap9>
+          Type: 1079 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 1077 PointerType *bucket<int,*main.deepMap9>
+          Type: 1079 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 1078 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 1082 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1080 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1084 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 159
       Name: hash<int,int>
@@ -11621,7 +11621,7 @@ Types:
       BucketType: 161 GoHMapBucketType bucket<int,int>
       BucketsType: 305 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 1085
+      ID: 1087
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -11642,18 +11642,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1086 PointerType *bucket<int,interface {}>
+          Type: 1088 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 1086 PointerType *bucket<int,interface {}>
+          Type: 1088 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 1087 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 1089 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1089 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1091 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 196
       Name: hash<int,uint8>
@@ -11757,7 +11757,7 @@ Types:
       BucketType: 176 GoHMapBucketType bucket<string,[]string>
       BucketsType: 311 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 787
+      ID: 789
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -11778,18 +11778,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 788 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 790 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 788 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 790 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 789 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 817 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 791 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 819 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 169
       Name: hash<string,int>
@@ -12131,7 +12131,7 @@ Types:
       BucketType: 203 GoHMapBucketType bucket<uint8,uint8>
       BucketsType: 326 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 630
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -12178,7 +12178,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 508
+      ID: 510
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -12204,25 +12204,25 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 825
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 719
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1007
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 715
+      ID: 717
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293056e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 445
+      ID: 447
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -12303,11 +12303,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 871
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 910
+      ID: 912
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.103392e+06
@@ -12320,7 +12320,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 941
+      ID: 943
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 980096
@@ -12333,7 +12333,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 898
+      ID: 900
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.068416e+06
@@ -12359,21 +12359,21 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 867
+      ID: 869
       Name: io.discard
       GoRuntimeType: 1.280416e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 843
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 715
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 920
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -12441,9 +12441,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1037 GoMapType map[int]*main.deepMap3
+          Type: 1039 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1046
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -12455,9 +12455,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1065 GoMapType map[int]*main.deepMap8
+          Type: 1067 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1072
+      ID: 1074
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.099168e+06
@@ -12465,9 +12465,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1074 GoMapType map[int]*main.deepMap9
+          Type: 1076 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1081
+      ID: 1083
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.09904e+06
@@ -12475,7 +12475,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1083 GoMapType map[int]interface {}
+          Type: 1085 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 121
       Name: main.deepPtr1
@@ -12495,9 +12495,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1008 PointerType *main.deepPtr3
+          Type: 1010 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1011
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -12509,9 +12509,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1046 PointerType *main.deepPtr8
+          Type: 1048 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1047
+      ID: 1049
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.10032e+06
@@ -12519,9 +12519,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1048 PointerType *main.deepPtr9
+          Type: 1050 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1049
+      ID: 1051
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.100192e+06
@@ -12549,9 +12549,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1031 GoSliceHeaderType []*main.deepSlice3
+          Type: 1033 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1036
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -12563,9 +12563,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1050 GoSliceHeaderType []*main.deepSlice8
+          Type: 1052 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1053
+      ID: 1055
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.101472e+06
@@ -12573,9 +12573,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1056 GoSliceHeaderType []*main.deepSlice9
+          Type: 1058 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1059
+      ID: 1061
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101344e+06
@@ -12583,7 +12583,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1062 GoSliceHeaderType []interface {}
+          Type: 1064 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 285
       Name: main.emptyStruct
@@ -12601,16 +12601,16 @@ Types:
           Type: 146 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1015 StructureType sync.Mutex
+          Type: 1017 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1016 StructureType sync.Once
+          Type: 1018 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1019 StructureType sync.WaitGroup
+          Type: 1021 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1023 StructureType sync/atomic.Int32
+          Type: 1025 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 146
       Name: main.esotericStack
@@ -12640,7 +12640,7 @@ Types:
           Offset: 56
           Type: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1025
+      ID: 1027
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.231488e+06
@@ -12685,7 +12685,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1027
+      ID: 1029
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.231648e+06
@@ -12705,7 +12705,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1016
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12716,18 +12716,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1011 PointerType *main.stringType1.str
+          Type: 1013 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1010 GoStringDataType main.stringType1.str
+      Data: 1012 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1010
+      ID: 1012
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1014
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -12830,16 +12830,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1028 PointerType **main.t
+          Type: 1030 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1029 GoSliceDataType main.t.array
+      Data: 1031 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1029
+      ID: 1031
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -12900,26 +12900,26 @@ Types:
       GoKind: 21
       HeaderType: 135 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1037
+      ID: 1039
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879744
       GoKind: 21
-      HeaderType: 1039 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1041 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1065
+      ID: 1067
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879264
       GoKind: 21
-      HeaderType: 1067 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1069 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1074
+      ID: 1076
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879168
       GoKind: 21
-      HeaderType: 1076 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1078 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 157
       Name: map[int]int
@@ -12928,12 +12928,12 @@ Types:
       GoKind: 21
       HeaderType: 159 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 1083
+      ID: 1085
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879072
       GoKind: 21
-      HeaderType: 1085 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1087 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 194
       Name: map[int]uint8
@@ -13020,7 +13020,7 @@ Types:
       GoKind: 21
       HeaderType: 201 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 542
+      ID: 544
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.247328e+06
@@ -13030,7 +13030,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 831
+      ID: 833
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.244128e+06
@@ -13040,11 +13040,11 @@ Types:
           Offset: 0
           Type: 120 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 744
+      ID: 746
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 807
+      ID: 809
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.405312e+06
@@ -13057,35 +13057,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 772
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 971
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 768
+      ID: 770
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 748
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 981
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 991
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 979
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 705
+      ID: 707
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.071616e+06
@@ -13093,28 +13093,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 707 PointerType *net.UnknownNetworkError.str
+          Type: 709 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 706 GoStringDataType net.UnknownNetworkError.str
+      Data: 708 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 706
+      ID: 708
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 674
+      ID: 676
       Name: net.canceledError
       GoRuntimeType: 1.195872e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 949
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 812
+      ID: 814
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.967136e+06
@@ -13122,7 +13122,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 807 GoInterfaceType net.Conn
+          Type: 809 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -13133,27 +13133,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 993
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 985
+      ID: 987
       Name: net.noReadFrom
       GoRuntimeType: 1.071872e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 984
+      ID: 986
       Name: net.noWriteTo
       GoRuntimeType: 1.071744e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 477
+      ID: 479
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 479
+      ID: 481
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.60256e+06
@@ -13161,7 +13161,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 795 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 797 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -13169,7 +13169,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 973
+      ID: 975
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.143456e+06
@@ -13177,12 +13177,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 985 StructureType net.noReadFrom
+          Type: 987 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 978 PointerType *net.TCPConn
+          Type: 980 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 971
+      ID: 973
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.142912e+06
@@ -13190,24 +13190,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 984 StructureType net.noWriteTo
+          Type: 986 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 978 PointerType *net.TCPConn
+          Type: 980 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 750
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 772
+      ID: 774
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 666
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 827
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.235648e+06
@@ -13217,19 +13217,19 @@ Types:
           Offset: 0
           Type: 120 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 374
+      ID: 376
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762240
       GoKind: 10
     - __kind: BaseType
-      ID: 784
+      ID: 786
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 948800
       GoKind: 10
     - __kind: StructureType
-      ID: 455
+      ID: 457
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.60064e+06
@@ -13240,12 +13240,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 784 BaseType net/http.http2ErrCode
+          Type: 786 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 764
+      ID: 766
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.766016e+06
@@ -13256,12 +13256,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 784 BaseType net/http.http2ErrCode
+          Type: 786 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 459
+      ID: 461
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.404832e+06
@@ -13269,16 +13269,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 784 BaseType net/http.http2ErrCode
+          Type: 786 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 889
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 378
+      ID: 380
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762432
@@ -13286,18 +13286,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 380 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 382 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 379 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 381 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 379
+      ID: 381
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 384
+      ID: 386
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762624
@@ -13305,18 +13305,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 386 PointerType *net/http.http2headerFieldNameError.str
+          Type: 388 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 385 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 387 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 385
+      ID: 387
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 381
+      ID: 383
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762528
@@ -13324,32 +13324,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 383 PointerType *net/http.http2headerFieldValueError.str
+          Type: 385 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 382 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 384 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 382
+      ID: 384
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 739
+      ID: 741
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 670
+      ID: 672
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.195232e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 940
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 375
+      ID: 377
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762336
@@ -13357,18 +13357,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 377 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 379 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 376 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 378 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 376
+      ID: 378
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 827
+      ID: 829
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.601408e+06
@@ -13376,22 +13376,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 807 GoInterfaceType net.Conn
+          Type: 809 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 906 BaseType time.Duration
+          Type: 908 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 99 PointerType *error
     - __kind: ArrayType
-      ID: 907
+      ID: 909
       Name: net/http.incomparable
       GoRuntimeType: 830880
       GoKind: 17
       HasCount: true
       Element: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 666
+      ID: 668
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.36672e+06
@@ -13401,11 +13401,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 891
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 847
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.36656e+06
@@ -13413,9 +13413,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 888 PointerType *net/http.persistConn
+          Type: 890 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 871
+      ID: 873
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.672704e+06
@@ -13423,15 +13423,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 907 ArrayType net/http.incomparable
+          Type: 909 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 908 PointerType *bufio.Reader
+          Type: 910 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 910 GoInterfaceType io.ReadWriteCloser
+          Type: 912 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 463
+      ID: 465
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.236608e+06
@@ -13441,17 +13441,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 766
+      ID: 768
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 737
+      ID: 739
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.295776e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 668
+      ID: 670
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.36688e+06
@@ -13461,11 +13461,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 452
+      ID: 454
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 940
+      ID: 942
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.904256e+06
@@ -13473,13 +13473,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 933 PointerType *bufio.Writer
+          Type: 935 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 857
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 534
+      ID: 536
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.6064e+06
@@ -13495,7 +13495,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 532
+      ID: 534
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.406752e+06
@@ -13508,11 +13508,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 897
+      ID: 899
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 859
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.408672e+06
@@ -13520,16 +13520,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 896 PointerType *net/smtp.Client
+          Type: 898 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 898 GoInterfaceType io.WriteCloser
+          Type: 900 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 518
+      ID: 520
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 409
+      ID: 411
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765216
@@ -13537,26 +13537,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 411 PointerType *net/textproto.ProtocolError.str
+          Type: 413 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 410 GoStringDataType net/textproto.ProtocolError.str
+      Data: 412 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 410
+      ID: 412
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 855
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 774
+      ID: 776
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 387
+      ID: 389
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763200
@@ -13564,18 +13564,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 389 PointerType *net/url.EscapeError.str
+          Type: 391 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 388 GoStringDataType net/url.EscapeError.str
+      Data: 390 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 388
+      ID: 390
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 390
+      ID: 392
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763296
@@ -13583,30 +13583,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 392 PointerType *net/url.InvalidHostError.str
+          Type: 394 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 391 GoStringDataType net/url.InvalidHostError.str
+      Data: 393 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 391
+      ID: 393
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 999
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 647
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 711
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 995
+      ID: 997
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.211648e+06
@@ -13614,12 +13614,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1001 StructureType os.noReadFrom
+          Type: 1003 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 996 PointerType *os.File
+          Type: 998 PointerType *os.File
     - __kind: StructureType
-      ID: 993
+      ID: 995
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.210848e+06
@@ -13627,36 +13627,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1000 StructureType os.noWriteTo
+          Type: 1002 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 996 PointerType *os.File
+          Type: 998 PointerType *os.File
     - __kind: StructureType
-      ID: 1001
+      ID: 1003
       Name: os.noReadFrom
       GoRuntimeType: 1.069312e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1000
+      ID: 1002
       Name: os.noWriteTo
       GoRuntimeType: 1.069184e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 678
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 817
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 877
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 678
+      ID: 680
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.509824e+06
@@ -13669,7 +13669,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 422
+      ID: 424
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768384
@@ -13677,36 +13677,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 424 PointerType *os/user.UnknownGroupIdError.str
+          Type: 426 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 423 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 425 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 423
+      ID: 425
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 421
+      ID: 423
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768288
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 447
+      ID: 449
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 542
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 650
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 653
+      ID: 655
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -13718,7 +13718,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 652
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.755584e+06
@@ -13735,9 +13735,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 813 BaseType runtime.boundsErrorCode
+          Type: 815 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 813
+      ID: 815
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532448
@@ -13757,7 +13757,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 711
+      ID: 713
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.626528e+06
@@ -13770,7 +13770,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 629
+      ID: 631
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 947648
@@ -13778,13 +13778,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 631 PointerType *runtime.errorString.str
+          Type: 633 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 630 GoStringDataType runtime.errorString.str
+      Data: 632 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 630
+      ID: 632
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -14410,7 +14410,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 632
+      ID: 634
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948224
@@ -14418,13 +14418,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 634 PointerType *runtime.plainError.str
+          Type: 636 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 633 GoStringDataType runtime.plainError.str
+      Data: 635 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 633
+      ID: 635
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -14506,7 +14506,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 657
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14529,15 +14529,15 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 938
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 845
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 839
+      ID: 841
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.272576e+06
@@ -14553,7 +14553,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1015
+      ID: 1017
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281216e+06
@@ -14566,7 +14566,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1016
+      ID: 1018
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282336e+06
@@ -14574,12 +14574,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1017 StructureType sync/atomic.Uint32
+          Type: 1019 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1015 StructureType sync.Mutex
+          Type: 1017 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1019
+      ID: 1021
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421024e+06
@@ -14587,21 +14587,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1020 StructureType sync.noCopy
+          Type: 1022 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1021 StructureType sync/atomic.Uint64
+          Type: 1023 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1020
+      ID: 1022
       Name: sync.noCopy
       GoRuntimeType: 946592
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1023
+      ID: 1025
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282656e+06
@@ -14609,12 +14609,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1018 StructureType sync/atomic.noCopy
+          Type: 1020 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1017
+      ID: 1019
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.282816e+06
@@ -14622,12 +14622,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1018 StructureType sync/atomic.noCopy
+          Type: 1020 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1021
+      ID: 1023
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.421408e+06
@@ -14635,37 +14635,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1018 StructureType sync/atomic.noCopy
+          Type: 1020 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1022 StructureType sync/atomic.align64
+          Type: 1024 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 1022
+      ID: 1024
       Name: sync/atomic.align64
       GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1018
+      ID: 1020
       Name: sync/atomic.noCopy
       GoRuntimeType: 946688
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 761
+      ID: 763
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.194464e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 969
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 704
+      ID: 706
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.51424e+06
@@ -14678,21 +14678,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 906
+      ID: 908
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.781856e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 779
+      ID: 781
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 450
+      ID: 452
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 777
+      ID: 779
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.223872e+06
@@ -14706,9 +14706,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 778 PointerType *time.Location
+          Type: 780 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 371
+      ID: 373
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761376
@@ -14716,13 +14716,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 373 PointerType *time.fileSizeError.str
+          Type: 375 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 372 GoStringDataType time.fileSizeError.str
+      Data: 374 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 372
+      ID: 374
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -14769,11 +14769,11 @@ Types:
       GoRuntimeType: 532384
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 932
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 795
+      ID: 797
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.925984e+06
@@ -14784,10 +14784,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 796 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 798 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 797 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 799 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -14802,18 +14802,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 798 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 800 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 798
+      ID: 800
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 952928
       GoKind: 9
     - __kind: StructureType
-      ID: 796
+      ID: 798
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.792352e+06
@@ -14838,21 +14838,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 536
+      ID: 538
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 797
+      ID: 799
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536032
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 961
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 520
+      ID: 522
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.244448e+06
@@ -14862,13 +14862,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 412
+      ID: 414
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765312
       GoKind: 2
     - __kind: StructureType
-      ID: 683
+      ID: 685
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510016e+06
@@ -14881,7 +14881,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 637
+      ID: 639
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 951776

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -2343,15 +2343,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd58d6..0xcd58e7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd58e7..0xcd5985
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcd59a0..0xcd5a02]
@@ -2368,29 +2359,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcd5a20..0xcd5b2e]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5a7b..0xcd5a85
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5a85..0xcd5aa0
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5aa0..0xcd5ab4
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5a76..0xcd5a80
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5a80..0xcd5aa0
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5aa0..0xcd5aaf
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcd5b40..0xcd5b46]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -3464,20 +3464,20 @@ Types:
       ByteSize: 8
       Pointee: 134 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1163
+      ID: 1165
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1164 PointerType *main.deepSlice3
+      Pointee: 1166 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1188
+      ID: 1190
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1189 PointerType *main.deepSlice8
+      Pointee: 1191 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1194
+      ID: 1196
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1195 PointerType *main.deepSlice9
+      Pointee: 1197 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 147
       Name: '**main.stringType2'
@@ -3485,7 +3485,7 @@ Types:
       GoKind: 22
       Pointee: 148 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1159
+      ID: 1161
       Name: '**main.t'
       ByteSize: 8
       Pointee: 227 PointerType *main.t
@@ -3522,30 +3522,30 @@ Types:
       ByteSize: 8
       Pointee: 142 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1171
+      ID: 1173
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1172 PointerType *table<int,*main.deepMap3>
+      Pointee: 1174 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1205
+      ID: 1207
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1206 PointerType *table<int,*main.deepMap8>
+      Pointee: 1208 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1220
+      ID: 1222
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1221 PointerType *table<int,*main.deepMap9>
+      Pointee: 1223 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 163
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 164 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1235
+      ID: 1237
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1236 PointerType *table<int,interface {}>
+      Pointee: 1238 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 200
       Name: '**table<int,uint8>'
@@ -3562,10 +3562,10 @@ Types:
       ByteSize: 8
       Pointee: 179 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 906 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 908 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 173
       Name: '**table<string,int>'
@@ -3622,20 +3622,20 @@ Types:
       ByteSize: 8
       Pointee: 299 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1167
+      ID: 1169
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1166 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1168 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1192
+      ID: 1194
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1191 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1193 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1198
+      ID: 1200
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1197 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1199 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 297
       Name: '*[]*string.array'
@@ -3697,15 +3697,15 @@ Types:
       ByteSize: 8
       Pointee: 419 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 942
+      ID: 944
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 941 GoSliceDataType []float64.array
+      Pointee: 943 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1201
+      ID: 1203
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1200 GoSliceDataType []interface {}.array
+      Pointee: 1202 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 246
       Name: '*[]main.structWithCyclicSlices'
@@ -3717,10 +3717,10 @@ Types:
       ByteSize: 8
       Pointee: 423 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1246
+      ID: 485
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1245 GoSliceDataType []main.structWithMap.array
+      Pointee: 484 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 416
       Name: '*[]main.structWithNoStrings.array'
@@ -3764,66 +3764,66 @@ Types:
       ByteSize: 8
       Pointee: 294 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1072
+      ID: 1074
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.976896e+06
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1075 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 713
+      ID: 715
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 926624
       GoKind: 22
-      Pointee: 714 GoSliceHeaderType archive/tar.headerError
+      Pointee: 716 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 716
+      ID: 718
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 715 GoSliceDataType archive/tar.headerError.array
+      Pointee: 717 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1007
+      ID: 1009
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.43072e+06
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1010 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 955
+      ID: 957
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 956 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 958 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 957
+      ID: 959
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 958 StructureType archive/zip.dirWriter
+      Pointee: 960 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1055
+      ID: 1057
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.896576e+06
       GoKind: 22
-      Pointee: 1056 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1058 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 983
+      ID: 985
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.053248e+06
       GoKind: 22
-      Pointee: 984 StructureType archive/zip.nopCloser
+      Pointee: 986 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 985
+      ID: 987
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.053504e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 988 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3832,421 +3832,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1030
+      ID: 1032
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.165024e+06
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType bufio.Reader
+      Pointee: 1033 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1059
+      ID: 1061
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.941088e+06
       GoKind: 22
-      Pointee: 1060 UnresolvedPointeeType bufio.Writer
+      Pointee: 1062 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1110
+      ID: 1112
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.262304e+06
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 625
+      ID: 627
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 909152
       GoKind: 22
-      Pointee: 517 BaseType compress/flate.CorruptInputError
+      Pointee: 519 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 909248
       GoKind: 22
-      Pointee: 518 GoStringHeaderType compress/flate.InternalError
+      Pointee: 520 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 520
+      ID: 522
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 519 GoStringDataType compress/flate.InternalError.str
+      Pointee: 521 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1005
+      ID: 1007
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.42016e+06
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1008 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 951
+      ID: 953
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 909344
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 954 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1027
+      ID: 1029
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.718336e+06
       GoKind: 22
-      Pointee: 1028 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1030 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 857
+      ID: 859
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.199456e+06
       GoKind: 22
-      Pointee: 858 StructureType context.deadlineExceededError
+      Pointee: 860 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 705
+      ID: 707
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921248
       GoKind: 22
-      Pointee: 531 BaseType crypto/aes.KeySizeError
+      Pointee: 533 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 706
+      ID: 708
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921440
       GoKind: 22
-      Pointee: 532 BaseType crypto/des.KeySizeError
+      Pointee: 534 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921728
       GoKind: 22
-      Pointee: 533 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 535 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1017
+      ID: 1019
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.56064e+06
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1020 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1051
+      ID: 1053
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.855008e+06
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1054 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1083
+      ID: 1085
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.112352e+06
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1086 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1057
+      ID: 1059
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.897088e+06
       GoKind: 22
-      Pointee: 1058 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1060 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1053
+      ID: 1055
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.85568e+06
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1056 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1049
+      ID: 1051
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.84784e+06
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1052 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 708
+      ID: 710
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922016
       GoKind: 22
-      Pointee: 534 BaseType crypto/rc4.KeySizeError
+      Pointee: 536 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1067
+      ID: 1069
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.946464e+06
       GoKind: 22
-      Pointee: 1068 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1070 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1039
+      ID: 1041
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.801824e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1042 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 631
+      ID: 633
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 910880
       GoKind: 22
-      Pointee: 521 BaseType crypto/tls.AlertError
+      Pointee: 523 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 797
+      ID: 799
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.041856e+06
       GoKind: 22
-      Pointee: 798 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 800 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1136
+      ID: 1138
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.374176e+06
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1139 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 629
+      ID: 631
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 632 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 627
+      ID: 629
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 910592
       GoKind: 22
-      Pointee: 628 StructureType crypto/tls.RecordHeaderError
+      Pointee: 630 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 796
+      ID: 798
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.040192e+06
       GoKind: 22
-      Pointee: 753 BaseType crypto/tls.alert
+      Pointee: 755 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1015
+      ID: 1017
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.5536e+06
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1018 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1022
+      ID: 1024
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.636032e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1025 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 892
+      ID: 894
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.42048e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 895 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.034944e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 910 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 701
+      ID: 703
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 702 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 704 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 695
+      ID: 697
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 919808
       GoKind: 22
-      Pointee: 696 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 698 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 697
+      ID: 699
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 698 StructureType crypto/x509.HostnameError
+      Pointee: 700 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 530 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 532 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 802
+      ID: 804
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.047616e+06
       GoKind: 22
-      Pointee: 803 StructureType crypto/x509.SystemRootsError
+      Pointee: 805 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 703
+      ID: 705
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 704 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 706 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 699
+      ID: 701
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 920192
       GoKind: 22
-      Pointee: 700 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 702 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 717
+      ID: 719
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 927104
       GoKind: 22
-      Pointee: 718 StructureType encoding/asn1.StructuralError
+      Pointee: 720 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 721
+      ID: 723
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927296
       GoKind: 22
-      Pointee: 722 StructureType encoding/asn1.SyntaxError
+      Pointee: 724 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 719
+      ID: 721
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 722 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 615
+      ID: 617
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 907232
       GoKind: 22
-      Pointee: 515 BaseType encoding/base64.CorruptInputError
+      Pointee: 517 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 973
+      ID: 975
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.037376e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 976 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 618
+      ID: 620
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 908096
       GoKind: 22
-      Pointee: 516 BaseType encoding/hex.InvalidByteError
+      Pointee: 518 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 901952
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 589 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 788
+      ID: 790
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.033664e+06
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 791 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 901568
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 581 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 901856
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 587 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 582
+      ID: 584
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 901760
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 585 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 580
+      ID: 582
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 901664
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 583 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1116
+      ID: 1118
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.287328e+06
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1119 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 902336
       GoKind: 22
-      Pointee: 589 StructureType encoding/json.jsonError
+      Pointee: 591 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 981
+      ID: 983
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.050176e+06
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 984 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 689
+      ID: 691
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 918752
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 692 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 687
+      ID: 689
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 918656
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 690 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 691
+      ID: 693
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 527 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 529 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 529
+      ID: 531
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 528 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 530 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 692
+      ID: 694
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918944
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 695 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1094
+      ID: 1096
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.150784e+06
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1097 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -4255,19 +4255,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 892256
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType errors.errorString
+      Pointee: 559 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 755
+      ID: 757
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.01856e+06
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType errors.joinError
+      Pointee: 758 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 106
       Name: '*float32'
@@ -4283,813 +4283,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1104
+      ID: 1106
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.254624e+06
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType fmt.pp
+      Pointee: 1107 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.020352e+06
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType fmt.wrapError
+      Pointee: 760 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 759
+      ID: 761
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.02048e+06
       GoKind: 22
-      Pointee: 760 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 762 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 907616
       GoKind: 22
-      Pointee: 617 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 619 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 597
+      ID: 599
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 904736
       GoKind: 22
-      Pointee: 598 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 600 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 599
+      ID: 601
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 904832
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 602 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 919
+      ID: 921
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 904544
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 922 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 603
+      ID: 605
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 22
-      Pointee: 604 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 606 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 904640
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 924 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 601
+      ID: 603
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 904928
       GoKind: 22
-      Pointee: 509 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 511 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 511
+      ID: 513
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 510 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 512 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 904448
       GoKind: 22
-      Pointee: 506 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 508 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 508
+      ID: 510
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 507 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 509 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 905024
       GoKind: 22
-      Pointee: 512 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 514 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 514
+      ID: 516
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 513 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 515 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 995
+      ID: 997
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.20496e+06
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 998 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1080
+      ID: 1082
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.049952e+06
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1083 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 711
+      ID: 713
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 712 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 714 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 866
+      ID: 868
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.208544e+06
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 869 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1112
+      ID: 1114
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.264352e+06
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1115 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 914240
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 641 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 645
+      ID: 647
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 915296
       GoKind: 22
-      Pointee: 646 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 648 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 526 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 528 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 643
+      ID: 645
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 915200
       GoKind: 22
-      Pointee: 644 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 646 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 641
+      ID: 643
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 915104
       GoKind: 22
-      Pointee: 642 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 644 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 661
+      ID: 663
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 662 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 664 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 665
+      ID: 667
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 917408
       GoKind: 22
-      Pointee: 666 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 668 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 663
+      ID: 665
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 917312
       GoKind: 22
-      Pointee: 664 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 666 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 659
+      ID: 661
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 917120
       GoKind: 22
-      Pointee: 660 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 662 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 944
+      ID: 946
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 943 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 945 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 673
+      ID: 675
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 917792
       GoKind: 22
-      Pointee: 674 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 676 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 667
+      ID: 669
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 668 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 670 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 671
+      ID: 673
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 917696
       GoKind: 22
-      Pointee: 672 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 674 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 669
+      ID: 671
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 670 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 672 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 917888
       GoKind: 22
-      Pointee: 676 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 678 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 681
+      ID: 683
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 682 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 684 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 683
+      ID: 685
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 684 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 686 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 679
+      ID: 681
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 680 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 682 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 677
+      ID: 679
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 917984
       GoKind: 22
-      Pointee: 678 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 680 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 685
+      ID: 687
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 918464
       GoKind: 22
-      Pointee: 686 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 688 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 605
+      ID: 607
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 906272
       GoKind: 22
-      Pointee: 606 StructureType github.com/cihub/seelog.baseError
+      Pointee: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1033
+      ID: 1035
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.794432e+06
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1036 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 607
+      ID: 609
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 906368
       GoKind: 22
-      Pointee: 608 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 610 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1013
+      ID: 1015
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.55248e+06
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1016 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 969
+      ID: 971
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.036352e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 972 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1003
+      ID: 1005
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.41824e+06
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1006 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 611
+      ID: 613
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 906560
       GoKind: 22
-      Pointee: 612 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 614 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1070
+      ID: 1072
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.966816e+06
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1073 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1087
+      ID: 1089
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.123936e+06
       GoKind: 22
-      Pointee: 1082 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1084 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1086
+      ID: 1088
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.123552e+06
       GoKind: 22
-      Pointee: 1085 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1087 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 971
+      ID: 973
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.03648e+06
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 974 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 609
+      ID: 611
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 906464
       GoKind: 22
-      Pointee: 610 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 612 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 613
+      ID: 615
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 906656
       GoKind: 22
-      Pointee: 614 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 616 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1035
+      ID: 1037
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.796224e+06
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1038 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1076
+      ID: 1078
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.003552e+06
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1079 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1078
+      ID: 1080
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.034624e+06
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1081 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.43312e+06
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 900 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 810
+      ID: 812
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.061696e+06
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 813 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 808
+      ID: 810
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.061568e+06
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 811 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 812
+      ID: 814
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.065664e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 815 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 814
+      ID: 816
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.065792e+06
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 817 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.663104e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1027 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 804
+      ID: 806
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.048256e+06
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 807 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 908288
       GoKind: 22
-      Pointee: 620 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 622 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1128
+      ID: 1130
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.3504e+06
       GoKind: 22
-      Pointee: 1129 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1131 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 868
+      ID: 870
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.216992e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 871 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 841
+      ID: 843
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.195744e+06
       GoKind: 22
-      Pointee: 842 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 844 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 835
+      ID: 837
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.19536e+06
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 838 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 774
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.027648e+06
       GoKind: 22
-      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 847
+      ID: 849
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.196128e+06
       GoKind: 22
-      Pointee: 848 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 850 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 773
+      ID: 775
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.02752e+06
       GoKind: 22
-      Pointee: 752 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 754 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 839
+      ID: 841
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.195616e+06
       GoKind: 22
-      Pointee: 840 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 842 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 837
+      ID: 839
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.195488e+06
       GoKind: 22
-      Pointee: 838 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 840 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 845
+      ID: 847
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.196e+06
       GoKind: 22
-      Pointee: 846 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 848 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 843
+      ID: 845
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195872e+06
       GoKind: 22
-      Pointee: 844 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 846 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1132
+      ID: 1134
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.362208e+06
       GoKind: 22
-      Pointee: 1133 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1135 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 851
+      ID: 853
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.196512e+06
       GoKind: 22
-      Pointee: 852 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 854 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.027904e+06
       GoKind: 22
-      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 776
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.027776e+06
       GoKind: 22
-      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 849
+      ID: 851
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.196384e+06
       GoKind: 22
-      Pointee: 850 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 852 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 733
+      ID: 735
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 940064
       GoKind: 22
-      Pointee: 539 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 541 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 541
+      ID: 543
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 540 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 542 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 910
+      ID: 912
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.661568e+06
       GoKind: 22
-      Pointee: 911 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 913 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 818
+      ID: 820
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.080512e+06
       GoKind: 22
-      Pointee: 819 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 821 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1001
+      ID: 1003
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.256544e+06
       GoKind: 22
-      Pointee: 1002 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1004 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1092
+      ID: 1094
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.138912e+06
       GoKind: 22
-      Pointee: 1093 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1095 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 987
+      ID: 989
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.082816e+06
       GoKind: 22
-      Pointee: 988 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 990 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 734
+      ID: 736
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 941312
       GoKind: 22
-      Pointee: 542 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 544 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 876
+      ID: 878
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.258208e+06
       GoKind: 22
-      Pointee: 877 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 879 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 737
+      ID: 739
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 941600
       GoKind: 22
-      Pointee: 738 StructureType golang.org/x/net/http2.connError
+      Pointee: 740 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 736
+      ID: 738
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941504
       GoKind: 22
-      Pointee: 546 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 548 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 548
+      ID: 550
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 547 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 549 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 740
+      ID: 742
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 941792
       GoKind: 22
-      Pointee: 552 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 554 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 554
+      ID: 556
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 553 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 555 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 739
+      ID: 741
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 941696
       GoKind: 22
-      Pointee: 549 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 551 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 551
+      ID: 553
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 550 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 552 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 735
+      ID: 737
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941408
       GoKind: 22
-      Pointee: 543 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 545 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 545
+      ID: 547
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 544 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 546 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1090
+      ID: 1092
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.136992e+06
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1093 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 741
+      ID: 743
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 941888
       GoKind: 22
-      Pointee: 742 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 744 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 743
+      ID: 745
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 555 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 557 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 729
+      ID: 731
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 935264
       GoKind: 22
-      Pointee: 730 StructureType google.golang.org/grpc.dropError
+      Pointee: 732 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.255264e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 877 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.44048e+06
       GoKind: 22
-      Pointee: 900 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 902 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 731
+      ID: 733
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 732 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 734 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1041
+      ID: 1043
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.802272e+06
       GoKind: 22
-      Pointee: 1042 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1044 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 999
+      ID: 1001
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.251808e+06
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1002 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 816
+      ID: 818
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.074752e+06
       GoKind: 22
-      Pointee: 817 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 819 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 959
+      ID: 961
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 938432
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 962 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 709
+      ID: 711
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 710 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 712 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 806
+      ID: 808
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.051584e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 809 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.223264e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 875 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.223008e+06
       GoKind: 22
-      Pointee: 871 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 873 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 723
+      ID: 725
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 928160
       GoKind: 22
-      Pointee: 724 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 726 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 725
+      ID: 727
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 928256
       GoKind: 22
-      Pointee: 726 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 728 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 653
+      ID: 655
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 915680
       GoKind: 22
-      Pointee: 654 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 656 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1047
+      ID: 1049
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.842912e+06
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1050 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 744
+      ID: 746
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 942752
       GoKind: 22
-      Pointee: 745 UnresolvedPointeeType html/template.Error
+      Pointee: 747 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 98
       Name: '*int'
@@ -5133,89 +5133,89 @@ Types:
       GoKind: 22
       Pointee: 151 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 623
+      ID: 625
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 626 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 621
+      ID: 623
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 908768
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 624 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 945
+      ID: 947
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 896768
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 948 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 833
+      ID: 835
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.194592e+06
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 836 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1134
+      ID: 1136
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.36784e+06
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1137 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 831
+      ID: 833
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.194464e+06
       GoKind: 22
-      Pointee: 832 StructureType internal/poll.errNetClosing
+      Pointee: 834 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 558
+      ID: 560
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 896000
       GoKind: 22
-      Pointee: 559 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 561 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 991
+      ID: 993
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.186016e+06
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType io.PipeWriter
+      Pointee: 994 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 989
+      ID: 991
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.185632e+06
       GoKind: 22
-      Pointee: 990 StructureType io.discard
+      Pointee: 992 StructureType io.discard
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.018816e+06
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType io.multiWriter
+      Pointee: 966 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 829
+      ID: 831
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.194208e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType io/fs.PathError
+      Pointee: 832 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1037
+      ID: 1039
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.796448e+06
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1040 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 307
       Name: '*main.deepMap2'
@@ -5224,12 +5224,12 @@ Types:
       GoKind: 22
       Pointee: 308 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1179
+      ID: 1181
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383168
       GoKind: 22
-      Pointee: 1180 UnresolvedPointeeType main.deepMap3
+      Pointee: 1182 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepMap7'
@@ -5238,19 +5238,19 @@ Types:
       GoKind: 22
       Pointee: 144 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1213
+      ID: 1215
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 382848
       GoKind: 22
-      Pointee: 1214 StructureType main.deepMap8
+      Pointee: 1216 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1228
+      ID: 1230
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382784
       GoKind: 22
-      Pointee: 1229 StructureType main.deepMap9
+      Pointee: 1231 StructureType main.deepMap9
     - __kind: PointerType
       ID: 127
       Name: '*main.deepPtr2'
@@ -5259,12 +5259,12 @@ Types:
       GoKind: 22
       Pointee: 128 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1138
+      ID: 1140
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1141 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 129
       Name: '*main.deepPtr7'
@@ -5273,19 +5273,19 @@ Types:
       GoKind: 22
       Pointee: 130 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1183
+      ID: 1185
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383424
       GoKind: 22
-      Pointee: 1184 StructureType main.deepPtr8
+      Pointee: 1186 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1185
+      ID: 1187
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383360
       GoKind: 22
-      Pointee: 1186 StructureType main.deepPtr9
+      Pointee: 1188 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 134
       Name: '*main.deepSlice2'
@@ -5294,12 +5294,12 @@ Types:
       GoKind: 22
       Pointee: 298 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1164
+      ID: 1166
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384320
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1167 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepSlice7'
@@ -5308,19 +5308,19 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1189
+      ID: 1191
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 384000
       GoKind: 22
-      Pointee: 1190 StructureType main.deepSlice8
+      Pointee: 1192 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1195
+      ID: 1197
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383936
       GoKind: 22
-      Pointee: 1196 StructureType main.deepSlice9
+      Pointee: 1198 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 289
       Name: '*main.emptyStruct'
@@ -5335,12 +5335,12 @@ Types:
       GoKind: 22
       Pointee: 154 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1155
+      ID: 1157
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 891968
       GoKind: 22
-      Pointee: 1156 StructureType main.firstBehavior
+      Pointee: 1158 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 226
       Name: '*main.node'
@@ -5355,19 +5355,19 @@ Types:
       GoKind: 22
       Pointee: 241 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1157
+      ID: 1159
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 892064
       GoKind: 22
-      Pointee: 1158 StructureType main.secondBehavior
+      Pointee: 1160 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1143
+      ID: 1145
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 892160
       GoKind: 22
-      Pointee: 1144 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1146 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 145
       Name: '*main.stringType1'
@@ -5375,16 +5375,16 @@ Types:
       GoKind: 22
       Pointee: 146 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1141
+      ID: 1143
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1140 GoStringDataType main.stringType1.str
+      Pointee: 1142 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 148
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1142 UnresolvedPointeeType main.stringType2
+      Pointee: 1144 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 244
       Name: '*main.structWithCyclicSlices'
@@ -5415,10 +5415,10 @@ Types:
       GoKind: 22
       Pointee: 228 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1161
+      ID: 1163
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1160 GoSliceDataType main.t.array
+      Pointee: 1162 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 239
       Name: '*main.threeStringStruct'
@@ -5451,30 +5451,30 @@ Types:
       ByteSize: 8
       Pointee: 140 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1169
+      ID: 1171
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1170 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1172 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1203
+      ID: 1205
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1204 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1206 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1218
+      ID: 1220
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1219 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1221 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 161
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 162 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1233
+      ID: 1235
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1234 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1236 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 198
       Name: '*map<int,uint8>'
@@ -5491,10 +5491,10 @@ Types:
       ByteSize: 8
       Pointee: 177 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 904 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 906 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 171
       Name: '*map<string,int>'
@@ -5552,451 +5552,451 @@ Types:
       GoKind: 22
       Pointee: 170 GoMapType map[string]int
     - __kind: PointerType
-      ID: 657
+      ID: 659
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 658 StructureType math/big.ErrNaN
+      Pointee: 660 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 953
+      ID: 955
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 911360
       GoKind: 22
-      Pointee: 954 StructureType mime/multipart.writerOnly·1
+      Pointee: 956 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 860
+      ID: 862
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.202784e+06
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType net.AddrError
+      Pointee: 863 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 886
+      ID: 888
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.41648e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType net.DNSError
+      Pointee: 889 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1098
+      ID: 1100
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.22544e+06
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType net.IPConn
+      Pointee: 1101 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 884
+      ID: 886
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.41616e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType net.OpError
+      Pointee: 887 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 862
+      ID: 864
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.202912e+06
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType net.ParseError
+      Pointee: 865 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1108
+      ID: 1110
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.255648e+06
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType net.TCPConn
+      Pointee: 1111 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1118
+      ID: 1120
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.30064e+06
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType net.UDPConn
+      Pointee: 1121 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1106
+      ID: 1108
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.255136e+06
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType net.UnixConn
+      Pointee: 1109 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 859
+      ID: 861
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.202016e+06
       GoKind: 22
-      Pointee: 822 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 824 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 824
+      ID: 826
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 823 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 825 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 790
+      ID: 792
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.03456e+06
       GoKind: 22
-      Pointee: 791 StructureType net.canceledError
+      Pointee: 793 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1074
+      ID: 1076
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.000672e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType net.conn
+      Pointee: 1077 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 928
+      ID: 930
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.838208e+06
       GoKind: 22
-      Pointee: 929 StructureType net.dialResult·1
+      Pointee: 931 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1120
+      ID: 1122
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.304896e+06
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType net.netFD
+      Pointee: 1123 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 903296
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType net.notFoundError
+      Pointee: 593 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 903968
       GoKind: 22
-      Pointee: 593 StructureType net.result·2
+      Pointee: 595 StructureType net.result·2
     - __kind: PointerType
-      ID: 1102
+      ID: 1104
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.241664e+06
       GoKind: 22
-      Pointee: 1103 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1105 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1100
+      ID: 1102
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.241184e+06
       GoKind: 22
-      Pointee: 1101 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1103 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 864
+      ID: 866
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.203552e+06
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType net.temporaryError
+      Pointee: 867 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 888
+      ID: 890
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.41664e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType net.timeoutError
+      Pointee: 891 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.030336e+06
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 783 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 947
+      ID: 949
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 899072
       GoKind: 22
-      Pointee: 948 StructureType net/http.bufioFlushWriter
+      Pointee: 950 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 567
+      ID: 569
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 899744
       GoKind: 22
-      Pointee: 487 BaseType net/http.http2ConnectionError
+      Pointee: 489 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 568
+      ID: 570
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 899840
       GoKind: 22
-      Pointee: 569 StructureType net/http.http2GoAwayError
+      Pointee: 571 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 880
+      ID: 882
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.41232e+06
       GoKind: 22
-      Pointee: 881 StructureType net/http.http2StreamError
+      Pointee: 883 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 900416
       GoKind: 22
-      Pointee: 573 StructureType net/http.http2connError
+      Pointee: 575 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1009
+      ID: 1011
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.54896e+06
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1012 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 571
+      ID: 573
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900320
       GoKind: 22
-      Pointee: 491 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 493 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 493
+      ID: 495
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 492 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 494 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 575
+      ID: 577
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 900608
       GoKind: 22
-      Pointee: 497 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 499 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 498 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 500 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 574
+      ID: 576
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 900512
       GoKind: 22
-      Pointee: 494 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 496 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 496
+      ID: 498
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 495 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 497 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 855
+      ID: 857
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.19856e+06
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 858 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.030976e+06
       GoKind: 22
-      Pointee: 787 StructureType net/http.http2noCachedConnError
+      Pointee: 789 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1063
+      ID: 1065
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.943136e+06
       GoKind: 22
-      Pointee: 1064 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1066 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900224
       GoKind: 22
-      Pointee: 488 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 490 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 490
+      ID: 492
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 489 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 491 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 949
+      ID: 951
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 900704
       GoKind: 22
-      Pointee: 950 StructureType net/http.http2stickyErrWriter
+      Pointee: 952 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.030592e+06
       GoKind: 22
-      Pointee: 783 StructureType net/http.nothingWrittenError
+      Pointee: 785 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1011
+      ID: 1013
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.166272e+06
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1014 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 967
+      ID: 969
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.030464e+06
       GoKind: 22
-      Pointee: 968 StructureType net/http.persistConnWriter
+      Pointee: 970 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 993
+      ID: 995
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.197664e+06
       GoKind: 22
-      Pointee: 994 StructureType net/http.readWriteCloserBody
+      Pointee: 996 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 900800
       GoKind: 22
-      Pointee: 577 StructureType net/http.requestBodyReadError
+      Pointee: 579 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 882
+      ID: 884
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.41344e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 885 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 853
+      ID: 855
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.198432e+06
       GoKind: 22
-      Pointee: 854 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 856 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 784
+      ID: 786
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.03072e+06
       GoKind: 22
-      Pointee: 785 StructureType net/http.transportReadFromServerError
+      Pointee: 787 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1045
+      ID: 1047
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.834848e+06
       GoKind: 22
-      Pointee: 1046 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1048 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 565
+      ID: 567
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 898976
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 568 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1065
+      ID: 1067
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.944672e+06
       GoKind: 22
-      Pointee: 1066 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1068 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 977
+      ID: 979
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.043008e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 980 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 649
+      ID: 651
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915488
       GoKind: 22
-      Pointee: 650 StructureType net/netip.parseAddrError
+      Pointee: 652 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 647
+      ID: 649
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915392
       GoKind: 22
-      Pointee: 648 StructureType net/netip.parsePrefixError
+      Pointee: 650 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1019
+      ID: 1021
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.110944e+06
       GoKind: 22
-      Pointee: 1020 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1022 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 979
+      ID: 981
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.047872e+06
       GoKind: 22
-      Pointee: 980 StructureType net/smtp.dataCloser
+      Pointee: 982 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 633
+      ID: 635
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 911552
       GoKind: 22
-      Pointee: 634 UnresolvedPointeeType net/textproto.Error
+      Pointee: 636 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 632
+      ID: 634
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 911456
       GoKind: 22
-      Pointee: 522 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 524 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 523 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 525 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 975
+      ID: 977
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.04224e+06
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 978 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 890
+      ID: 892
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.41696e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType net/url.Error
+      Pointee: 893 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 904064
       GoKind: 22
-      Pointee: 500 GoStringHeaderType net/url.EscapeError
+      Pointee: 502 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 502
+      ID: 504
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 501 GoStringDataType net/url.EscapeError.str
+      Pointee: 503 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 595
+      ID: 597
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 22
-      Pointee: 503 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 505 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 505
+      ID: 507
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 504 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 506 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 405
       Name: '*noalg.map.group[[4]int][4]int'
@@ -6023,30 +6023,30 @@ Types:
       ByteSize: 8
       Pointee: 304 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1175
+      ID: 1177
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1176 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1178 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1209
+      ID: 1211
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1210 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1212 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1224
+      ID: 1226
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1225 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1227 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 313
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 314 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1239
+      ID: 1241
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1240 StructureType noalg.map.group[int]interface {}
+      Pointee: 1242 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 372
       Name: '*noalg.map.group[int]uint8'
@@ -6063,10 +6063,10 @@ Types:
       ByteSize: 8
       Pointee: 338 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 935
+      ID: 937
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 936 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 938 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 329
       Name: '*noalg.map.group[string]int'
@@ -6118,115 +6118,115 @@ Types:
       ByteSize: 8
       Pointee: 381 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1126
+      ID: 1128
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.343552e+06
       GoKind: 22
-      Pointee: 1127 UnresolvedPointeeType os.File
+      Pointee: 1129 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 761
+      ID: 763
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.021632e+06
       GoKind: 22
-      Pointee: 762 UnresolvedPointeeType os.LinkError
+      Pointee: 764 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 825
+      ID: 827
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.187552e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType os.SyscallError
+      Pointee: 828 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1124
+      ID: 1126
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.339872e+06
       GoKind: 22
-      Pointee: 1125 StructureType os.fileWithoutReadFrom
+      Pointee: 1127 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1122
+      ID: 1124
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.339136e+06
       GoKind: 22
-      Pointee: 1123 StructureType os.fileWithoutWriteTo
+      Pointee: 1125 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 792
+      ID: 794
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.038912e+06
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType os/exec.Error
+      Pointee: 795 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.0808e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 934 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 997
+      ID: 999
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.209824e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1000 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 794
+      ID: 796
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.03904e+06
       GoKind: 22
-      Pointee: 795 StructureType os/exec.wrappedError
+      Pointee: 797 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 728
+      ID: 730
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 933344
       GoKind: 22
-      Pointee: 536 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 538 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 538
+      ID: 540
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 537 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 539 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 727
+      ID: 729
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 933248
       GoKind: 22
-      Pointee: 535 BaseType os/user.UnknownUserIdError
+      Pointee: 537 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 560
+      ID: 562
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 896672
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType reflect.ValueError
+      Pointee: 563 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 655
+      ID: 657
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 916160
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 658 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 765
+      ID: 767
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.023168e+06
       GoKind: 22
-      Pointee: 766 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 768 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 769
+      ID: 771
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.02496e+06
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 772 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -6242,12 +6242,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 767
+      ID: 769
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.023296e+06
       GoKind: 22
-      Pointee: 768 StructureType runtime.boundsError
+      Pointee: 770 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -6263,24 +6263,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 827
+      ID: 829
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.192928e+06
       GoKind: 22
-      Pointee: 828 StructureType runtime.errorAddressString
+      Pointee: 830 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 763
+      ID: 765
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.022784e+06
       GoKind: 22
-      Pointee: 746 GoStringHeaderType runtime.errorString
+      Pointee: 748 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 748
+      ID: 750
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 747 GoStringDataType runtime.errorString.str
+      Pointee: 749 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -6296,17 +6296,17 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 764
+      ID: 766
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.022912e+06
       GoKind: 22
-      Pointee: 749 GoStringHeaderType runtime.plainError
+      Pointee: 751 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 751
+      ID: 753
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType runtime.plainError.str
+      Pointee: 752 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -6336,12 +6336,12 @@ Types:
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 771
+      ID: 773
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.025216e+06
       GoKind: 22
-      Pointee: 772 UnresolvedPointeeType strconv.NumError
+      Pointee: 774 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 93
       Name: '*string'
@@ -6355,33 +6355,33 @@ Types:
       ByteSize: 8
       Pointee: 290 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1061
+      ID: 1063
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.941856e+06
       GoKind: 22
-      Pointee: 1062 UnresolvedPointeeType strings.Builder
+      Pointee: 1064 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 965
+      ID: 967
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.025344e+06
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 968 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 961
+      ID: 963
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 966144
       GoKind: 22
-      Pointee: 962 StructureType struct { io.Writer }
+      Pointee: 964 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.41168e+06
       GoKind: 22
-      Pointee: 878 BaseType syscall.Errno
+      Pointee: 880 BaseType syscall.Errno
     - __kind: PointerType
       ID: 221
       Name: '*table<[4]int,[4]int>'
@@ -6408,30 +6408,30 @@ Types:
       ByteSize: 8
       Pointee: 301 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1172
+      ID: 1174
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1173 StructureType table<int,*main.deepMap3>
+      Pointee: 1175 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1206
+      ID: 1208
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1207 StructureType table<int,*main.deepMap8>
+      Pointee: 1209 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1221
+      ID: 1223
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1222 StructureType table<int,*main.deepMap9>
+      Pointee: 1224 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 164
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 311 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1236
+      ID: 1238
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1237 StructureType table<int,interface {}>
+      Pointee: 1239 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 201
       Name: '*table<int,uint8>'
@@ -6448,10 +6448,10 @@ Types:
       ByteSize: 8
       Pointee: 335 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 906
+      ID: 908
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 933 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 935 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 174
       Name: '*table<string,int>'
@@ -6503,45 +6503,45 @@ Types:
       ByteSize: 8
       Pointee: 378 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1096
+      ID: 1098
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.151168e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1099 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 820
+      ID: 822
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.084352e+06
       GoKind: 22
-      Pointee: 821 StructureType text/template.ExecError
+      Pointee: 823 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 895
+      ID: 897
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.617024e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType time.Location
+      Pointee: 898 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 563
+      ID: 565
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 897536
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType time.ParseError
+      Pointee: 566 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 562
+      ID: 564
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 897440
       GoKind: 22
-      Pointee: 484 GoStringHeaderType time.fileSizeError
+      Pointee: 486 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 486
+      ID: 488
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 485 GoStringDataType time.fileSizeError.str
+      Pointee: 487 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -6585,47 +6585,47 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 651
+      ID: 653
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 915584
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 654 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1088
+      ID: 1090
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.126624e+06
       GoKind: 22
-      Pointee: 1089 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1091 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 635
+      ID: 637
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 636 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 638 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 637
+      ID: 639
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 911840
       GoKind: 22
-      Pointee: 525 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 527 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.042752e+06
       GoKind: 22
-      Pointee: 800 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 802 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.04288e+06
       GoKind: 22
-      Pointee: 754 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 756 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1346
       Name: Probe[main.stackC]
@@ -8740,7 +8740,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 923
+      ID: 925
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 680672
@@ -8790,7 +8790,7 @@ Types:
       ByteSize: 8
       Element: 134 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1162
+      ID: 1164
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474944
@@ -8798,22 +8798,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1163 PointerType **main.deepSlice3
+          Type: 1165 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1166 GoSliceDataType []*main.deepSlice3.array
+      Data: 1168 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1166
+      ID: 1168
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1164 PointerType *main.deepSlice3
+      Element: 1166 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1187
+      ID: 1189
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474624
@@ -8821,22 +8821,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1188 PointerType **main.deepSlice8
+          Type: 1190 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1191 GoSliceDataType []*main.deepSlice8.array
+      Data: 1193 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1191
+      ID: 1193
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1189 PointerType *main.deepSlice8
+      Element: 1191 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1193
+      ID: 1195
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474560
@@ -8844,20 +8844,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1194 PointerType **main.deepSlice9
+          Type: 1196 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1197 GoSliceDataType []*main.deepSlice9.array
+      Data: 1199 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1197
+      ID: 1199
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1195 PointerType *main.deepSlice9
+      Element: 1197 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 123
       Name: '[]*string'
@@ -8912,23 +8912,23 @@ Types:
       ByteSize: 8
       Element: 142 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1181
+      ID: 1183
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1172 PointerType *table<int,*main.deepMap3>
+      Element: 1174 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1215
+      ID: 1217
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1206 PointerType *table<int,*main.deepMap8>
+      Element: 1208 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1230
+      ID: 1232
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1221 PointerType *table<int,*main.deepMap9>
+      Element: 1223 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 317
       Name: '[]*table<int,int>.array'
@@ -8936,11 +8936,11 @@ Types:
       ByteSize: 8
       Element: 164 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1243
+      ID: 1245
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1236 PointerType *table<int,interface {}>
+      Element: 1238 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 376
       Name: '[]*table<int,uint8>.array'
@@ -8960,11 +8960,11 @@ Types:
       ByteSize: 8
       Element: 179 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 939
+      ID: 941
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 906 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 908 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 333
       Name: '[]*table<string,int>.array'
@@ -9181,7 +9181,7 @@ Types:
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 918
+      ID: 920
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 483776
@@ -9196,15 +9196,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 941 GoSliceDataType []float64.array
+      Data: 943 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 941
+      ID: 943
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1199
+      ID: 1201
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484224
@@ -9219,9 +9219,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1200 GoSliceDataType []interface {}.array
+      Data: 1202 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1200
+      ID: 1202
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -9264,9 +9264,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1245 GoSliceDataType []main.structWithMap.array
+      Data: 484 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1245
+      ID: 484
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -9324,23 +9324,23 @@ Types:
       ByteSize: 136
       Element: 304 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1182
+      ID: 1184
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1176 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1178 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1216
+      ID: 1218
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1210 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1212 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1231
+      ID: 1233
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1225 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1227 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 318
       Name: '[]noalg.map.group[int]int.array'
@@ -9348,11 +9348,11 @@ Types:
       ByteSize: 136
       Element: 314 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1244
+      ID: 1246
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 1240 StructureType noalg.map.group[int]interface {}
+      Element: 1242 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 377
       Name: '[]noalg.map.group[int]uint8.array'
@@ -9372,11 +9372,11 @@ Types:
       ByteSize: 328
       Element: 338 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 940
+      ID: 942
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 936 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 938 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 334
       Name: '[]noalg.map.group[string]int.array'
@@ -9557,11 +9557,11 @@ Types:
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1075
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 714
+      ID: 716
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 926720
@@ -9576,33 +9576,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 715 GoSliceDataType archive/tar.headerError.array
+      Data: 717 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 715
+      ID: 717
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1010
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 956
+      ID: 958
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 958
+      ID: 960
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.115488e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1056
+      ID: 1058
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 984
+      ID: 986
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.55952e+06
@@ -9612,7 +9612,7 @@ Types:
           Offset: 0
           Type: 125 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 988
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9622,15 +9622,15 @@ Types:
       GoRuntimeType: 581408
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1033
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1060
+      ID: 1062
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1113
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9656,13 +9656,13 @@ Types:
       GoRuntimeType: 581152
       GoKind: 15
     - __kind: BaseType
-      ID: 517
+      ID: 519
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831136
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 518
+      ID: 520
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 831232
@@ -9670,110 +9670,110 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 520 PointerType *compress/flate.InternalError.str
+          Type: 522 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 519 GoStringDataType compress/flate.InternalError.str
+      Data: 521 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 519
+      ID: 521
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1008
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 954
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1028
+      ID: 1030
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 858
+      ID: 860
       Name: context.deadlineExceededError
       GoRuntimeType: 1.47392e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 531
+      ID: 533
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833728
       GoKind: 2
     - __kind: BaseType
-      ID: 532
+      ID: 534
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833824
       GoKind: 2
     - __kind: BaseType
-      ID: 533
+      ID: 535
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833920
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1020
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1054
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1086
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1058
+      ID: 1060
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1056
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1052
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 534
+      ID: 536
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834016
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1068
+      ID: 1070
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1042
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 521
+      ID: 523
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 831712
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 798
+      ID: 800
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1139
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 632
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 630
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.722944e+06
@@ -9784,34 +9784,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 923 ArrayType [5]uint8
+          Type: 925 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 753
+      ID: 755
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 988960
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1018
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1025
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 895
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 910
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 704
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.725824e+06
@@ -9819,21 +9819,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 907 PointerType *crypto/x509.Certificate
+          Type: 909 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 926 BaseType crypto/x509.InvalidReason
+          Type: 928 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 696
+      ID: 698
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.113056e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 698
+      ID: 700
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.59424e+06
@@ -9841,24 +9841,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 907 PointerType *crypto/x509.Certificate
+          Type: 909 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 530
+      ID: 532
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 833344
       GoKind: 2
     - __kind: BaseType
-      ID: 926
+      ID: 928
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 586592
       GoKind: 2
     - __kind: StructureType
-      ID: 803
+      ID: 805
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.55552e+06
@@ -9868,13 +9868,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 704
+      ID: 706
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.113312e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 700
+      ID: 702
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.725632e+06
@@ -9882,15 +9882,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 907 PointerType *crypto/x509.Certificate
+          Type: 909 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 907 PointerType *crypto/x509.Certificate
+          Type: 909 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 718
+      ID: 720
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.43136e+06
@@ -9900,7 +9900,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 722
+      ID: 724
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.43152e+06
@@ -9910,55 +9910,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 722
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 515
+      ID: 517
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830752
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 976
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 516
+      ID: 518
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 830944
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 589
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 791
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 581
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 587
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 585
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 583
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1119
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 589
+      ID: 591
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.4152e+06
@@ -9968,19 +9968,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 984
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 692
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 690
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 527
+      ID: 529
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 833248
@@ -9988,22 +9988,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 529 PointerType *encoding/xml.UnmarshalError.str
+          Type: 531 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 528 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 530 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 528
+      ID: 530
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 695
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1097
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -10020,11 +10020,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 559
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 758
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -10040,15 +10040,15 @@ Types:
       GoRuntimeType: 581344
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1107
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 760
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 760
+      ID: 762
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -10064,11 +10064,11 @@ Types:
       GoRuntimeType: 844864
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 617
+      ID: 619
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 598
+      ID: 600
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.721792e+06
@@ -10076,7 +10076,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 916 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 918 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -10084,25 +10084,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 602
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 922
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 604
+      ID: 606
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.109344e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 509
+      ID: 511
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 830176
@@ -10110,18 +10110,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 511 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 513 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 510 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 512 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 510
+      ID: 512
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 916
+      ID: 918
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.210976e+06
@@ -10129,7 +10129,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 917 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 919 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10144,7 +10144,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 918 GoSliceHeaderType []float64
+          Type: 920 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -10153,10 +10153,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 919 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 921 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 921 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 923 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 235 GoSliceHeaderType []string
@@ -10170,13 +10170,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 917
+      ID: 919
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 583200
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 506
+      ID: 508
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 830080
@@ -10184,18 +10184,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 508 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 510 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 507 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 509 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 507
+      ID: 509
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 512
+      ID: 514
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 830272
@@ -10203,60 +10203,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 514 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 516 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 513 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 515 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 513
+      ID: 515
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 998
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1083
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 712
+      ID: 714
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 869
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1115
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 641
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 646
+      ID: 648
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.112288e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 526
+      ID: 528
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 832384
       GoKind: 2
     - __kind: StructureType
-      ID: 644
+      ID: 646
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.11216e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 642
+      ID: 644
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.59232e+06
@@ -10269,7 +10269,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 664
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.59312e+06
@@ -10282,7 +10282,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 666
+      ID: 668
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.725056e+06
@@ -10298,7 +10298,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 664
+      ID: 666
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.42496e+06
@@ -10308,7 +10308,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 660
+      ID: 662
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.42464e+06
@@ -10318,14 +10318,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 902
+      ID: 904
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.49488e+06
       GoKind: 21
-      HeaderType: 904 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 906 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 925
+      ID: 927
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.046336e+06
@@ -10340,15 +10340,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 943 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 945 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 943
+      ID: 945
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 674
+      ID: 676
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.59344e+06
@@ -10356,12 +10356,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 902 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 904 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 902 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 904 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 668
+      ID: 670
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.42512e+06
@@ -10371,7 +10371,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 672
+      ID: 674
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.725248e+06
@@ -10382,12 +10382,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 925 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 927 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 925 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 927 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 670
+      ID: 672
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.59328e+06
@@ -10400,7 +10400,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 676
+      ID: 678
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.42528e+06
@@ -10408,9 +10408,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 894 StructureType time.Time
+          Type: 896 StructureType time.Time
     - __kind: StructureType
-      ID: 682
+      ID: 684
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.59376e+06
@@ -10423,7 +10423,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 684
+      ID: 686
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.4256e+06
@@ -10433,7 +10433,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 680
+      ID: 682
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.5936e+06
@@ -10446,7 +10446,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 678
+      ID: 680
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.42544e+06
@@ -10456,7 +10456,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 686
+      ID: 688
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.59392e+06
@@ -10469,7 +10469,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 606
+      ID: 608
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.41744e+06
@@ -10479,11 +10479,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1036
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 608
+      ID: 610
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.4176e+06
@@ -10491,21 +10491,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 606 StructureType github.com/cihub/seelog.baseError
+          Type: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1016
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 972
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1006
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 612
+      ID: 614
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.41792e+06
@@ -10513,13 +10513,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 606 StructureType github.com/cihub/seelog.baseError
+          Type: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1073
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1082
+      ID: 1084
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.09936e+06
@@ -10527,12 +10527,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1070 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1072 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1085
+      ID: 1087
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.123168e+06
@@ -10540,7 +10540,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1070 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1072 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10548,11 +10548,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 974
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 610
+      ID: 612
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.41776e+06
@@ -10560,9 +10560,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 606 StructureType github.com/cihub/seelog.baseError
+          Type: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 614
+      ID: 616
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.41808e+06
@@ -10570,64 +10570,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 606 StructureType github.com/cihub/seelog.baseError
+          Type: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1038
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1079
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1081
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 900
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 813
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 811
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 815
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 817
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1027
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 807
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 620
+      ID: 622
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.41904e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1129
+      ID: 1131
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 871
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 844
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.833056e+06
@@ -10643,11 +10643,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 838
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 775
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.69584e+06
@@ -10660,7 +10660,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 848
+      ID: 850
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.833504e+06
@@ -10676,13 +10676,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 752
+      ID: 754
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 986272
       GoKind: 8
     - __kind: StructureType
-      ID: 840
+      ID: 842
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.832832e+06
@@ -10698,13 +10698,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 927
+      ID: 929
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 828352
       GoKind: 8
     - __kind: StructureType
-      ID: 838
+      ID: 840
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.832608e+06
@@ -10712,15 +10712,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 927 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 929 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 927 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 929 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 846
+      ID: 848
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.747296e+06
@@ -10733,7 +10733,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 844
+      ID: 846
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.83328e+06
@@ -10749,11 +10749,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1133
+      ID: 1135
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 852
+      ID: 854
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.617984e+06
@@ -10763,19 +10763,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 779
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.278752e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 777
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.278624e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 850
+      ID: 852
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.747488e+06
@@ -10788,7 +10788,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 539
+      ID: 541
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835840
@@ -10796,22 +10796,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 541 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 543 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 540 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 542 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 540
+      ID: 542
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 911
+      ID: 913
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 819
+      ID: 821
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.4432e+06
@@ -10821,7 +10821,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1002
+      ID: 1004
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.671936e+06
@@ -10829,13 +10829,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1026 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1028 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1093
+      ID: 1095
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1026
+      ID: 1028
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.12304e+06
@@ -10848,7 +10848,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 988
+      ID: 990
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.56448e+06
@@ -10858,19 +10858,19 @@ Types:
           Offset: 0
           Type: 125 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 542
+      ID: 544
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 836416
       GoKind: 10
     - __kind: BaseType
-      ID: 909
+      ID: 911
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 999424
       GoKind: 10
     - __kind: StructureType
-      ID: 877
+      ID: 879
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.872256e+06
@@ -10881,12 +10881,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 909 BaseType golang.org/x/net/http2.ErrCode
+          Type: 911 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 738
+      ID: 740
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.60096e+06
@@ -10894,12 +10894,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 909 BaseType golang.org/x/net/http2.ErrCode
+          Type: 911 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 546
+      ID: 548
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836608
@@ -10907,18 +10907,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 548 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 550 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 547 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 549 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 547
+      ID: 549
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 552
+      ID: 554
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836800
@@ -10926,18 +10926,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 554 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 556 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 553 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 555 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 553
+      ID: 555
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 549
+      ID: 551
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836704
@@ -10945,18 +10945,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 551 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 553 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 550 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 552 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 550
+      ID: 552
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 543
+      ID: 545
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836512
@@ -10964,22 +10964,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 545 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 547 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 544 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 546 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 544
+      ID: 546
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1093
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 742
+      ID: 744
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.44384e+06
@@ -10989,13 +10989,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 555
+      ID: 557
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 2
     - __kind: StructureType
-      ID: 730
+      ID: 732
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.43888e+06
@@ -11005,11 +11005,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 877
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 900
+      ID: 902
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.90016e+06
@@ -11025,7 +11025,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 732
+      ID: 734
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.60048e+06
@@ -11038,7 +11038,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1042
+      ID: 1044
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.957728e+06
@@ -11046,16 +11046,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1069 GoInterfaceType io.Reader
+          Type: 1071 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1002
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 817
+      ID: 819
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.56208e+06
@@ -11065,29 +11065,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 962
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 710
+      ID: 712
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 809
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 875
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 873
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.50544e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 724
+      ID: 726
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.43216e+06
@@ -11097,7 +11097,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 726
+      ID: 728
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.43232e+06
@@ -11107,7 +11107,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 654
+      ID: 656
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -11181,47 +11181,47 @@ Types:
       GroupType: 304 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 310 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1174
+      ID: 1176
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1175 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1177 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1176 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1182 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1178 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1184 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1208
+      ID: 1210
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1209 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1211 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1210 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1216 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1212 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1218 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1223
+      ID: 1225
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1224 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1226 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1225 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1231 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1227 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1233 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 312
       Name: groupReference<int,int>
@@ -11237,19 +11237,19 @@ Types:
       GroupType: 314 StructureType noalg.map.group[int]int
       GroupSliceType: 318 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1238
+      ID: 1240
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1239 PointerType *noalg.map.group[int]interface {}
+          Type: 1241 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1240 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1244 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1242 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1246 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 371
       Name: groupReference<int,uint8>
@@ -11293,19 +11293,19 @@ Types:
       GroupType: 338 StructureType noalg.map.group[string][]string
       GroupSliceType: 342 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 934
+      ID: 936
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 935 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 937 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 936 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 940 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 938 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 942 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 328
       Name: groupReference<string,int>
@@ -11447,11 +11447,11 @@ Types:
       GroupType: 381 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 385 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1050
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 745
+      ID: 747
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11498,7 +11498,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 626
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -11524,29 +11524,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 624
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 948
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 836
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1137
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 832
+      ID: 834
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.47072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 559
+      ID: 561
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -11627,7 +11627,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1147
+      ID: 1149
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.46816e+06
@@ -11640,11 +11640,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 994
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1032
+      ID: 1034
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.18576e+06
@@ -11657,7 +11657,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1069
+      ID: 1071
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.018944e+06
@@ -11670,7 +11670,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1021
+      ID: 1023
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.105632e+06
@@ -11696,21 +11696,21 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 990
+      ID: 992
       Name: io.discard
       GoRuntimeType: 1.45808e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 966
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 832
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1040
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -11778,9 +11778,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1168 GoMapType map[int]*main.deepMap3
+          Type: 1170 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1180
+      ID: 1182
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11792,9 +11792,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1202 GoMapType map[int]*main.deepMap8
+          Type: 1204 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1214
+      ID: 1216
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.181536e+06
@@ -11802,9 +11802,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1217 GoMapType map[int]*main.deepMap9
+          Type: 1219 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1229
+      ID: 1231
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.181408e+06
@@ -11812,7 +11812,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1232 GoMapType map[int]interface {}
+          Type: 1234 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 126
       Name: main.deepPtr1
@@ -11832,9 +11832,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1138 PointerType *main.deepPtr3
+          Type: 1140 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1141
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11846,9 +11846,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1183 PointerType *main.deepPtr8
+          Type: 1185 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1184
+      ID: 1186
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.182688e+06
@@ -11856,9 +11856,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1185 PointerType *main.deepPtr9
+          Type: 1187 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1186
+      ID: 1188
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18256e+06
@@ -11886,9 +11886,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1162 GoSliceHeaderType []*main.deepSlice3
+          Type: 1164 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1167
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11900,9 +11900,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1187 GoSliceHeaderType []*main.deepSlice8
+          Type: 1189 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1190
+      ID: 1192
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.18384e+06
@@ -11910,9 +11910,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1193 GoSliceHeaderType []*main.deepSlice9
+          Type: 1195 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1196
+      ID: 1198
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.183712e+06
@@ -11920,7 +11920,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1199 GoSliceHeaderType []interface {}
+          Type: 1201 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 288
       Name: main.emptyStruct
@@ -11938,16 +11938,16 @@ Types:
           Type: 149 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1145 StructureType sync.Mutex
+          Type: 1147 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1148 StructureType sync.Once
+          Type: 1150 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1151 StructureType sync.WaitGroup
+          Type: 1153 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1154 StructureType sync/atomic.Int32
+          Type: 1156 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 149
       Name: main.esotericStack
@@ -11977,7 +11977,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1156
+      ID: 1158
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.40832e+06
@@ -12022,7 +12022,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1158
+      ID: 1160
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.40848e+06
@@ -12042,7 +12042,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1144
+      ID: 1146
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12053,18 +12053,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1141 PointerType *main.stringType1.str
+          Type: 1143 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1140 GoStringDataType main.stringType1.str
+      Data: 1142 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1140
+      ID: 1142
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1142
+      ID: 1144
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -12167,16 +12167,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1159 PointerType **main.t
+          Type: 1161 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1160 GoSliceDataType main.t.array
+      Data: 1162 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1160
+      ID: 1162
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -12362,7 +12362,7 @@ Types:
       TablePtrSliceType: 309 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 304 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1170
+      ID: 1172
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -12375,7 +12375,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1171 PointerType **table<int,*main.deepMap3>
+          Type: 1173 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12391,10 +12391,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1181 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1176 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1183 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1178 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1204
+      ID: 1206
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -12407,7 +12407,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1205 PointerType **table<int,*main.deepMap8>
+          Type: 1207 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12423,10 +12423,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1215 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1210 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1217 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1212 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1219
+      ID: 1221
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -12439,7 +12439,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1220 PointerType **table<int,*main.deepMap9>
+          Type: 1222 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12455,8 +12455,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1230 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1225 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1232 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1227 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 162
       Name: map<int,int>
@@ -12490,7 +12490,7 @@ Types:
       TablePtrSliceType: 317 GoSliceDataType []*table<int,int>.array
       GroupType: 314 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1234
+      ID: 1236
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -12503,7 +12503,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1235 PointerType **table<int,interface {}>
+          Type: 1237 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12519,8 +12519,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1243 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1240 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1245 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1242 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 199
       Name: map<int,uint8>
@@ -12618,7 +12618,7 @@ Types:
       TablePtrSliceType: 341 GoSliceDataType []*table<string,[]string>.array
       GroupType: 338 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 904
+      ID: 906
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -12631,7 +12631,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 905 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 907 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12647,8 +12647,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 939 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 936 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 941 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 938 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 172
       Name: map<string,int>
@@ -13005,26 +13005,26 @@ Types:
       GoKind: 21
       HeaderType: 140 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1168
+      ID: 1170
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124704e+06
       GoKind: 21
-      HeaderType: 1170 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1172 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1202
+      ID: 1204
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.124064e+06
       GoKind: 21
-      HeaderType: 1204 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1206 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1217
+      ID: 1219
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.123936e+06
       GoKind: 21
-      HeaderType: 1219 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1221 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 160
       Name: map[int]int
@@ -13033,12 +13033,12 @@ Types:
       GoKind: 21
       HeaderType: 162 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1232
+      ID: 1234
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.123808e+06
       GoKind: 21
-      HeaderType: 1234 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1236 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 197
       Name: map[int]uint8
@@ -13125,7 +13125,7 @@ Types:
       GoKind: 21
       HeaderType: 204 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 658
+      ID: 660
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.42432e+06
@@ -13135,7 +13135,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 954
+      ID: 956
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.42112e+06
@@ -13145,11 +13145,11 @@ Types:
           Offset: 0
           Type: 125 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 863
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 924
+      ID: 926
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.59104e+06
@@ -13162,35 +13162,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 889
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1101
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 887
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 865
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1111
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1121
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1109
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 822
+      ID: 824
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.10896e+06
@@ -13198,28 +13198,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 824 PointerType *net.UnknownNetworkError.str
+          Type: 826 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 823 GoStringDataType net.UnknownNetworkError.str
+      Data: 825 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 823
+      ID: 825
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 791
+      ID: 793
       Name: net.canceledError
       GoRuntimeType: 1.279776e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1077
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 929
+      ID: 931
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.098656e+06
@@ -13227,7 +13227,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -13238,27 +13238,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1123
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1115
+      ID: 1117
       Name: net.noReadFrom
       GoRuntimeType: 1.109216e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1114
+      ID: 1116
       Name: net.noWriteTo
       GoRuntimeType: 1.109088e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 593
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 593
+      ID: 595
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.7216e+06
@@ -13266,7 +13266,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 912 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 914 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -13274,7 +13274,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1103
+      ID: 1105
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.283392e+06
@@ -13282,12 +13282,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1115 StructureType net.noReadFrom
+          Type: 1117 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1108 PointerType *net.TCPConn
+          Type: 1110 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1101
+      ID: 1103
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.282848e+06
@@ -13295,24 +13295,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1114 StructureType net.noWriteTo
+          Type: 1116 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1108 PointerType *net.TCPConn
+          Type: 1110 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 867
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 891
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 783
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 948
+      ID: 950
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.41264e+06
@@ -13322,19 +13322,19 @@ Types:
           Offset: 0
           Type: 125 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 487
+      ID: 489
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 828832
       GoKind: 10
     - __kind: BaseType
-      ID: 901
+      ID: 903
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 986368
       GoKind: 10
     - __kind: StructureType
-      ID: 569
+      ID: 571
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.719872e+06
@@ -13345,12 +13345,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 901 BaseType net/http.http2ErrCode
+          Type: 903 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 881
+      ID: 883
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.891456e+06
@@ -13361,12 +13361,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 901 BaseType net/http.http2ErrCode
+          Type: 903 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 573
+      ID: 575
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.59056e+06
@@ -13374,16 +13374,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 901 BaseType net/http.http2ErrCode
+          Type: 903 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1012
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 491
+      ID: 493
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829024
@@ -13391,18 +13391,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 493 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 495 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 492 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 494 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 492
+      ID: 494
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 497
+      ID: 499
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 829216
@@ -13410,18 +13410,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 499 PointerType *net/http.http2headerFieldNameError.str
+          Type: 501 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 498 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 500 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 498
+      ID: 500
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 494
+      ID: 496
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 829120
@@ -13429,32 +13429,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 496 PointerType *net/http.http2headerFieldValueError.str
+          Type: 498 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 495 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 497 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 495
+      ID: 497
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 858
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 787
+      ID: 789
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.279008e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1064
+      ID: 1066
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 488
+      ID: 490
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828928
@@ -13462,18 +13462,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 490 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 492 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 489 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 491 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 489
+      ID: 491
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 950
+      ID: 952
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.815744e+06
@@ -13481,18 +13481,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1043 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1045 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1044 BaseType time.Duration
+          Type: 1046 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 104 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1043
+      ID: 1045
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.412e+06
@@ -13505,14 +13505,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1029
+      ID: 1031
       Name: net/http.incomparable
       GoRuntimeType: 898784
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 783
+      ID: 785
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.5496e+06
@@ -13522,11 +13522,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1014
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 968
+      ID: 970
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.54944e+06
@@ -13534,9 +13534,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1011 PointerType *net/http.persistConn
+          Type: 1013 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 994
+      ID: 996
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.791744e+06
@@ -13544,15 +13544,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1029 ArrayType net/http.incomparable
+          Type: 1031 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1030 PointerType *bufio.Reader
+          Type: 1032 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1032 GoInterfaceType io.ReadWriteCloser
+          Type: 1034 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 577
+      ID: 579
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.4136e+06
@@ -13562,17 +13562,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 885
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 854
+      ID: 856
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.4736e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 785
+      ID: 787
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.54976e+06
@@ -13582,7 +13582,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1046
+      ID: 1048
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.017632e+06
@@ -13590,16 +13590,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 568
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1066
+      ID: 1068
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.033664e+06
@@ -13607,13 +13607,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1059 PointerType *bufio.Writer
+          Type: 1061 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 980
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 652
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.724672e+06
@@ -13629,7 +13629,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 648
+      ID: 650
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.59248e+06
@@ -13642,11 +13642,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1020
+      ID: 1022
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 980
+      ID: 982
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.5944e+06
@@ -13654,16 +13654,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1019 PointerType *net/smtp.Client
+          Type: 1021 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1021 GoInterfaceType io.WriteCloser
+          Type: 1023 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 634
+      ID: 636
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 522
+      ID: 524
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 831808
@@ -13671,26 +13671,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 524 PointerType *net/textproto.ProtocolError.str
+          Type: 526 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 523 GoStringDataType net/textproto.ProtocolError.str
+      Data: 525 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 523
+      ID: 525
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 978
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 893
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 500
+      ID: 502
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 829792
@@ -13698,18 +13698,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 502 PointerType *net/url.EscapeError.str
+          Type: 504 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 501 GoStringDataType net/url.EscapeError.str
+      Data: 503 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 501
+      ID: 503
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 503
+      ID: 505
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 829888
@@ -13717,13 +13717,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 505 PointerType *net/url.InvalidHostError.str
+          Type: 507 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 504 GoStringDataType net/url.InvalidHostError.str
+      Data: 506 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 504
+      ID: 506
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -13773,32 +13773,32 @@ Types:
       HasCount: true
       Element: 306 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1177
+      ID: 1179
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678464
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1178 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1180 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1211
+      ID: 1213
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 677984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1212 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1214 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1226
+      ID: 1228
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1227 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1229 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 315
       Name: noalg.[8]struct { key int; elem int }
@@ -13809,14 +13809,14 @@ Types:
       HasCount: true
       Element: 316 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1241
+      ID: 1243
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1242 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1244 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 374
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -13845,14 +13845,14 @@ Types:
       HasCount: true
       Element: 340 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 937
+      ID: 939
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 755104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 938 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 940 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 331
       Name: noalg.[8]struct { key string; elem int }
@@ -14003,7 +14003,7 @@ Types:
           Offset: 8
           Type: 305 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1176
+      ID: 1178
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.290272e+06
@@ -14014,9 +14014,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1177 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1179 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1210
+      ID: 1212
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.288992e+06
@@ -14027,9 +14027,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1211 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1213 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1225
+      ID: 1227
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.288736e+06
@@ -14040,7 +14040,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1226 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1228 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 314
       Name: noalg.map.group[int]int
@@ -14055,7 +14055,7 @@ Types:
           Offset: 8
           Type: 315 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1240
+      ID: 1242
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.28848e+06
@@ -14066,7 +14066,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1241 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1243 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 373
       Name: noalg.map.group[int]uint8
@@ -14107,7 +14107,7 @@ Types:
           Offset: 8
           Type: 339 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 936
+      ID: 938
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.353504e+06
@@ -14118,7 +14118,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 937 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 939 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 330
       Name: noalg.map.group[string]int
@@ -14309,7 +14309,7 @@ Types:
           Offset: 8
           Type: 307 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1178
+      ID: 1180
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.290144e+06
@@ -14320,9 +14320,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1179 PointerType *main.deepMap3
+          Type: 1181 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1212
+      ID: 1214
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.288864e+06
@@ -14333,9 +14333,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1213 PointerType *main.deepMap8
+          Type: 1215 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1227
+      ID: 1229
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.288608e+06
@@ -14346,7 +14346,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1228 PointerType *main.deepMap9
+          Type: 1230 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 316
       Name: noalg.struct { key int; elem int }
@@ -14361,7 +14361,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1242
+      ID: 1244
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.288352e+06
@@ -14413,7 +14413,7 @@ Types:
           Offset: 16
           Type: 235 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 938
+      ID: 940
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.353376e+06
@@ -14424,7 +14424,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 925 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 927 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 332
       Name: noalg.struct { key string; elem int }
@@ -14550,19 +14550,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1127
+      ID: 1129
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 762
+      ID: 764
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 828
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1125
+      ID: 1127
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.352e+06
@@ -14570,12 +14570,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1131 StructureType os.noReadFrom
+          Type: 1133 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1126 PointerType *os.File
+          Type: 1128 PointerType *os.File
     - __kind: StructureType
-      ID: 1123
+      ID: 1125
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.3512e+06
@@ -14583,36 +14583,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1130 StructureType os.noWriteTo
+          Type: 1132 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1126 PointerType *os.File
+          Type: 1128 PointerType *os.File
     - __kind: StructureType
-      ID: 1131
+      ID: 1133
       Name: os.noReadFrom
       GoRuntimeType: 1.106528e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1130
+      ID: 1132
       Name: os.noWriteTo
       GoRuntimeType: 1.1064e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 795
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 934
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1000
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 795
+      ID: 797
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.696416e+06
@@ -14625,7 +14625,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 536
+      ID: 538
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 835072
@@ -14633,36 +14633,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 538 PointerType *os/user.UnknownGroupIdError.str
+          Type: 540 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 537 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 539 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 537
+      ID: 539
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 535
+      ID: 537
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 834976
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 563
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 658
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 766
+      ID: 768
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 772
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -14674,7 +14674,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 768
+      ID: 770
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.879872e+06
@@ -14691,9 +14691,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 930 BaseType runtime.boundsErrorCode
+          Type: 932 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 930
+      ID: 932
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 581536
@@ -14713,7 +14713,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 828
+      ID: 830
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.744224e+06
@@ -14726,7 +14726,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 746
+      ID: 748
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 985024
@@ -14734,13 +14734,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 748 PointerType *runtime.errorString.str
+          Type: 750 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 747 GoStringDataType runtime.errorString.str
+      Data: 749 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 747
+      ID: 749
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15396,7 +15396,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 751
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 985120
@@ -15404,13 +15404,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *runtime.plainError.str
+          Type: 753 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 750 GoStringDataType runtime.plainError.str
+      Data: 752 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 752
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15496,7 +15496,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 772
+      ID: 774
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -15519,15 +15519,15 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1062
+      ID: 1064
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 968
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 962
+      ID: 964
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.4504e+06
@@ -15543,7 +15543,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1145
+      ID: 1147
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.45888e+06
@@ -15551,12 +15551,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1146 StructureType sync.noCopy
+          Type: 1148 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1147 StructureType internal/sync.Mutex
+          Type: 1149 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1148
+      ID: 1150
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.607232e+06
@@ -15564,15 +15564,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1146 StructureType sync.noCopy
+          Type: 1148 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1149 StructureType sync/atomic.Uint32
+          Type: 1151 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1145 StructureType sync.Mutex
+          Type: 1147 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1151
+      ID: 1153
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.607424e+06
@@ -15580,21 +15580,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1146 StructureType sync.noCopy
+          Type: 1148 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1152 StructureType sync/atomic.Uint64
+          Type: 1154 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1146
+      ID: 1148
       Name: sync.noCopy
       GoRuntimeType: 983968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1154
+      ID: 1156
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.46016e+06
@@ -15602,12 +15602,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1150 StructureType sync/atomic.noCopy
+          Type: 1152 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1149
+      ID: 1151
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.46032e+06
@@ -15615,12 +15615,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1150 StructureType sync/atomic.noCopy
+          Type: 1152 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1152
+      ID: 1154
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607808e+06
@@ -15628,27 +15628,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1150 StructureType sync/atomic.noCopy
+          Type: 1152 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1153 StructureType sync/atomic.align64
+          Type: 1155 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1153
+      ID: 1155
       Name: sync/atomic.align64
       GoRuntimeType: 984160
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1150
+      ID: 1152
       Name: sync/atomic.noCopy
       GoRuntimeType: 984064
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 878
+      ID: 880
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.278368e+06
@@ -15774,7 +15774,7 @@ Types:
           Offset: 16
           Type: 302 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1173
+      ID: 1175
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -15796,9 +15796,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1174 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1176 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1207
+      ID: 1209
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -15820,9 +15820,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1208 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1210 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1222
+      ID: 1224
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -15844,7 +15844,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1223 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1225 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 311
       Name: table<int,int>
@@ -15870,7 +15870,7 @@ Types:
           Offset: 16
           Type: 312 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1237
+      ID: 1239
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -15892,7 +15892,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1238 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1240 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 370
       Name: table<int,uint8>
@@ -15966,7 +15966,7 @@ Types:
           Offset: 16
           Type: 336 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 933
+      ID: 935
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -15988,7 +15988,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 934 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 936 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 327
       Name: table<string,int>
@@ -16230,11 +16230,11 @@ Types:
           Offset: 16
           Type: 379 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1099
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 821
+      ID: 823
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.700832e+06
@@ -16247,21 +16247,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 1044
+      ID: 1046
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.906016e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 898
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 566
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 894
+      ID: 896
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.36688e+06
@@ -16275,9 +16275,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 895 PointerType *time.Location
+          Type: 897 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 484
+      ID: 486
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 827968
@@ -16285,13 +16285,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 486 PointerType *time.fileSizeError.str
+          Type: 488 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 485 GoStringDataType time.fileSizeError.str
+      Data: 487 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 485
+      ID: 487
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -16338,7 +16338,7 @@ Types:
       GoRuntimeType: 581472
       GoKind: 26
     - __kind: StructureType
-      ID: 912
+      ID: 914
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.055072e+06
@@ -16349,10 +16349,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 913 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 915 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 914 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 916 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -16367,18 +16367,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 915 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 917 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 915
+      ID: 917
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 990592
       GoKind: 9
     - __kind: StructureType
-      ID: 913
+      ID: 915
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.916768e+06
@@ -16403,21 +16403,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 654
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 914
+      ID: 916
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 585120
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1089
+      ID: 1091
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 636
+      ID: 638
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.42144e+06
@@ -16427,13 +16427,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 525
+      ID: 527
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 831904
       GoKind: 2
     - __kind: StructureType
-      ID: 800
+      ID: 802
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.696608e+06
@@ -16446,7 +16446,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 754
+      ID: 756
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 989440

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -3464,20 +3464,20 @@ Types:
       ByteSize: 8
       Pointee: 136 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1182
+      ID: 1184
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1183 PointerType *main.deepSlice3
+      Pointee: 1185 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1207
+      ID: 1209
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1208 PointerType *main.deepSlice8
+      Pointee: 1210 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1213
+      ID: 1215
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1214 PointerType *main.deepSlice9
+      Pointee: 1216 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 149
       Name: '**main.stringType2'
@@ -3485,7 +3485,7 @@ Types:
       GoKind: 22
       Pointee: 150 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1178
+      ID: 1180
       Name: '**main.t'
       ByteSize: 8
       Pointee: 229 PointerType *main.t
@@ -3528,30 +3528,30 @@ Types:
       ByteSize: 8
       Pointee: 144 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1190
+      ID: 1192
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1191 PointerType *table<int,*main.deepMap3>
+      Pointee: 1193 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1224
+      ID: 1226
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1225 PointerType *table<int,*main.deepMap8>
+      Pointee: 1227 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1239
+      ID: 1241
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1240 PointerType *table<int,*main.deepMap9>
+      Pointee: 1242 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 165
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 166 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1254
+      ID: 1256
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1255 PointerType *table<int,interface {}>
+      Pointee: 1257 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 202
       Name: '**table<int,uint8>'
@@ -3568,10 +3568,10 @@ Types:
       ByteSize: 8
       Pointee: 181 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 924
+      ID: 926
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 925 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 927 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 175
       Name: '**table<string,int>'
@@ -3628,20 +3628,20 @@ Types:
       ByteSize: 8
       Pointee: 304 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1186
+      ID: 1188
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1185 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1187 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1211
+      ID: 1213
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1210 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1212 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1217
+      ID: 1219
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1216 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1218 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 300
       Name: '*[]*runtime.p.array'
@@ -3708,15 +3708,15 @@ Types:
       ByteSize: 8
       Pointee: 424 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 961
+      ID: 963
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 960 GoSliceDataType []float64.array
+      Pointee: 962 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1220
+      ID: 1222
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1219 GoSliceDataType []interface {}.array
+      Pointee: 1221 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 248
       Name: '*[]main.structWithCyclicSlices'
@@ -3728,10 +3728,10 @@ Types:
       ByteSize: 8
       Pointee: 428 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1265
+      ID: 490
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1264 GoSliceDataType []main.structWithMap.array
+      Pointee: 489 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 421
       Name: '*[]main.structWithNoStrings.array'
@@ -3775,66 +3775,66 @@ Types:
       ByteSize: 8
       Pointee: 296 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1091
+      ID: 1093
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.985952e+06
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1094 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 726
+      ID: 728
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 931392
       GoKind: 22
-      Pointee: 727 GoSliceHeaderType archive/tar.headerError
+      Pointee: 729 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 729
+      ID: 731
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 728 GoSliceDataType archive/tar.headerError.array
+      Pointee: 730 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1026
+      ID: 1028
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.435072e+06
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1029 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 974
+      ID: 976
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 931584
       GoKind: 22
-      Pointee: 975 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 977 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 976
+      ID: 978
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 977 StructureType archive/zip.dirWriter
+      Pointee: 979 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1070
+      ID: 1072
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.904096e+06
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1073 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1002
+      ID: 1004
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.057792e+06
       GoKind: 22
-      Pointee: 1003 StructureType archive/zip.nopCloser
+      Pointee: 1005 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1004
+      ID: 1006
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.058048e+06
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1007 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3843,435 +3843,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1049
+      ID: 1051
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.174048e+06
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType bufio.Reader
+      Pointee: 1052 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1078
+      ID: 1080
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.948832e+06
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType bufio.Writer
+      Pointee: 1081 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1129
+      ID: 1131
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.266912e+06
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1132 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 636
+      ID: 638
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 913824
       GoKind: 22
-      Pointee: 525 BaseType compress/flate.CorruptInputError
+      Pointee: 527 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 637
+      ID: 639
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 913920
       GoKind: 22
-      Pointee: 526 GoStringHeaderType compress/flate.InternalError
+      Pointee: 528 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 528
+      ID: 530
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 527 GoStringDataType compress/flate.InternalError.str
+      Pointee: 529 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.424672e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1027 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 970
+      ID: 972
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 914016
       GoKind: 22
-      Pointee: 971 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 973 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1046
+      ID: 1048
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.725376e+06
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1049 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.203328e+06
       GoKind: 22
-      Pointee: 875 StructureType context.deadlineExceededError
+      Pointee: 877 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 718
+      ID: 720
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926016
       GoKind: 22
-      Pointee: 539 BaseType crypto/aes.KeySizeError
+      Pointee: 541 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 719
+      ID: 721
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 540 BaseType crypto/des.KeySizeError
+      Pointee: 542 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 720
+      ID: 722
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 541 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 543 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1041
+      ID: 1043
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.666112e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1044 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 823
+      ID: 825
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.0656e+06
       GoKind: 22
-      Pointee: 824 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 826 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1072
+      ID: 1074
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904608e+06
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1075 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1102
+      ID: 1104
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.1192e+06
       GoKind: 22
-      Pointee: 1103 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1105 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1076
+      ID: 1078
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.90512e+06
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1079 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1074
+      ID: 1076
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904864e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1077 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1068
+      ID: 1070
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.902304e+06
       GoKind: 22
-      Pointee: 1069 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1071 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 721
+      ID: 723
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926784
       GoKind: 22
-      Pointee: 542 BaseType crypto/rc4.KeySizeError
+      Pointee: 544 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1089
+      ID: 1091
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.983072e+06
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1092 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1064
+      ID: 1066
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.87168e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1067 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 915648
       GoKind: 22
-      Pointee: 529 BaseType crypto/tls.AlertError
+      Pointee: 531 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 812
+      ID: 814
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.0464e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 815 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1155
+      ID: 1157
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.378432e+06
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1158 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 915360
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 643 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 915264
       GoKind: 22
-      Pointee: 639 StructureType crypto/tls.RecordHeaderError
+      Pointee: 641 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.044736e+06
       GoKind: 22
-      Pointee: 766 BaseType crypto/tls.alert
+      Pointee: 768 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1034
+      ID: 1036
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.558976e+06
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1037 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 642
+      ID: 644
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 645 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1039
+      ID: 1041
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.641152e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1042 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 909
+      ID: 911
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.425152e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 912 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 926
+      ID: 928
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.04224e+06
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 929 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 714
+      ID: 716
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 715 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 717 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 708
+      ID: 710
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 924576
       GoKind: 22
-      Pointee: 709 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 711 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 710
+      ID: 712
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 924672
       GoKind: 22
-      Pointee: 711 StructureType crypto/x509.HostnameError
+      Pointee: 713 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 538 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 540 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 817
+      ID: 819
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.05216e+06
       GoKind: 22
-      Pointee: 818 StructureType crypto/x509.SystemRootsError
+      Pointee: 820 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 716
+      ID: 718
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 925152
       GoKind: 22
-      Pointee: 717 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 719 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 712
+      ID: 714
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 713 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 715 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 730
+      ID: 732
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 731 StructureType encoding/asn1.StructuralError
+      Pointee: 733 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 734
+      ID: 736
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932064
       GoKind: 22
-      Pointee: 735 StructureType encoding/asn1.SyntaxError
+      Pointee: 737 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 732
+      ID: 734
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 931968
       GoKind: 22
-      Pointee: 733 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 735 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 625
+      ID: 627
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 520 BaseType encoding/base64.CorruptInputError
+      Pointee: 522 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 992
+      ID: 994
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.041792e+06
       GoKind: 22
-      Pointee: 993 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 995 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 628
+      ID: 630
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 521 BaseType encoding/hex.InvalidByteError
+      Pointee: 523 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 597 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 599 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.037952e+06
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 804 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 906240
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 591 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 906528
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 597 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 906432
       GoKind: 22
-      Pointee: 593 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 595 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 906336
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 593 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1135
+      ID: 1137
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.292448e+06
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1138 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 598
+      ID: 600
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 599 StructureType encoding/json.jsonError
+      Pointee: 601 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1000
+      ID: 1002
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.05472e+06
       GoKind: 22
-      Pointee: 1001 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1003 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 702
+      ID: 704
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 705 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 700
+      ID: 702
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 703 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 704
+      ID: 706
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923616
       GoKind: 22
-      Pointee: 535 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 537 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 537
+      ID: 539
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 538 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 705
+      ID: 707
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 708 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1113
+      ID: 1115
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.15904e+06
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1116 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -4280,19 +4280,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 564
+      ID: 566
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896640
       GoKind: 22
-      Pointee: 565 UnresolvedPointeeType errors.errorString
+      Pointee: 567 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 768
+      ID: 770
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.022848e+06
       GoKind: 22
-      Pointee: 769 UnresolvedPointeeType errors.joinError
+      Pointee: 771 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -4308,813 +4308,813 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 1123
+      ID: 1125
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.259232e+06
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType fmt.pp
+      Pointee: 1126 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 770
+      ID: 772
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.02464e+06
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType fmt.wrapError
+      Pointee: 773 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 772
+      ID: 774
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.024768e+06
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 775 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 912192
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 629 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 607
+      ID: 609
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 608 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 610 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 609
+      ID: 611
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 612 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 938
+      ID: 940
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 909216
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 941 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 613
+      ID: 615
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 909792
       GoKind: 22
-      Pointee: 614 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 616 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 940
+      ID: 942
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 909312
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 943 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 611
+      ID: 613
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 514 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 516 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 516
+      ID: 518
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 515 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 517 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 606
+      ID: 608
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 909120
       GoKind: 22
-      Pointee: 511 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 513 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 513
+      ID: 515
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 512 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 514 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 517 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 519 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 519
+      ID: 521
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 518 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 520 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1012
+      ID: 1014
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.208832e+06
       GoKind: 22
-      Pointee: 1013 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1015 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1099
+      ID: 1101
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.057248e+06
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1102 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 724
+      ID: 726
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 930336
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 727 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 883
+      ID: 885
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.212416e+06
       GoKind: 22
-      Pointee: 884 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 886 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1131
+      ID: 1133
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.26896e+06
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1134 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 651
+      ID: 653
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 654 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 658
+      ID: 660
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 920064
       GoKind: 22
-      Pointee: 659 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 661 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 653
+      ID: 655
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 534 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 536 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 919968
       GoKind: 22
-      Pointee: 657 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 659 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 919872
       GoKind: 22
-      Pointee: 655 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 657 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 674
+      ID: 676
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 921984
       GoKind: 22
-      Pointee: 675 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 677 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 678
+      ID: 680
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 922176
       GoKind: 22
-      Pointee: 679 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 681 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 676
+      ID: 678
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 677 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 679 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 672
+      ID: 674
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 921888
       GoKind: 22
-      Pointee: 673 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 675 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 962 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 964 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 686
+      ID: 688
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 687 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 689 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 680
+      ID: 682
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 681 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 683 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 684
+      ID: 686
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 685 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 687 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 682
+      ID: 684
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 683 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 685 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 688
+      ID: 690
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 922656
       GoKind: 22
-      Pointee: 689 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 691 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 922944
       GoKind: 22
-      Pointee: 695 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 697 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 696
+      ID: 698
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 923040
       GoKind: 22
-      Pointee: 697 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 699 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 692
+      ID: 694
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 922848
       GoKind: 22
-      Pointee: 693 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 695 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 690
+      ID: 692
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 691 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 693 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 698
+      ID: 700
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 923232
       GoKind: 22
-      Pointee: 699 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 701 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 615
+      ID: 617
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 910944
       GoKind: 22
-      Pointee: 616 StructureType github.com/cihub/seelog.baseError
+      Pointee: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1052
+      ID: 1054
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.80224e+06
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1055 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 617
+      ID: 619
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 911040
       GoKind: 22
-      Pointee: 618 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 620 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1032
+      ID: 1034
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.557696e+06
       GoKind: 22
-      Pointee: 1033 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1035 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 988
+      ID: 990
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.04064e+06
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 991 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1022
+      ID: 1024
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.422752e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1025 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 621
+      ID: 623
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 911232
       GoKind: 22
-      Pointee: 622 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 624 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1087
+      ID: 1089
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.975296e+06
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1090 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1106
+      ID: 1108
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.13184e+06
       GoKind: 22
-      Pointee: 1101 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1103 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1105
+      ID: 1107
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.131456e+06
       GoKind: 22
-      Pointee: 1104 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1106 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 990
+      ID: 992
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.040768e+06
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 993 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 620 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 622 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 623
+      ID: 625
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 624 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 626 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1054
+      ID: 1056
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.804032e+06
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1057 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1095
+      ID: 1097
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.011424e+06
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1098 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1097
+      ID: 1099
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.04192e+06
       GoKind: 22
-      Pointee: 1098 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1100 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 914
+      ID: 916
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.437472e+06
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 917 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 827
+      ID: 829
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.066368e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 830 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 825
+      ID: 827
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.06624e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 828 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 829
+      ID: 831
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.070336e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 832 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 831
+      ID: 833
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.070464e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 834 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1043
+      ID: 1045
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.668416e+06
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1046 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.0528e+06
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 822 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 629
+      ID: 631
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 912864
       GoKind: 22
-      Pointee: 630 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 632 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1147
+      ID: 1149
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.35488e+06
       GoKind: 22
-      Pointee: 1148 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1150 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 885
+      ID: 887
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.220992e+06
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 888 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 858
+      ID: 860
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.199872e+06
       GoKind: 22
-      Pointee: 859 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 861 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 852
+      ID: 854
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.199488e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 855 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 787
+      ID: 789
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.031936e+06
       GoKind: 22
-      Pointee: 788 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 790 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 864
+      ID: 866
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.200256e+06
       GoKind: 22
-      Pointee: 865 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 867 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.031808e+06
       GoKind: 22
-      Pointee: 765 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 767 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 856
+      ID: 858
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.199744e+06
       GoKind: 22
-      Pointee: 857 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 859 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 854
+      ID: 856
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.199616e+06
       GoKind: 22
-      Pointee: 855 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 857 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 862
+      ID: 864
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.200128e+06
       GoKind: 22
-      Pointee: 863 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 865 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 860
+      ID: 862
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.2e+06
       GoKind: 22
-      Pointee: 861 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 863 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1151
+      ID: 1153
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.367488e+06
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1154 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 868
+      ID: 870
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.20064e+06
       GoKind: 22
-      Pointee: 869 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 871 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 791
+      ID: 793
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.032192e+06
       GoKind: 22
-      Pointee: 792 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 794 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 789
+      ID: 791
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.032064e+06
       GoKind: 22
-      Pointee: 790 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 792 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 866
+      ID: 868
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.200512e+06
       GoKind: 22
-      Pointee: 867 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 869 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 746
+      ID: 748
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944832
       GoKind: 22
-      Pointee: 547 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 549 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 549
+      ID: 551
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 548 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 550 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.66688e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 932 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 835
+      ID: 837
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.085184e+06
       GoKind: 22
-      Pointee: 836 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 838 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1018
+      ID: 1020
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.2608e+06
       GoKind: 22
-      Pointee: 1019 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1021 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1111
+      ID: 1113
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.1472e+06
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1114 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1006
+      ID: 1008
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.087488e+06
       GoKind: 22
-      Pointee: 1007 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1009 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 946080
       GoKind: 22
-      Pointee: 550 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 552 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 893
+      ID: 895
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.262464e+06
       GoKind: 22
-      Pointee: 894 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 896 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 750
+      ID: 752
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 946368
       GoKind: 22
-      Pointee: 751 StructureType golang.org/x/net/http2.connError
+      Pointee: 753 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 749
+      ID: 751
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946272
       GoKind: 22
-      Pointee: 554 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 556 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 555 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 557 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 753
+      ID: 755
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 946560
       GoKind: 22
-      Pointee: 560 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 562 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 562
+      ID: 564
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 561 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 563 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 752
+      ID: 754
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 946464
       GoKind: 22
-      Pointee: 557 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 559 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 560 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 748
+      ID: 750
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946176
       GoKind: 22
-      Pointee: 551 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 553 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 553
+      ID: 555
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 552 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 554 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1109
+      ID: 1111
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.14528e+06
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1112 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 754
+      ID: 756
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 946656
       GoKind: 22
-      Pointee: 755 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 757 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 756
+      ID: 758
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 946752
       GoKind: 22
-      Pointee: 563 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 565 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 742
+      ID: 744
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 743 StructureType google.golang.org/grpc.dropError
+      Pointee: 745 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 891
+      ID: 893
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.25952e+06
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 894 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 916
+      ID: 918
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.444832e+06
       GoKind: 22
-      Pointee: 917 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 919 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 744
+      ID: 746
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 943104
       GoKind: 22
-      Pointee: 745 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 747 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1058
+      ID: 1060
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.809632e+06
       GoKind: 22
-      Pointee: 1059 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1061 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1016
+      ID: 1018
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.256064e+06
       GoKind: 22
-      Pointee: 1017 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1019 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 833
+      ID: 835
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.079424e+06
       GoKind: 22
-      Pointee: 834 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 836 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 978
+      ID: 980
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 943200
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 981 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 722
+      ID: 724
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 928224
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 725 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 821
+      ID: 823
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.056128e+06
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 824 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 889
+      ID: 891
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.227392e+06
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 892 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 887
+      ID: 889
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.227136e+06
       GoKind: 22
-      Pointee: 888 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 890 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 736
+      ID: 738
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932928
       GoKind: 22
-      Pointee: 737 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 739 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 738
+      ID: 740
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 933024
       GoKind: 22
-      Pointee: 739 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 741 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 666
+      ID: 668
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 669 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1066
+      ID: 1068
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.900256e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1069 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 947520
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType html/template.Error
+      Pointee: 760 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -5158,115 +5158,115 @@ Types:
       GoKind: 22
       Pointee: 153 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 918
+      ID: 920
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.211552e+06
       GoKind: 22
-      Pointee: 919 UnresolvedPointeeType internal/abi.Type
+      Pointee: 921 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 634
+      ID: 636
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 913536
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 637 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 632
+      ID: 634
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 913440
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 635 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 964
+      ID: 966
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 901440
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 967 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 850
+      ID: 852
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.19872e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 853 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1153
+      ID: 1155
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.373152e+06
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1156 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 848
+      ID: 850
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.198592e+06
       GoKind: 22
-      Pointee: 849 StructureType internal/poll.errNetClosing
+      Pointee: 851 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 568
+      ID: 570
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900672
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 571 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 631
+      ID: 633
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 913248
       GoKind: 22
-      Pointee: 522 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 524 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 523 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 525 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 805
+      ID: 807
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.043072e+06
       GoKind: 22
-      Pointee: 806 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 808 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1010
+      ID: 1012
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.190016e+06
       GoKind: 22
-      Pointee: 1011 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1013 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1008
+      ID: 1010
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.189632e+06
       GoKind: 22
-      Pointee: 1009 StructureType io.discard
+      Pointee: 1011 StructureType io.discard
     - __kind: PointerType
-      ID: 982
+      ID: 984
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.023104e+06
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType io.multiWriter
+      Pointee: 985 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 846
+      ID: 848
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.19808e+06
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType io/fs.PathError
+      Pointee: 849 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1056
+      ID: 1058
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.804256e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1059 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 312
       Name: '*main.deepMap2'
@@ -5275,12 +5275,12 @@ Types:
       GoKind: 22
       Pointee: 313 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1198
+      ID: 1200
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385984
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType main.deepMap3
+      Pointee: 1201 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 145
       Name: '*main.deepMap7'
@@ -5289,19 +5289,19 @@ Types:
       GoKind: 22
       Pointee: 146 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1232
+      ID: 1234
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 385664
       GoKind: 22
-      Pointee: 1233 StructureType main.deepMap8
+      Pointee: 1235 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1247
+      ID: 1249
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385600
       GoKind: 22
-      Pointee: 1248 StructureType main.deepMap9
+      Pointee: 1250 StructureType main.deepMap9
     - __kind: PointerType
       ID: 129
       Name: '*main.deepPtr2'
@@ -5310,12 +5310,12 @@ Types:
       GoKind: 22
       Pointee: 130 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1157
+      ID: 1159
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1160 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 131
       Name: '*main.deepPtr7'
@@ -5324,19 +5324,19 @@ Types:
       GoKind: 22
       Pointee: 132 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1202
+      ID: 1204
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386240
       GoKind: 22
-      Pointee: 1203 StructureType main.deepPtr8
+      Pointee: 1205 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1204
+      ID: 1206
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386176
       GoKind: 22
-      Pointee: 1205 StructureType main.deepPtr9
+      Pointee: 1207 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 136
       Name: '*main.deepSlice2'
@@ -5345,12 +5345,12 @@ Types:
       GoKind: 22
       Pointee: 303 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1183
+      ID: 1185
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387136
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1186 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 137
       Name: '*main.deepSlice7'
@@ -5359,19 +5359,19 @@ Types:
       GoKind: 22
       Pointee: 138 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1208
+      ID: 1210
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386816
       GoKind: 22
-      Pointee: 1209 StructureType main.deepSlice8
+      Pointee: 1211 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1214
+      ID: 1216
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386752
       GoKind: 22
-      Pointee: 1215 StructureType main.deepSlice9
+      Pointee: 1217 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 291
       Name: '*main.emptyStruct'
@@ -5386,12 +5386,12 @@ Types:
       GoKind: 22
       Pointee: 156 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1174
+      ID: 1176
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 896352
       GoKind: 22
-      Pointee: 1175 StructureType main.firstBehavior
+      Pointee: 1177 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 228
       Name: '*main.node'
@@ -5406,19 +5406,19 @@ Types:
       GoKind: 22
       Pointee: 243 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1176
+      ID: 1178
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 896448
       GoKind: 22
-      Pointee: 1177 StructureType main.secondBehavior
+      Pointee: 1179 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1162
+      ID: 1164
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 896544
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1165 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 147
       Name: '*main.stringType1'
@@ -5426,16 +5426,16 @@ Types:
       GoKind: 22
       Pointee: 148 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1160
+      ID: 1162
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1159 GoStringDataType main.stringType1.str
+      Pointee: 1161 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 150
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1161 UnresolvedPointeeType main.stringType2
+      Pointee: 1163 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 246
       Name: '*main.structWithCyclicSlices'
@@ -5466,10 +5466,10 @@ Types:
       GoKind: 22
       Pointee: 230 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1180
+      ID: 1182
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1179 GoSliceDataType main.t.array
+      Pointee: 1181 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 241
       Name: '*main.threeStringStruct'
@@ -5502,30 +5502,30 @@ Types:
       ByteSize: 8
       Pointee: 142 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1188
+      ID: 1190
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1189 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1191 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1222
+      ID: 1224
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1223 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1225 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1237
+      ID: 1239
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1238 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1240 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 163
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 164 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1252
+      ID: 1254
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1253 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1255 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 200
       Name: '*map<int,uint8>'
@@ -5542,10 +5542,10 @@ Types:
       ByteSize: 8
       Pointee: 179 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 922
+      ID: 924
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 923 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 925 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 173
       Name: '*map<string,int>'
@@ -5603,451 +5603,451 @@ Types:
       GoKind: 22
       Pointee: 172 GoMapType map[string]int
     - __kind: PointerType
-      ID: 670
+      ID: 672
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 921312
       GoKind: 22
-      Pointee: 671 StructureType math/big.ErrNaN
+      Pointee: 673 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 972
+      ID: 974
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 916128
       GoKind: 22
-      Pointee: 973 StructureType mime/multipart.writerOnly·1
+      Pointee: 975 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 877
+      ID: 879
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.206656e+06
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType net.AddrError
+      Pointee: 880 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.420992e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType net.DNSError
+      Pointee: 906 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1117
+      ID: 1119
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.231904e+06
       GoKind: 22
-      Pointee: 1118 UnresolvedPointeeType net.IPConn
+      Pointee: 1120 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.420672e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType net.OpError
+      Pointee: 904 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.206784e+06
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType net.ParseError
+      Pointee: 882 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1127
+      ID: 1129
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.260256e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType net.TCPConn
+      Pointee: 1130 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1137
+      ID: 1139
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.30576e+06
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType net.UDPConn
+      Pointee: 1140 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1125
+      ID: 1127
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.259744e+06
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType net.UnixConn
+      Pointee: 1128 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 876
+      ID: 878
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.205888e+06
       GoKind: 22
-      Pointee: 839 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 841 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 841
+      ID: 843
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 840 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 842 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 803
+      ID: 805
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.038848e+06
       GoKind: 22
-      Pointee: 804 StructureType net.canceledError
+      Pointee: 806 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1093
+      ID: 1095
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.008832e+06
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType net.conn
+      Pointee: 1096 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 947
+      ID: 949
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.84704e+06
       GoKind: 22
-      Pointee: 948 StructureType net.dialResult·1
+      Pointee: 950 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1139
+      ID: 1141
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.310016e+06
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType net.netFD
+      Pointee: 1142 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 600
+      ID: 602
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907968
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType net.notFoundError
+      Pointee: 603 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 603 StructureType net.result·2
+      Pointee: 605 StructureType net.result·2
     - __kind: PointerType
-      ID: 1121
+      ID: 1123
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.246272e+06
       GoKind: 22
-      Pointee: 1122 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1124 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1119
+      ID: 1121
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.245792e+06
       GoKind: 22
-      Pointee: 1120 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1122 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 881
+      ID: 883
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.207424e+06
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType net.temporaryError
+      Pointee: 884 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.421152e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType net.timeoutError
+      Pointee: 908 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 793
+      ID: 795
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.034624e+06
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 796 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 966
+      ID: 968
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 903744
       GoKind: 22
-      Pointee: 967 StructureType net/http.bufioFlushWriter
+      Pointee: 969 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 577
+      ID: 579
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 904416
       GoKind: 22
-      Pointee: 492 BaseType net/http.http2ConnectionError
+      Pointee: 494 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 579 StructureType net/http.http2GoAwayError
+      Pointee: 581 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.416672e+06
       GoKind: 22
-      Pointee: 898 StructureType net/http.http2StreamError
+      Pointee: 900 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 582
+      ID: 584
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 583 StructureType net/http.http2connError
+      Pointee: 585 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1028
+      ID: 1030
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.554176e+06
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1031 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 581
+      ID: 583
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 22
-      Pointee: 496 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 498 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 498
+      ID: 500
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 497 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 499 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 585
+      ID: 587
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 905280
       GoKind: 22
-      Pointee: 502 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 504 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 504
+      ID: 506
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 503 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 505 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 905184
       GoKind: 22
-      Pointee: 499 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 501 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 501
+      ID: 503
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 500 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 502 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.20256e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 875 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.035264e+06
       GoKind: 22
-      Pointee: 800 StructureType net/http.http2noCachedConnError
+      Pointee: 802 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1082
+      ID: 1084
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.951136e+06
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1085 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 580
+      ID: 582
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 493 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 495 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 494 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 496 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 968
+      ID: 970
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 905376
       GoKind: 22
-      Pointee: 969 StructureType net/http.http2stickyErrWriter
+      Pointee: 971 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 795
+      ID: 797
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.03488e+06
       GoKind: 22
-      Pointee: 796 StructureType net/http.nothingWrittenError
+      Pointee: 798 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1030
+      ID: 1032
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.175296e+06
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1033 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 986
+      ID: 988
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.034752e+06
       GoKind: 22
-      Pointee: 987 StructureType net/http.persistConnWriter
+      Pointee: 989 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1020
+      ID: 1022
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.416832e+06
       GoKind: 22
-      Pointee: 1021 StructureType net/http.readWriteCloserBody
+      Pointee: 1023 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 587 StructureType net/http.requestBodyReadError
+      Pointee: 589 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.417952e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 902 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.202432e+06
       GoKind: 22
-      Pointee: 871 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 873 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 797
+      ID: 799
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.035008e+06
       GoKind: 22
-      Pointee: 798 StructureType net/http.transportReadFromServerError
+      Pointee: 800 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1062
+      ID: 1064
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.84368e+06
       GoKind: 22
-      Pointee: 1063 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1065 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 575
+      ID: 577
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 903648
       GoKind: 22
-      Pointee: 576 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 578 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1084
+      ID: 1086
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.952928e+06
       GoKind: 22
-      Pointee: 1085 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1087 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 996
+      ID: 998
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.047552e+06
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 999 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 662
+      ID: 664
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 920256
       GoKind: 22
-      Pointee: 663 StructureType net/netip.parseAddrError
+      Pointee: 665 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 660
+      ID: 662
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 661 StructureType net/netip.parsePrefixError
+      Pointee: 663 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1036
+      ID: 1038
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.117792e+06
       GoKind: 22
-      Pointee: 1037 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1039 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 998
+      ID: 1000
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.052416e+06
       GoKind: 22
-      Pointee: 999 StructureType net/smtp.dataCloser
+      Pointee: 1001 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 916320
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType net/textproto.Error
+      Pointee: 649 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 645
+      ID: 647
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 916224
       GoKind: 22
-      Pointee: 530 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 532 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 532
+      ID: 534
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 531 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 533 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 994
+      ID: 996
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.046784e+06
       GoKind: 22
-      Pointee: 995 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 997 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.421472e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType net/url.Error
+      Pointee: 910 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 604
+      ID: 606
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 505 GoStringHeaderType net/url.EscapeError
+      Pointee: 507 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 506 GoStringDataType net/url.EscapeError.str
+      Pointee: 508 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 605
+      ID: 607
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 908832
       GoKind: 22
-      Pointee: 508 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 510 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 510
+      ID: 512
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 509 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 511 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 410
       Name: '*noalg.map.group[[4]int][4]int'
@@ -6074,30 +6074,30 @@ Types:
       ByteSize: 8
       Pointee: 309 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1194
+      ID: 1196
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1195 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1197 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1228
+      ID: 1230
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1229 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1231 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1243
+      ID: 1245
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1244 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1246 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 318
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 319 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1258
+      ID: 1260
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1259 StructureType noalg.map.group[int]interface {}
+      Pointee: 1261 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 377
       Name: '*noalg.map.group[int]uint8'
@@ -6114,10 +6114,10 @@ Types:
       ByteSize: 8
       Pointee: 343 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 954
+      ID: 956
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 955 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 957 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 334
       Name: '*noalg.map.group[string]int'
@@ -6169,115 +6169,115 @@ Types:
       ByteSize: 8
       Pointee: 386 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1145
+      ID: 1147
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.349504e+06
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType os.File
+      Pointee: 1148 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 774
+      ID: 776
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.02592e+06
       GoKind: 22
-      Pointee: 775 UnresolvedPointeeType os.LinkError
+      Pointee: 777 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 842
+      ID: 844
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.191424e+06
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType os.SyscallError
+      Pointee: 845 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1143
+      ID: 1145
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.348032e+06
       GoKind: 22
-      Pointee: 1144 StructureType os.fileWithoutReadFrom
+      Pointee: 1146 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1141
+      ID: 1143
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.347296e+06
       GoKind: 22
-      Pointee: 1142 StructureType os.fileWithoutWriteTo
+      Pointee: 1144 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 807
+      ID: 809
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.043456e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType os/exec.Error
+      Pointee: 810 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 950
+      ID: 952
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.089056e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 953 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1014
+      ID: 1016
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.213696e+06
       GoKind: 22
-      Pointee: 1015 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1017 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 809
+      ID: 811
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.043584e+06
       GoKind: 22
-      Pointee: 810 StructureType os/exec.wrappedError
+      Pointee: 812 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 741
+      ID: 743
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 938112
       GoKind: 22
-      Pointee: 544 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 546 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 546
+      ID: 548
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 545 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 547 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 740
+      ID: 742
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 938016
       GoKind: 22
-      Pointee: 543 BaseType os/user.UnknownUserIdError
+      Pointee: 545 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 901344
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType reflect.ValueError
+      Pointee: 573 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 668
+      ID: 670
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 920928
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 671 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.027456e+06
       GoKind: 22
-      Pointee: 779 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 781 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.029248e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 785 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -6293,12 +6293,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.027584e+06
       GoKind: 22
-      Pointee: 781 StructureType runtime.boundsError
+      Pointee: 783 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
@@ -6314,24 +6314,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 844
+      ID: 846
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.196928e+06
       GoKind: 22
-      Pointee: 845 StructureType runtime.errorAddressString
+      Pointee: 847 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 776
+      ID: 778
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.027072e+06
       GoKind: 22
-      Pointee: 759 GoStringHeaderType runtime.errorString
+      Pointee: 761 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 761
+      ID: 763
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 760 GoStringDataType runtime.errorString.str
+      Pointee: 762 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -6354,17 +6354,17 @@ Types:
       GoKind: 22
       Pointee: 298 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 777
+      ID: 779
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.0272e+06
       GoKind: 22
-      Pointee: 762 GoStringHeaderType runtime.plainError
+      Pointee: 764 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 764
+      ID: 766
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 763 GoStringDataType runtime.plainError.str
+      Pointee: 765 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -6380,12 +6380,12 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 566
+      ID: 568
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 900000
       GoKind: 22
-      Pointee: 567 StructureType runtime.synctestDeadlockError
+      Pointee: 569 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
@@ -6401,12 +6401,12 @@ Types:
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 784
+      ID: 786
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.029504e+06
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType strconv.NumError
+      Pointee: 787 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -6420,33 +6420,33 @@ Types:
       ByteSize: 8
       Pointee: 292 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1080
+      ID: 1082
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.949856e+06
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType strings.Builder
+      Pointee: 1083 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 984
+      ID: 986
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.029632e+06
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 987 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 980
+      ID: 982
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 971104
       GoKind: 22
-      Pointee: 981 StructureType struct { io.Writer }
+      Pointee: 983 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 896
+      ID: 898
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.416032e+06
       GoKind: 22
-      Pointee: 895 BaseType syscall.Errno
+      Pointee: 897 BaseType syscall.Errno
     - __kind: PointerType
       ID: 223
       Name: '*table<[4]int,[4]int>'
@@ -6473,30 +6473,30 @@ Types:
       ByteSize: 8
       Pointee: 306 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1191
+      ID: 1193
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1192 StructureType table<int,*main.deepMap3>
+      Pointee: 1194 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1225
+      ID: 1227
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1226 StructureType table<int,*main.deepMap8>
+      Pointee: 1228 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1240
+      ID: 1242
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1241 StructureType table<int,*main.deepMap9>
+      Pointee: 1243 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 166
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 316 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1255
+      ID: 1257
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1256 StructureType table<int,interface {}>
+      Pointee: 1258 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 203
       Name: '*table<int,uint8>'
@@ -6513,10 +6513,10 @@ Types:
       ByteSize: 8
       Pointee: 340 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 952 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 954 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 176
       Name: '*table<string,int>'
@@ -6568,45 +6568,45 @@ Types:
       ByteSize: 8
       Pointee: 383 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1115
+      ID: 1117
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.159424e+06
       GoKind: 22
-      Pointee: 1116 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1118 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 837
+      ID: 839
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.089024e+06
       GoKind: 22
-      Pointee: 838 StructureType text/template.ExecError
+      Pointee: 840 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 912
+      ID: 914
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.622144e+06
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType time.Location
+      Pointee: 915 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 573
+      ID: 575
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902208
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType time.ParseError
+      Pointee: 576 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902112
       GoKind: 22
-      Pointee: 489 GoStringHeaderType time.fileSizeError
+      Pointee: 491 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 491
+      ID: 493
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 490 GoStringDataType time.fileSizeError.str
+      Pointee: 492 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -6650,47 +6650,47 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 664
+      ID: 666
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 920352
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 667 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1107
+      ID: 1109
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.134912e+06
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1110 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 648
+      ID: 650
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 916512
       GoKind: 22
-      Pointee: 649 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 651 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 650
+      ID: 652
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 533 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 535 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 814
+      ID: 816
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.047296e+06
       GoKind: 22
-      Pointee: 815 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 817 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 816
+      ID: 818
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.047424e+06
       GoKind: 22
-      Pointee: 767 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 769 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1365
       Name: Probe[main.stackC]
@@ -8798,7 +8798,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 942
+      ID: 944
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684416
@@ -8848,7 +8848,7 @@ Types:
       ByteSize: 8
       Element: 136 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1181
+      ID: 1183
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477824
@@ -8856,22 +8856,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1182 PointerType **main.deepSlice3
+          Type: 1184 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1185 GoSliceDataType []*main.deepSlice3.array
+      Data: 1187 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1185
+      ID: 1187
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1183 PointerType *main.deepSlice3
+      Element: 1185 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1206
+      ID: 1208
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477504
@@ -8879,22 +8879,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1207 PointerType **main.deepSlice8
+          Type: 1209 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1210 GoSliceDataType []*main.deepSlice8.array
+      Data: 1212 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1210
+      ID: 1212
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1208 PointerType *main.deepSlice8
+      Element: 1210 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1212
+      ID: 1214
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477440
@@ -8902,20 +8902,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1213 PointerType **main.deepSlice9
+          Type: 1215 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1216 GoSliceDataType []*main.deepSlice9.array
+      Data: 1218 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1216
+      ID: 1218
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1214 PointerType *main.deepSlice9
+      Element: 1216 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*runtime.p'
@@ -8993,23 +8993,23 @@ Types:
       ByteSize: 8
       Element: 144 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1200
+      ID: 1202
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1191 PointerType *table<int,*main.deepMap3>
+      Element: 1193 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1234
+      ID: 1236
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1225 PointerType *table<int,*main.deepMap8>
+      Element: 1227 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1249
+      ID: 1251
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1240 PointerType *table<int,*main.deepMap9>
+      Element: 1242 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 322
       Name: '[]*table<int,int>.array'
@@ -9017,11 +9017,11 @@ Types:
       ByteSize: 8
       Element: 166 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1262
+      ID: 1264
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1255 PointerType *table<int,interface {}>
+      Element: 1257 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 381
       Name: '[]*table<int,uint8>.array'
@@ -9041,11 +9041,11 @@ Types:
       ByteSize: 8
       Element: 181 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 958
+      ID: 960
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 925 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 927 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 338
       Name: '[]*table<string,int>.array'
@@ -9262,7 +9262,7 @@ Types:
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 937
+      ID: 939
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487104
@@ -9277,15 +9277,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 960 GoSliceDataType []float64.array
+      Data: 962 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 960
+      ID: 962
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 15 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1218
+      ID: 1220
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487552
@@ -9300,9 +9300,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1219 GoSliceDataType []interface {}.array
+      Data: 1221 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1219
+      ID: 1221
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -9345,9 +9345,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1264 GoSliceDataType []main.structWithMap.array
+      Data: 489 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1264
+      ID: 489
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -9405,23 +9405,23 @@ Types:
       ByteSize: 136
       Element: 309 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1201
+      ID: 1203
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1195 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1197 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1235
+      ID: 1237
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1229 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1231 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1250
+      ID: 1252
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1244 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1246 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 323
       Name: '[]noalg.map.group[int]int.array'
@@ -9429,11 +9429,11 @@ Types:
       ByteSize: 136
       Element: 319 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1263
+      ID: 1265
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 1259 StructureType noalg.map.group[int]interface {}
+      Element: 1261 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 382
       Name: '[]noalg.map.group[int]uint8.array'
@@ -9453,11 +9453,11 @@ Types:
       ByteSize: 328
       Element: 343 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 959
+      ID: 961
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 955 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 957 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 339
       Name: '[]noalg.map.group[string]int.array'
@@ -9638,11 +9638,11 @@ Types:
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1094
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 727
+      ID: 729
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 931488
@@ -9657,33 +9657,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 728 GoSliceDataType archive/tar.headerError.array
+      Data: 730 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 728
+      ID: 730
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1029
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 975
+      ID: 977
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 977
+      ID: 979
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.12032e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1073
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1003
+      ID: 1005
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.564896e+06
@@ -9693,7 +9693,7 @@ Types:
           Offset: 0
           Type: 127 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1007
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9703,15 +9703,15 @@ Types:
       GoRuntimeType: 585184
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1052
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1081
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1132
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9737,13 +9737,13 @@ Types:
       GoRuntimeType: 584928
       GoKind: 15
     - __kind: BaseType
-      ID: 525
+      ID: 527
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834656
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 526
+      ID: 528
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 834752
@@ -9751,116 +9751,116 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 528 PointerType *compress/flate.InternalError.str
+          Type: 530 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 527 GoStringDataType compress/flate.InternalError.str
+      Data: 529 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 527
+      ID: 529
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1027
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 971
+      ID: 973
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1049
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 877
       Name: context.deadlineExceededError
       GoRuntimeType: 1.479296e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 539
+      ID: 541
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 2
     - __kind: BaseType
-      ID: 540
+      ID: 542
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837344
       GoKind: 2
     - __kind: BaseType
-      ID: 541
+      ID: 543
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837440
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1044
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 824
+      ID: 826
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.28928e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1075
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1103
+      ID: 1105
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1079
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1077
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1069
+      ID: 1071
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 542
+      ID: 544
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837536
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1092
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1067
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 529
+      ID: 531
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835232
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 815
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1158
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 643
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 639
+      ID: 641
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.729984e+06
@@ -9871,38 +9871,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 942 ArrayType [5]uint8
+          Type: 944 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 766
+      ID: 768
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 993472
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1037
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 645
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1042
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 912
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 929
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 715
+      ID: 717
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.732864e+06
@@ -9910,21 +9910,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 926 PointerType *crypto/x509.Certificate
+          Type: 928 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 945 BaseType crypto/x509.InvalidReason
+          Type: 947 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 709
+      ID: 711
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.117888e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 711
+      ID: 713
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.599008e+06
@@ -9932,24 +9932,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 926 PointerType *crypto/x509.Certificate
+          Type: 928 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 538
+      ID: 540
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836864
       GoKind: 2
     - __kind: BaseType
-      ID: 945
+      ID: 947
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 590368
       GoKind: 2
     - __kind: StructureType
-      ID: 818
+      ID: 820
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.560896e+06
@@ -9959,13 +9959,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 717
+      ID: 719
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.118144e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 713
+      ID: 715
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.732672e+06
@@ -9973,15 +9973,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 926 PointerType *crypto/x509.Certificate
+          Type: 928 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 926 PointerType *crypto/x509.Certificate
+          Type: 928 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 731
+      ID: 733
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.435712e+06
@@ -9991,7 +9991,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 735
+      ID: 737
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.435872e+06
@@ -10001,55 +10001,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 733
+      ID: 735
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 520
+      ID: 522
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834176
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 993
+      ID: 995
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 521
+      ID: 523
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 834368
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 597
+      ID: 599
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 804
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 591
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 597
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 593
+      ID: 595
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 593
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1138
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 599
+      ID: 601
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.419712e+06
@@ -10059,19 +10059,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1001
+      ID: 1003
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 705
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 703
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 537
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -10079,22 +10079,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *encoding/xml.UnmarshalError.str
+          Type: 539 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 536 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 538 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 538
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 708
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1116
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -10111,11 +10111,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 565
+      ID: 567
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 769
+      ID: 771
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -10131,15 +10131,15 @@ Types:
       GoRuntimeType: 585120
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1126
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 773
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 775
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -10155,11 +10155,11 @@ Types:
       GoRuntimeType: 848384
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 629
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 608
+      ID: 610
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.728832e+06
@@ -10167,7 +10167,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 935 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 937 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -10175,25 +10175,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 612
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 941
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 614
+      ID: 616
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.114176e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 943
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 514
+      ID: 516
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 833600
@@ -10201,18 +10201,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 516 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 518 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 515 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 517 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 515
+      ID: 517
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 935
+      ID: 937
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.21872e+06
@@ -10220,7 +10220,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 936 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 938 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10235,7 +10235,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 937 GoSliceHeaderType []float64
+          Type: 939 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -10244,10 +10244,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 938 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 940 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 940 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 942 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 237 GoSliceHeaderType []string
@@ -10261,13 +10261,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 936
+      ID: 938
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586976
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 511
+      ID: 513
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 833504
@@ -10275,18 +10275,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 513 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 515 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 512 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 514 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 512
+      ID: 514
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 517
+      ID: 519
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 833696
@@ -10294,60 +10294,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 519 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 521 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 518 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 520 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 518
+      ID: 520
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1013
+      ID: 1015
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1102
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 727
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 884
+      ID: 886
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1134
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 654
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 659
+      ID: 661
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.11712e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 534
+      ID: 536
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 835904
       GoKind: 2
     - __kind: StructureType
-      ID: 657
+      ID: 659
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.116992e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 655
+      ID: 657
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.597088e+06
@@ -10360,7 +10360,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 675
+      ID: 677
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.597888e+06
@@ -10373,7 +10373,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 679
+      ID: 681
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.732096e+06
@@ -10389,7 +10389,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 677
+      ID: 679
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.429632e+06
@@ -10399,7 +10399,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 673
+      ID: 675
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.429312e+06
@@ -10409,14 +10409,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 921
+      ID: 923
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.500096e+06
       GoKind: 21
-      HeaderType: 923 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 925 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 944
+      ID: 946
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.05088e+06
@@ -10431,15 +10431,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 962 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 964 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 962
+      ID: 964
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 687
+      ID: 689
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.598208e+06
@@ -10447,12 +10447,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 921 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 923 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 921 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 923 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 681
+      ID: 683
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.429792e+06
@@ -10462,7 +10462,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 685
+      ID: 687
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.732288e+06
@@ -10473,12 +10473,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 944 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 946 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 944 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 946 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 683
+      ID: 685
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.598048e+06
@@ -10491,7 +10491,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 689
+      ID: 691
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.429952e+06
@@ -10499,9 +10499,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 911 StructureType time.Time
+          Type: 913 StructureType time.Time
     - __kind: StructureType
-      ID: 695
+      ID: 697
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.598528e+06
@@ -10514,7 +10514,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 697
+      ID: 699
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.430272e+06
@@ -10524,7 +10524,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 693
+      ID: 695
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.598368e+06
@@ -10537,7 +10537,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 691
+      ID: 693
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.430112e+06
@@ -10547,7 +10547,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 699
+      ID: 701
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.598688e+06
@@ -10560,7 +10560,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 616
+      ID: 618
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.421952e+06
@@ -10570,11 +10570,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1055
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 618
+      ID: 620
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.422112e+06
@@ -10582,21 +10582,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 616 StructureType github.com/cihub/seelog.baseError
+          Type: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1033
+      ID: 1035
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 991
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1025
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 622
+      ID: 624
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.422432e+06
@@ -10604,13 +10604,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 616 StructureType github.com/cihub/seelog.baseError
+          Type: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1090
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1101
+      ID: 1103
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.106208e+06
@@ -10618,12 +10618,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1087 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1089 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1104
+      ID: 1106
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.131072e+06
@@ -10631,7 +10631,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1087 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1089 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10639,11 +10639,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 993
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 620
+      ID: 622
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.422272e+06
@@ -10651,9 +10651,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 616 StructureType github.com/cihub/seelog.baseError
+          Type: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 624
+      ID: 626
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.422592e+06
@@ -10661,64 +10661,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 616 StructureType github.com/cihub/seelog.baseError
+          Type: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1057
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1098
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1098
+      ID: 1100
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 917
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 830
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 828
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 832
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 834
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1046
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 822
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 630
+      ID: 632
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.423552e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1148
+      ID: 1150
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 888
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 859
+      ID: 861
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.841888e+06
@@ -10734,11 +10734,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 855
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 788
+      ID: 790
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.701536e+06
@@ -10751,7 +10751,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 865
+      ID: 867
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.842336e+06
@@ -10767,13 +10767,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 765
+      ID: 767
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 990784
       GoKind: 8
     - __kind: StructureType
-      ID: 857
+      ID: 859
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.841664e+06
@@ -10789,13 +10789,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 946
+      ID: 948
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 831776
       GoKind: 8
     - __kind: StructureType
-      ID: 855
+      ID: 857
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.84144e+06
@@ -10803,15 +10803,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 946 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 948 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 946 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 948 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 863
+      ID: 865
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.755488e+06
@@ -10824,7 +10824,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 861
+      ID: 863
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.842112e+06
@@ -10840,11 +10840,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1154
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 869
+      ID: 871
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.623104e+06
@@ -10854,19 +10854,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 792
+      ID: 794
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.283264e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 790
+      ID: 792
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.283136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 867
+      ID: 869
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.75568e+06
@@ -10879,7 +10879,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 547
+      ID: 549
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839360
@@ -10887,22 +10887,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 549 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 551 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 548 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 550 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 548
+      ID: 550
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 932
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 836
+      ID: 838
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.447552e+06
@@ -10912,7 +10912,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1019
+      ID: 1021
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.677248e+06
@@ -10920,13 +10920,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1045 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1047 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1114
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1045
+      ID: 1047
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.127872e+06
@@ -10939,7 +10939,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1007
+      ID: 1009
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.569696e+06
@@ -10949,19 +10949,19 @@ Types:
           Offset: 0
           Type: 127 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 550
+      ID: 552
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 839936
       GoKind: 10
     - __kind: BaseType
-      ID: 928
+      ID: 930
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.003936e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 894
+      ID: 896
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.880416e+06
@@ -10972,12 +10972,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 928 BaseType golang.org/x/net/http2.ErrCode
+          Type: 930 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 751
+      ID: 753
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.605728e+06
@@ -10985,12 +10985,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 928 BaseType golang.org/x/net/http2.ErrCode
+          Type: 930 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 554
+      ID: 556
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840128
@@ -10998,18 +10998,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 556 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 558 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 555 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 557 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 555
+      ID: 557
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 560
+      ID: 562
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840320
@@ -11017,18 +11017,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 562 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 564 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 561 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 563 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 561
+      ID: 563
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 559
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -11036,18 +11036,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 561 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 558 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 560 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 560
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 551
+      ID: 553
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840032
@@ -11055,22 +11055,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 553 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 555 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 552 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 554 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 552
+      ID: 554
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1112
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 755
+      ID: 757
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.448192e+06
@@ -11080,13 +11080,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 563
+      ID: 565
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840416
       GoKind: 2
     - __kind: StructureType
-      ID: 743
+      ID: 745
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.443232e+06
@@ -11096,11 +11096,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 894
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 917
+      ID: 919
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.908192e+06
@@ -11116,7 +11116,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 745
+      ID: 747
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.605248e+06
@@ -11129,7 +11129,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1059
+      ID: 1061
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.96624e+06
@@ -11137,16 +11137,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1086 GoInterfaceType io.Reader
+          Type: 1088 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1017
+      ID: 1019
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 836
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.567296e+06
@@ -11156,29 +11156,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 981
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 725
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 824
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 892
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 890
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.510816e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 737
+      ID: 739
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.436512e+06
@@ -11188,7 +11188,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 739
+      ID: 741
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.436672e+06
@@ -11198,7 +11198,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 669
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -11272,47 +11272,47 @@ Types:
       GroupType: 309 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 315 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1193
+      ID: 1195
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1194 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1196 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1195 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1201 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1197 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1203 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1227
+      ID: 1229
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1228 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1230 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1229 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1235 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1231 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1237 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1242
+      ID: 1244
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1243 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1245 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1244 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1250 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1246 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1252 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 317
       Name: groupReference<int,int>
@@ -11328,19 +11328,19 @@ Types:
       GroupType: 319 StructureType noalg.map.group[int]int
       GroupSliceType: 323 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1257
+      ID: 1259
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1258 PointerType *noalg.map.group[int]interface {}
+          Type: 1260 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1259 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1263 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1261 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1265 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 376
       Name: groupReference<int,uint8>
@@ -11384,19 +11384,19 @@ Types:
       GroupType: 343 StructureType noalg.map.group[string][]string
       GroupSliceType: 347 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 953
+      ID: 955
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 954 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 956 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 955 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 959 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 957 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 961 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 333
       Name: groupReference<string,int>
@@ -11538,11 +11538,11 @@ Types:
       GroupType: 386 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 390 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1069
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 760
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11589,11 +11589,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 919
+      ID: 921
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 637
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -11619,29 +11619,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 635
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 967
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 853
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1156
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 849
+      ID: 851
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.476096e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 571
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -11722,7 +11722,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 522
+      ID: 524
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 834560
@@ -11730,18 +11730,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 524 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 526 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 523 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 525 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 523
+      ID: 525
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 806
+      ID: 808
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.558656e+06
@@ -11749,9 +11749,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 918 PointerType *internal/abi.Type
+          Type: 920 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 1166
+      ID: 1168
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.473536e+06
@@ -11764,11 +11764,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1011
+      ID: 1013
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1051
+      ID: 1053
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.18976e+06
@@ -11781,7 +11781,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1086
+      ID: 1088
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.023232e+06
@@ -11794,7 +11794,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1038
+      ID: 1040
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -11820,21 +11820,21 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1009
+      ID: 1011
       Name: io.discard
       GoRuntimeType: 1.462656e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 985
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 849
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1059
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -11902,9 +11902,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1187 GoMapType map[int]*main.deepMap3
+          Type: 1189 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1201
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11916,9 +11916,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1221 GoMapType map[int]*main.deepMap8
+          Type: 1223 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1233
+      ID: 1235
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.185536e+06
@@ -11926,9 +11926,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1236 GoMapType map[int]*main.deepMap9
+          Type: 1238 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1248
+      ID: 1250
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.185408e+06
@@ -11936,7 +11936,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1251 GoMapType map[int]interface {}
+          Type: 1253 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 128
       Name: main.deepPtr1
@@ -11956,9 +11956,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1157 PointerType *main.deepPtr3
+          Type: 1159 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1160
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11970,9 +11970,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1202 PointerType *main.deepPtr8
+          Type: 1204 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1203
+      ID: 1205
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.186688e+06
@@ -11980,9 +11980,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1204 PointerType *main.deepPtr9
+          Type: 1206 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1205
+      ID: 1207
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.18656e+06
@@ -12010,9 +12010,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1181 GoSliceHeaderType []*main.deepSlice3
+          Type: 1183 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1186
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -12024,9 +12024,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1206 GoSliceHeaderType []*main.deepSlice8
+          Type: 1208 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1209
+      ID: 1211
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.18784e+06
@@ -12034,9 +12034,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1212 GoSliceHeaderType []*main.deepSlice9
+          Type: 1214 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1215
+      ID: 1217
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.187712e+06
@@ -12044,7 +12044,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1218 GoSliceHeaderType []interface {}
+          Type: 1220 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 290
       Name: main.emptyStruct
@@ -12062,16 +12062,16 @@ Types:
           Type: 151 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1164 StructureType sync.Mutex
+          Type: 1166 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1167 StructureType sync.Once
+          Type: 1169 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1170 StructureType sync.WaitGroup
+          Type: 1172 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1173 StructureType sync/atomic.Int32
+          Type: 1175 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 151
       Name: main.esotericStack
@@ -12101,7 +12101,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1175
+      ID: 1177
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.412192e+06
@@ -12146,7 +12146,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1177
+      ID: 1179
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.412352e+06
@@ -12166,7 +12166,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1165
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12177,18 +12177,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1160 PointerType *main.stringType1.str
+          Type: 1162 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1159 GoStringDataType main.stringType1.str
+      Data: 1161 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1159
+      ID: 1161
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1161
+      ID: 1163
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -12291,16 +12291,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1178 PointerType **main.t
+          Type: 1180 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1179 GoSliceDataType main.t.array
+      Data: 1181 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1179
+      ID: 1181
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -12501,7 +12501,7 @@ Types:
       TablePtrSliceType: 314 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 309 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1189
+      ID: 1191
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -12514,7 +12514,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1190 PointerType **table<int,*main.deepMap3>
+          Type: 1192 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12533,10 +12533,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1200 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1195 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1202 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1197 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1223
+      ID: 1225
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -12549,7 +12549,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1224 PointerType **table<int,*main.deepMap8>
+          Type: 1226 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12568,10 +12568,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1234 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1229 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1236 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1231 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1238
+      ID: 1240
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -12584,7 +12584,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1239 PointerType **table<int,*main.deepMap9>
+          Type: 1241 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12603,8 +12603,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1249 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1244 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1251 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1246 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 164
       Name: map<int,int>
@@ -12641,7 +12641,7 @@ Types:
       TablePtrSliceType: 322 GoSliceDataType []*table<int,int>.array
       GroupType: 319 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1253
+      ID: 1255
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -12654,7 +12654,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1254 PointerType **table<int,interface {}>
+          Type: 1256 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12673,8 +12673,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1262 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1259 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1264 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1261 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 201
       Name: map<int,uint8>
@@ -12781,7 +12781,7 @@ Types:
       TablePtrSliceType: 346 GoSliceDataType []*table<string,[]string>.array
       GroupType: 343 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 923
+      ID: 925
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -12794,7 +12794,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 924 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 926 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12813,8 +12813,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 958 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 955 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 960 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 957 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 174
       Name: map<string,int>
@@ -13201,26 +13201,26 @@ Types:
       GoKind: 21
       HeaderType: 142 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1187
+      ID: 1189
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.129536e+06
       GoKind: 21
-      HeaderType: 1189 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1191 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1221
+      ID: 1223
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.128896e+06
       GoKind: 21
-      HeaderType: 1223 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1225 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1236
+      ID: 1238
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.128768e+06
       GoKind: 21
-      HeaderType: 1238 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1240 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 162
       Name: map[int]int
@@ -13229,12 +13229,12 @@ Types:
       GoKind: 21
       HeaderType: 164 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1251
+      ID: 1253
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.12864e+06
       GoKind: 21
-      HeaderType: 1253 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1255 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 199
       Name: map[int]uint8
@@ -13321,7 +13321,7 @@ Types:
       GoKind: 21
       HeaderType: 206 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 671
+      ID: 673
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.428832e+06
@@ -13331,7 +13331,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 973
+      ID: 975
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.425632e+06
@@ -13341,11 +13341,11 @@ Types:
           Offset: 0
           Type: 127 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 880
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 943
+      ID: 945
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.595808e+06
@@ -13358,35 +13358,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 906
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1118
+      ID: 1120
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 882
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1130
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1140
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1128
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 839
+      ID: 841
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.113792e+06
@@ -13394,28 +13394,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 841 PointerType *net.UnknownNetworkError.str
+          Type: 843 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 840 GoStringDataType net.UnknownNetworkError.str
+      Data: 842 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 840
+      ID: 842
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 804
+      ID: 806
       Name: net.canceledError
       GoRuntimeType: 1.284288e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1096
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 948
+      ID: 950
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.105504e+06
@@ -13423,7 +13423,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -13434,27 +13434,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1142
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1134
+      ID: 1136
       Name: net.noReadFrom
       GoRuntimeType: 1.114048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1133
+      ID: 1135
       Name: net.noWriteTo
       GoRuntimeType: 1.11392e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 603
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 603
+      ID: 605
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.72864e+06
@@ -13462,7 +13462,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 931 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 933 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -13470,7 +13470,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1122
+      ID: 1124
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.288512e+06
@@ -13478,12 +13478,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1134 StructureType net.noReadFrom
+          Type: 1136 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1127 PointerType *net.TCPConn
+          Type: 1129 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1120
+      ID: 1122
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.287968e+06
@@ -13491,24 +13491,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1133 StructureType net.noWriteTo
+          Type: 1135 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1127 PointerType *net.TCPConn
+          Type: 1129 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 884
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 908
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 796
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 967
+      ID: 969
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.417152e+06
@@ -13518,19 +13518,19 @@ Types:
           Offset: 0
           Type: 127 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 492
+      ID: 494
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832256
       GoKind: 10
     - __kind: BaseType
-      ID: 920
+      ID: 922
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 990880
       GoKind: 10
     - __kind: StructureType
-      ID: 579
+      ID: 581
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.726912e+06
@@ -13541,12 +13541,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 920 BaseType net/http.http2ErrCode
+          Type: 922 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 898
+      ID: 900
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.89872e+06
@@ -13557,12 +13557,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 920 BaseType net/http.http2ErrCode
+          Type: 922 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 583
+      ID: 585
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.595328e+06
@@ -13570,16 +13570,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 920 BaseType net/http.http2ErrCode
+          Type: 922 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1031
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 496
+      ID: 498
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832448
@@ -13587,18 +13587,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 498 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 500 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 497 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 499 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 497
+      ID: 499
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 502
+      ID: 504
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -13606,18 +13606,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 504 PointerType *net/http.http2headerFieldNameError.str
+          Type: 506 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 503 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 505 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 503
+      ID: 505
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 499
+      ID: 501
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832544
@@ -13625,32 +13625,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 501 PointerType *net/http.http2headerFieldValueError.str
+          Type: 503 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 500 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 502 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 500
+      ID: 502
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 875
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 800
+      ID: 802
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.28352e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1085
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 493
+      ID: 495
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832352
@@ -13658,18 +13658,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 495 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 497 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 494 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 496 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 494
+      ID: 496
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 969
+      ID: 971
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.824576e+06
@@ -13677,18 +13677,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1060 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1062 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1061 BaseType time.Duration
+          Type: 1063 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1060
+      ID: 1062
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.416352e+06
@@ -13701,14 +13701,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1048
+      ID: 1050
       Name: net/http.incomparable
       GoRuntimeType: 903456
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 796
+      ID: 798
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.554816e+06
@@ -13718,11 +13718,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1033
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 987
+      ID: 989
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.554656e+06
@@ -13730,9 +13730,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1030 PointerType *net/http.persistConn
+          Type: 1032 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1021
+      ID: 1023
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.799552e+06
@@ -13740,15 +13740,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1048 ArrayType net/http.incomparable
+          Type: 1050 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1049 PointerType *bufio.Reader
+          Type: 1051 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1051 GoInterfaceType io.ReadWriteCloser
+          Type: 1053 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 587
+      ID: 589
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.418112e+06
@@ -13758,17 +13758,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 902
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 873
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.478976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 798
+      ID: 800
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.554976e+06
@@ -13778,7 +13778,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1063
+      ID: 1065
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.025216e+06
@@ -13786,16 +13786,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 576
+      ID: 578
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1085
+      ID: 1087
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.04096e+06
@@ -13803,13 +13803,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1078 PointerType *bufio.Writer
+          Type: 1080 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 999
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 663
+      ID: 665
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.731712e+06
@@ -13825,7 +13825,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 661
+      ID: 663
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.597248e+06
@@ -13838,11 +13838,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1037
+      ID: 1039
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 999
+      ID: 1001
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.599168e+06
@@ -13850,16 +13850,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1036 PointerType *net/smtp.Client
+          Type: 1038 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1038 GoInterfaceType io.WriteCloser
+          Type: 1040 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 649
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 530
+      ID: 532
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835328
@@ -13867,26 +13867,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 532 PointerType *net/textproto.ProtocolError.str
+          Type: 534 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 531 GoStringDataType net/textproto.ProtocolError.str
+      Data: 533 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 531
+      ID: 533
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 995
+      ID: 997
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 910
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 505
+      ID: 507
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833216
@@ -13894,18 +13894,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 507 PointerType *net/url.EscapeError.str
+          Type: 509 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 506 GoStringDataType net/url.EscapeError.str
+      Data: 508 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 506
+      ID: 508
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 508
+      ID: 510
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833312
@@ -13913,13 +13913,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 510 PointerType *net/url.InvalidHostError.str
+          Type: 512 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 509 GoStringDataType net/url.InvalidHostError.str
+      Data: 511 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 509
+      ID: 511
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -13969,32 +13969,32 @@ Types:
       HasCount: true
       Element: 311 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1196
+      ID: 1198
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1197 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1199 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1230
+      ID: 1232
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1231 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1233 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1245
+      ID: 1247
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681632
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1246 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1248 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 320
       Name: noalg.[8]struct { key int; elem int }
@@ -14005,14 +14005,14 @@ Types:
       HasCount: true
       Element: 321 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1260
+      ID: 1262
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1261 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1263 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 379
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -14041,14 +14041,14 @@ Types:
       HasCount: true
       Element: 345 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 956
+      ID: 958
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 759488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 957 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 959 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 336
       Name: noalg.[8]struct { key string; elem int }
@@ -14199,7 +14199,7 @@ Types:
           Offset: 8
           Type: 310 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1195
+      ID: 1197
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.294784e+06
@@ -14210,9 +14210,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1196 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1198 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1229
+      ID: 1231
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.293504e+06
@@ -14223,9 +14223,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1230 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1232 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1244
+      ID: 1246
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.293248e+06
@@ -14236,7 +14236,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1245 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1247 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 319
       Name: noalg.map.group[int]int
@@ -14251,7 +14251,7 @@ Types:
           Offset: 8
           Type: 320 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1259
+      ID: 1261
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.292992e+06
@@ -14262,7 +14262,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1260 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1262 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 378
       Name: noalg.map.group[int]uint8
@@ -14303,7 +14303,7 @@ Types:
           Offset: 8
           Type: 344 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 955
+      ID: 957
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.35776e+06
@@ -14314,7 +14314,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 956 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 958 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 335
       Name: noalg.map.group[string]int
@@ -14505,7 +14505,7 @@ Types:
           Offset: 8
           Type: 312 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1197
+      ID: 1199
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.294656e+06
@@ -14516,9 +14516,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1198 PointerType *main.deepMap3
+          Type: 1200 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1231
+      ID: 1233
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.293376e+06
@@ -14529,9 +14529,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1232 PointerType *main.deepMap8
+          Type: 1234 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1246
+      ID: 1248
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.29312e+06
@@ -14542,7 +14542,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1247 PointerType *main.deepMap9
+          Type: 1249 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 321
       Name: noalg.struct { key int; elem int }
@@ -14557,7 +14557,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1261
+      ID: 1263
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.292864e+06
@@ -14609,7 +14609,7 @@ Types:
           Offset: 16
           Type: 237 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 957
+      ID: 959
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.357632e+06
@@ -14620,7 +14620,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 944 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 946 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 337
       Name: noalg.struct { key string; elem int }
@@ -14746,19 +14746,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1148
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 775
+      ID: 777
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 845
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1144
+      ID: 1146
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.35888e+06
@@ -14766,12 +14766,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1150 StructureType os.noReadFrom
+          Type: 1152 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1145 PointerType *os.File
+          Type: 1147 PointerType *os.File
     - __kind: StructureType
-      ID: 1142
+      ID: 1144
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.35808e+06
@@ -14779,36 +14779,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1149 StructureType os.noWriteTo
+          Type: 1151 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1145 PointerType *os.File
+          Type: 1147 PointerType *os.File
     - __kind: StructureType
-      ID: 1150
+      ID: 1152
       Name: os.noReadFrom
       GoRuntimeType: 1.11136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1149
+      ID: 1151
       Name: os.noWriteTo
       GoRuntimeType: 1.111232e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 810
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 953
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1015
+      ID: 1017
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 812
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.702112e+06
@@ -14821,7 +14821,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 544
+      ID: 546
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 838592
@@ -14829,36 +14829,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 546 PointerType *os/user.UnknownGroupIdError.str
+          Type: 548 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 545 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 547 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 545
+      ID: 547
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 543
+      ID: 545
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 838496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 573
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 671
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 779
+      ID: 781
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 785
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -14870,7 +14870,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 781
+      ID: 783
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.887584e+06
@@ -14887,9 +14887,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 949 BaseType runtime.boundsErrorCode
+          Type: 951 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 949
+      ID: 951
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585312
@@ -14909,7 +14909,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 845
+      ID: 847
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.752416e+06
@@ -14922,7 +14922,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 759
+      ID: 761
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 989440
@@ -14930,13 +14930,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 761 PointerType *runtime.errorString.str
+          Type: 763 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 760 GoStringDataType runtime.errorString.str
+      Data: 762 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 760
+      ID: 762
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15599,7 +15599,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 762
+      ID: 764
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 989536
@@ -15607,13 +15607,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 764 PointerType *runtime.plainError.str
+          Type: 766 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 763 GoStringDataType runtime.plainError.str
+      Data: 765 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 763
+      ID: 765
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15654,7 +15654,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 567
+      ID: 569
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.595008e+06
@@ -15712,7 +15712,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 787
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -15735,15 +15735,15 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1083
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 987
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 981
+      ID: 983
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.454912e+06
@@ -15759,7 +15759,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1164
+      ID: 1166
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.463456e+06
@@ -15767,12 +15767,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1165 StructureType sync.noCopy
+          Type: 1167 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1166 StructureType internal/sync.Mutex
+          Type: 1168 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1167
+      ID: 1169
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.612352e+06
@@ -15780,15 +15780,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1165 StructureType sync.noCopy
+          Type: 1167 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1168 StructureType sync/atomic.Bool
+          Type: 1170 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1164 StructureType sync.Mutex
+          Type: 1166 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1170
+      ID: 1172
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.61216e+06
@@ -15796,21 +15796,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1165 StructureType sync.noCopy
+          Type: 1167 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1171 StructureType sync/atomic.Uint64
+          Type: 1173 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1165
+      ID: 1167
       Name: sync.noCopy
       GoRuntimeType: 988384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1168
+      ID: 1170
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.464576e+06
@@ -15818,12 +15818,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1169 StructureType sync/atomic.noCopy
+          Type: 1171 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1173
+      ID: 1175
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464736e+06
@@ -15831,12 +15831,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1169 StructureType sync/atomic.noCopy
+          Type: 1171 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1171
+      ID: 1173
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612736e+06
@@ -15844,27 +15844,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1169 StructureType sync/atomic.noCopy
+          Type: 1171 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1172 StructureType sync/atomic.align64
+          Type: 1174 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1172
+      ID: 1174
       Name: sync/atomic.align64
       GoRuntimeType: 988576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1169
+      ID: 1171
       Name: sync/atomic.noCopy
       GoRuntimeType: 988480
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 895
+      ID: 897
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.28288e+06
@@ -15990,7 +15990,7 @@ Types:
           Offset: 16
           Type: 307 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1192
+      ID: 1194
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -16012,9 +16012,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1193 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1195 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1226
+      ID: 1228
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -16036,9 +16036,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1227 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1229 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1241
+      ID: 1243
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -16060,7 +16060,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1242 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1244 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 316
       Name: table<int,int>
@@ -16086,7 +16086,7 @@ Types:
           Offset: 16
           Type: 317 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1256
+      ID: 1258
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -16108,7 +16108,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1257 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1259 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 375
       Name: table<int,uint8>
@@ -16182,7 +16182,7 @@ Types:
           Offset: 16
           Type: 341 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 952
+      ID: 954
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -16204,7 +16204,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 953 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 955 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 332
       Name: table<string,int>
@@ -16446,11 +16446,11 @@ Types:
           Offset: 16
           Type: 384 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1116
+      ID: 1118
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 838
+      ID: 840
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.706528e+06
@@ -16463,21 +16463,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 1061
+      ID: 1063
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.91504e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 915
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 576
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 911
+      ID: 913
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.372192e+06
@@ -16491,9 +16491,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 912 PointerType *time.Location
+          Type: 914 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 489
+      ID: 491
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 831392
@@ -16501,13 +16501,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 491 PointerType *time.fileSizeError.str
+          Type: 493 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 490 GoStringDataType time.fileSizeError.str
+      Data: 492 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 490
+      ID: 492
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -16554,7 +16554,7 @@ Types:
       GoRuntimeType: 585248
       GoKind: 26
     - __kind: StructureType
-      ID: 931
+      ID: 933
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.062688e+06
@@ -16565,10 +16565,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 932 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 934 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 933 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 935 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -16583,18 +16583,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 934 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 936 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 934
+      ID: 936
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995104
       GoKind: 9
     - __kind: StructureType
-      ID: 932
+      ID: 934
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.926048e+06
@@ -16619,21 +16619,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 667
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 933
+      ID: 935
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1110
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 649
+      ID: 651
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.425952e+06
@@ -16643,13 +16643,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 533
+      ID: 535
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 2
     - __kind: StructureType
-      ID: 815
+      ID: 817
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.702304e+06
@@ -16662,7 +16662,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 767
+      ID: 769
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 993952

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -2343,15 +2343,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda1b6..0xcda1c7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda1c7..0xcda265
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcda280..0xcda2e2]
@@ -2368,29 +2359,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcda300..0xcda405]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda35b..0xcda365
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcda365..0xcda375
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcda375..0xcda389
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda356..0xcda360
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcda360..0xcda375
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcda375..0xcda384
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcda420..0xcda426]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -3464,20 +3464,20 @@ Types:
       ByteSize: 8
       Pointee: 129 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1032
+      ID: 1034
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1033 PointerType *main.deepSlice3
+      Pointee: 1035 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1051
+      ID: 1053
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1052 PointerType *main.deepSlice8
+      Pointee: 1054 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1057
+      ID: 1059
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1058 PointerType *main.deepSlice9
+      Pointee: 1060 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 144
       Name: '**main.stringType2'
@@ -3485,7 +3485,7 @@ Types:
       GoKind: 22
       Pointee: 145 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1028
+      ID: 1030
       Name: '**main.t'
       ByteSize: 8
       Pointee: 224 PointerType *main.t
@@ -3502,20 +3502,20 @@ Types:
       ByteSize: 8
       Pointee: 296 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1036
+      ID: 1038
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1035 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1037 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1055
+      ID: 1057
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1054 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1056 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1061
+      ID: 1063
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1060 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1062 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 294
       Name: '*[]*string.array'
@@ -3577,15 +3577,15 @@ Types:
       ByteSize: 8
       Pointee: 341 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 818 GoSliceDataType []float64.array
+      Pointee: 820 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1064
+      ID: 1066
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1063 GoSliceDataType []interface {}.array
+      Pointee: 1065 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 243
       Name: '*[]main.structWithCyclicSlices'
@@ -3597,10 +3597,10 @@ Types:
       ByteSize: 8
       Pointee: 345 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1091
+      ID: 372
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1090 GoSliceDataType []main.structWithMap.array
+      Pointee: 371 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 338
       Name: '*[]main.structWithNoStrings.array'
@@ -3644,66 +3644,66 @@ Types:
       ByteSize: 8
       Pointee: 291 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 944
+      ID: 946
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.848928e+06
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 947 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858432
       GoKind: 22
-      Pointee: 597 GoSliceHeaderType archive/tar.headerError
+      Pointee: 599 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 599
+      ID: 601
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 598 GoSliceDataType archive/tar.headerError.array
+      Pointee: 600 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 884
+      ID: 886
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.25312e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 887 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 832
+      ID: 834
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858624
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 835 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 834
+      ID: 836
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858720
       GoKind: 22
-      Pointee: 835 StructureType archive/zip.dirWriter
+      Pointee: 837 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.773216e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 934 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 860
+      ID: 862
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.01664e+06
       GoKind: 22
-      Pointee: 861 StructureType archive/zip.nopCloser
+      Pointee: 863 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 862
+      ID: 864
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.016896e+06
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 865 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3737,30 +3737,30 @@ Types:
       ByteSize: 8
       Pointee: 137 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1040
+      ID: 1042
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1041 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1043 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1068
+      ID: 1070
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1069 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1071 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1077
+      ID: 1079
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1078 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1080 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 160
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 161 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 1086
+      ID: 1088
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 1087 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1089 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 197
       Name: '*bucket<int,uint8>'
@@ -3777,10 +3777,10 @@ Types:
       ByteSize: 8
       Pointee: 176 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 788
+      ID: 790
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 789 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 791 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 170
       Name: '*bucket<string,int>'
@@ -3832,393 +3832,393 @@ Types:
       ByteSize: 8
       Pointee: 203 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 908
+      ID: 910
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.029408e+06
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType bufio.Reader
+      Pointee: 911 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 933
+      ID: 935
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.814656e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType bufio.Writer
+      Pointee: 936 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 980
+      ID: 982
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.122368e+06
       GoKind: 22
-      Pointee: 981 UnresolvedPointeeType bytes.Buffer
+      Pointee: 983 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 509
+      ID: 511
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 404 BaseType compress/flate.CorruptInputError
+      Pointee: 406 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 510
+      ID: 512
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 405 GoStringHeaderType compress/flate.InternalError
+      Pointee: 407 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 407
+      ID: 409
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 406 GoStringDataType compress/flate.InternalError.str
+      Pointee: 408 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 882
+      ID: 884
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.24336e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 885 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 828
+      ID: 830
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841248
       GoKind: 22
-      Pointee: 829 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 831 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 904
+      ID: 906
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.59984e+06
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 907 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 740
+      ID: 742
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.117792e+06
       GoKind: 22
-      Pointee: 741 StructureType context.deadlineExceededError
+      Pointee: 743 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 589
+      ID: 591
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853344
       GoKind: 22
-      Pointee: 418 BaseType crypto/aes.KeySizeError
+      Pointee: 420 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853536
       GoKind: 22
-      Pointee: 419 BaseType crypto/des.KeySizeError
+      Pointee: 421 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 894
+      ID: 896
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.373792e+06
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 897 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 919
+      ID: 921
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.678848e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 922 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 591
+      ID: 593
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853824
       GoKind: 22
-      Pointee: 420 BaseType crypto/rc4.KeySizeError
+      Pointee: 422 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 927
+      ID: 929
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.7704e+06
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 930 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.679296e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 924 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 923
+      ID: 925
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.679744e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 926 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 515
+      ID: 517
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842688
       GoKind: 22
-      Pointee: 408 BaseType crypto/tls.AlertError
+      Pointee: 410 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 680
+      ID: 682
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.00448e+06
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 683 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1006
+      ID: 1008
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.231488e+06
       GoKind: 22
-      Pointee: 1007 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1009 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 513
+      ID: 515
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842496
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 516 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 511
+      ID: 513
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842400
       GoKind: 22
-      Pointee: 512 StructureType crypto/tls.RecordHeaderError
+      Pointee: 514 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 679
+      ID: 681
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.002816e+06
       GoKind: 22
-      Pointee: 636 BaseType crypto/tls.alert
+      Pointee: 638 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 892
+      ID: 894
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.370912e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 895 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.449984e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 902 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 775
+      ID: 777
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.24368e+06
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 778 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 790
+      ID: 792
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90608e+06
       GoKind: 22
-      Pointee: 791 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 793 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 585
+      ID: 587
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852288
       GoKind: 22
-      Pointee: 586 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 588 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 579
+      ID: 581
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851808
       GoKind: 22
-      Pointee: 580 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 582 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 581
+      ID: 583
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 851904
       GoKind: 22
-      Pointee: 582 StructureType crypto/x509.HostnameError
+      Pointee: 584 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851712
       GoKind: 22
-      Pointee: 417 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 419 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 685
+      ID: 687
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010368e+06
       GoKind: 22
-      Pointee: 686 StructureType crypto/x509.SystemRootsError
+      Pointee: 688 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 587
+      ID: 589
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852384
       GoKind: 22
-      Pointee: 588 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 590 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 583
+      ID: 585
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 584 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 586 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 600
+      ID: 602
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 858912
       GoKind: 22
-      Pointee: 601 StructureType encoding/asn1.StructuralError
+      Pointee: 603 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 604
+      ID: 606
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859104
       GoKind: 22
-      Pointee: 605 StructureType encoding/asn1.SyntaxError
+      Pointee: 607 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 859008
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 605 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 501
+      ID: 503
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839328
       GoKind: 22
-      Pointee: 402 BaseType encoding/base64.CorruptInputError
+      Pointee: 404 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 850
+      ID: 852
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 999616
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 853 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 504
+      ID: 506
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840192
       GoKind: 22
-      Pointee: 403 BaseType encoding/hex.InvalidByteError
+      Pointee: 405 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 472
+      ID: 474
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 834048
       GoKind: 22
-      Pointee: 473 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 475 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 671
+      ID: 673
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995264
       GoKind: 22
-      Pointee: 672 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 674 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 464
+      ID: 466
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833664
       GoKind: 22
-      Pointee: 465 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 467 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 470
+      ID: 472
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 833952
       GoKind: 22
-      Pointee: 471 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 473 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 468
+      ID: 470
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 469 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 471 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 466
+      ID: 468
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833760
       GoKind: 22
-      Pointee: 467 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 469 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 986
+      ID: 988
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.147936e+06
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 989 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 474
+      ID: 476
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834432
       GoKind: 22
-      Pointee: 475 StructureType encoding/json.jsonError
+      Pointee: 477 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 858
+      ID: 860
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.013184e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 861 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 573
+      ID: 575
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 576 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 571
+      ID: 573
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 574 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 575
+      ID: 577
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 414 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 416 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 416
+      ID: 418
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 415 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 417 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 850944
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 579 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 964
+      ID: 966
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.017888e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 967 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -4227,19 +4227,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 442
+      ID: 444
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824352
       GoKind: 22
-      Pointee: 443 UnresolvedPointeeType errors.errorString
+      Pointee: 445 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 979904
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType errors.joinError
+      Pointee: 641 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 101
       Name: '*float32'
@@ -4255,806 +4255,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 974
+      ID: 976
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.113664e+06
       GoKind: 22
-      Pointee: 975 UnresolvedPointeeType fmt.pp
+      Pointee: 977 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 981696
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType fmt.wrapError
+      Pointee: 643 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 642
+      ID: 644
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 981824
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 645 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 502
+      ID: 504
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839712
       GoKind: 22
-      Pointee: 503 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 505 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 483
+      ID: 485
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 22
-      Pointee: 484 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 486 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 485
+      ID: 487
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 488 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 802
+      ID: 804
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 805 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 489
+      ID: 491
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837216
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 492 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 804
+      ID: 806
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 807 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 487
+      ID: 489
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 22
-      Pointee: 396 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 398 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 398
+      ID: 400
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 397 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 399 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 482
+      ID: 484
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836544
       GoKind: 22
-      Pointee: 393 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 395 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 395
+      ID: 397
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 394 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 396 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 488
+      ID: 490
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 399 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 401 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 401
+      ID: 403
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 400 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 402 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.123552e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 875 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 952
+      ID: 954
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.921088e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 955 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857376
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 597 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 749
+      ID: 751
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.12688e+06
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 752 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 982
+      ID: 984
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.123904e+06
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 985 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 522
+      ID: 524
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 525 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 529
+      ID: 531
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847296
       GoKind: 22
-      Pointee: 530 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 532 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 22
-      Pointee: 413 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 415 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 527
+      ID: 529
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847200
       GoKind: 22
-      Pointee: 528 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 530 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 525
+      ID: 527
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 22
-      Pointee: 526 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 528 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 545
+      ID: 547
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849216
       GoKind: 22
-      Pointee: 546 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 548 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 549
+      ID: 551
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849408
       GoKind: 22
-      Pointee: 550 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 552 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 547
+      ID: 549
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849312
       GoKind: 22
-      Pointee: 548 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 550 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 543
+      ID: 545
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849120
       GoKind: 22
-      Pointee: 544 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 546 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 821
+      ID: 823
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 820 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 822 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 557
+      ID: 559
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849792
       GoKind: 22
-      Pointee: 558 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 560 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 551
+      ID: 553
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 22
-      Pointee: 552 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 554 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 555
+      ID: 557
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 22
-      Pointee: 556 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 558 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 553
+      ID: 555
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849600
       GoKind: 22
-      Pointee: 554 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 556 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 849888
       GoKind: 22
-      Pointee: 560 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 562 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 565
+      ID: 567
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850176
       GoKind: 22
-      Pointee: 566 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 568 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 567
+      ID: 569
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850272
       GoKind: 22
-      Pointee: 568 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 570 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 563
+      ID: 565
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 850080
       GoKind: 22
-      Pointee: 564 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 566 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 561
+      ID: 563
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 849984
       GoKind: 22
-      Pointee: 562 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 564 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 569
+      ID: 571
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850464
       GoKind: 22
-      Pointee: 570 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 572 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 491
+      ID: 493
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838368
       GoKind: 22
-      Pointee: 492 StructureType github.com/cihub/seelog.baseError
+      Pointee: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 911
+      ID: 913
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.675936e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 914 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 493
+      ID: 495
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838464
       GoKind: 22
-      Pointee: 494 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 496 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 890
+      ID: 892
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.369792e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 893 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 846
+      ID: 848
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 998592
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 849 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 880
+      ID: 882
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.24144e+06
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 883 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 497
+      ID: 499
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838656
       GoKind: 22
-      Pointee: 498 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 500 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 942
+      ID: 944
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.839136e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 945 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 957
+      ID: 959
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.992544e+06
       GoKind: 22
-      Pointee: 954 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 956 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 956
+      ID: 958
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.99216e+06
       GoKind: 22
-      Pointee: 955 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 957 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 848
+      ID: 850
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 998720
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 851 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838560
       GoKind: 22
-      Pointee: 496 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 498 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838752
       GoKind: 22
-      Pointee: 500 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 502 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 915
+      ID: 917
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.677504e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 948
+      ID: 950
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.875008e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 951 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 950
+      ID: 952
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.90576e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 953 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.25552e+06
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 783 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 693
+      ID: 695
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.024576e+06
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 696 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 691
+      ID: 693
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024448e+06
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 694 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 695
+      ID: 697
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.028544e+06
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 698 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 697
+      ID: 699
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.028672e+06
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 700 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.477632e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 904 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 687
+      ID: 689
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.011136e+06
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 690 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 505
+      ID: 507
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840384
       GoKind: 22
-      Pointee: 506 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 508 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 998
+      ID: 1000
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.210592e+06
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1001 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 751
+      ID: 753
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.135072e+06
       GoKind: 22
-      Pointee: 752 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 754 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 724
+      ID: 726
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.113952e+06
       GoKind: 22
-      Pointee: 725 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 727 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 718
+      ID: 720
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.113568e+06
       GoKind: 22
-      Pointee: 719 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 721 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 657
+      ID: 659
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 989120
       GoKind: 22
-      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 730
+      ID: 732
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114336e+06
       GoKind: 22
-      Pointee: 731 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 733 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 988992
       GoKind: 22
-      Pointee: 635 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 637 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 722
+      ID: 724
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.113824e+06
       GoKind: 22
-      Pointee: 723 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 725 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 720
+      ID: 722
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.113696e+06
       GoKind: 22
-      Pointee: 721 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 723 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 728
+      ID: 730
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 729 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 731 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 726
+      ID: 728
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.11408e+06
       GoKind: 22
-      Pointee: 727 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 729 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1002
+      ID: 1004
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.221632e+06
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1005 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 734
+      ID: 736
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.11472e+06
       GoKind: 22
-      Pointee: 735 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 737 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 661
+      ID: 663
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989376
       GoKind: 22
-      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 659
+      ID: 661
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989248
       GoKind: 22
-      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 732
+      ID: 734
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.114592e+06
       GoKind: 22
-      Pointee: 733 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 735 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871008
       GoKind: 22
-      Pointee: 425 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 427 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 427
+      ID: 429
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 426 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 428 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 793
+      ID: 795
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.476096e+06
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 796 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 701
+      ID: 703
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.04352e+06
       GoKind: 22
-      Pointee: 702 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 704 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 878
+      ID: 880
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.173984e+06
       GoKind: 22
-      Pointee: 879 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 881 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 962
+      ID: 964
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.00752e+06
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 965 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 864
+      ID: 866
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.045824e+06
       GoKind: 22
-      Pointee: 865 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 867 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 617
+      ID: 619
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872256
       GoKind: 22
-      Pointee: 428 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 430 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 759
+      ID: 761
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.175648e+06
       GoKind: 22
-      Pointee: 760 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 762 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 620
+      ID: 622
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872544
       GoKind: 22
-      Pointee: 621 StructureType golang.org/x/net/http2.connError
+      Pointee: 623 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872448
       GoKind: 22
-      Pointee: 432 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 434 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 434
+      ID: 436
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 433 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 435 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 623
+      ID: 625
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872736
       GoKind: 22
-      Pointee: 438 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 440 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 440
+      ID: 442
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 439 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 441 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 622
+      ID: 624
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872640
       GoKind: 22
-      Pointee: 435 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 437 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 437
+      ID: 439
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 436 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 438 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 618
+      ID: 620
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872352
       GoKind: 22
-      Pointee: 429 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 431 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 431
+      ID: 433
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 430 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 432 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 960
+      ID: 962
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.0056e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 963 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 624
+      ID: 626
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872832
       GoKind: 22
-      Pointee: 625 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 627 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 872928
       GoKind: 22
-      Pointee: 441 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 443 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866400
       GoKind: 22
-      Pointee: 613 StructureType google.golang.org/grpc.dropError
+      Pointee: 615 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.172576e+06
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 760 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.26288e+06
       GoKind: 22
-      Pointee: 783 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 785 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 614
+      ID: 616
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869280
       GoKind: 22
-      Pointee: 615 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 617 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.684224e+06
       GoKind: 22
-      Pointee: 926 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 928 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 876
+      ID: 878
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.16912e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 879 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 699
+      ID: 701
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.03776e+06
       GoKind: 22
-      Pointee: 700 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 702 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 836
+      ID: 838
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869376
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 839 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855264
       GoKind: 22
-      Pointee: 593 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 595 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 689
+      ID: 691
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.014592e+06
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 692 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 755
+      ID: 757
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.140832e+06
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 758 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 753
+      ID: 755
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.140576e+06
       GoKind: 22
-      Pointee: 754 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 756 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 606
+      ID: 608
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 22
-      Pointee: 607 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 609 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 608
+      ID: 610
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 860064
       GoKind: 22
-      Pointee: 609 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 611 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 537
+      ID: 539
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847680
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 540 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 913
+      ID: 915
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.676608e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 916 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 215
       Name: '*hash<[4]int,[4]int>'
@@ -5081,30 +5081,30 @@ Types:
       ByteSize: 8
       Pointee: 135 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1038
+      ID: 1040
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1039 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1041 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1066
+      ID: 1068
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1067 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1069 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1075
+      ID: 1077
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1076 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1078 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 158
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 159 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 1084
+      ID: 1086
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 1085 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1087 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 195
       Name: '*hash<int,uint8>'
@@ -5121,10 +5121,10 @@ Types:
       ByteSize: 8
       Pointee: 174 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 787 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 789 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 168
       Name: '*hash<string,int>'
@@ -5176,12 +5176,12 @@ Types:
       ByteSize: 8
       Pointee: 201 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 627
+      ID: 629
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873696
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType html/template.Error
+      Pointee: 630 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 94
       Name: '*int'
@@ -5225,82 +5225,82 @@ Types:
       GoKind: 22
       Pointee: 148 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840768
       GoKind: 22
-      Pointee: 508 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 510 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 822
+      ID: 824
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 828960
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 825 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 716
+      ID: 718
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.1128e+06
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 719 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1004
+      ID: 1006
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.226304e+06
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1007 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 714
+      ID: 716
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.112672e+06
       GoKind: 22
-      Pointee: 715 StructureType internal/poll.errNetClosing
+      Pointee: 717 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 444
+      ID: 446
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828096
       GoKind: 22
-      Pointee: 445 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 447 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 868
+      ID: 870
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.10384e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType io.PipeWriter
+      Pointee: 871 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 866
+      ID: 868
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.103456e+06
       GoKind: 22
-      Pointee: 867 StructureType io.discard
+      Pointee: 869 StructureType io.discard
     - __kind: PointerType
-      ID: 840
+      ID: 842
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 980160
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType io.multiWriter
+      Pointee: 843 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 712
+      ID: 714
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112416e+06
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType io/fs.PathError
+      Pointee: 715 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 917
+      ID: 919
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.677728e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 920 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 301
       Name: '*main.deepMap2'
@@ -5309,12 +5309,12 @@ Types:
       GoKind: 22
       Pointee: 302 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1043
+      ID: 1045
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356288
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType main.deepMap3
+      Pointee: 1046 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 140
       Name: '*main.deepMap7'
@@ -5323,19 +5323,19 @@ Types:
       GoKind: 22
       Pointee: 141 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1071
+      ID: 1073
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 355968
       GoKind: 22
-      Pointee: 1072 StructureType main.deepMap8
+      Pointee: 1074 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1080
+      ID: 1082
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 355904
       GoKind: 22
-      Pointee: 1081 StructureType main.deepMap9
+      Pointee: 1083 StructureType main.deepMap9
     - __kind: PointerType
       ID: 122
       Name: '*main.deepPtr2'
@@ -5344,12 +5344,12 @@ Types:
       GoKind: 22
       Pointee: 123 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1008
+      ID: 1010
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356864
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1011 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 124
       Name: '*main.deepPtr7'
@@ -5358,19 +5358,19 @@ Types:
       GoKind: 22
       Pointee: 125 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1046
+      ID: 1048
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356544
       GoKind: 22
-      Pointee: 1047 StructureType main.deepPtr8
+      Pointee: 1049 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1048
+      ID: 1050
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356480
       GoKind: 22
-      Pointee: 1049 StructureType main.deepPtr9
+      Pointee: 1051 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 129
       Name: '*main.deepSlice2'
@@ -5379,12 +5379,12 @@ Types:
       GoKind: 22
       Pointee: 295 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1033
+      ID: 1035
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357440
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1036 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 130
       Name: '*main.deepSlice7'
@@ -5393,19 +5393,19 @@ Types:
       GoKind: 22
       Pointee: 131 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1052
+      ID: 1054
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357120
       GoKind: 22
-      Pointee: 1053 StructureType main.deepSlice8
+      Pointee: 1055 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1058
+      ID: 1060
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 357056
       GoKind: 22
-      Pointee: 1059 StructureType main.deepSlice9
+      Pointee: 1061 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 286
       Name: '*main.emptyStruct'
@@ -5420,12 +5420,12 @@ Types:
       GoKind: 22
       Pointee: 151 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 824064
       GoKind: 22
-      Pointee: 1025 StructureType main.firstBehavior
+      Pointee: 1027 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 223
       Name: '*main.node'
@@ -5440,19 +5440,19 @@ Types:
       GoKind: 22
       Pointee: 238 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1026
+      ID: 1028
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824160
       GoKind: 22
-      Pointee: 1027 StructureType main.secondBehavior
+      Pointee: 1029 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1013
+      ID: 1015
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824256
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1016 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 142
       Name: '*main.stringType1'
@@ -5460,16 +5460,16 @@ Types:
       GoKind: 22
       Pointee: 143 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1011
+      ID: 1013
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1010 GoStringDataType main.stringType1.str
+      Pointee: 1012 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 145
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType main.stringType2
+      Pointee: 1014 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 241
       Name: '*main.structWithCyclicSlices'
@@ -5500,10 +5500,10 @@ Types:
       GoKind: 22
       Pointee: 225 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1030
+      ID: 1032
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1029 GoSliceDataType main.t.array
+      Pointee: 1031 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 236
       Name: '*main.threeStringStruct'
@@ -5517,554 +5517,554 @@ Types:
       GoKind: 22
       Pointee: 167 GoMapType map[string]int
     - __kind: PointerType
-      ID: 541
+      ID: 543
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848544
       GoKind: 22
-      Pointee: 542 StructureType math/big.ErrNaN
+      Pointee: 544 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 830
+      ID: 832
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843168
       GoKind: 22
-      Pointee: 831 StructureType mime/multipart.writerOnly·1
+      Pointee: 833 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 743
+      ID: 745
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.12112e+06
       GoKind: 22
-      Pointee: 744 UnresolvedPointeeType net.AddrError
+      Pointee: 746 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 769
+      ID: 771
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.23968e+06
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType net.DNSError
+      Pointee: 772 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 968
+      ID: 970
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.085856e+06
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType net.IPConn
+      Pointee: 971 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 767
+      ID: 769
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.23936e+06
       GoKind: 22
-      Pointee: 768 UnresolvedPointeeType net.OpError
+      Pointee: 770 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 745
+      ID: 747
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121248e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType net.ParseError
+      Pointee: 748 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 978
+      ID: 980
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.115712e+06
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType net.TCPConn
+      Pointee: 981 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 988
+      ID: 990
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.160672e+06
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType net.UDPConn
+      Pointee: 991 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 976
+      ID: 978
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.1152e+06
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType net.UnixConn
+      Pointee: 979 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 742
+      ID: 744
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.120352e+06
       GoKind: 22
-      Pointee: 705 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 707 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 706 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 708 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 673
+      ID: 675
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 996032
       GoKind: 22
-      Pointee: 674 StructureType net.canceledError
+      Pointee: 676 StructureType net.canceledError
     - __kind: PointerType
-      ID: 946
+      ID: 948
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.872704e+06
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType net.conn
+      Pointee: 949 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.716928e+06
       GoKind: 22
-      Pointee: 812 StructureType net.dialResult·1
+      Pointee: 814 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 990
+      ID: 992
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.164928e+06
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType net.netFD
+      Pointee: 993 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 476
+      ID: 478
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835392
       GoKind: 22
-      Pointee: 477 UnresolvedPointeeType net.notFoundError
+      Pointee: 479 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 478
+      ID: 480
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 836064
       GoKind: 22
-      Pointee: 479 StructureType net.result·2
+      Pointee: 481 StructureType net.result·2
     - __kind: PointerType
-      ID: 972
+      ID: 974
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.099744e+06
       GoKind: 22
-      Pointee: 973 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 975 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 970
+      ID: 972
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.099264e+06
       GoKind: 22
-      Pointee: 971 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 973 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.121888e+06
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType net.temporaryError
+      Pointee: 750 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 771
+      ID: 773
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.23984e+06
       GoKind: 22
-      Pointee: 772 UnresolvedPointeeType net.timeoutError
+      Pointee: 774 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 663
+      ID: 665
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 991808
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 666 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 824
+      ID: 826
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831264
       GoKind: 22
-      Pointee: 825 StructureType net/http.bufioFlushWriter
+      Pointee: 827 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 453
+      ID: 455
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 831936
       GoKind: 22
-      Pointee: 374 BaseType net/http.http2ConnectionError
+      Pointee: 376 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 454
+      ID: 456
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 832032
       GoKind: 22
-      Pointee: 455 StructureType net/http.http2GoAwayError
+      Pointee: 457 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 763
+      ID: 765
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.23552e+06
       GoKind: 22
-      Pointee: 764 StructureType net/http.http2StreamError
+      Pointee: 766 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 458
+      ID: 460
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832512
       GoKind: 22
-      Pointee: 459 StructureType net/http.http2connError
+      Pointee: 461 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 886
+      ID: 888
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.366432e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 889 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 457
+      ID: 459
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832416
       GoKind: 22
-      Pointee: 378 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 380 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 380
+      ID: 382
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 379 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 381 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 461
+      ID: 463
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832704
       GoKind: 22
-      Pointee: 384 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 386 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 386
+      ID: 388
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 385 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 387 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 460
+      ID: 462
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832608
       GoKind: 22
-      Pointee: 381 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 383 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 383
+      ID: 385
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 382 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 384 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 738
+      ID: 740
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.116896e+06
       GoKind: 22
-      Pointee: 739 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 741 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 669
+      ID: 671
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992448
       GoKind: 22
-      Pointee: 670 StructureType net/http.http2noCachedConnError
+      Pointee: 672 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 937
+      ID: 939
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.816704e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 940 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 456
+      ID: 458
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832320
       GoKind: 22
-      Pointee: 375 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 377 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 377
+      ID: 379
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 376 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 378 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 826
+      ID: 828
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832800
       GoKind: 22
-      Pointee: 827 StructureType net/http.http2stickyErrWriter
+      Pointee: 829 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 665
+      ID: 667
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 992064
       GoKind: 22
-      Pointee: 666 StructureType net/http.nothingWrittenError
+      Pointee: 668 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 888
+      ID: 890
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.030656e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType net/http.persistConn
+      Pointee: 891 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 844
+      ID: 846
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 991936
       GoKind: 22
-      Pointee: 845 StructureType net/http.persistConnWriter
+      Pointee: 847 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.115872e+06
       GoKind: 22
-      Pointee: 871 StructureType net/http.readWriteCloserBody
+      Pointee: 873 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 462
+      ID: 464
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 832896
       GoKind: 22
-      Pointee: 463 StructureType net/http.requestBodyReadError
+      Pointee: 465 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 765
+      ID: 767
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.23664e+06
       GoKind: 22
-      Pointee: 766 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 768 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 736
+      ID: 738
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.116768e+06
       GoKind: 22
-      Pointee: 737 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 739 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 667
+      ID: 669
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992192
       GoKind: 22
-      Pointee: 668 StructureType net/http.transportReadFromServerError
+      Pointee: 670 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 451
+      ID: 453
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831168
       GoKind: 22
-      Pointee: 452 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 454 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 939
+      ID: 941
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.81824e+06
       GoKind: 22
-      Pointee: 940 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 942 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 854
+      ID: 856
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.005504e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 857 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 533
+      ID: 535
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847488
       GoKind: 22
-      Pointee: 534 StructureType net/netip.parseAddrError
+      Pointee: 536 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 531
+      ID: 533
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847392
       GoKind: 22
-      Pointee: 532 StructureType net/netip.parsePrefixError
+      Pointee: 534 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 896
+      ID: 898
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.98032e+06
       GoKind: 22
-      Pointee: 897 UnresolvedPointeeType net/smtp.Client
+      Pointee: 899 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 856
+      ID: 858
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.010624e+06
       GoKind: 22
-      Pointee: 857 StructureType net/smtp.dataCloser
+      Pointee: 859 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 517
+      ID: 519
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843360
       GoKind: 22
-      Pointee: 518 UnresolvedPointeeType net/textproto.Error
+      Pointee: 520 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 516
+      ID: 518
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843264
       GoKind: 22
-      Pointee: 409 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 411 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 411
+      ID: 413
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 410 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 412 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 852
+      ID: 854
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.004864e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 855 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 773
+      ID: 775
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.24016e+06
       GoKind: 22
-      Pointee: 774 UnresolvedPointeeType net/url.Error
+      Pointee: 776 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 480
+      ID: 482
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836160
       GoKind: 22
-      Pointee: 387 GoStringHeaderType net/url.EscapeError
+      Pointee: 389 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 389
+      ID: 391
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 388 GoStringDataType net/url.EscapeError.str
+      Pointee: 390 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 481
+      ID: 483
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836256
       GoKind: 22
-      Pointee: 390 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 392 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 392
+      ID: 394
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 391 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 393 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 996
+      ID: 998
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.202176e+06
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType os.File
+      Pointee: 999 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 982976
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType os.LinkError
+      Pointee: 647 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 708
+      ID: 710
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105376e+06
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType os.SyscallError
+      Pointee: 711 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 994
+      ID: 996
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.199232e+06
       GoKind: 22
-      Pointee: 995 StructureType os.fileWithoutReadFrom
+      Pointee: 997 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 992
+      ID: 994
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.198496e+06
       GoKind: 22
-      Pointee: 993 StructureType os.fileWithoutWriteTo
+      Pointee: 995 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001536e+06
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType os/exec.Error
+      Pointee: 678 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 814
+      ID: 816
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.952288e+06
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 817 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.127904e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 877 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 677
+      ID: 679
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.001664e+06
       GoKind: 22
-      Pointee: 678 StructureType os/exec.wrappedError
+      Pointee: 680 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 611
+      ID: 613
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864480
       GoKind: 22
-      Pointee: 422 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 424 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 424
+      ID: 426
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 423 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 425 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 610
+      ID: 612
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864384
       GoKind: 22
-      Pointee: 421 BaseType os/user.UnknownUserIdError
+      Pointee: 423 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 446
+      ID: 448
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 828864
       GoKind: 22
-      Pointee: 447 UnresolvedPointeeType reflect.ValueError
+      Pointee: 449 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 539
+      ID: 541
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848160
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 542 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 647
+      ID: 649
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984512
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 650 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 652
+      ID: 654
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986432
       GoKind: 22
-      Pointee: 653 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 655 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -6080,12 +6080,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 649
+      ID: 651
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 984640
       GoKind: 22
-      Pointee: 650 StructureType runtime.boundsError
+      Pointee: 652 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
@@ -6101,24 +6101,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 710
+      ID: 712
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.110752e+06
       GoKind: 22
-      Pointee: 711 StructureType runtime.errorAddressString
+      Pointee: 713 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984256
       GoKind: 22
-      Pointee: 629 GoStringHeaderType runtime.errorString
+      Pointee: 631 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 631
+      ID: 633
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 630 GoStringDataType runtime.errorString.str
+      Pointee: 632 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
@@ -6141,17 +6141,17 @@ Types:
       GoKind: 22
       Pointee: 139 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 651
+      ID: 653
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 986176
       GoKind: 22
-      Pointee: 632 GoStringHeaderType runtime.plainError
+      Pointee: 634 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 634
+      ID: 636
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 633 GoStringDataType runtime.plainError.str
+      Pointee: 635 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -6174,12 +6174,12 @@ Types:
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 986688
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType strconv.NumError
+      Pointee: 657 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
@@ -6193,73 +6193,73 @@ Types:
       ByteSize: 8
       Pointee: 287 GoStringDataType string.str
     - __kind: PointerType
-      ID: 935
+      ID: 937
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.815424e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType strings.Builder
+      Pointee: 938 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 842
+      ID: 844
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 986816
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 845 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 838
+      ID: 840
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 839 StructureType struct { io.Writer }
+      Pointee: 841 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 762
+      ID: 764
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.23488e+06
       GoKind: 22
-      Pointee: 761 BaseType syscall.Errno
+      Pointee: 763 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 966
+      ID: 968
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.018272e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 969 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 703
+      ID: 705
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.04736e+06
       GoKind: 22
-      Pointee: 704 StructureType text/template.ExecError
+      Pointee: 706 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.431552e+06
       GoKind: 22
-      Pointee: 779 UnresolvedPointeeType time.Location
+      Pointee: 781 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 449
+      ID: 451
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829728
       GoKind: 22
-      Pointee: 450 UnresolvedPointeeType time.ParseError
+      Pointee: 452 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 448
+      ID: 450
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829632
       GoKind: 22
-      Pointee: 371 GoStringHeaderType time.fileSizeError
+      Pointee: 373 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 373
+      ID: 375
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 372 GoStringDataType time.fileSizeError.str
+      Pointee: 374 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -6303,54 +6303,54 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.77168e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 932 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 535
+      ID: 537
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 22
-      Pointee: 536 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 538 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 958
+      ID: 960
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.994848e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 961 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 519
+      ID: 521
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843744
       GoKind: 22
-      Pointee: 520 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 522 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 521
+      ID: 523
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 843840
       GoKind: 22
-      Pointee: 412 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 414 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 682
+      ID: 684
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005248e+06
       GoKind: 22
-      Pointee: 683 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 685 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 684
+      ID: 686
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005376e+06
       GoKind: 22
-      Pointee: 637 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 639 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1191
       Name: Probe[main.stackC]
@@ -8449,7 +8449,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 806
+      ID: 808
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 624192
@@ -8508,7 +8508,7 @@ Types:
       ByteSize: 8
       Element: 129 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1031
+      ID: 1033
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446976
@@ -8516,22 +8516,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1032 PointerType **main.deepSlice3
+          Type: 1034 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1035 GoSliceDataType []*main.deepSlice3.array
+      Data: 1037 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1035
+      ID: 1037
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1033 PointerType *main.deepSlice3
+      Element: 1035 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1050
+      ID: 1052
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446656
@@ -8539,22 +8539,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1051 PointerType **main.deepSlice8
+          Type: 1053 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1054 GoSliceDataType []*main.deepSlice8.array
+      Data: 1056 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1054
+      ID: 1056
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1052 PointerType *main.deepSlice8
+      Element: 1054 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1056
+      ID: 1058
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446592
@@ -8562,20 +8562,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1057 PointerType **main.deepSlice9
+          Type: 1059 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1060 GoSliceDataType []*main.deepSlice9.array
+      Data: 1062 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1060
+      ID: 1062
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1058 PointerType *main.deepSlice9
+      Element: 1060 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 118
       Name: '[]*string'
@@ -8785,23 +8785,23 @@ Types:
       ByteSize: 144
       Element: 137 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1045
+      ID: 1047
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1041 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1043 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1073
+      ID: 1075
       Name: '[]bucket<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1069 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1071 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1082
+      ID: 1084
       Name: '[]bucket<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1078 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1080 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 305
       Name: '[]bucket<int,int>.array'
@@ -8809,11 +8809,11 @@ Types:
       ByteSize: 144
       Element: 161 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 1089
+      ID: 1091
       Name: '[]bucket<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 1087 GoHMapBucketType bucket<int,interface {}>
+      Element: 1089 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
       ID: 324
       Name: '[]bucket<int,uint8>.array'
@@ -8833,11 +8833,11 @@ Types:
       ByteSize: 336
       Element: 176 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 817
+      ID: 819
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 789 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 791 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 309
       Name: '[]bucket<string,int>.array'
@@ -8899,7 +8899,7 @@ Types:
       ByteSize: 32
       Element: 203 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 801
+      ID: 803
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454208
@@ -8914,15 +8914,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 818 GoSliceDataType []float64.array
+      Data: 820 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 818
+      ID: 820
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1062
+      ID: 1064
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454656
@@ -8937,9 +8937,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1063 GoSliceDataType []interface {}.array
+      Data: 1065 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1063
+      ID: 1065
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -9030,9 +9030,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1090 GoSliceDataType []main.structWithMap.array
+      Data: 371 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1090
+      ID: 371
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -9186,26 +9186,26 @@ Types:
       HasCount: true
       Element: 301 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1042
+      ID: 1044
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1043 PointerType *main.deepMap3
+      Element: 1045 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 1070
+      ID: 1072
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1071 PointerType *main.deepMap8
+      Element: 1073 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 1079
+      ID: 1081
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1080 PointerType *main.deepMap9
+      Element: 1082 PointerType *main.deepMap9
     - __kind: ArrayType
       ID: 314
       Name: '[]val<[2]int>'
@@ -9235,12 +9235,12 @@ Types:
       HasCount: true
       Element: 232 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 816
+      ID: 818
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 808 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 810 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
       ID: 304
       Name: '[]val<int>'
@@ -9249,7 +9249,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1088
+      ID: 1090
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
@@ -9319,11 +9319,11 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 947
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 597
+      ID: 599
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858528
@@ -9338,33 +9338,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 598 GoSliceDataType archive/tar.headerError.array
+      Data: 600 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 598
+      ID: 600
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 887
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 835
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 837
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.078464e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 934
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 861
+      ID: 863
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.376512e+06
@@ -9374,7 +9374,7 @@ Types:
           Offset: 0
           Type: 120 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 865
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9479,7 +9479,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 301 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1041
+      ID: 1043
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
@@ -9491,14 +9491,14 @@ Types:
           Type: 299 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1042 ArrayType []val<*main.deepMap3>
+          Type: 1044 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1040 PointerType *bucket<int,*main.deepMap3>
+          Type: 1042 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 1043 PointerType *main.deepMap3
+      ValueType: 1045 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 1069
+      ID: 1071
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
@@ -9510,14 +9510,14 @@ Types:
           Type: 299 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1070 ArrayType []val<*main.deepMap8>
+          Type: 1072 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 1068 PointerType *bucket<int,*main.deepMap8>
+          Type: 1070 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 1071 PointerType *main.deepMap8
+      ValueType: 1073 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 1078
+      ID: 1080
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
@@ -9529,12 +9529,12 @@ Types:
           Type: 299 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1079 ArrayType []val<*main.deepMap9>
+          Type: 1081 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 1077 PointerType *bucket<int,*main.deepMap9>
+          Type: 1079 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 1080 PointerType *main.deepMap9
+      ValueType: 1082 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 161
       Name: bucket<int,int>
@@ -9555,7 +9555,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 1087
+      ID: 1089
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
@@ -9567,10 +9567,10 @@ Types:
           Type: 299 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1088 ArrayType []val<interface {}>
+          Type: 1090 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 1086 PointerType *bucket<int,interface {}>
+          Type: 1088 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 148 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -9631,7 +9631,7 @@ Types:
       KeyType: 11 GoStringHeaderType string
       ValueType: 232 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 789
+      ID: 791
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
@@ -9643,12 +9643,12 @@ Types:
           Type: 306 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 816 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 818 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 788 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 790 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 808 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 810 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 171
       Name: bucket<string,int>
@@ -9840,15 +9840,15 @@ Types:
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 911
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 936
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 981
+      ID: 983
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9874,13 +9874,13 @@ Types:
       GoRuntimeType: 532256
       GoKind: 15
     - __kind: BaseType
-      ID: 404
+      ID: 406
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764640
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 405
+      ID: 407
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764736
@@ -9888,92 +9888,92 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 407 PointerType *compress/flate.InternalError.str
+          Type: 409 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 406 GoStringDataType compress/flate.InternalError.str
+      Data: 408 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 406
+      ID: 408
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 885
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 829
+      ID: 831
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 907
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 741
+      ID: 743
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296288e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 418
+      ID: 420
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767232
       GoKind: 2
     - __kind: BaseType
-      ID: 419
+      ID: 421
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767328
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 897
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 922
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 420
+      ID: 422
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767424
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 930
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 926
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 408
+      ID: 410
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765216
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 683
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1007
+      ID: 1009
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 516
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 512
+      ID: 514
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.605024e+06
@@ -9984,34 +9984,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 806 ArrayType [5]uint8
+          Type: 808 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 807 GoInterfaceType net.Conn
+          Type: 809 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 636
+      ID: 638
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951488
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 895
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 902
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 778
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 791
+      ID: 793
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 586
+      ID: 588
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.608096e+06
@@ -10019,21 +10019,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 790 PointerType *crypto/x509.Certificate
+          Type: 792 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 809 BaseType crypto/x509.InvalidReason
+          Type: 811 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 580
+      ID: 582
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.075776e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 582
+      ID: 584
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.408864e+06
@@ -10041,24 +10041,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 790 PointerType *crypto/x509.Certificate
+          Type: 792 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 417
+      ID: 419
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 766848
       GoKind: 2
     - __kind: BaseType
-      ID: 809
+      ID: 811
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537760
       GoKind: 2
     - __kind: StructureType
-      ID: 686
+      ID: 688
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.372832e+06
@@ -10068,13 +10068,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 588
+      ID: 590
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.076032e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 584
+      ID: 586
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.607904e+06
@@ -10082,15 +10082,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 790 PointerType *crypto/x509.Certificate
+          Type: 792 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 790 PointerType *crypto/x509.Certificate
+          Type: 792 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 601
+      ID: 603
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.25376e+06
@@ -10100,7 +10100,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 605
+      ID: 607
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.25392e+06
@@ -10110,55 +10110,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 605
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 402
+      ID: 404
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764256
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 853
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 403
+      ID: 405
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764448
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 473
+      ID: 475
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 672
+      ID: 674
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 465
+      ID: 467
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 471
+      ID: 473
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 469
+      ID: 471
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 467
+      ID: 469
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 989
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 475
+      ID: 477
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.2384e+06
@@ -10168,19 +10168,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 861
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 576
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 574
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 414
+      ID: 416
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766752
@@ -10188,22 +10188,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 416 PointerType *encoding/xml.UnmarshalError.str
+          Type: 418 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 415 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 417 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 415
+      ID: 417
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 579
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 967
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -10220,11 +10220,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 443
+      ID: 445
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 641
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -10240,15 +10240,15 @@ Types:
       GoRuntimeType: 532448
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 975
+      ID: 977
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 643
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 645
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -10264,11 +10264,11 @@ Types:
       GoRuntimeType: 777984
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 503
+      ID: 505
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 484
+      ID: 486
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.603296e+06
@@ -10276,7 +10276,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 799 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 801 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -10284,25 +10284,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 488
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 805
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 490
+      ID: 492
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.072192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 807
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 396
+      ID: 398
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763680
@@ -10310,18 +10310,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 398 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 400 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 397 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 399 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 397
+      ID: 399
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 799
+      ID: 801
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.074112e+06
@@ -10329,7 +10329,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 800 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 802 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -10344,7 +10344,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 801 GoSliceHeaderType []float64
+          Type: 803 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -10353,10 +10353,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 802 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 804 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 804 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 806 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 232 GoSliceHeaderType []string
@@ -10370,13 +10370,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 800
+      ID: 802
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534304
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 393
+      ID: 395
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763584
@@ -10384,18 +10384,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 395 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 397 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 394 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 396 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 394
+      ID: 396
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 399
+      ID: 401
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763776
@@ -10403,60 +10403,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 401 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 403 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 400 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 402 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 400
+      ID: 402
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 875
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 955
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 597
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 752
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 985
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 525
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 530
+      ID: 532
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.075008e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 413
+      ID: 415
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 765888
       GoKind: 2
     - __kind: StructureType
-      ID: 528
+      ID: 530
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.07488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 526
+      ID: 528
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.406944e+06
@@ -10469,7 +10469,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 546
+      ID: 548
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.407744e+06
@@ -10482,7 +10482,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 550
+      ID: 552
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.607328e+06
@@ -10498,7 +10498,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 548
+      ID: 550
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.24816e+06
@@ -10508,7 +10508,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 544
+      ID: 546
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.24784e+06
@@ -10518,14 +10518,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 785
+      ID: 787
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135328e+06
       GoKind: 21
-      HeaderType: 787 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 789 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 808
+      ID: 810
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.00896e+06
@@ -10540,15 +10540,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 820 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 822 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 820
+      ID: 822
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 558
+      ID: 560
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.408064e+06
@@ -10556,12 +10556,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 785 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 787 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 785 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 787 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 552
+      ID: 554
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.24832e+06
@@ -10571,7 +10571,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 556
+      ID: 558
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.60752e+06
@@ -10582,12 +10582,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 808 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 810 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 808 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 810 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 554
+      ID: 556
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.407904e+06
@@ -10600,7 +10600,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 560
+      ID: 562
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.24848e+06
@@ -10608,9 +10608,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 777 StructureType time.Time
+          Type: 779 StructureType time.Time
     - __kind: StructureType
-      ID: 566
+      ID: 568
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.408384e+06
@@ -10623,7 +10623,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 568
+      ID: 570
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.2488e+06
@@ -10633,7 +10633,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 564
+      ID: 566
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.408224e+06
@@ -10646,7 +10646,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 562
+      ID: 564
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.24864e+06
@@ -10656,7 +10656,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 570
+      ID: 572
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.408544e+06
@@ -10669,7 +10669,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 492
+      ID: 494
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.24064e+06
@@ -10679,11 +10679,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 914
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 494
+      ID: 496
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.2408e+06
@@ -10691,21 +10691,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 492 StructureType github.com/cihub/seelog.baseError
+          Type: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 893
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 849
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 883
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 498
+      ID: 500
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.24112e+06
@@ -10713,13 +10713,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 492 StructureType github.com/cihub/seelog.baseError
+          Type: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 945
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 954
+      ID: 956
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.968384e+06
@@ -10727,12 +10727,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 942 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 944 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 955
+      ID: 957
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.991776e+06
@@ -10740,7 +10740,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 942 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 944 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -10748,11 +10748,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 851
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 496
+      ID: 498
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.24096e+06
@@ -10760,9 +10760,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 492 StructureType github.com/cihub/seelog.baseError
+          Type: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 500
+      ID: 502
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.24128e+06
@@ -10770,64 +10770,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 492 StructureType github.com/cihub/seelog.baseError
+          Type: 494 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 918
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 951
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 953
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 783
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 696
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 694
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 698
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 700
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 690
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 506
+      ID: 508
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.24224e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1001
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 752
+      ID: 754
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 725
+      ID: 727
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.712e+06
@@ -10843,11 +10843,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 719
+      ID: 721
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 658
+      ID: 660
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.5096e+06
@@ -10860,7 +10860,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 731
+      ID: 733
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.712448e+06
@@ -10876,13 +10876,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 635
+      ID: 637
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 948896
       GoKind: 8
     - __kind: StructureType
-      ID: 723
+      ID: 725
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.711776e+06
@@ -10898,13 +10898,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 810
+      ID: 812
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 761856
       GoKind: 8
     - __kind: StructureType
-      ID: 721
+      ID: 723
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.711552e+06
@@ -10912,15 +10912,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 810 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 812 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 810 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 812 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 729
+      ID: 731
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.630144e+06
@@ -10933,7 +10933,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 727
+      ID: 729
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.712224e+06
@@ -10949,11 +10949,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1005
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 735
+      ID: 737
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.432512e+06
@@ -10963,19 +10963,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 664
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.195168e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 660
+      ID: 662
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.19504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 733
+      ID: 735
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.630336e+06
@@ -10988,7 +10988,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 425
+      ID: 427
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769248
@@ -10996,22 +10996,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 427 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 429 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 426 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 428 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 426
+      ID: 428
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 796
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 704
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.2656e+06
@@ -11021,7 +11021,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 879
+      ID: 881
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.486464e+06
@@ -11029,13 +11029,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 903 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 905 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 965
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 903
+      ID: 905
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.085888e+06
@@ -11048,7 +11048,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 865
+      ID: 867
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.381312e+06
@@ -11058,19 +11058,19 @@ Types:
           Offset: 0
           Type: 120 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 428
+      ID: 430
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769824
       GoKind: 10
     - __kind: BaseType
-      ID: 792
+      ID: 794
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 962144
       GoKind: 10
     - __kind: StructureType
-      ID: 760
+      ID: 762
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.750528e+06
@@ -11081,12 +11081,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 792 BaseType golang.org/x/net/http2.ErrCode
+          Type: 794 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 621
+      ID: 623
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.415744e+06
@@ -11094,12 +11094,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 792 BaseType golang.org/x/net/http2.ErrCode
+          Type: 794 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 432
+      ID: 434
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770016
@@ -11107,18 +11107,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 434 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 436 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 433 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 435 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 433
+      ID: 435
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 438
+      ID: 440
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770208
@@ -11126,18 +11126,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 440 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 442 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 439 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 441 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 439
+      ID: 441
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 435
+      ID: 437
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770112
@@ -11145,18 +11145,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 437 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 439 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 436 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 438 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 436
+      ID: 438
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 429
+      ID: 431
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769920
@@ -11164,22 +11164,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 431 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 433 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 430 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 432 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 430
+      ID: 432
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 963
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 625
+      ID: 627
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.26624e+06
@@ -11189,13 +11189,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 441
+      ID: 443
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770304
       GoKind: 2
     - __kind: StructureType
-      ID: 613
+      ID: 615
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.26128e+06
@@ -11205,11 +11205,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 760
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 783
+      ID: 785
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.776288e+06
@@ -11225,7 +11225,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 615
+      ID: 617
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.415264e+06
@@ -11238,7 +11238,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 926
+      ID: 928
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.82976e+06
@@ -11246,16 +11246,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 807 GoInterfaceType net.Conn
+          Type: 809 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 941 GoInterfaceType io.Reader
+          Type: 943 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 879
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 700
+      ID: 702
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.378912e+06
@@ -11265,29 +11265,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 839
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 593
+      ID: 595
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 692
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 758
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 754
+      ID: 756
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.326048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 607
+      ID: 609
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.25456e+06
@@ -11297,7 +11297,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 609
+      ID: 611
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.25472e+06
@@ -11307,11 +11307,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 540
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 916
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -11485,7 +11485,7 @@ Types:
       BucketType: 137 GoHMapBucketType bucket<int,*main.deepMap2>
       BucketsType: 303 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1039
+      ID: 1041
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -11506,20 +11506,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1040 PointerType *bucket<int,*main.deepMap3>
+          Type: 1042 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1040 PointerType *bucket<int,*main.deepMap3>
+          Type: 1042 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 1041 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1045 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1043 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1047 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 1067
+      ID: 1069
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -11540,20 +11540,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1068 PointerType *bucket<int,*main.deepMap8>
+          Type: 1070 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 1068 PointerType *bucket<int,*main.deepMap8>
+          Type: 1070 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 1069 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 1073 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1071 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1075 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 1076
+      ID: 1078
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -11574,18 +11574,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1077 PointerType *bucket<int,*main.deepMap9>
+          Type: 1079 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 1077 PointerType *bucket<int,*main.deepMap9>
+          Type: 1079 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 1078 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 1082 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1080 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1084 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 159
       Name: hash<int,int>
@@ -11621,7 +11621,7 @@ Types:
       BucketType: 161 GoHMapBucketType bucket<int,int>
       BucketsType: 305 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 1085
+      ID: 1087
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -11642,18 +11642,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1086 PointerType *bucket<int,interface {}>
+          Type: 1088 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 1086 PointerType *bucket<int,interface {}>
+          Type: 1088 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 1087 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 1089 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1089 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1091 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 196
       Name: hash<int,uint8>
@@ -11757,7 +11757,7 @@ Types:
       BucketType: 176 GoHMapBucketType bucket<string,[]string>
       BucketsType: 311 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 787
+      ID: 789
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -11778,18 +11778,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 788 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 790 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 788 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 790 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 138 PointerType *runtime.mapextra
-      BucketType: 789 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 817 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 791 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 819 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 169
       Name: hash<string,int>
@@ -12131,7 +12131,7 @@ Types:
       BucketType: 203 GoHMapBucketType bucket<uint8,uint8>
       BucketsType: 326 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 630
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -12178,7 +12178,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 508
+      ID: 510
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -12204,25 +12204,25 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 825
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 719
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1007
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 715
+      ID: 717
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293248e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 445
+      ID: 447
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -12303,11 +12303,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 871
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 910
+      ID: 912
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.103584e+06
@@ -12320,7 +12320,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 941
+      ID: 943
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 980288
@@ -12333,7 +12333,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 898
+      ID: 900
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.068608e+06
@@ -12359,21 +12359,21 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 867
+      ID: 869
       Name: io.discard
       GoRuntimeType: 1.280608e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 843
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 715
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 920
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -12441,9 +12441,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1037 GoMapType map[int]*main.deepMap3
+          Type: 1039 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1046
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -12455,9 +12455,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1065 GoMapType map[int]*main.deepMap8
+          Type: 1067 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1072
+      ID: 1074
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.09936e+06
@@ -12465,9 +12465,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1074 GoMapType map[int]*main.deepMap9
+          Type: 1076 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1081
+      ID: 1083
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.099232e+06
@@ -12475,7 +12475,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1083 GoMapType map[int]interface {}
+          Type: 1085 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 121
       Name: main.deepPtr1
@@ -12495,9 +12495,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1008 PointerType *main.deepPtr3
+          Type: 1010 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1011
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -12509,9 +12509,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1046 PointerType *main.deepPtr8
+          Type: 1048 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1047
+      ID: 1049
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.100512e+06
@@ -12519,9 +12519,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1048 PointerType *main.deepPtr9
+          Type: 1050 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1049
+      ID: 1051
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.100384e+06
@@ -12549,9 +12549,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1031 GoSliceHeaderType []*main.deepSlice3
+          Type: 1033 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1036
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -12563,9 +12563,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1050 GoSliceHeaderType []*main.deepSlice8
+          Type: 1052 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1053
+      ID: 1055
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.101664e+06
@@ -12573,9 +12573,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1056 GoSliceHeaderType []*main.deepSlice9
+          Type: 1058 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1059
+      ID: 1061
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101536e+06
@@ -12583,7 +12583,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1062 GoSliceHeaderType []interface {}
+          Type: 1064 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 285
       Name: main.emptyStruct
@@ -12601,16 +12601,16 @@ Types:
           Type: 146 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1015 StructureType sync.Mutex
+          Type: 1017 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1016 StructureType sync.Once
+          Type: 1018 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1019 StructureType sync.WaitGroup
+          Type: 1021 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1023 StructureType sync/atomic.Int32
+          Type: 1025 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 146
       Name: main.esotericStack
@@ -12640,7 +12640,7 @@ Types:
           Offset: 56
           Type: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1025
+      ID: 1027
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.23168e+06
@@ -12685,7 +12685,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1027
+      ID: 1029
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.23184e+06
@@ -12705,7 +12705,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1016
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12716,18 +12716,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1011 PointerType *main.stringType1.str
+          Type: 1013 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1010 GoStringDataType main.stringType1.str
+      Data: 1012 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1010
+      ID: 1012
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1014
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -12830,16 +12830,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1028 PointerType **main.t
+          Type: 1030 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1029 GoSliceDataType main.t.array
+      Data: 1031 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1029
+      ID: 1031
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -12900,26 +12900,26 @@ Types:
       GoKind: 21
       HeaderType: 135 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1037
+      ID: 1039
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879840
       GoKind: 21
-      HeaderType: 1039 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1041 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1065
+      ID: 1067
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879360
       GoKind: 21
-      HeaderType: 1067 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1069 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1074
+      ID: 1076
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879264
       GoKind: 21
-      HeaderType: 1076 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1078 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 157
       Name: map[int]int
@@ -12928,12 +12928,12 @@ Types:
       GoKind: 21
       HeaderType: 159 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 1083
+      ID: 1085
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879168
       GoKind: 21
-      HeaderType: 1085 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1087 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 194
       Name: map[int]uint8
@@ -13020,7 +13020,7 @@ Types:
       GoKind: 21
       HeaderType: 201 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 542
+      ID: 544
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.24752e+06
@@ -13030,7 +13030,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 831
+      ID: 833
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.24432e+06
@@ -13040,11 +13040,11 @@ Types:
           Offset: 0
           Type: 120 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 744
+      ID: 746
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 807
+      ID: 809
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.405664e+06
@@ -13057,35 +13057,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 772
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 971
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 768
+      ID: 770
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 748
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 981
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 991
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 979
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 705
+      ID: 707
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.071808e+06
@@ -13093,28 +13093,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 707 PointerType *net.UnknownNetworkError.str
+          Type: 709 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 706 GoStringDataType net.UnknownNetworkError.str
+      Data: 708 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 706
+      ID: 708
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 674
+      ID: 676
       Name: net.canceledError
       GoRuntimeType: 1.196064e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 949
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 812
+      ID: 814
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.96768e+06
@@ -13122,7 +13122,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 807 GoInterfaceType net.Conn
+          Type: 809 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -13133,27 +13133,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 993
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 985
+      ID: 987
       Name: net.noReadFrom
       GoRuntimeType: 1.072064e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 984
+      ID: 986
       Name: net.noWriteTo
       GoRuntimeType: 1.071936e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 477
+      ID: 479
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 479
+      ID: 481
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.603104e+06
@@ -13161,7 +13161,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 795 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 797 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -13169,7 +13169,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 973
+      ID: 975
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.144e+06
@@ -13177,12 +13177,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 985 StructureType net.noReadFrom
+          Type: 987 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 978 PointerType *net.TCPConn
+          Type: 980 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 971
+      ID: 973
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.143456e+06
@@ -13190,24 +13190,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 984 StructureType net.noWriteTo
+          Type: 986 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 978 PointerType *net.TCPConn
+          Type: 980 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 750
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 772
+      ID: 774
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 666
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 827
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.23584e+06
@@ -13217,19 +13217,19 @@ Types:
           Offset: 0
           Type: 120 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 374
+      ID: 376
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762336
       GoKind: 10
     - __kind: BaseType
-      ID: 784
+      ID: 786
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 948992
       GoKind: 10
     - __kind: StructureType
-      ID: 455
+      ID: 457
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.601184e+06
@@ -13240,12 +13240,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 784 BaseType net/http.http2ErrCode
+          Type: 786 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 764
+      ID: 766
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.76656e+06
@@ -13256,12 +13256,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 784 BaseType net/http.http2ErrCode
+          Type: 786 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 459
+      ID: 461
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.405184e+06
@@ -13269,16 +13269,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 784 BaseType net/http.http2ErrCode
+          Type: 786 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 889
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 378
+      ID: 380
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762528
@@ -13286,18 +13286,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 380 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 382 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 379 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 381 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 379
+      ID: 381
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 384
+      ID: 386
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762720
@@ -13305,18 +13305,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 386 PointerType *net/http.http2headerFieldNameError.str
+          Type: 388 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 385 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 387 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 385
+      ID: 387
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 381
+      ID: 383
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762624
@@ -13324,32 +13324,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 383 PointerType *net/http.http2headerFieldValueError.str
+          Type: 385 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 382 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 384 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 382
+      ID: 384
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 739
+      ID: 741
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 670
+      ID: 672
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.195424e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 940
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 375
+      ID: 377
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762432
@@ -13357,18 +13357,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 377 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 379 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 376 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 378 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 376
+      ID: 378
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 827
+      ID: 829
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.601952e+06
@@ -13376,22 +13376,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 807 GoInterfaceType net.Conn
+          Type: 809 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 906 BaseType time.Duration
+          Type: 908 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 99 PointerType *error
     - __kind: ArrayType
-      ID: 907
+      ID: 909
       Name: net/http.incomparable
       GoRuntimeType: 830976
       GoKind: 17
       HasCount: true
       Element: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 666
+      ID: 668
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.367072e+06
@@ -13401,11 +13401,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 891
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 847
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.366912e+06
@@ -13413,9 +13413,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 888 PointerType *net/http.persistConn
+          Type: 890 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 871
+      ID: 873
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.673248e+06
@@ -13423,15 +13423,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 907 ArrayType net/http.incomparable
+          Type: 909 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 908 PointerType *bufio.Reader
+          Type: 910 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 910 GoInterfaceType io.ReadWriteCloser
+          Type: 912 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 463
+      ID: 465
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.2368e+06
@@ -13441,17 +13441,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 766
+      ID: 768
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 737
+      ID: 739
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.295968e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 668
+      ID: 670
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.367232e+06
@@ -13461,11 +13461,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 452
+      ID: 454
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 940
+      ID: 942
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.9048e+06
@@ -13473,13 +13473,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 933 PointerType *bufio.Writer
+          Type: 935 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 857
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 534
+      ID: 536
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.606944e+06
@@ -13495,7 +13495,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 532
+      ID: 534
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.407104e+06
@@ -13508,11 +13508,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 897
+      ID: 899
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 859
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.409024e+06
@@ -13520,16 +13520,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 896 PointerType *net/smtp.Client
+          Type: 898 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 898 GoInterfaceType io.WriteCloser
+          Type: 900 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 518
+      ID: 520
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 409
+      ID: 411
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765312
@@ -13537,26 +13537,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 411 PointerType *net/textproto.ProtocolError.str
+          Type: 413 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 410 GoStringDataType net/textproto.ProtocolError.str
+      Data: 412 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 410
+      ID: 412
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 855
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 774
+      ID: 776
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 387
+      ID: 389
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763296
@@ -13564,18 +13564,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 389 PointerType *net/url.EscapeError.str
+          Type: 391 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 388 GoStringDataType net/url.EscapeError.str
+      Data: 390 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 388
+      ID: 390
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 390
+      ID: 392
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763392
@@ -13583,30 +13583,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 392 PointerType *net/url.InvalidHostError.str
+          Type: 394 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 391 GoStringDataType net/url.InvalidHostError.str
+      Data: 393 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 391
+      ID: 393
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 999
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 647
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 711
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 995
+      ID: 997
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.212192e+06
@@ -13614,12 +13614,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1001 StructureType os.noReadFrom
+          Type: 1003 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 996 PointerType *os.File
+          Type: 998 PointerType *os.File
     - __kind: StructureType
-      ID: 993
+      ID: 995
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.211392e+06
@@ -13627,36 +13627,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1000 StructureType os.noWriteTo
+          Type: 1002 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 996 PointerType *os.File
+          Type: 998 PointerType *os.File
     - __kind: StructureType
-      ID: 1001
+      ID: 1003
       Name: os.noReadFrom
       GoRuntimeType: 1.069504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1000
+      ID: 1002
       Name: os.noWriteTo
       GoRuntimeType: 1.069376e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 678
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 817
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 877
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 678
+      ID: 680
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.510176e+06
@@ -13669,7 +13669,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 422
+      ID: 424
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768480
@@ -13677,36 +13677,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 424 PointerType *os/user.UnknownGroupIdError.str
+          Type: 426 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 423 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 425 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 423
+      ID: 425
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 421
+      ID: 423
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768384
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 447
+      ID: 449
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 542
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 650
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 653
+      ID: 655
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -13718,7 +13718,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 652
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.756128e+06
@@ -13735,9 +13735,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 813 BaseType runtime.boundsErrorCode
+          Type: 815 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 813
+      ID: 815
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532640
@@ -13757,7 +13757,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 711
+      ID: 713
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.627072e+06
@@ -13770,7 +13770,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 629
+      ID: 631
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 947840
@@ -13778,13 +13778,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 631 PointerType *runtime.errorString.str
+          Type: 633 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 630 GoStringDataType runtime.errorString.str
+      Data: 632 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 630
+      ID: 632
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -14410,7 +14410,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 632
+      ID: 634
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948416
@@ -14418,13 +14418,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 634 PointerType *runtime.plainError.str
+          Type: 636 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 633 GoStringDataType runtime.plainError.str
+      Data: 635 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 633
+      ID: 635
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -14506,7 +14506,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 657
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14529,15 +14529,15 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 938
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 845
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 839
+      ID: 841
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.272768e+06
@@ -14553,7 +14553,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1015
+      ID: 1017
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281408e+06
@@ -14566,7 +14566,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1016
+      ID: 1018
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282528e+06
@@ -14574,12 +14574,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1017 StructureType sync/atomic.Uint32
+          Type: 1019 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1015 StructureType sync.Mutex
+          Type: 1017 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1019
+      ID: 1021
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421376e+06
@@ -14587,21 +14587,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1020 StructureType sync.noCopy
+          Type: 1022 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1021 StructureType sync/atomic.Uint64
+          Type: 1023 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1020
+      ID: 1022
       Name: sync.noCopy
       GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1023
+      ID: 1025
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282848e+06
@@ -14609,12 +14609,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1018 StructureType sync/atomic.noCopy
+          Type: 1020 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 1017
+      ID: 1019
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.283008e+06
@@ -14622,12 +14622,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1018 StructureType sync/atomic.noCopy
+          Type: 1020 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1021
+      ID: 1023
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.42176e+06
@@ -14635,37 +14635,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1018 StructureType sync/atomic.noCopy
+          Type: 1020 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1022 StructureType sync/atomic.align64
+          Type: 1024 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 1022
+      ID: 1024
       Name: sync/atomic.align64
       GoRuntimeType: 946976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1018
+      ID: 1020
       Name: sync/atomic.noCopy
       GoRuntimeType: 946880
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 761
+      ID: 763
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.194656e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 969
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 704
+      ID: 706
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.514592e+06
@@ -14678,21 +14678,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 906
+      ID: 908
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.7824e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 779
+      ID: 781
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 450
+      ID: 452
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 777
+      ID: 779
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.224416e+06
@@ -14706,9 +14706,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 778 PointerType *time.Location
+          Type: 780 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 371
+      ID: 373
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761472
@@ -14716,13 +14716,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 373 PointerType *time.fileSizeError.str
+          Type: 375 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 372 GoStringDataType time.fileSizeError.str
+      Data: 374 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 372
+      ID: 374
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -14769,11 +14769,11 @@ Types:
       GoRuntimeType: 532576
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 932
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 795
+      ID: 797
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.926528e+06
@@ -14784,10 +14784,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 796 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 798 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 797 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 799 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -14802,18 +14802,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 798 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 800 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 798
+      ID: 800
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 953120
       GoKind: 9
     - __kind: StructureType
-      ID: 796
+      ID: 798
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.792896e+06
@@ -14838,21 +14838,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 536
+      ID: 538
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 797
+      ID: 799
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536224
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 961
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 520
+      ID: 522
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.24464e+06
@@ -14862,13 +14862,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 412
+      ID: 414
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765408
       GoKind: 2
     - __kind: StructureType
-      ID: 683
+      ID: 685
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510368e+06
@@ -14881,7 +14881,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 637
+      ID: 639
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 951968

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -2343,15 +2343,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d60c..0x88d61c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d61c..0x88d6c0
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x88d6c0..0x88d740]
@@ -2368,29 +2359,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x88d740..0x88d860]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d7a8..0x88d7b0
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d7b0..0x88d7c8
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d7c8..0x88d7dc
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d7a4..0x88d7ac
-              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d7ac..0x88d7c8
-              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d7c8..0x88d7d8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x88d860..0x88d870]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -3464,20 +3464,20 @@ Types:
       ByteSize: 8
       Pointee: 134 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1163
+      ID: 1165
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1164 PointerType *main.deepSlice3
+      Pointee: 1166 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1188
+      ID: 1190
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1189 PointerType *main.deepSlice8
+      Pointee: 1191 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1194
+      ID: 1196
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1195 PointerType *main.deepSlice9
+      Pointee: 1197 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 147
       Name: '**main.stringType2'
@@ -3485,7 +3485,7 @@ Types:
       GoKind: 22
       Pointee: 148 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1159
+      ID: 1161
       Name: '**main.t'
       ByteSize: 8
       Pointee: 227 PointerType *main.t
@@ -3522,30 +3522,30 @@ Types:
       ByteSize: 8
       Pointee: 142 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1171
+      ID: 1173
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1172 PointerType *table<int,*main.deepMap3>
+      Pointee: 1174 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1205
+      ID: 1207
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1206 PointerType *table<int,*main.deepMap8>
+      Pointee: 1208 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1220
+      ID: 1222
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1221 PointerType *table<int,*main.deepMap9>
+      Pointee: 1223 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 163
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 164 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1235
+      ID: 1237
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1236 PointerType *table<int,interface {}>
+      Pointee: 1238 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 200
       Name: '**table<int,uint8>'
@@ -3562,10 +3562,10 @@ Types:
       ByteSize: 8
       Pointee: 179 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 906 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 908 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 173
       Name: '**table<string,int>'
@@ -3622,20 +3622,20 @@ Types:
       ByteSize: 8
       Pointee: 299 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1167
+      ID: 1169
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1166 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1168 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1192
+      ID: 1194
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1191 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1193 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1198
+      ID: 1200
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1197 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1199 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 297
       Name: '*[]*string.array'
@@ -3697,15 +3697,15 @@ Types:
       ByteSize: 8
       Pointee: 419 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 942
+      ID: 944
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 941 GoSliceDataType []float64.array
+      Pointee: 943 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1201
+      ID: 1203
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1200 GoSliceDataType []interface {}.array
+      Pointee: 1202 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 246
       Name: '*[]main.structWithCyclicSlices'
@@ -3717,10 +3717,10 @@ Types:
       ByteSize: 8
       Pointee: 423 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1246
+      ID: 485
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1245 GoSliceDataType []main.structWithMap.array
+      Pointee: 484 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 416
       Name: '*[]main.structWithNoStrings.array'
@@ -3764,66 +3764,66 @@ Types:
       ByteSize: 8
       Pointee: 294 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1072
+      ID: 1074
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.976128e+06
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1075 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 713
+      ID: 715
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 925920
       GoKind: 22
-      Pointee: 714 GoSliceHeaderType archive/tar.headerError
+      Pointee: 716 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 716
+      ID: 718
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 715 GoSliceDataType archive/tar.headerError.array
+      Pointee: 717 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1007
+      ID: 1009
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.430016e+06
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1010 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 955
+      ID: 957
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 956 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 958 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 957
+      ID: 959
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 958 StructureType archive/zip.dirWriter
+      Pointee: 960 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1055
+      ID: 1057
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.895808e+06
       GoKind: 22
-      Pointee: 1056 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1058 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 983
+      ID: 985
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.052544e+06
       GoKind: 22
-      Pointee: 984 StructureType archive/zip.nopCloser
+      Pointee: 986 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 985
+      ID: 987
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.0528e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 988 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3832,421 +3832,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1030
+      ID: 1032
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.164256e+06
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType bufio.Reader
+      Pointee: 1033 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1059
+      ID: 1061
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.94032e+06
       GoKind: 22
-      Pointee: 1060 UnresolvedPointeeType bufio.Writer
+      Pointee: 1062 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1110
+      ID: 1112
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.261536e+06
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 625
+      ID: 627
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 908544
       GoKind: 22
-      Pointee: 517 BaseType compress/flate.CorruptInputError
+      Pointee: 519 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 518 GoStringHeaderType compress/flate.InternalError
+      Pointee: 520 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 520
+      ID: 522
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 519 GoStringDataType compress/flate.InternalError.str
+      Pointee: 521 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1005
+      ID: 1007
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.419456e+06
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1008 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 951
+      ID: 953
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 954 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1027
+      ID: 1029
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.717792e+06
       GoKind: 22
-      Pointee: 1028 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1030 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 857
+      ID: 859
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.198752e+06
       GoKind: 22
-      Pointee: 858 StructureType context.deadlineExceededError
+      Pointee: 860 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 705
+      ID: 707
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 920544
       GoKind: 22
-      Pointee: 531 BaseType crypto/aes.KeySizeError
+      Pointee: 533 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 706
+      ID: 708
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 532 BaseType crypto/des.KeySizeError
+      Pointee: 534 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921024
       GoKind: 22
-      Pointee: 533 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 535 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1017
+      ID: 1019
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.560096e+06
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1020 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1051
+      ID: 1053
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.854464e+06
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1054 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1083
+      ID: 1085
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.111584e+06
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1086 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1057
+      ID: 1059
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.89632e+06
       GoKind: 22
-      Pointee: 1058 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1060 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1053
+      ID: 1055
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.854912e+06
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1056 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1049
+      ID: 1051
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.847296e+06
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1052 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 708
+      ID: 710
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921312
       GoKind: 22
-      Pointee: 534 BaseType crypto/rc4.KeySizeError
+      Pointee: 536 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1067
+      ID: 1069
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.945696e+06
       GoKind: 22
-      Pointee: 1068 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1070 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1039
+      ID: 1041
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.80128e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1042 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 631
+      ID: 633
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 521 BaseType crypto/tls.AlertError
+      Pointee: 523 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 797
+      ID: 799
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.041152e+06
       GoKind: 22
-      Pointee: 798 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 800 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1136
+      ID: 1138
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.373408e+06
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1139 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 629
+      ID: 631
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 632 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 627
+      ID: 629
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 628 StructureType crypto/tls.RecordHeaderError
+      Pointee: 630 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 796
+      ID: 798
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.039488e+06
       GoKind: 22
-      Pointee: 753 BaseType crypto/tls.alert
+      Pointee: 755 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1015
+      ID: 1017
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.553056e+06
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1018 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1022
+      ID: 1024
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.635488e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1025 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 892
+      ID: 894
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.419776e+06
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 895 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.034176e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 910 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 701
+      ID: 703
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 919584
       GoKind: 22
-      Pointee: 702 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 704 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 695
+      ID: 697
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 919104
       GoKind: 22
-      Pointee: 696 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 698 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 697
+      ID: 699
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 919200
       GoKind: 22
-      Pointee: 698 StructureType crypto/x509.HostnameError
+      Pointee: 700 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 530 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 532 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 802
+      ID: 804
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.046912e+06
       GoKind: 22
-      Pointee: 803 StructureType crypto/x509.SystemRootsError
+      Pointee: 805 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 703
+      ID: 705
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 919680
       GoKind: 22
-      Pointee: 704 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 706 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 699
+      ID: 701
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 919488
       GoKind: 22
-      Pointee: 700 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 702 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 717
+      ID: 719
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 926400
       GoKind: 22
-      Pointee: 718 StructureType encoding/asn1.StructuralError
+      Pointee: 720 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 721
+      ID: 723
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 926592
       GoKind: 22
-      Pointee: 722 StructureType encoding/asn1.SyntaxError
+      Pointee: 724 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 719
+      ID: 721
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 722 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 615
+      ID: 617
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 515 BaseType encoding/base64.CorruptInputError
+      Pointee: 517 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 973
+      ID: 975
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.036672e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 976 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 618
+      ID: 620
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 907488
       GoKind: 22
-      Pointee: 516 BaseType encoding/hex.InvalidByteError
+      Pointee: 518 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 901344
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 589 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 788
+      ID: 790
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.03296e+06
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 791 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 900960
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 581 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 901248
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 587 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 582
+      ID: 584
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 901152
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 585 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 580
+      ID: 582
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 901056
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 583 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1116
+      ID: 1118
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.28656e+06
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1119 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 589 StructureType encoding/json.jsonError
+      Pointee: 591 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 981
+      ID: 983
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.049472e+06
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 984 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 689
+      ID: 691
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 918048
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 692 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 687
+      ID: 689
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 917952
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 690 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 691
+      ID: 693
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918144
       GoKind: 22
-      Pointee: 527 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 529 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 529
+      ID: 531
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 528 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 530 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 692
+      ID: 694
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918240
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 695 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1094
+      ID: 1096
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.150016e+06
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1097 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -4255,19 +4255,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 891648
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType errors.errorString
+      Pointee: 559 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 755
+      ID: 757
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.017856e+06
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType errors.joinError
+      Pointee: 758 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 106
       Name: '*float32'
@@ -4283,813 +4283,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1104
+      ID: 1106
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.253856e+06
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType fmt.pp
+      Pointee: 1107 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.019648e+06
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType fmt.wrapError
+      Pointee: 760 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 759
+      ID: 761
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.019776e+06
       GoKind: 22
-      Pointee: 760 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 762 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 617 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 619 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 597
+      ID: 599
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 904128
       GoKind: 22
-      Pointee: 598 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 600 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 599
+      ID: 601
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 904224
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 602 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 919
+      ID: 921
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 922 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 603
+      ID: 605
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 604 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 606 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 924 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 601
+      ID: 603
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 904320
       GoKind: 22
-      Pointee: 509 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 511 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 511
+      ID: 513
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 510 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 512 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 903840
       GoKind: 22
-      Pointee: 506 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 508 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 508
+      ID: 510
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 507 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 509 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 904416
       GoKind: 22
-      Pointee: 512 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 514 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 514
+      ID: 516
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 513 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 515 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 995
+      ID: 997
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.204256e+06
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 998 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1080
+      ID: 1082
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.049184e+06
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1083 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 711
+      ID: 713
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 924864
       GoKind: 22
-      Pointee: 712 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 714 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 866
+      ID: 868
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.20784e+06
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 869 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1112
+      ID: 1114
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.263584e+06
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1115 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 913536
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 641 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 645
+      ID: 647
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 914592
       GoKind: 22
-      Pointee: 646 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 648 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 526 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 528 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 643
+      ID: 645
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 914496
       GoKind: 22
-      Pointee: 644 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 646 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 641
+      ID: 643
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 642 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 644 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 661
+      ID: 663
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 916512
       GoKind: 22
-      Pointee: 662 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 664 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 665
+      ID: 667
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 916704
       GoKind: 22
-      Pointee: 666 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 668 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 663
+      ID: 665
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 664 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 666 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 659
+      ID: 661
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 916416
       GoKind: 22
-      Pointee: 660 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 662 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 944
+      ID: 946
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 943 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 945 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 673
+      ID: 675
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 917088
       GoKind: 22
-      Pointee: 674 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 676 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 667
+      ID: 669
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 668 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 670 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 671
+      ID: 673
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 672 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 674 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 669
+      ID: 671
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 916896
       GoKind: 22
-      Pointee: 670 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 672 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 917184
       GoKind: 22
-      Pointee: 676 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 678 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 681
+      ID: 683
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 682 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 684 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 683
+      ID: 685
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 684 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 686 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 679
+      ID: 681
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 917376
       GoKind: 22
-      Pointee: 680 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 682 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 677
+      ID: 679
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 917280
       GoKind: 22
-      Pointee: 678 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 680 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 685
+      ID: 687
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 917760
       GoKind: 22
-      Pointee: 686 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 688 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 605
+      ID: 607
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 905664
       GoKind: 22
-      Pointee: 606 StructureType github.com/cihub/seelog.baseError
+      Pointee: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1033
+      ID: 1035
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.793888e+06
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1036 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 607
+      ID: 609
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 905760
       GoKind: 22
-      Pointee: 608 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 610 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1013
+      ID: 1015
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.551936e+06
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1016 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 969
+      ID: 971
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.035648e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 972 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1003
+      ID: 1005
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.417536e+06
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1006 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 611
+      ID: 613
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 905952
       GoKind: 22
-      Pointee: 612 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 614 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1070
+      ID: 1072
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.966048e+06
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1073 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1087
+      ID: 1089
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.123168e+06
       GoKind: 22
-      Pointee: 1082 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1084 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1086
+      ID: 1088
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.122784e+06
       GoKind: 22
-      Pointee: 1085 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1087 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 971
+      ID: 973
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.035776e+06
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 974 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 609
+      ID: 611
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 905856
       GoKind: 22
-      Pointee: 610 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 612 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 613
+      ID: 615
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 906048
       GoKind: 22
-      Pointee: 614 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 616 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1035
+      ID: 1037
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.79568e+06
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1038 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1076
+      ID: 1078
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.002784e+06
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1079 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1078
+      ID: 1080
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.033856e+06
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1081 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.432416e+06
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 900 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 810
+      ID: 812
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.060992e+06
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 813 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 808
+      ID: 810
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.060864e+06
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 811 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 812
+      ID: 814
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.06496e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 815 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 814
+      ID: 816
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.065088e+06
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 817 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.66256e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1027 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 804
+      ID: 806
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.047552e+06
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 807 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 907680
       GoKind: 22
-      Pointee: 620 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 622 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1128
+      ID: 1130
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.349632e+06
       GoKind: 22
-      Pointee: 1129 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1131 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 868
+      ID: 870
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.216288e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 871 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 841
+      ID: 843
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.19504e+06
       GoKind: 22
-      Pointee: 842 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 844 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 835
+      ID: 837
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.194656e+06
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 838 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 774
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.026944e+06
       GoKind: 22
-      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 847
+      ID: 849
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195424e+06
       GoKind: 22
-      Pointee: 848 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 850 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 773
+      ID: 775
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.026816e+06
       GoKind: 22
-      Pointee: 752 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 754 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 839
+      ID: 841
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.194912e+06
       GoKind: 22
-      Pointee: 840 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 842 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 837
+      ID: 839
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.194784e+06
       GoKind: 22
-      Pointee: 838 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 840 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 845
+      ID: 847
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.195296e+06
       GoKind: 22
-      Pointee: 846 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 848 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 843
+      ID: 845
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195168e+06
       GoKind: 22
-      Pointee: 844 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 846 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1132
+      ID: 1134
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.36144e+06
       GoKind: 22
-      Pointee: 1133 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1135 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 851
+      ID: 853
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.195808e+06
       GoKind: 22
-      Pointee: 852 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 854 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.0272e+06
       GoKind: 22
-      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 776
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.027072e+06
       GoKind: 22
-      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 849
+      ID: 851
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.19568e+06
       GoKind: 22
-      Pointee: 850 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 852 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 733
+      ID: 735
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 939360
       GoKind: 22
-      Pointee: 539 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 541 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 541
+      ID: 543
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 540 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 542 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 910
+      ID: 912
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.661024e+06
       GoKind: 22
-      Pointee: 911 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 913 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 818
+      ID: 820
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.079808e+06
       GoKind: 22
-      Pointee: 819 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 821 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1001
+      ID: 1003
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.25584e+06
       GoKind: 22
-      Pointee: 1002 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1004 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1092
+      ID: 1094
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.138144e+06
       GoKind: 22
-      Pointee: 1093 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1095 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 987
+      ID: 989
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.082112e+06
       GoKind: 22
-      Pointee: 988 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 990 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 734
+      ID: 736
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 940608
       GoKind: 22
-      Pointee: 542 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 544 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 876
+      ID: 878
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.257504e+06
       GoKind: 22
-      Pointee: 877 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 879 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 737
+      ID: 739
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 940896
       GoKind: 22
-      Pointee: 738 StructureType golang.org/x/net/http2.connError
+      Pointee: 740 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 736
+      ID: 738
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940800
       GoKind: 22
-      Pointee: 546 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 548 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 548
+      ID: 550
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 547 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 549 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 740
+      ID: 742
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 941088
       GoKind: 22
-      Pointee: 552 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 554 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 554
+      ID: 556
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 553 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 555 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 739
+      ID: 741
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 940992
       GoKind: 22
-      Pointee: 549 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 551 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 551
+      ID: 553
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 550 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 552 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 735
+      ID: 737
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940704
       GoKind: 22
-      Pointee: 543 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 545 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 545
+      ID: 547
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 544 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 546 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1090
+      ID: 1092
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.136224e+06
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1093 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 741
+      ID: 743
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 941184
       GoKind: 22
-      Pointee: 742 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 744 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 743
+      ID: 745
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 941280
       GoKind: 22
-      Pointee: 555 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 557 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 729
+      ID: 731
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 934560
       GoKind: 22
-      Pointee: 730 StructureType google.golang.org/grpc.dropError
+      Pointee: 732 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.25456e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 877 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.439776e+06
       GoKind: 22
-      Pointee: 900 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 902 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 731
+      ID: 733
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 732 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 734 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1041
+      ID: 1043
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.801728e+06
       GoKind: 22
-      Pointee: 1042 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1044 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 999
+      ID: 1001
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.251104e+06
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1002 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 816
+      ID: 818
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.074048e+06
       GoKind: 22
-      Pointee: 817 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 819 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 959
+      ID: 961
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 937728
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 962 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 709
+      ID: 711
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 710 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 712 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 806
+      ID: 808
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.05088e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 809 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.22256e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 875 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.222304e+06
       GoKind: 22
-      Pointee: 871 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 873 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 723
+      ID: 725
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 927456
       GoKind: 22
-      Pointee: 724 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 726 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 725
+      ID: 727
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 927552
       GoKind: 22
-      Pointee: 726 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 728 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 653
+      ID: 655
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 914976
       GoKind: 22
-      Pointee: 654 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 656 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1047
+      ID: 1049
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.842368e+06
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1050 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 744
+      ID: 746
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 942048
       GoKind: 22
-      Pointee: 745 UnresolvedPointeeType html/template.Error
+      Pointee: 747 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -5133,89 +5133,89 @@ Types:
       GoKind: 22
       Pointee: 151 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 623
+      ID: 625
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 626 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 621
+      ID: 623
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 624 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 945
+      ID: 947
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 896160
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 948 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 833
+      ID: 835
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.193888e+06
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 836 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1134
+      ID: 1136
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.367072e+06
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1137 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 831
+      ID: 833
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.19376e+06
       GoKind: 22
-      Pointee: 832 StructureType internal/poll.errNetClosing
+      Pointee: 834 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 558
+      ID: 560
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 895392
       GoKind: 22
-      Pointee: 559 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 561 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 991
+      ID: 993
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.185312e+06
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType io.PipeWriter
+      Pointee: 994 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 989
+      ID: 991
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.184928e+06
       GoKind: 22
-      Pointee: 990 StructureType io.discard
+      Pointee: 992 StructureType io.discard
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.018112e+06
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType io.multiWriter
+      Pointee: 966 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 829
+      ID: 831
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.193504e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType io/fs.PathError
+      Pointee: 832 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1037
+      ID: 1039
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.795904e+06
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1040 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 307
       Name: '*main.deepMap2'
@@ -5224,12 +5224,12 @@ Types:
       GoKind: 22
       Pointee: 308 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1179
+      ID: 1181
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383072
       GoKind: 22
-      Pointee: 1180 UnresolvedPointeeType main.deepMap3
+      Pointee: 1182 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepMap7'
@@ -5238,19 +5238,19 @@ Types:
       GoKind: 22
       Pointee: 144 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1213
+      ID: 1215
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 382752
       GoKind: 22
-      Pointee: 1214 StructureType main.deepMap8
+      Pointee: 1216 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1228
+      ID: 1230
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 382688
       GoKind: 22
-      Pointee: 1229 StructureType main.deepMap9
+      Pointee: 1231 StructureType main.deepMap9
     - __kind: PointerType
       ID: 127
       Name: '*main.deepPtr2'
@@ -5259,12 +5259,12 @@ Types:
       GoKind: 22
       Pointee: 128 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1138
+      ID: 1140
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383648
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1141 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 129
       Name: '*main.deepPtr7'
@@ -5273,19 +5273,19 @@ Types:
       GoKind: 22
       Pointee: 130 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1183
+      ID: 1185
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383328
       GoKind: 22
-      Pointee: 1184 StructureType main.deepPtr8
+      Pointee: 1186 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1185
+      ID: 1187
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383264
       GoKind: 22
-      Pointee: 1186 StructureType main.deepPtr9
+      Pointee: 1188 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 134
       Name: '*main.deepSlice2'
@@ -5294,12 +5294,12 @@ Types:
       GoKind: 22
       Pointee: 298 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1164
+      ID: 1166
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384224
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1167 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepSlice7'
@@ -5308,19 +5308,19 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1189
+      ID: 1191
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 383904
       GoKind: 22
-      Pointee: 1190 StructureType main.deepSlice8
+      Pointee: 1192 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1195
+      ID: 1197
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 383840
       GoKind: 22
-      Pointee: 1196 StructureType main.deepSlice9
+      Pointee: 1198 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 289
       Name: '*main.emptyStruct'
@@ -5335,12 +5335,12 @@ Types:
       GoKind: 22
       Pointee: 154 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1155
+      ID: 1157
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 891360
       GoKind: 22
-      Pointee: 1156 StructureType main.firstBehavior
+      Pointee: 1158 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 226
       Name: '*main.node'
@@ -5355,19 +5355,19 @@ Types:
       GoKind: 22
       Pointee: 241 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1157
+      ID: 1159
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 891456
       GoKind: 22
-      Pointee: 1158 StructureType main.secondBehavior
+      Pointee: 1160 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1143
+      ID: 1145
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 891552
       GoKind: 22
-      Pointee: 1144 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1146 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 145
       Name: '*main.stringType1'
@@ -5375,16 +5375,16 @@ Types:
       GoKind: 22
       Pointee: 146 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1141
+      ID: 1143
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1140 GoStringDataType main.stringType1.str
+      Pointee: 1142 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 148
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1142 UnresolvedPointeeType main.stringType2
+      Pointee: 1144 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 244
       Name: '*main.structWithCyclicSlices'
@@ -5415,10 +5415,10 @@ Types:
       GoKind: 22
       Pointee: 228 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1161
+      ID: 1163
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1160 GoSliceDataType main.t.array
+      Pointee: 1162 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 239
       Name: '*main.threeStringStruct'
@@ -5451,30 +5451,30 @@ Types:
       ByteSize: 8
       Pointee: 140 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1169
+      ID: 1171
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1170 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1172 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1203
+      ID: 1205
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1204 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1206 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1218
+      ID: 1220
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1219 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1221 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 161
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 162 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1233
+      ID: 1235
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1234 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1236 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 198
       Name: '*map<int,uint8>'
@@ -5491,10 +5491,10 @@ Types:
       ByteSize: 8
       Pointee: 177 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 904 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 906 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 171
       Name: '*map<string,int>'
@@ -5552,451 +5552,451 @@ Types:
       GoKind: 22
       Pointee: 170 GoMapType map[string]int
     - __kind: PointerType
-      ID: 657
+      ID: 659
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 915840
       GoKind: 22
-      Pointee: 658 StructureType math/big.ErrNaN
+      Pointee: 660 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 953
+      ID: 955
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 910656
       GoKind: 22
-      Pointee: 954 StructureType mime/multipart.writerOnly·1
+      Pointee: 956 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 860
+      ID: 862
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.20208e+06
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType net.AddrError
+      Pointee: 863 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 886
+      ID: 888
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.415776e+06
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType net.DNSError
+      Pointee: 889 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1098
+      ID: 1100
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.224192e+06
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType net.IPConn
+      Pointee: 1101 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 884
+      ID: 886
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.415456e+06
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType net.OpError
+      Pointee: 887 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 862
+      ID: 864
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.202208e+06
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType net.ParseError
+      Pointee: 865 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1108
+      ID: 1110
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.25488e+06
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType net.TCPConn
+      Pointee: 1111 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1118
+      ID: 1120
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.299872e+06
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType net.UDPConn
+      Pointee: 1121 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1106
+      ID: 1108
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.254368e+06
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType net.UnixConn
+      Pointee: 1109 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 859
+      ID: 861
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.201312e+06
       GoKind: 22
-      Pointee: 822 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 824 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 824
+      ID: 826
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 823 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 825 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 790
+      ID: 792
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.033856e+06
       GoKind: 22
-      Pointee: 791 StructureType net.canceledError
+      Pointee: 793 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1074
+      ID: 1076
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.999904e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType net.conn
+      Pointee: 1077 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 928
+      ID: 930
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.837664e+06
       GoKind: 22
-      Pointee: 929 StructureType net.dialResult·1
+      Pointee: 931 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1120
+      ID: 1122
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.304128e+06
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType net.netFD
+      Pointee: 1123 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType net.notFoundError
+      Pointee: 593 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 903360
       GoKind: 22
-      Pointee: 593 StructureType net.result·2
+      Pointee: 595 StructureType net.result·2
     - __kind: PointerType
-      ID: 1102
+      ID: 1104
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.240416e+06
       GoKind: 22
-      Pointee: 1103 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1105 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1100
+      ID: 1102
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.239936e+06
       GoKind: 22
-      Pointee: 1101 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1103 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 864
+      ID: 866
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.202848e+06
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType net.temporaryError
+      Pointee: 867 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 888
+      ID: 890
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.415936e+06
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType net.timeoutError
+      Pointee: 891 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.029632e+06
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 783 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 947
+      ID: 949
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 898464
       GoKind: 22
-      Pointee: 948 StructureType net/http.bufioFlushWriter
+      Pointee: 950 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 567
+      ID: 569
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 899136
       GoKind: 22
-      Pointee: 487 BaseType net/http.http2ConnectionError
+      Pointee: 489 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 568
+      ID: 570
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 899232
       GoKind: 22
-      Pointee: 569 StructureType net/http.http2GoAwayError
+      Pointee: 571 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 880
+      ID: 882
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.411616e+06
       GoKind: 22
-      Pointee: 881 StructureType net/http.http2StreamError
+      Pointee: 883 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 899808
       GoKind: 22
-      Pointee: 573 StructureType net/http.http2connError
+      Pointee: 575 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1009
+      ID: 1011
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.548416e+06
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1012 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 571
+      ID: 573
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 899712
       GoKind: 22
-      Pointee: 491 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 493 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 493
+      ID: 495
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 492 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 494 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 575
+      ID: 577
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 900000
       GoKind: 22
-      Pointee: 497 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 499 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 498 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 500 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 574
+      ID: 576
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 899904
       GoKind: 22
-      Pointee: 494 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 496 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 496
+      ID: 498
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 495 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 497 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 855
+      ID: 857
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.197856e+06
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 858 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.030272e+06
       GoKind: 22
-      Pointee: 787 StructureType net/http.http2noCachedConnError
+      Pointee: 789 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1063
+      ID: 1065
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.942368e+06
       GoKind: 22
-      Pointee: 1064 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1066 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 899616
       GoKind: 22
-      Pointee: 488 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 490 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 490
+      ID: 492
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 489 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 491 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 949
+      ID: 951
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 900096
       GoKind: 22
-      Pointee: 950 StructureType net/http.http2stickyErrWriter
+      Pointee: 952 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.029888e+06
       GoKind: 22
-      Pointee: 783 StructureType net/http.nothingWrittenError
+      Pointee: 785 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1011
+      ID: 1013
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.165504e+06
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1014 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 967
+      ID: 969
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.02976e+06
       GoKind: 22
-      Pointee: 968 StructureType net/http.persistConnWriter
+      Pointee: 970 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 993
+      ID: 995
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.19696e+06
       GoKind: 22
-      Pointee: 994 StructureType net/http.readWriteCloserBody
+      Pointee: 996 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 577 StructureType net/http.requestBodyReadError
+      Pointee: 579 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 882
+      ID: 884
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.412736e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 885 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 853
+      ID: 855
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.197728e+06
       GoKind: 22
-      Pointee: 854 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 856 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 784
+      ID: 786
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.030016e+06
       GoKind: 22
-      Pointee: 785 StructureType net/http.transportReadFromServerError
+      Pointee: 787 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1045
+      ID: 1047
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.834304e+06
       GoKind: 22
-      Pointee: 1046 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1048 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 565
+      ID: 567
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 898368
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 568 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1065
+      ID: 1067
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.943904e+06
       GoKind: 22
-      Pointee: 1066 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1068 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 977
+      ID: 979
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.042304e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 980 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 649
+      ID: 651
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 914784
       GoKind: 22
-      Pointee: 650 StructureType net/netip.parseAddrError
+      Pointee: 652 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 647
+      ID: 649
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 914688
       GoKind: 22
-      Pointee: 648 StructureType net/netip.parsePrefixError
+      Pointee: 650 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1019
+      ID: 1021
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.110176e+06
       GoKind: 22
-      Pointee: 1020 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1022 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 979
+      ID: 981
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.047168e+06
       GoKind: 22
-      Pointee: 980 StructureType net/smtp.dataCloser
+      Pointee: 982 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 633
+      ID: 635
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 910848
       GoKind: 22
-      Pointee: 634 UnresolvedPointeeType net/textproto.Error
+      Pointee: 636 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 632
+      ID: 634
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 910752
       GoKind: 22
-      Pointee: 522 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 524 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 523 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 525 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 975
+      ID: 977
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.041536e+06
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 978 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 890
+      ID: 892
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.416256e+06
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType net/url.Error
+      Pointee: 893 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 903456
       GoKind: 22
-      Pointee: 500 GoStringHeaderType net/url.EscapeError
+      Pointee: 502 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 502
+      ID: 504
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 501 GoStringDataType net/url.EscapeError.str
+      Pointee: 503 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 595
+      ID: 597
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 903552
       GoKind: 22
-      Pointee: 503 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 505 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 505
+      ID: 507
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 504 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 506 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 405
       Name: '*noalg.map.group[[4]int][4]int'
@@ -6023,30 +6023,30 @@ Types:
       ByteSize: 8
       Pointee: 304 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1175
+      ID: 1177
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1176 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1178 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1209
+      ID: 1211
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1210 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1212 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1224
+      ID: 1226
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1225 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1227 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 313
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 314 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1239
+      ID: 1241
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1240 StructureType noalg.map.group[int]interface {}
+      Pointee: 1242 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 372
       Name: '*noalg.map.group[int]uint8'
@@ -6063,10 +6063,10 @@ Types:
       ByteSize: 8
       Pointee: 338 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 935
+      ID: 937
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 936 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 938 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 329
       Name: '*noalg.map.group[string]int'
@@ -6118,115 +6118,115 @@ Types:
       ByteSize: 8
       Pointee: 381 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1126
+      ID: 1128
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.342784e+06
       GoKind: 22
-      Pointee: 1127 UnresolvedPointeeType os.File
+      Pointee: 1129 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 761
+      ID: 763
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.020928e+06
       GoKind: 22
-      Pointee: 762 UnresolvedPointeeType os.LinkError
+      Pointee: 764 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 825
+      ID: 827
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.186848e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType os.SyscallError
+      Pointee: 828 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1124
+      ID: 1126
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.339104e+06
       GoKind: 22
-      Pointee: 1125 StructureType os.fileWithoutReadFrom
+      Pointee: 1127 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1122
+      ID: 1124
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.338368e+06
       GoKind: 22
-      Pointee: 1123 StructureType os.fileWithoutWriteTo
+      Pointee: 1125 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 792
+      ID: 794
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.038208e+06
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType os/exec.Error
+      Pointee: 795 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.080032e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 934 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 997
+      ID: 999
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.20912e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1000 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 794
+      ID: 796
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.038336e+06
       GoKind: 22
-      Pointee: 795 StructureType os/exec.wrappedError
+      Pointee: 797 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 728
+      ID: 730
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 932640
       GoKind: 22
-      Pointee: 536 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 538 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 538
+      ID: 540
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 537 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 539 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 727
+      ID: 729
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 932544
       GoKind: 22
-      Pointee: 535 BaseType os/user.UnknownUserIdError
+      Pointee: 537 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 560
+      ID: 562
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 896064
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType reflect.ValueError
+      Pointee: 563 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 655
+      ID: 657
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 658 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 765
+      ID: 767
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.022464e+06
       GoKind: 22
-      Pointee: 766 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 768 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 769
+      ID: 771
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.024256e+06
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 772 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -6242,12 +6242,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 767
+      ID: 769
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.022592e+06
       GoKind: 22
-      Pointee: 768 StructureType runtime.boundsError
+      Pointee: 770 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -6263,24 +6263,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 827
+      ID: 829
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.192224e+06
       GoKind: 22
-      Pointee: 828 StructureType runtime.errorAddressString
+      Pointee: 830 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 763
+      ID: 765
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.02208e+06
       GoKind: 22
-      Pointee: 746 GoStringHeaderType runtime.errorString
+      Pointee: 748 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 748
+      ID: 750
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 747 GoStringDataType runtime.errorString.str
+      Pointee: 749 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -6296,17 +6296,17 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 764
+      ID: 766
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.022208e+06
       GoKind: 22
-      Pointee: 749 GoStringHeaderType runtime.plainError
+      Pointee: 751 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 751
+      ID: 753
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType runtime.plainError.str
+      Pointee: 752 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -6336,12 +6336,12 @@ Types:
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 771
+      ID: 773
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.024512e+06
       GoKind: 22
-      Pointee: 772 UnresolvedPointeeType strconv.NumError
+      Pointee: 774 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 93
       Name: '*string'
@@ -6355,33 +6355,33 @@ Types:
       ByteSize: 8
       Pointee: 290 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1061
+      ID: 1063
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.941088e+06
       GoKind: 22
-      Pointee: 1062 UnresolvedPointeeType strings.Builder
+      Pointee: 1064 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 965
+      ID: 967
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.02464e+06
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 968 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 961
+      ID: 963
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 965440
       GoKind: 22
-      Pointee: 962 StructureType struct { io.Writer }
+      Pointee: 964 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.410976e+06
       GoKind: 22
-      Pointee: 878 BaseType syscall.Errno
+      Pointee: 880 BaseType syscall.Errno
     - __kind: PointerType
       ID: 221
       Name: '*table<[4]int,[4]int>'
@@ -6408,30 +6408,30 @@ Types:
       ByteSize: 8
       Pointee: 301 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1172
+      ID: 1174
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1173 StructureType table<int,*main.deepMap3>
+      Pointee: 1175 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1206
+      ID: 1208
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1207 StructureType table<int,*main.deepMap8>
+      Pointee: 1209 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1221
+      ID: 1223
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1222 StructureType table<int,*main.deepMap9>
+      Pointee: 1224 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 164
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 311 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1236
+      ID: 1238
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1237 StructureType table<int,interface {}>
+      Pointee: 1239 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 201
       Name: '*table<int,uint8>'
@@ -6448,10 +6448,10 @@ Types:
       ByteSize: 8
       Pointee: 335 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 906
+      ID: 908
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 933 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 935 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 174
       Name: '*table<string,int>'
@@ -6503,45 +6503,45 @@ Types:
       ByteSize: 8
       Pointee: 378 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1096
+      ID: 1098
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.1504e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1099 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 820
+      ID: 822
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.083648e+06
       GoKind: 22
-      Pointee: 821 StructureType text/template.ExecError
+      Pointee: 823 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 895
+      ID: 897
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.61648e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType time.Location
+      Pointee: 898 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 563
+      ID: 565
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 896928
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType time.ParseError
+      Pointee: 566 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 562
+      ID: 564
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 896832
       GoKind: 22
-      Pointee: 484 GoStringHeaderType time.fileSizeError
+      Pointee: 486 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 486
+      ID: 488
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 485 GoStringDataType time.fileSizeError.str
+      Pointee: 487 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -6585,47 +6585,47 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 651
+      ID: 653
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 914880
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 654 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1088
+      ID: 1090
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.125856e+06
       GoKind: 22
-      Pointee: 1089 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1091 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 635
+      ID: 637
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 911040
       GoKind: 22
-      Pointee: 636 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 638 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 637
+      ID: 639
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 525 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 527 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.042048e+06
       GoKind: 22
-      Pointee: 800 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 802 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.042176e+06
       GoKind: 22
-      Pointee: 754 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 756 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1346
       Name: Probe[main.stackC]
@@ -8740,7 +8740,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 923
+      ID: 925
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 680448
@@ -8790,7 +8790,7 @@ Types:
       ByteSize: 8
       Element: 134 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1162
+      ID: 1164
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474784
@@ -8798,22 +8798,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1163 PointerType **main.deepSlice3
+          Type: 1165 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1166 GoSliceDataType []*main.deepSlice3.array
+      Data: 1168 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1166
+      ID: 1168
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1164 PointerType *main.deepSlice3
+      Element: 1166 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1187
+      ID: 1189
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 474464
@@ -8821,22 +8821,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1188 PointerType **main.deepSlice8
+          Type: 1190 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1191 GoSliceDataType []*main.deepSlice8.array
+      Data: 1193 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1191
+      ID: 1193
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1189 PointerType *main.deepSlice8
+      Element: 1191 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1193
+      ID: 1195
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474400
@@ -8844,20 +8844,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1194 PointerType **main.deepSlice9
+          Type: 1196 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1197 GoSliceDataType []*main.deepSlice9.array
+      Data: 1199 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1197
+      ID: 1199
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1195 PointerType *main.deepSlice9
+      Element: 1197 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 123
       Name: '[]*string'
@@ -8912,23 +8912,23 @@ Types:
       ByteSize: 8
       Element: 142 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1181
+      ID: 1183
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1172 PointerType *table<int,*main.deepMap3>
+      Element: 1174 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1215
+      ID: 1217
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1206 PointerType *table<int,*main.deepMap8>
+      Element: 1208 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1230
+      ID: 1232
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1221 PointerType *table<int,*main.deepMap9>
+      Element: 1223 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 317
       Name: '[]*table<int,int>.array'
@@ -8936,11 +8936,11 @@ Types:
       ByteSize: 8
       Element: 164 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1243
+      ID: 1245
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1236 PointerType *table<int,interface {}>
+      Element: 1238 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 376
       Name: '[]*table<int,uint8>.array'
@@ -8960,11 +8960,11 @@ Types:
       ByteSize: 8
       Element: 179 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 939
+      ID: 941
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 906 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 908 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 333
       Name: '[]*table<string,int>.array'
@@ -9181,7 +9181,7 @@ Types:
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 918
+      ID: 920
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 483616
@@ -9196,15 +9196,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 941 GoSliceDataType []float64.array
+      Data: 943 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 941
+      ID: 943
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1199
+      ID: 1201
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484064
@@ -9219,9 +9219,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1200 GoSliceDataType []interface {}.array
+      Data: 1202 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1200
+      ID: 1202
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -9264,9 +9264,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1245 GoSliceDataType []main.structWithMap.array
+      Data: 484 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1245
+      ID: 484
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -9324,23 +9324,23 @@ Types:
       ByteSize: 136
       Element: 304 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1182
+      ID: 1184
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1176 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1178 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1216
+      ID: 1218
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1210 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1212 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1231
+      ID: 1233
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1225 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1227 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 318
       Name: '[]noalg.map.group[int]int.array'
@@ -9348,11 +9348,11 @@ Types:
       ByteSize: 136
       Element: 314 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1244
+      ID: 1246
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 1240 StructureType noalg.map.group[int]interface {}
+      Element: 1242 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 377
       Name: '[]noalg.map.group[int]uint8.array'
@@ -9372,11 +9372,11 @@ Types:
       ByteSize: 328
       Element: 338 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 940
+      ID: 942
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 936 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 938 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 334
       Name: '[]noalg.map.group[string]int.array'
@@ -9557,11 +9557,11 @@ Types:
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1075
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 714
+      ID: 716
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 926016
@@ -9576,33 +9576,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 715 GoSliceDataType archive/tar.headerError.array
+      Data: 717 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 715
+      ID: 717
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1010
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 956
+      ID: 958
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 958
+      ID: 960
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.114784e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1056
+      ID: 1058
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 984
+      ID: 986
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.558976e+06
@@ -9612,7 +9612,7 @@ Types:
           Offset: 0
           Type: 125 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 988
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9622,15 +9622,15 @@ Types:
       GoRuntimeType: 581184
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1033
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1060
+      ID: 1062
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1113
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9656,13 +9656,13 @@ Types:
       GoRuntimeType: 580928
       GoKind: 15
     - __kind: BaseType
-      ID: 517
+      ID: 519
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830528
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 518
+      ID: 520
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 830624
@@ -9670,110 +9670,110 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 520 PointerType *compress/flate.InternalError.str
+          Type: 522 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 519 GoStringDataType compress/flate.InternalError.str
+      Data: 521 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 519
+      ID: 521
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1008
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 954
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1028
+      ID: 1030
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 858
+      ID: 860
       Name: context.deadlineExceededError
       GoRuntimeType: 1.473216e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 531
+      ID: 533
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833120
       GoKind: 2
     - __kind: BaseType
-      ID: 532
+      ID: 534
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833216
       GoKind: 2
     - __kind: BaseType
-      ID: 533
+      ID: 535
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833312
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1020
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1054
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1086
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1058
+      ID: 1060
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1056
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1052
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 534
+      ID: 536
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833408
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1068
+      ID: 1070
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1042
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 521
+      ID: 523
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 831104
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 798
+      ID: 800
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1139
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 632
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 630
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.7224e+06
@@ -9784,34 +9784,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 923 ArrayType [5]uint8
+          Type: 925 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 753
+      ID: 755
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 988256
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1018
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1025
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 895
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 910
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 704
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.72528e+06
@@ -9819,21 +9819,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 907 PointerType *crypto/x509.Certificate
+          Type: 909 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 926 BaseType crypto/x509.InvalidReason
+          Type: 928 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 696
+      ID: 698
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.112352e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 698
+      ID: 700
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.593696e+06
@@ -9841,24 +9841,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 907 PointerType *crypto/x509.Certificate
+          Type: 909 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 530
+      ID: 532
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 832736
       GoKind: 2
     - __kind: BaseType
-      ID: 926
+      ID: 928
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 586368
       GoKind: 2
     - __kind: StructureType
-      ID: 803
+      ID: 805
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.554976e+06
@@ -9868,13 +9868,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 704
+      ID: 706
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.112608e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 700
+      ID: 702
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.725088e+06
@@ -9882,15 +9882,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 907 PointerType *crypto/x509.Certificate
+          Type: 909 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 907 PointerType *crypto/x509.Certificate
+          Type: 909 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 718
+      ID: 720
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.430656e+06
@@ -9900,7 +9900,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 722
+      ID: 724
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.430816e+06
@@ -9910,55 +9910,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 722
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 515
+      ID: 517
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830144
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 976
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 516
+      ID: 518
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 830336
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 589
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 791
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 581
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 587
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 585
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 583
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1119
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 589
+      ID: 591
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.414496e+06
@@ -9968,19 +9968,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 984
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 692
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 690
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 527
+      ID: 529
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -9988,22 +9988,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 529 PointerType *encoding/xml.UnmarshalError.str
+          Type: 531 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 528 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 530 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 528
+      ID: 530
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 695
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1097
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -10020,11 +10020,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 559
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 758
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -10040,15 +10040,15 @@ Types:
       GoRuntimeType: 581120
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1107
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 760
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 760
+      ID: 762
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -10064,11 +10064,11 @@ Types:
       GoRuntimeType: 844256
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 617
+      ID: 619
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 598
+      ID: 600
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.721248e+06
@@ -10076,7 +10076,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 916 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 918 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -10084,25 +10084,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 602
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 922
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 604
+      ID: 606
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.10864e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 509
+      ID: 511
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 829568
@@ -10110,18 +10110,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 511 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 513 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 510 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 512 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 510
+      ID: 512
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 916
+      ID: 918
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.210208e+06
@@ -10129,7 +10129,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 917 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 919 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10144,7 +10144,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 918 GoSliceHeaderType []float64
+          Type: 920 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -10153,10 +10153,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 919 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 921 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 921 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 923 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 235 GoSliceHeaderType []string
@@ -10170,13 +10170,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 917
+      ID: 919
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 582976
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 506
+      ID: 508
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 829472
@@ -10184,18 +10184,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 508 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 510 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 507 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 509 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 507
+      ID: 509
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 512
+      ID: 514
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 829664
@@ -10203,60 +10203,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 514 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 516 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 513 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 515 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 513
+      ID: 515
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 998
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1083
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 712
+      ID: 714
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 869
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1115
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 641
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 646
+      ID: 648
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.111584e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 526
+      ID: 528
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 831776
       GoKind: 2
     - __kind: StructureType
-      ID: 644
+      ID: 646
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.111456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 642
+      ID: 644
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.591776e+06
@@ -10269,7 +10269,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 664
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.592576e+06
@@ -10282,7 +10282,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 666
+      ID: 668
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.724512e+06
@@ -10298,7 +10298,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 664
+      ID: 666
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.424256e+06
@@ -10308,7 +10308,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 660
+      ID: 662
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.423936e+06
@@ -10318,14 +10318,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 902
+      ID: 904
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.494336e+06
       GoKind: 21
-      HeaderType: 904 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 906 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 925
+      ID: 927
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.045632e+06
@@ -10340,15 +10340,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 943 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 945 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 943
+      ID: 945
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 674
+      ID: 676
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.592896e+06
@@ -10356,12 +10356,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 902 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 904 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 902 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 904 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 668
+      ID: 670
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.424416e+06
@@ -10371,7 +10371,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 672
+      ID: 674
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.724704e+06
@@ -10382,12 +10382,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 925 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 927 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 925 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 927 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 670
+      ID: 672
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.592736e+06
@@ -10400,7 +10400,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 676
+      ID: 678
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.424576e+06
@@ -10408,9 +10408,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 894 StructureType time.Time
+          Type: 896 StructureType time.Time
     - __kind: StructureType
-      ID: 682
+      ID: 684
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.593216e+06
@@ -10423,7 +10423,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 684
+      ID: 686
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.424896e+06
@@ -10433,7 +10433,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 680
+      ID: 682
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.593056e+06
@@ -10446,7 +10446,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 678
+      ID: 680
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.424736e+06
@@ -10456,7 +10456,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 686
+      ID: 688
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.593376e+06
@@ -10469,7 +10469,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 606
+      ID: 608
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.416736e+06
@@ -10479,11 +10479,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1036
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 608
+      ID: 610
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.416896e+06
@@ -10491,21 +10491,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 606 StructureType github.com/cihub/seelog.baseError
+          Type: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1016
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 972
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1006
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 612
+      ID: 614
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.417216e+06
@@ -10513,13 +10513,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 606 StructureType github.com/cihub/seelog.baseError
+          Type: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1073
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1082
+      ID: 1084
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.098592e+06
@@ -10527,12 +10527,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1070 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1072 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1085
+      ID: 1087
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.1224e+06
@@ -10540,7 +10540,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1070 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1072 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10548,11 +10548,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 974
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 610
+      ID: 612
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.417056e+06
@@ -10560,9 +10560,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 606 StructureType github.com/cihub/seelog.baseError
+          Type: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 614
+      ID: 616
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.417376e+06
@@ -10570,64 +10570,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 606 StructureType github.com/cihub/seelog.baseError
+          Type: 608 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1038
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1079
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1081
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 900
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 813
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 811
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 815
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 817
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1027
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 807
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 620
+      ID: 622
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.418336e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1129
+      ID: 1131
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 871
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 844
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.832512e+06
@@ -10643,11 +10643,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 838
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 775
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.695296e+06
@@ -10660,7 +10660,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 848
+      ID: 850
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.83296e+06
@@ -10676,13 +10676,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 752
+      ID: 754
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 985568
       GoKind: 8
     - __kind: StructureType
-      ID: 840
+      ID: 842
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.832288e+06
@@ -10698,13 +10698,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 927
+      ID: 929
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 827744
       GoKind: 8
     - __kind: StructureType
-      ID: 838
+      ID: 840
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.832064e+06
@@ -10712,15 +10712,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 927 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 929 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 927 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 929 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 846
+      ID: 848
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.746752e+06
@@ -10733,7 +10733,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 844
+      ID: 846
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.832736e+06
@@ -10749,11 +10749,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1133
+      ID: 1135
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 852
+      ID: 854
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.61744e+06
@@ -10763,19 +10763,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 779
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.278048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 777
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.27792e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 850
+      ID: 852
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.746944e+06
@@ -10788,7 +10788,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 539
+      ID: 541
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835232
@@ -10796,22 +10796,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 541 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 543 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 540 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 542 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 540
+      ID: 542
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 911
+      ID: 913
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 819
+      ID: 821
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.442496e+06
@@ -10821,7 +10821,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1002
+      ID: 1004
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.671392e+06
@@ -10829,13 +10829,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1026 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1028 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1093
+      ID: 1095
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1026
+      ID: 1028
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.122336e+06
@@ -10848,7 +10848,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 988
+      ID: 990
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.563936e+06
@@ -10858,19 +10858,19 @@ Types:
           Offset: 0
           Type: 125 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 542
+      ID: 544
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 835808
       GoKind: 10
     - __kind: BaseType
-      ID: 909
+      ID: 911
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 998720
       GoKind: 10
     - __kind: StructureType
-      ID: 877
+      ID: 879
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.871488e+06
@@ -10881,12 +10881,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 909 BaseType golang.org/x/net/http2.ErrCode
+          Type: 911 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 738
+      ID: 740
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.600416e+06
@@ -10894,12 +10894,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 909 BaseType golang.org/x/net/http2.ErrCode
+          Type: 911 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 546
+      ID: 548
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836000
@@ -10907,18 +10907,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 548 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 550 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 547 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 549 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 547
+      ID: 549
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 552
+      ID: 554
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836192
@@ -10926,18 +10926,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 554 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 556 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 553 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 555 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 553
+      ID: 555
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 549
+      ID: 551
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836096
@@ -10945,18 +10945,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 551 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 553 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 550 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 552 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 550
+      ID: 552
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 543
+      ID: 545
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 835904
@@ -10964,22 +10964,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 545 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 547 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 544 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 546 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 544
+      ID: 546
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1093
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 742
+      ID: 744
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.443136e+06
@@ -10989,13 +10989,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 555
+      ID: 557
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836288
       GoKind: 2
     - __kind: StructureType
-      ID: 730
+      ID: 732
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.438176e+06
@@ -11005,11 +11005,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 877
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 900
+      ID: 902
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.899392e+06
@@ -11025,7 +11025,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 732
+      ID: 734
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.599936e+06
@@ -11038,7 +11038,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1042
+      ID: 1044
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.95696e+06
@@ -11046,16 +11046,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1069 GoInterfaceType io.Reader
+          Type: 1071 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1002
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 817
+      ID: 819
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.561536e+06
@@ -11065,29 +11065,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 962
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 710
+      ID: 712
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 809
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 875
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 873
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.504896e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 724
+      ID: 726
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.431456e+06
@@ -11097,7 +11097,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 726
+      ID: 728
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.431616e+06
@@ -11107,7 +11107,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 654
+      ID: 656
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -11181,47 +11181,47 @@ Types:
       GroupType: 304 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 310 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1174
+      ID: 1176
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1175 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1177 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1176 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1182 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1178 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1184 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1208
+      ID: 1210
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1209 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1211 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1210 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1216 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1212 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1218 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1223
+      ID: 1225
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1224 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1226 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1225 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1231 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1227 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1233 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 312
       Name: groupReference<int,int>
@@ -11237,19 +11237,19 @@ Types:
       GroupType: 314 StructureType noalg.map.group[int]int
       GroupSliceType: 318 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1238
+      ID: 1240
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1239 PointerType *noalg.map.group[int]interface {}
+          Type: 1241 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1240 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1244 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1242 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1246 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 371
       Name: groupReference<int,uint8>
@@ -11293,19 +11293,19 @@ Types:
       GroupType: 338 StructureType noalg.map.group[string][]string
       GroupSliceType: 342 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 934
+      ID: 936
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 935 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 937 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 936 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 940 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 938 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 942 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 328
       Name: groupReference<string,int>
@@ -11447,11 +11447,11 @@ Types:
       GroupType: 381 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 385 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1050
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 745
+      ID: 747
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11498,7 +11498,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 626
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -11524,29 +11524,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 624
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 948
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 836
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1137
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 832
+      ID: 834
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.470016e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 559
+      ID: 561
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -11627,7 +11627,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1147
+      ID: 1149
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.467456e+06
@@ -11640,11 +11640,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 994
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1032
+      ID: 1034
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.185056e+06
@@ -11657,7 +11657,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1069
+      ID: 1071
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.01824e+06
@@ -11670,7 +11670,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1021
+      ID: 1023
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.104928e+06
@@ -11696,21 +11696,21 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 990
+      ID: 992
       Name: io.discard
       GoRuntimeType: 1.457376e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 966
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 832
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1040
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -11778,9 +11778,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1168 GoMapType map[int]*main.deepMap3
+          Type: 1170 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1180
+      ID: 1182
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11792,9 +11792,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1202 GoMapType map[int]*main.deepMap8
+          Type: 1204 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1214
+      ID: 1216
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.180832e+06
@@ -11802,9 +11802,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1217 GoMapType map[int]*main.deepMap9
+          Type: 1219 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1229
+      ID: 1231
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.180704e+06
@@ -11812,7 +11812,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1232 GoMapType map[int]interface {}
+          Type: 1234 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 126
       Name: main.deepPtr1
@@ -11832,9 +11832,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1138 PointerType *main.deepPtr3
+          Type: 1140 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1141
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11846,9 +11846,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1183 PointerType *main.deepPtr8
+          Type: 1185 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1184
+      ID: 1186
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.181984e+06
@@ -11856,9 +11856,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1185 PointerType *main.deepPtr9
+          Type: 1187 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1186
+      ID: 1188
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.181856e+06
@@ -11886,9 +11886,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1162 GoSliceHeaderType []*main.deepSlice3
+          Type: 1164 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1167
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11900,9 +11900,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1187 GoSliceHeaderType []*main.deepSlice8
+          Type: 1189 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1190
+      ID: 1192
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.183136e+06
@@ -11910,9 +11910,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1193 GoSliceHeaderType []*main.deepSlice9
+          Type: 1195 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1196
+      ID: 1198
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.183008e+06
@@ -11920,7 +11920,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1199 GoSliceHeaderType []interface {}
+          Type: 1201 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 288
       Name: main.emptyStruct
@@ -11938,16 +11938,16 @@ Types:
           Type: 149 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1145 StructureType sync.Mutex
+          Type: 1147 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1148 StructureType sync.Once
+          Type: 1150 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1151 StructureType sync.WaitGroup
+          Type: 1153 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1154 StructureType sync/atomic.Int32
+          Type: 1156 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 149
       Name: main.esotericStack
@@ -11977,7 +11977,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1156
+      ID: 1158
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.407616e+06
@@ -12022,7 +12022,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1158
+      ID: 1160
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.407776e+06
@@ -12042,7 +12042,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1144
+      ID: 1146
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12053,18 +12053,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1141 PointerType *main.stringType1.str
+          Type: 1143 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1140 GoStringDataType main.stringType1.str
+      Data: 1142 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1140
+      ID: 1142
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1142
+      ID: 1144
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -12167,16 +12167,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1159 PointerType **main.t
+          Type: 1161 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1160 GoSliceDataType main.t.array
+      Data: 1162 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1160
+      ID: 1162
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -12362,7 +12362,7 @@ Types:
       TablePtrSliceType: 309 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 304 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1170
+      ID: 1172
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -12375,7 +12375,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1171 PointerType **table<int,*main.deepMap3>
+          Type: 1173 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12391,10 +12391,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1181 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1176 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1183 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1178 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1204
+      ID: 1206
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -12407,7 +12407,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1205 PointerType **table<int,*main.deepMap8>
+          Type: 1207 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12423,10 +12423,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1215 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1210 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1217 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1212 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1219
+      ID: 1221
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -12439,7 +12439,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1220 PointerType **table<int,*main.deepMap9>
+          Type: 1222 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12455,8 +12455,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1230 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1225 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1232 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1227 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 162
       Name: map<int,int>
@@ -12490,7 +12490,7 @@ Types:
       TablePtrSliceType: 317 GoSliceDataType []*table<int,int>.array
       GroupType: 314 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1234
+      ID: 1236
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -12503,7 +12503,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1235 PointerType **table<int,interface {}>
+          Type: 1237 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12519,8 +12519,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1243 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1240 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1245 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1242 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 199
       Name: map<int,uint8>
@@ -12618,7 +12618,7 @@ Types:
       TablePtrSliceType: 341 GoSliceDataType []*table<string,[]string>.array
       GroupType: 338 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 904
+      ID: 906
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -12631,7 +12631,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 905 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 907 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12647,8 +12647,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 939 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 936 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 941 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 938 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 172
       Name: map<string,int>
@@ -13005,26 +13005,26 @@ Types:
       GoKind: 21
       HeaderType: 140 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1168
+      ID: 1170
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124e+06
       GoKind: 21
-      HeaderType: 1170 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1172 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1202
+      ID: 1204
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.12336e+06
       GoKind: 21
-      HeaderType: 1204 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1206 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1217
+      ID: 1219
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.123232e+06
       GoKind: 21
-      HeaderType: 1219 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1221 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 160
       Name: map[int]int
@@ -13033,12 +13033,12 @@ Types:
       GoKind: 21
       HeaderType: 162 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1232
+      ID: 1234
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.123104e+06
       GoKind: 21
-      HeaderType: 1234 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1236 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 197
       Name: map[int]uint8
@@ -13125,7 +13125,7 @@ Types:
       GoKind: 21
       HeaderType: 204 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 658
+      ID: 660
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.423616e+06
@@ -13135,7 +13135,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 954
+      ID: 956
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.420416e+06
@@ -13145,11 +13145,11 @@ Types:
           Offset: 0
           Type: 125 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 863
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 924
+      ID: 926
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.590496e+06
@@ -13162,35 +13162,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 889
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1101
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 887
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 865
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1111
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1121
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1109
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 822
+      ID: 824
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.108256e+06
@@ -13198,28 +13198,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 824 PointerType *net.UnknownNetworkError.str
+          Type: 826 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 823 GoStringDataType net.UnknownNetworkError.str
+      Data: 825 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 823
+      ID: 825
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 791
+      ID: 793
       Name: net.canceledError
       GoRuntimeType: 1.279072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1077
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 929
+      ID: 931
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.097888e+06
@@ -13227,7 +13227,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -13238,27 +13238,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1123
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1115
+      ID: 1117
       Name: net.noReadFrom
       GoRuntimeType: 1.108512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1114
+      ID: 1116
       Name: net.noWriteTo
       GoRuntimeType: 1.108384e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 593
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 593
+      ID: 595
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.721056e+06
@@ -13266,7 +13266,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 912 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 914 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -13274,7 +13274,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1103
+      ID: 1105
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.282624e+06
@@ -13282,12 +13282,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1115 StructureType net.noReadFrom
+          Type: 1117 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1108 PointerType *net.TCPConn
+          Type: 1110 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1101
+      ID: 1103
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.28208e+06
@@ -13295,24 +13295,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1114 StructureType net.noWriteTo
+          Type: 1116 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1108 PointerType *net.TCPConn
+          Type: 1110 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 867
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 891
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 783
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 948
+      ID: 950
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.411936e+06
@@ -13322,19 +13322,19 @@ Types:
           Offset: 0
           Type: 125 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 487
+      ID: 489
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 828224
       GoKind: 10
     - __kind: BaseType
-      ID: 901
+      ID: 903
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 985664
       GoKind: 10
     - __kind: StructureType
-      ID: 569
+      ID: 571
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.719328e+06
@@ -13345,12 +13345,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 901 BaseType net/http.http2ErrCode
+          Type: 903 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 881
+      ID: 883
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.890688e+06
@@ -13361,12 +13361,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 901 BaseType net/http.http2ErrCode
+          Type: 903 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 573
+      ID: 575
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.590016e+06
@@ -13374,16 +13374,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 901 BaseType net/http.http2ErrCode
+          Type: 903 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1012
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 491
+      ID: 493
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828416
@@ -13391,18 +13391,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 493 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 495 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 492 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 494 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 492
+      ID: 494
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 497
+      ID: 499
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 828608
@@ -13410,18 +13410,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 499 PointerType *net/http.http2headerFieldNameError.str
+          Type: 501 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 498 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 500 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 498
+      ID: 500
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 494
+      ID: 496
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 828512
@@ -13429,32 +13429,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 496 PointerType *net/http.http2headerFieldValueError.str
+          Type: 498 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 495 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 497 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 495
+      ID: 497
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 858
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 787
+      ID: 789
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.278304e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1064
+      ID: 1066
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 488
+      ID: 490
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828320
@@ -13462,18 +13462,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 490 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 492 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 489 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 491 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 489
+      ID: 491
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 950
+      ID: 952
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.8152e+06
@@ -13481,18 +13481,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1043 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1045 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1044 BaseType time.Duration
+          Type: 1046 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 104 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1043
+      ID: 1045
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.411296e+06
@@ -13505,14 +13505,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1029
+      ID: 1031
       Name: net/http.incomparable
       GoRuntimeType: 898176
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 783
+      ID: 785
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.549056e+06
@@ -13522,11 +13522,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1014
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 968
+      ID: 970
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.548896e+06
@@ -13534,9 +13534,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1011 PointerType *net/http.persistConn
+          Type: 1013 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 994
+      ID: 996
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.7912e+06
@@ -13544,15 +13544,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1029 ArrayType net/http.incomparable
+          Type: 1031 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1030 PointerType *bufio.Reader
+          Type: 1032 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1032 GoInterfaceType io.ReadWriteCloser
+          Type: 1034 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 577
+      ID: 579
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.412896e+06
@@ -13562,17 +13562,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 885
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 854
+      ID: 856
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.472896e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 785
+      ID: 787
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.549216e+06
@@ -13582,7 +13582,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1046
+      ID: 1048
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.016864e+06
@@ -13590,16 +13590,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 924 GoInterfaceType net.Conn
+          Type: 926 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 568
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1066
+      ID: 1068
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.032896e+06
@@ -13607,13 +13607,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1059 PointerType *bufio.Writer
+          Type: 1061 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 980
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 652
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.724128e+06
@@ -13629,7 +13629,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 648
+      ID: 650
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.591936e+06
@@ -13642,11 +13642,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1020
+      ID: 1022
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 980
+      ID: 982
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.593856e+06
@@ -13654,16 +13654,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1019 PointerType *net/smtp.Client
+          Type: 1021 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1021 GoInterfaceType io.WriteCloser
+          Type: 1023 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 634
+      ID: 636
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 522
+      ID: 524
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 831200
@@ -13671,26 +13671,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 524 PointerType *net/textproto.ProtocolError.str
+          Type: 526 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 523 GoStringDataType net/textproto.ProtocolError.str
+      Data: 525 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 523
+      ID: 525
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 978
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 893
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 500
+      ID: 502
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 829184
@@ -13698,18 +13698,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 502 PointerType *net/url.EscapeError.str
+          Type: 504 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 501 GoStringDataType net/url.EscapeError.str
+      Data: 503 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 501
+      ID: 503
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 503
+      ID: 505
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 829280
@@ -13717,13 +13717,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 505 PointerType *net/url.InvalidHostError.str
+          Type: 507 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 504 GoStringDataType net/url.InvalidHostError.str
+      Data: 506 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 504
+      ID: 506
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -13773,32 +13773,32 @@ Types:
       HasCount: true
       Element: 306 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1177
+      ID: 1179
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1178 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1180 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1211
+      ID: 1213
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 677760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1212 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1214 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1226
+      ID: 1228
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 677664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1227 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1229 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 315
       Name: noalg.[8]struct { key int; elem int }
@@ -13809,14 +13809,14 @@ Types:
       HasCount: true
       Element: 316 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1241
+      ID: 1243
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 677568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1242 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1244 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 374
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -13845,14 +13845,14 @@ Types:
       HasCount: true
       Element: 340 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 937
+      ID: 939
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 754592
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 938 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 940 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 331
       Name: noalg.[8]struct { key string; elem int }
@@ -14003,7 +14003,7 @@ Types:
           Offset: 8
           Type: 305 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1176
+      ID: 1178
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.289568e+06
@@ -14014,9 +14014,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1177 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1179 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1210
+      ID: 1212
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.288288e+06
@@ -14027,9 +14027,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1211 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1213 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1225
+      ID: 1227
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.288032e+06
@@ -14040,7 +14040,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1226 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1228 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 314
       Name: noalg.map.group[int]int
@@ -14055,7 +14055,7 @@ Types:
           Offset: 8
           Type: 315 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1240
+      ID: 1242
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.287776e+06
@@ -14066,7 +14066,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1241 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1243 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 373
       Name: noalg.map.group[int]uint8
@@ -14107,7 +14107,7 @@ Types:
           Offset: 8
           Type: 339 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 936
+      ID: 938
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.3528e+06
@@ -14118,7 +14118,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 937 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 939 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 330
       Name: noalg.map.group[string]int
@@ -14309,7 +14309,7 @@ Types:
           Offset: 8
           Type: 307 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1178
+      ID: 1180
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.28944e+06
@@ -14320,9 +14320,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1179 PointerType *main.deepMap3
+          Type: 1181 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1212
+      ID: 1214
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.28816e+06
@@ -14333,9 +14333,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1213 PointerType *main.deepMap8
+          Type: 1215 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1227
+      ID: 1229
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.287904e+06
@@ -14346,7 +14346,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1228 PointerType *main.deepMap9
+          Type: 1230 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 316
       Name: noalg.struct { key int; elem int }
@@ -14361,7 +14361,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1242
+      ID: 1244
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.287648e+06
@@ -14413,7 +14413,7 @@ Types:
           Offset: 16
           Type: 235 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 938
+      ID: 940
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.352672e+06
@@ -14424,7 +14424,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 925 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 927 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 332
       Name: noalg.struct { key string; elem int }
@@ -14550,19 +14550,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1127
+      ID: 1129
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 762
+      ID: 764
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 828
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1125
+      ID: 1127
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.351232e+06
@@ -14570,12 +14570,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1131 StructureType os.noReadFrom
+          Type: 1133 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1126 PointerType *os.File
+          Type: 1128 PointerType *os.File
     - __kind: StructureType
-      ID: 1123
+      ID: 1125
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.350432e+06
@@ -14583,36 +14583,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1130 StructureType os.noWriteTo
+          Type: 1132 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1126 PointerType *os.File
+          Type: 1128 PointerType *os.File
     - __kind: StructureType
-      ID: 1131
+      ID: 1133
       Name: os.noReadFrom
       GoRuntimeType: 1.105824e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1130
+      ID: 1132
       Name: os.noWriteTo
       GoRuntimeType: 1.105696e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 795
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 934
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1000
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 795
+      ID: 797
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.695872e+06
@@ -14625,7 +14625,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 536
+      ID: 538
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 834464
@@ -14633,36 +14633,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 538 PointerType *os/user.UnknownGroupIdError.str
+          Type: 540 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 537 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 539 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 537
+      ID: 539
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 535
+      ID: 537
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 834368
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 563
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 658
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 766
+      ID: 768
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 772
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -14674,7 +14674,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 768
+      ID: 770
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.879104e+06
@@ -14691,9 +14691,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 930 BaseType runtime.boundsErrorCode
+          Type: 932 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 930
+      ID: 932
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 581312
@@ -14713,7 +14713,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 828
+      ID: 830
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.74368e+06
@@ -14726,7 +14726,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 746
+      ID: 748
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 984320
@@ -14734,13 +14734,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 748 PointerType *runtime.errorString.str
+          Type: 750 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 747 GoStringDataType runtime.errorString.str
+      Data: 749 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 747
+      ID: 749
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15396,7 +15396,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 751
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 984416
@@ -15404,13 +15404,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *runtime.plainError.str
+          Type: 753 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 750 GoStringDataType runtime.plainError.str
+      Data: 752 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 752
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15496,7 +15496,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 772
+      ID: 774
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -15519,15 +15519,15 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1062
+      ID: 1064
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 968
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 962
+      ID: 964
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.449696e+06
@@ -15543,7 +15543,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1145
+      ID: 1147
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.458176e+06
@@ -15551,12 +15551,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1146 StructureType sync.noCopy
+          Type: 1148 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1147 StructureType internal/sync.Mutex
+          Type: 1149 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1148
+      ID: 1150
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.606688e+06
@@ -15564,15 +15564,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1146 StructureType sync.noCopy
+          Type: 1148 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1149 StructureType sync/atomic.Uint32
+          Type: 1151 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1145 StructureType sync.Mutex
+          Type: 1147 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1151
+      ID: 1153
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.60688e+06
@@ -15580,21 +15580,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1146 StructureType sync.noCopy
+          Type: 1148 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1152 StructureType sync/atomic.Uint64
+          Type: 1154 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1146
+      ID: 1148
       Name: sync.noCopy
       GoRuntimeType: 983264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1154
+      ID: 1156
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.459456e+06
@@ -15602,12 +15602,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1150 StructureType sync/atomic.noCopy
+          Type: 1152 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1149
+      ID: 1151
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.459616e+06
@@ -15615,12 +15615,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1150 StructureType sync/atomic.noCopy
+          Type: 1152 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1152
+      ID: 1154
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607264e+06
@@ -15628,27 +15628,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1150 StructureType sync/atomic.noCopy
+          Type: 1152 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1153 StructureType sync/atomic.align64
+          Type: 1155 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1153
+      ID: 1155
       Name: sync/atomic.align64
       GoRuntimeType: 983456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1150
+      ID: 1152
       Name: sync/atomic.noCopy
       GoRuntimeType: 983360
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 878
+      ID: 880
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.277664e+06
@@ -15774,7 +15774,7 @@ Types:
           Offset: 16
           Type: 302 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1173
+      ID: 1175
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -15796,9 +15796,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1174 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1176 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1207
+      ID: 1209
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -15820,9 +15820,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1208 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1210 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1222
+      ID: 1224
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -15844,7 +15844,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1223 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1225 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 311
       Name: table<int,int>
@@ -15870,7 +15870,7 @@ Types:
           Offset: 16
           Type: 312 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1237
+      ID: 1239
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -15892,7 +15892,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1238 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1240 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 370
       Name: table<int,uint8>
@@ -15966,7 +15966,7 @@ Types:
           Offset: 16
           Type: 336 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 933
+      ID: 935
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -15988,7 +15988,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 934 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 936 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 327
       Name: table<string,int>
@@ -16230,11 +16230,11 @@ Types:
           Offset: 16
           Type: 379 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1099
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 821
+      ID: 823
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.700288e+06
@@ -16247,21 +16247,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 1044
+      ID: 1046
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.905248e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 898
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 566
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 894
+      ID: 896
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.366112e+06
@@ -16275,9 +16275,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 895 PointerType *time.Location
+          Type: 897 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 484
+      ID: 486
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 827360
@@ -16285,13 +16285,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 486 PointerType *time.fileSizeError.str
+          Type: 488 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 485 GoStringDataType time.fileSizeError.str
+      Data: 487 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 485
+      ID: 487
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -16338,7 +16338,7 @@ Types:
       GoRuntimeType: 581248
       GoKind: 26
     - __kind: StructureType
-      ID: 912
+      ID: 914
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.054304e+06
@@ -16349,10 +16349,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 913 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 915 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 914 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 916 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -16367,18 +16367,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 915 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 917 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 915
+      ID: 917
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 989888
       GoKind: 9
     - __kind: StructureType
-      ID: 913
+      ID: 915
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.916e+06
@@ -16403,21 +16403,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 654
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 914
+      ID: 916
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 584896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1089
+      ID: 1091
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 636
+      ID: 638
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.420736e+06
@@ -16427,13 +16427,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 525
+      ID: 527
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 831296
       GoKind: 2
     - __kind: StructureType
-      ID: 800
+      ID: 802
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.696064e+06
@@ -16446,7 +16446,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 754
+      ID: 756
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 988736

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -2343,15 +2343,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84ad2c..0x84ad3c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ad3c..0x84add0
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x84add0..0x84ae50]
@@ -2368,29 +2359,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x84ae50..0x84af70]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84aeb8..0x84aec0
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84aec0..0x84aed8
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84aed8..0x84aeec
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84aeb4..0x84aebc
-              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84aebc..0x84aed8
-              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84aed8..0x84aee8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x84af70..0x84af80]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -3464,20 +3464,20 @@ Types:
       ByteSize: 8
       Pointee: 136 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1182
+      ID: 1184
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1183 PointerType *main.deepSlice3
+      Pointee: 1185 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1207
+      ID: 1209
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1208 PointerType *main.deepSlice8
+      Pointee: 1210 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1213
+      ID: 1215
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1214 PointerType *main.deepSlice9
+      Pointee: 1216 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 149
       Name: '**main.stringType2'
@@ -3485,7 +3485,7 @@ Types:
       GoKind: 22
       Pointee: 150 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1178
+      ID: 1180
       Name: '**main.t'
       ByteSize: 8
       Pointee: 229 PointerType *main.t
@@ -3528,30 +3528,30 @@ Types:
       ByteSize: 8
       Pointee: 144 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1190
+      ID: 1192
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1191 PointerType *table<int,*main.deepMap3>
+      Pointee: 1193 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1224
+      ID: 1226
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1225 PointerType *table<int,*main.deepMap8>
+      Pointee: 1227 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1239
+      ID: 1241
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1240 PointerType *table<int,*main.deepMap9>
+      Pointee: 1242 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 165
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 166 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1254
+      ID: 1256
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1255 PointerType *table<int,interface {}>
+      Pointee: 1257 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 202
       Name: '**table<int,uint8>'
@@ -3568,10 +3568,10 @@ Types:
       ByteSize: 8
       Pointee: 181 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 924
+      ID: 926
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 925 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 927 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 175
       Name: '**table<string,int>'
@@ -3628,20 +3628,20 @@ Types:
       ByteSize: 8
       Pointee: 304 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1186
+      ID: 1188
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1185 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1187 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1211
+      ID: 1213
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1210 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1212 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1217
+      ID: 1219
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1216 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1218 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
       ID: 300
       Name: '*[]*runtime.p.array'
@@ -3708,15 +3708,15 @@ Types:
       ByteSize: 8
       Pointee: 424 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 961
+      ID: 963
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 960 GoSliceDataType []float64.array
+      Pointee: 962 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1220
+      ID: 1222
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1219 GoSliceDataType []interface {}.array
+      Pointee: 1221 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 248
       Name: '*[]main.structWithCyclicSlices'
@@ -3728,10 +3728,10 @@ Types:
       ByteSize: 8
       Pointee: 428 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1265
+      ID: 490
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1264 GoSliceDataType []main.structWithMap.array
+      Pointee: 489 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 421
       Name: '*[]main.structWithNoStrings.array'
@@ -3775,66 +3775,66 @@ Types:
       ByteSize: 8
       Pointee: 296 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1091
+      ID: 1093
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.985184e+06
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1094 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 726
+      ID: 728
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 930688
       GoKind: 22
-      Pointee: 727 GoSliceHeaderType archive/tar.headerError
+      Pointee: 729 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 729
+      ID: 731
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 728 GoSliceDataType archive/tar.headerError.array
+      Pointee: 730 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1026
+      ID: 1028
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.434368e+06
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1029 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 974
+      ID: 976
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 930880
       GoKind: 22
-      Pointee: 975 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 977 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 976
+      ID: 978
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 930976
       GoKind: 22
-      Pointee: 977 StructureType archive/zip.dirWriter
+      Pointee: 979 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1070
+      ID: 1072
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.903328e+06
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1073 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1002
+      ID: 1004
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.057088e+06
       GoKind: 22
-      Pointee: 1003 StructureType archive/zip.nopCloser
+      Pointee: 1005 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1004
+      ID: 1006
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.057344e+06
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1007 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3843,435 +3843,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1049
+      ID: 1051
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.17328e+06
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType bufio.Reader
+      Pointee: 1052 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1078
+      ID: 1080
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.948064e+06
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType bufio.Writer
+      Pointee: 1081 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1129
+      ID: 1131
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.266144e+06
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1132 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 636
+      ID: 638
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 913216
       GoKind: 22
-      Pointee: 525 BaseType compress/flate.CorruptInputError
+      Pointee: 527 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 637
+      ID: 639
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 913312
       GoKind: 22
-      Pointee: 526 GoStringHeaderType compress/flate.InternalError
+      Pointee: 528 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 528
+      ID: 530
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 527 GoStringDataType compress/flate.InternalError.str
+      Pointee: 529 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.423968e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1027 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 970
+      ID: 972
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 913408
       GoKind: 22
-      Pointee: 971 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 973 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1046
+      ID: 1048
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.724832e+06
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1049 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.202624e+06
       GoKind: 22
-      Pointee: 875 StructureType context.deadlineExceededError
+      Pointee: 877 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 718
+      ID: 720
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925312
       GoKind: 22
-      Pointee: 539 BaseType crypto/aes.KeySizeError
+      Pointee: 541 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 719
+      ID: 721
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925504
       GoKind: 22
-      Pointee: 540 BaseType crypto/des.KeySizeError
+      Pointee: 542 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 720
+      ID: 722
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 541 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 543 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1041
+      ID: 1043
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.665568e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1044 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 823
+      ID: 825
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.064896e+06
       GoKind: 22
-      Pointee: 824 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 826 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1072
+      ID: 1074
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.90384e+06
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1075 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1102
+      ID: 1104
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.118432e+06
       GoKind: 22
-      Pointee: 1103 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1105 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1076
+      ID: 1078
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.904352e+06
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1079 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1074
+      ID: 1076
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904096e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1077 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1068
+      ID: 1070
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.901536e+06
       GoKind: 22
-      Pointee: 1069 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1071 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 721
+      ID: 723
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926080
       GoKind: 22
-      Pointee: 542 BaseType crypto/rc4.KeySizeError
+      Pointee: 544 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1089
+      ID: 1091
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.982304e+06
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1092 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1064
+      ID: 1066
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.870912e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1067 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 914944
       GoKind: 22
-      Pointee: 529 BaseType crypto/tls.AlertError
+      Pointee: 531 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 812
+      ID: 814
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.045696e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 815 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1155
+      ID: 1157
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.377664e+06
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1158 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 914656
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 643 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 639 StructureType crypto/tls.RecordHeaderError
+      Pointee: 641 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.044032e+06
       GoKind: 22
-      Pointee: 766 BaseType crypto/tls.alert
+      Pointee: 768 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1034
+      ID: 1036
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.558432e+06
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1037 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 642
+      ID: 644
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 914752
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 645 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1039
+      ID: 1041
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.640608e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1042 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 909
+      ID: 911
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.424448e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 912 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 926
+      ID: 928
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.041472e+06
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 929 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 714
+      ID: 716
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 924352
       GoKind: 22
-      Pointee: 715 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 717 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 708
+      ID: 710
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 923872
       GoKind: 22
-      Pointee: 709 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 711 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 710
+      ID: 712
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 923968
       GoKind: 22
-      Pointee: 711 StructureType crypto/x509.HostnameError
+      Pointee: 713 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 538 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 540 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 817
+      ID: 819
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.051456e+06
       GoKind: 22
-      Pointee: 818 StructureType crypto/x509.SystemRootsError
+      Pointee: 820 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 716
+      ID: 718
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 717 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 719 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 712
+      ID: 714
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 924256
       GoKind: 22
-      Pointee: 713 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 715 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 730
+      ID: 732
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 931168
       GoKind: 22
-      Pointee: 731 StructureType encoding/asn1.StructuralError
+      Pointee: 733 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 734
+      ID: 736
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931360
       GoKind: 22
-      Pointee: 735 StructureType encoding/asn1.SyntaxError
+      Pointee: 737 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 732
+      ID: 734
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 931264
       GoKind: 22
-      Pointee: 733 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 735 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 625
+      ID: 627
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 911200
       GoKind: 22
-      Pointee: 520 BaseType encoding/base64.CorruptInputError
+      Pointee: 522 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 992
+      ID: 994
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.041088e+06
       GoKind: 22
-      Pointee: 993 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 995 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 628
+      ID: 630
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 912064
       GoKind: 22
-      Pointee: 521 BaseType encoding/hex.InvalidByteError
+      Pointee: 523 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 906016
       GoKind: 22
-      Pointee: 597 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 599 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.037248e+06
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 804 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 905632
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 591 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 905920
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 597 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 905824
       GoKind: 22
-      Pointee: 593 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 595 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 905728
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 593 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1135
+      ID: 1137
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.29168e+06
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1138 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 598
+      ID: 600
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 906400
       GoKind: 22
-      Pointee: 599 StructureType encoding/json.jsonError
+      Pointee: 601 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1000
+      ID: 1002
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.054016e+06
       GoKind: 22
-      Pointee: 1001 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1003 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 702
+      ID: 704
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 705 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 700
+      ID: 702
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 922720
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 703 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 704
+      ID: 706
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 535 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 537 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 537
+      ID: 539
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 538 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 705
+      ID: 707
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923008
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 708 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1113
+      ID: 1115
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.158272e+06
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1116 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -4280,19 +4280,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 564
+      ID: 566
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896032
       GoKind: 22
-      Pointee: 565 UnresolvedPointeeType errors.errorString
+      Pointee: 567 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 768
+      ID: 770
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.022144e+06
       GoKind: 22
-      Pointee: 769 UnresolvedPointeeType errors.joinError
+      Pointee: 771 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -4308,813 +4308,813 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 1123
+      ID: 1125
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.258464e+06
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType fmt.pp
+      Pointee: 1126 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 770
+      ID: 772
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.023936e+06
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType fmt.wrapError
+      Pointee: 773 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 772
+      ID: 774
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.024064e+06
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 775 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 629 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 607
+      ID: 609
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 908800
       GoKind: 22
-      Pointee: 608 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 610 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 609
+      ID: 611
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 908896
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 612 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 938
+      ID: 940
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 941 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 613
+      ID: 615
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 909184
       GoKind: 22
-      Pointee: 614 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 616 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 940
+      ID: 942
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 943 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 611
+      ID: 613
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 908992
       GoKind: 22
-      Pointee: 514 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 516 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 516
+      ID: 518
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 515 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 517 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 606
+      ID: 608
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 511 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 513 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 513
+      ID: 515
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 512 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 514 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 909088
       GoKind: 22
-      Pointee: 517 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 519 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 519
+      ID: 521
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 518 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 520 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1012
+      ID: 1014
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.208128e+06
       GoKind: 22
-      Pointee: 1013 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1015 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1099
+      ID: 1101
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.05648e+06
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1102 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 724
+      ID: 726
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 929632
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 727 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 883
+      ID: 885
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.211712e+06
       GoKind: 22
-      Pointee: 884 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 886 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1131
+      ID: 1133
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.268192e+06
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1134 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 651
+      ID: 653
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 654 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 658
+      ID: 660
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 919360
       GoKind: 22
-      Pointee: 659 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 661 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 653
+      ID: 655
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 919072
       GoKind: 22
-      Pointee: 534 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 536 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 657 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 659 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 919168
       GoKind: 22
-      Pointee: 655 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 657 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 674
+      ID: 676
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 675 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 677 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 678
+      ID: 680
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 921472
       GoKind: 22
-      Pointee: 679 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 681 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 676
+      ID: 678
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 677 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 679 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 672
+      ID: 674
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 673 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 675 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 962 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 964 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 686
+      ID: 688
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 921856
       GoKind: 22
-      Pointee: 687 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 689 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 680
+      ID: 682
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 921568
       GoKind: 22
-      Pointee: 681 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 683 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 684
+      ID: 686
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 685 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 687 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 682
+      ID: 684
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 921664
       GoKind: 22
-      Pointee: 683 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 685 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 688
+      ID: 690
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 921952
       GoKind: 22
-      Pointee: 689 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 691 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 922240
       GoKind: 22
-      Pointee: 695 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 697 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 696
+      ID: 698
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 922336
       GoKind: 22
-      Pointee: 697 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 699 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 692
+      ID: 694
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 922144
       GoKind: 22
-      Pointee: 693 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 695 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 690
+      ID: 692
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 922048
       GoKind: 22
-      Pointee: 691 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 693 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 698
+      ID: 700
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 922528
       GoKind: 22
-      Pointee: 699 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 701 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 615
+      ID: 617
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 910336
       GoKind: 22
-      Pointee: 616 StructureType github.com/cihub/seelog.baseError
+      Pointee: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1052
+      ID: 1054
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.801696e+06
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1055 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 617
+      ID: 619
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 910432
       GoKind: 22
-      Pointee: 618 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 620 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1032
+      ID: 1034
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.557152e+06
       GoKind: 22
-      Pointee: 1033 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1035 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 988
+      ID: 990
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.039936e+06
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 991 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1022
+      ID: 1024
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.422048e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1025 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 621
+      ID: 623
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 910624
       GoKind: 22
-      Pointee: 622 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 624 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1087
+      ID: 1089
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.974528e+06
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1090 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1106
+      ID: 1108
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.131072e+06
       GoKind: 22
-      Pointee: 1101 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1103 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1105
+      ID: 1107
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.130688e+06
       GoKind: 22
-      Pointee: 1104 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1106 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 990
+      ID: 992
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.040064e+06
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 993 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 910528
       GoKind: 22
-      Pointee: 620 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 622 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 623
+      ID: 625
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 910720
       GoKind: 22
-      Pointee: 624 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 626 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1054
+      ID: 1056
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.803488e+06
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1057 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1095
+      ID: 1097
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.010656e+06
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1098 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1097
+      ID: 1099
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.041152e+06
       GoKind: 22
-      Pointee: 1098 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1100 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 914
+      ID: 916
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.436768e+06
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 917 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 827
+      ID: 829
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.065664e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 830 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 825
+      ID: 827
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.065536e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 828 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 829
+      ID: 831
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.069632e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 832 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 831
+      ID: 833
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.06976e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 834 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1043
+      ID: 1045
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.667872e+06
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1046 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.052096e+06
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 822 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 629
+      ID: 631
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 912256
       GoKind: 22
-      Pointee: 630 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 632 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1147
+      ID: 1149
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.354112e+06
       GoKind: 22
-      Pointee: 1148 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1150 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 885
+      ID: 887
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.220288e+06
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 888 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 858
+      ID: 860
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.199168e+06
       GoKind: 22
-      Pointee: 859 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 861 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 852
+      ID: 854
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.198784e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 855 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 787
+      ID: 789
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.031232e+06
       GoKind: 22
-      Pointee: 788 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 790 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 864
+      ID: 866
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.199552e+06
       GoKind: 22
-      Pointee: 865 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 867 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.031104e+06
       GoKind: 22
-      Pointee: 765 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 767 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 856
+      ID: 858
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.19904e+06
       GoKind: 22
-      Pointee: 857 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 859 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 854
+      ID: 856
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.198912e+06
       GoKind: 22
-      Pointee: 855 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 857 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 862
+      ID: 864
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.199424e+06
       GoKind: 22
-      Pointee: 863 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 865 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 860
+      ID: 862
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.199296e+06
       GoKind: 22
-      Pointee: 861 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 863 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1151
+      ID: 1153
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.36672e+06
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1154 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 868
+      ID: 870
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.199936e+06
       GoKind: 22
-      Pointee: 869 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 871 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 791
+      ID: 793
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.031488e+06
       GoKind: 22
-      Pointee: 792 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 794 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 789
+      ID: 791
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.03136e+06
       GoKind: 22
-      Pointee: 790 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 792 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 866
+      ID: 868
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.199808e+06
       GoKind: 22
-      Pointee: 867 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 869 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 746
+      ID: 748
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944128
       GoKind: 22
-      Pointee: 547 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 549 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 549
+      ID: 551
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 548 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 550 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.666336e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 932 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 835
+      ID: 837
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.08448e+06
       GoKind: 22
-      Pointee: 836 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 838 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1018
+      ID: 1020
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.260096e+06
       GoKind: 22
-      Pointee: 1019 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1021 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1111
+      ID: 1113
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.146432e+06
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1114 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1006
+      ID: 1008
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.086784e+06
       GoKind: 22
-      Pointee: 1007 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1009 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 945376
       GoKind: 22
-      Pointee: 550 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 552 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 893
+      ID: 895
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.26176e+06
       GoKind: 22
-      Pointee: 894 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 896 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 750
+      ID: 752
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 945664
       GoKind: 22
-      Pointee: 751 StructureType golang.org/x/net/http2.connError
+      Pointee: 753 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 749
+      ID: 751
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945568
       GoKind: 22
-      Pointee: 554 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 556 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 555 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 557 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 753
+      ID: 755
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 945856
       GoKind: 22
-      Pointee: 560 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 562 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 562
+      ID: 564
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 561 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 563 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 752
+      ID: 754
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 945760
       GoKind: 22
-      Pointee: 557 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 559 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 560 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 748
+      ID: 750
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945472
       GoKind: 22
-      Pointee: 551 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 553 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 553
+      ID: 555
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 552 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 554 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1109
+      ID: 1111
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.144512e+06
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1112 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 754
+      ID: 756
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 945952
       GoKind: 22
-      Pointee: 755 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 757 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 756
+      ID: 758
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 946048
       GoKind: 22
-      Pointee: 563 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 565 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 742
+      ID: 744
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 743 StructureType google.golang.org/grpc.dropError
+      Pointee: 745 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 891
+      ID: 893
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.258816e+06
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 894 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 916
+      ID: 918
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.444128e+06
       GoKind: 22
-      Pointee: 917 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 919 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 744
+      ID: 746
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942400
       GoKind: 22
-      Pointee: 745 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 747 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1058
+      ID: 1060
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.809088e+06
       GoKind: 22
-      Pointee: 1059 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1061 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1016
+      ID: 1018
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.25536e+06
       GoKind: 22
-      Pointee: 1017 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1019 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 833
+      ID: 835
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.07872e+06
       GoKind: 22
-      Pointee: 834 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 836 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 978
+      ID: 980
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 942496
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 981 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 722
+      ID: 724
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 927520
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 725 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 821
+      ID: 823
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.055424e+06
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 824 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 889
+      ID: 891
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.226688e+06
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 892 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 887
+      ID: 889
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.226432e+06
       GoKind: 22
-      Pointee: 888 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 890 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 736
+      ID: 738
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932224
       GoKind: 22
-      Pointee: 737 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 739 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 738
+      ID: 740
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 932320
       GoKind: 22
-      Pointee: 739 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 741 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 666
+      ID: 668
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 919744
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 669 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1066
+      ID: 1068
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.899488e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1069 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 946816
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType html/template.Error
+      Pointee: 760 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -5158,115 +5158,115 @@ Types:
       GoKind: 22
       Pointee: 153 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 918
+      ID: 920
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.210784e+06
       GoKind: 22
-      Pointee: 919 UnresolvedPointeeType internal/abi.Type
+      Pointee: 921 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 634
+      ID: 636
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 912928
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 637 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 632
+      ID: 634
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 912832
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 635 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 964
+      ID: 966
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 900832
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 967 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 850
+      ID: 852
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.198016e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 853 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1153
+      ID: 1155
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.372384e+06
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1156 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 848
+      ID: 850
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.197888e+06
       GoKind: 22
-      Pointee: 849 StructureType internal/poll.errNetClosing
+      Pointee: 851 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 568
+      ID: 570
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900064
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 571 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 631
+      ID: 633
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 912640
       GoKind: 22
-      Pointee: 522 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 524 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 523 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 525 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 805
+      ID: 807
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.042368e+06
       GoKind: 22
-      Pointee: 806 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 808 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1010
+      ID: 1012
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.189312e+06
       GoKind: 22
-      Pointee: 1011 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1013 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1008
+      ID: 1010
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.188928e+06
       GoKind: 22
-      Pointee: 1009 StructureType io.discard
+      Pointee: 1011 StructureType io.discard
     - __kind: PointerType
-      ID: 982
+      ID: 984
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.0224e+06
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType io.multiWriter
+      Pointee: 985 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 846
+      ID: 848
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.197376e+06
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType io/fs.PathError
+      Pointee: 849 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1056
+      ID: 1058
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.803712e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1059 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 312
       Name: '*main.deepMap2'
@@ -5275,12 +5275,12 @@ Types:
       GoKind: 22
       Pointee: 313 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1198
+      ID: 1200
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385888
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType main.deepMap3
+      Pointee: 1201 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 145
       Name: '*main.deepMap7'
@@ -5289,19 +5289,19 @@ Types:
       GoKind: 22
       Pointee: 146 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1232
+      ID: 1234
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 385568
       GoKind: 22
-      Pointee: 1233 StructureType main.deepMap8
+      Pointee: 1235 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1247
+      ID: 1249
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 385504
       GoKind: 22
-      Pointee: 1248 StructureType main.deepMap9
+      Pointee: 1250 StructureType main.deepMap9
     - __kind: PointerType
       ID: 129
       Name: '*main.deepPtr2'
@@ -5310,12 +5310,12 @@ Types:
       GoKind: 22
       Pointee: 130 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1157
+      ID: 1159
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1160 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 131
       Name: '*main.deepPtr7'
@@ -5324,19 +5324,19 @@ Types:
       GoKind: 22
       Pointee: 132 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1202
+      ID: 1204
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386144
       GoKind: 22
-      Pointee: 1203 StructureType main.deepPtr8
+      Pointee: 1205 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1204
+      ID: 1206
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386080
       GoKind: 22
-      Pointee: 1205 StructureType main.deepPtr9
+      Pointee: 1207 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 136
       Name: '*main.deepSlice2'
@@ -5345,12 +5345,12 @@ Types:
       GoKind: 22
       Pointee: 303 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1183
+      ID: 1185
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387040
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1186 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 137
       Name: '*main.deepSlice7'
@@ -5359,19 +5359,19 @@ Types:
       GoKind: 22
       Pointee: 138 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1208
+      ID: 1210
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386720
       GoKind: 22
-      Pointee: 1209 StructureType main.deepSlice8
+      Pointee: 1211 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1214
+      ID: 1216
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386656
       GoKind: 22
-      Pointee: 1215 StructureType main.deepSlice9
+      Pointee: 1217 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 291
       Name: '*main.emptyStruct'
@@ -5386,12 +5386,12 @@ Types:
       GoKind: 22
       Pointee: 156 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1174
+      ID: 1176
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 895744
       GoKind: 22
-      Pointee: 1175 StructureType main.firstBehavior
+      Pointee: 1177 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 228
       Name: '*main.node'
@@ -5406,19 +5406,19 @@ Types:
       GoKind: 22
       Pointee: 243 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1176
+      ID: 1178
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 895840
       GoKind: 22
-      Pointee: 1177 StructureType main.secondBehavior
+      Pointee: 1179 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1162
+      ID: 1164
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 895936
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1165 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 147
       Name: '*main.stringType1'
@@ -5426,16 +5426,16 @@ Types:
       GoKind: 22
       Pointee: 148 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1160
+      ID: 1162
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1159 GoStringDataType main.stringType1.str
+      Pointee: 1161 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 150
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1161 UnresolvedPointeeType main.stringType2
+      Pointee: 1163 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 246
       Name: '*main.structWithCyclicSlices'
@@ -5466,10 +5466,10 @@ Types:
       GoKind: 22
       Pointee: 230 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1180
+      ID: 1182
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1179 GoSliceDataType main.t.array
+      Pointee: 1181 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 241
       Name: '*main.threeStringStruct'
@@ -5502,30 +5502,30 @@ Types:
       ByteSize: 8
       Pointee: 142 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1188
+      ID: 1190
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1189 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1191 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1222
+      ID: 1224
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1223 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1225 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1237
+      ID: 1239
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1238 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1240 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 163
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 164 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1252
+      ID: 1254
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1253 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1255 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 200
       Name: '*map<int,uint8>'
@@ -5542,10 +5542,10 @@ Types:
       ByteSize: 8
       Pointee: 179 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 922
+      ID: 924
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 923 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 925 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 173
       Name: '*map<string,int>'
@@ -5603,451 +5603,451 @@ Types:
       GoKind: 22
       Pointee: 172 GoMapType map[string]int
     - __kind: PointerType
-      ID: 670
+      ID: 672
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920608
       GoKind: 22
-      Pointee: 671 StructureType math/big.ErrNaN
+      Pointee: 673 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 972
+      ID: 974
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 915424
       GoKind: 22
-      Pointee: 973 StructureType mime/multipart.writerOnly·1
+      Pointee: 975 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 877
+      ID: 879
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.205952e+06
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType net.AddrError
+      Pointee: 880 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.420288e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType net.DNSError
+      Pointee: 906 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1117
+      ID: 1119
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.230656e+06
       GoKind: 22
-      Pointee: 1118 UnresolvedPointeeType net.IPConn
+      Pointee: 1120 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.419968e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType net.OpError
+      Pointee: 904 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.20608e+06
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType net.ParseError
+      Pointee: 882 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1127
+      ID: 1129
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.259488e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType net.TCPConn
+      Pointee: 1130 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1137
+      ID: 1139
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.304992e+06
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType net.UDPConn
+      Pointee: 1140 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1125
+      ID: 1127
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.258976e+06
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType net.UnixConn
+      Pointee: 1128 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 876
+      ID: 878
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.205184e+06
       GoKind: 22
-      Pointee: 839 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 841 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 841
+      ID: 843
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 840 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 842 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 803
+      ID: 805
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.038144e+06
       GoKind: 22
-      Pointee: 804 StructureType net.canceledError
+      Pointee: 806 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1093
+      ID: 1095
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.008064e+06
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType net.conn
+      Pointee: 1096 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 947
+      ID: 949
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.846496e+06
       GoKind: 22
-      Pointee: 948 StructureType net.dialResult·1
+      Pointee: 950 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1139
+      ID: 1141
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.309248e+06
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType net.netFD
+      Pointee: 1142 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 600
+      ID: 602
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907360
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType net.notFoundError
+      Pointee: 603 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908032
       GoKind: 22
-      Pointee: 603 StructureType net.result·2
+      Pointee: 605 StructureType net.result·2
     - __kind: PointerType
-      ID: 1121
+      ID: 1123
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.245024e+06
       GoKind: 22
-      Pointee: 1122 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1124 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1119
+      ID: 1121
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.244544e+06
       GoKind: 22
-      Pointee: 1120 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1122 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 881
+      ID: 883
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.20672e+06
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType net.temporaryError
+      Pointee: 884 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.420448e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType net.timeoutError
+      Pointee: 908 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 793
+      ID: 795
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.03392e+06
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 796 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 966
+      ID: 968
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 903136
       GoKind: 22
-      Pointee: 967 StructureType net/http.bufioFlushWriter
+      Pointee: 969 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 577
+      ID: 579
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 903808
       GoKind: 22
-      Pointee: 492 BaseType net/http.http2ConnectionError
+      Pointee: 494 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 903904
       GoKind: 22
-      Pointee: 579 StructureType net/http.http2GoAwayError
+      Pointee: 581 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.415968e+06
       GoKind: 22
-      Pointee: 898 StructureType net/http.http2StreamError
+      Pointee: 900 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 582
+      ID: 584
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 904480
       GoKind: 22
-      Pointee: 583 StructureType net/http.http2connError
+      Pointee: 585 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1028
+      ID: 1030
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.553632e+06
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1031 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 581
+      ID: 583
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904384
       GoKind: 22
-      Pointee: 496 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 498 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 498
+      ID: 500
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 497 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 499 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 585
+      ID: 587
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 904672
       GoKind: 22
-      Pointee: 502 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 504 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 504
+      ID: 506
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 503 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 505 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 904576
       GoKind: 22
-      Pointee: 499 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 501 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 501
+      ID: 503
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 500 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 502 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.201856e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 875 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.03456e+06
       GoKind: 22
-      Pointee: 800 StructureType net/http.http2noCachedConnError
+      Pointee: 802 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1082
+      ID: 1084
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.950368e+06
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1085 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 580
+      ID: 582
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904288
       GoKind: 22
-      Pointee: 493 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 495 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 494 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 496 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 968
+      ID: 970
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 904768
       GoKind: 22
-      Pointee: 969 StructureType net/http.http2stickyErrWriter
+      Pointee: 971 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 795
+      ID: 797
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.034176e+06
       GoKind: 22
-      Pointee: 796 StructureType net/http.nothingWrittenError
+      Pointee: 798 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1030
+      ID: 1032
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.174528e+06
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1033 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 986
+      ID: 988
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.034048e+06
       GoKind: 22
-      Pointee: 987 StructureType net/http.persistConnWriter
+      Pointee: 989 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1020
+      ID: 1022
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.416128e+06
       GoKind: 22
-      Pointee: 1021 StructureType net/http.readWriteCloserBody
+      Pointee: 1023 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 904864
       GoKind: 22
-      Pointee: 587 StructureType net/http.requestBodyReadError
+      Pointee: 589 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.417248e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 902 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.201728e+06
       GoKind: 22
-      Pointee: 871 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 873 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 797
+      ID: 799
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.034304e+06
       GoKind: 22
-      Pointee: 798 StructureType net/http.transportReadFromServerError
+      Pointee: 800 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1062
+      ID: 1064
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.843136e+06
       GoKind: 22
-      Pointee: 1063 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1065 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 575
+      ID: 577
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 903040
       GoKind: 22
-      Pointee: 576 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 578 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1084
+      ID: 1086
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.95216e+06
       GoKind: 22
-      Pointee: 1085 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1087 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 996
+      ID: 998
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.046848e+06
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 999 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 662
+      ID: 664
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 919552
       GoKind: 22
-      Pointee: 663 StructureType net/netip.parseAddrError
+      Pointee: 665 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 660
+      ID: 662
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 919456
       GoKind: 22
-      Pointee: 661 StructureType net/netip.parsePrefixError
+      Pointee: 663 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1036
+      ID: 1038
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.117024e+06
       GoKind: 22
-      Pointee: 1037 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1039 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 998
+      ID: 1000
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.051712e+06
       GoKind: 22
-      Pointee: 999 StructureType net/smtp.dataCloser
+      Pointee: 1001 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 915616
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType net/textproto.Error
+      Pointee: 649 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 645
+      ID: 647
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 915520
       GoKind: 22
-      Pointee: 530 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 532 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 532
+      ID: 534
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 531 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 533 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 994
+      ID: 996
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.04608e+06
       GoKind: 22
-      Pointee: 995 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 997 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.420768e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType net/url.Error
+      Pointee: 910 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 604
+      ID: 606
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 908128
       GoKind: 22
-      Pointee: 505 GoStringHeaderType net/url.EscapeError
+      Pointee: 507 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 506 GoStringDataType net/url.EscapeError.str
+      Pointee: 508 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 605
+      ID: 607
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 508 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 510 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 510
+      ID: 512
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 509 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 511 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 410
       Name: '*noalg.map.group[[4]int][4]int'
@@ -6074,30 +6074,30 @@ Types:
       ByteSize: 8
       Pointee: 309 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1194
+      ID: 1196
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1195 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1197 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1228
+      ID: 1230
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1229 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1231 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1243
+      ID: 1245
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1244 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1246 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
       ID: 318
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
       Pointee: 319 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1258
+      ID: 1260
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1259 StructureType noalg.map.group[int]interface {}
+      Pointee: 1261 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
       ID: 377
       Name: '*noalg.map.group[int]uint8'
@@ -6114,10 +6114,10 @@ Types:
       ByteSize: 8
       Pointee: 343 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 954
+      ID: 956
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 955 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 957 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 334
       Name: '*noalg.map.group[string]int'
@@ -6169,115 +6169,115 @@ Types:
       ByteSize: 8
       Pointee: 386 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1145
+      ID: 1147
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.348736e+06
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType os.File
+      Pointee: 1148 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 774
+      ID: 776
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.025216e+06
       GoKind: 22
-      Pointee: 775 UnresolvedPointeeType os.LinkError
+      Pointee: 777 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 842
+      ID: 844
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.19072e+06
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType os.SyscallError
+      Pointee: 845 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1143
+      ID: 1145
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.347264e+06
       GoKind: 22
-      Pointee: 1144 StructureType os.fileWithoutReadFrom
+      Pointee: 1146 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1141
+      ID: 1143
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.346528e+06
       GoKind: 22
-      Pointee: 1142 StructureType os.fileWithoutWriteTo
+      Pointee: 1144 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 807
+      ID: 809
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.042752e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType os/exec.Error
+      Pointee: 810 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 950
+      ID: 952
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.088288e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 953 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1014
+      ID: 1016
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.212992e+06
       GoKind: 22
-      Pointee: 1015 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1017 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 809
+      ID: 811
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.04288e+06
       GoKind: 22
-      Pointee: 810 StructureType os/exec.wrappedError
+      Pointee: 812 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 741
+      ID: 743
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 544 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 546 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 546
+      ID: 548
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 545 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 547 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 740
+      ID: 742
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 937312
       GoKind: 22
-      Pointee: 543 BaseType os/user.UnknownUserIdError
+      Pointee: 545 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 900736
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType reflect.ValueError
+      Pointee: 573 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 668
+      ID: 670
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 671 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.026752e+06
       GoKind: 22
-      Pointee: 779 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 781 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.028544e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 785 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -6293,12 +6293,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.02688e+06
       GoKind: 22
-      Pointee: 781 StructureType runtime.boundsError
+      Pointee: 783 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
@@ -6314,24 +6314,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 844
+      ID: 846
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.196224e+06
       GoKind: 22
-      Pointee: 845 StructureType runtime.errorAddressString
+      Pointee: 847 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 776
+      ID: 778
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.026368e+06
       GoKind: 22
-      Pointee: 759 GoStringHeaderType runtime.errorString
+      Pointee: 761 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 761
+      ID: 763
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 760 GoStringDataType runtime.errorString.str
+      Pointee: 762 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -6354,17 +6354,17 @@ Types:
       GoKind: 22
       Pointee: 298 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 777
+      ID: 779
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.026496e+06
       GoKind: 22
-      Pointee: 762 GoStringHeaderType runtime.plainError
+      Pointee: 764 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 764
+      ID: 766
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 763 GoStringDataType runtime.plainError.str
+      Pointee: 765 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -6380,12 +6380,12 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 566
+      ID: 568
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 899392
       GoKind: 22
-      Pointee: 567 StructureType runtime.synctestDeadlockError
+      Pointee: 569 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
@@ -6401,12 +6401,12 @@ Types:
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 784
+      ID: 786
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.0288e+06
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType strconv.NumError
+      Pointee: 787 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -6420,33 +6420,33 @@ Types:
       ByteSize: 8
       Pointee: 292 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1080
+      ID: 1082
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.949088e+06
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType strings.Builder
+      Pointee: 1083 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 984
+      ID: 986
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.028928e+06
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 987 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 980
+      ID: 982
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 970400
       GoKind: 22
-      Pointee: 981 StructureType struct { io.Writer }
+      Pointee: 983 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 896
+      ID: 898
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.415328e+06
       GoKind: 22
-      Pointee: 895 BaseType syscall.Errno
+      Pointee: 897 BaseType syscall.Errno
     - __kind: PointerType
       ID: 223
       Name: '*table<[4]int,[4]int>'
@@ -6473,30 +6473,30 @@ Types:
       ByteSize: 8
       Pointee: 306 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1191
+      ID: 1193
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1192 StructureType table<int,*main.deepMap3>
+      Pointee: 1194 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1225
+      ID: 1227
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1226 StructureType table<int,*main.deepMap8>
+      Pointee: 1228 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1240
+      ID: 1242
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1241 StructureType table<int,*main.deepMap9>
+      Pointee: 1243 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 166
       Name: '*table<int,int>'
       ByteSize: 8
       Pointee: 316 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1255
+      ID: 1257
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1256 StructureType table<int,interface {}>
+      Pointee: 1258 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 203
       Name: '*table<int,uint8>'
@@ -6513,10 +6513,10 @@ Types:
       ByteSize: 8
       Pointee: 340 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 952 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 954 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 176
       Name: '*table<string,int>'
@@ -6568,45 +6568,45 @@ Types:
       ByteSize: 8
       Pointee: 383 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1115
+      ID: 1117
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.158656e+06
       GoKind: 22
-      Pointee: 1116 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1118 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 837
+      ID: 839
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.08832e+06
       GoKind: 22
-      Pointee: 838 StructureType text/template.ExecError
+      Pointee: 840 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 912
+      ID: 914
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6216e+06
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType time.Location
+      Pointee: 915 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 573
+      ID: 575
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 901600
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType time.ParseError
+      Pointee: 576 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 901504
       GoKind: 22
-      Pointee: 489 GoStringHeaderType time.fileSizeError
+      Pointee: 491 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 491
+      ID: 493
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 490 GoStringDataType time.fileSizeError.str
+      Pointee: 492 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -6650,47 +6650,47 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 664
+      ID: 666
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 919648
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 667 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1107
+      ID: 1109
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.134144e+06
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1110 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 648
+      ID: 650
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 915808
       GoKind: 22
-      Pointee: 649 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 651 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 650
+      ID: 652
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 533 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 535 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 814
+      ID: 816
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.046592e+06
       GoKind: 22
-      Pointee: 815 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 817 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 816
+      ID: 818
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.04672e+06
       GoKind: 22
-      Pointee: 767 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 769 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1365
       Name: Probe[main.stackC]
@@ -8798,7 +8798,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 942
+      ID: 944
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684192
@@ -8848,7 +8848,7 @@ Types:
       ByteSize: 8
       Element: 136 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1181
+      ID: 1183
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477664
@@ -8856,22 +8856,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1182 PointerType **main.deepSlice3
+          Type: 1184 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1185 GoSliceDataType []*main.deepSlice3.array
+      Data: 1187 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1185
+      ID: 1187
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1183 PointerType *main.deepSlice3
+      Element: 1185 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1206
+      ID: 1208
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477344
@@ -8879,22 +8879,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1207 PointerType **main.deepSlice8
+          Type: 1209 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1210 GoSliceDataType []*main.deepSlice8.array
+      Data: 1212 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1210
+      ID: 1212
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1208 PointerType *main.deepSlice8
+      Element: 1210 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1212
+      ID: 1214
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477280
@@ -8902,20 +8902,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1213 PointerType **main.deepSlice9
+          Type: 1215 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1216 GoSliceDataType []*main.deepSlice9.array
+      Data: 1218 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1216
+      ID: 1218
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1214 PointerType *main.deepSlice9
+      Element: 1216 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*runtime.p'
@@ -8993,23 +8993,23 @@ Types:
       ByteSize: 8
       Element: 144 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1200
+      ID: 1202
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1191 PointerType *table<int,*main.deepMap3>
+      Element: 1193 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1234
+      ID: 1236
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1225 PointerType *table<int,*main.deepMap8>
+      Element: 1227 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1249
+      ID: 1251
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1240 PointerType *table<int,*main.deepMap9>
+      Element: 1242 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
       ID: 322
       Name: '[]*table<int,int>.array'
@@ -9017,11 +9017,11 @@ Types:
       ByteSize: 8
       Element: 166 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1262
+      ID: 1264
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1255 PointerType *table<int,interface {}>
+      Element: 1257 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
       ID: 381
       Name: '[]*table<int,uint8>.array'
@@ -9041,11 +9041,11 @@ Types:
       ByteSize: 8
       Element: 181 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 958
+      ID: 960
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 925 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 927 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 338
       Name: '[]*table<string,int>.array'
@@ -9262,7 +9262,7 @@ Types:
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 937
+      ID: 939
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 486944
@@ -9277,15 +9277,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 960 GoSliceDataType []float64.array
+      Data: 962 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 960
+      ID: 962
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 16 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1218
+      ID: 1220
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487392
@@ -9300,9 +9300,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1219 GoSliceDataType []interface {}.array
+      Data: 1221 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1219
+      ID: 1221
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -9345,9 +9345,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1264 GoSliceDataType []main.structWithMap.array
+      Data: 489 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1264
+      ID: 489
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -9405,23 +9405,23 @@ Types:
       ByteSize: 136
       Element: 309 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1201
+      ID: 1203
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1195 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1197 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1235
+      ID: 1237
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1229 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1231 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1250
+      ID: 1252
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: slice
       ByteSize: 136
-      Element: 1244 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1246 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
       ID: 323
       Name: '[]noalg.map.group[int]int.array'
@@ -9429,11 +9429,11 @@ Types:
       ByteSize: 136
       Element: 319 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1263
+      ID: 1265
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 1259 StructureType noalg.map.group[int]interface {}
+      Element: 1261 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
       ID: 382
       Name: '[]noalg.map.group[int]uint8.array'
@@ -9453,11 +9453,11 @@ Types:
       ByteSize: 328
       Element: 343 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 959
+      ID: 961
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: slice
       ByteSize: 328
-      Element: 955 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 957 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 339
       Name: '[]noalg.map.group[string]int.array'
@@ -9638,11 +9638,11 @@ Types:
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1094
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 727
+      ID: 729
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 930784
@@ -9657,33 +9657,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 728 GoSliceDataType archive/tar.headerError.array
+      Data: 730 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 728
+      ID: 730
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1029
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 975
+      ID: 977
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 977
+      ID: 979
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.119616e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1073
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1003
+      ID: 1005
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.564352e+06
@@ -9693,7 +9693,7 @@ Types:
           Offset: 0
           Type: 127 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1007
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9703,15 +9703,15 @@ Types:
       GoRuntimeType: 584960
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1052
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1081
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1132
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9737,13 +9737,13 @@ Types:
       GoRuntimeType: 584704
       GoKind: 15
     - __kind: BaseType
-      ID: 525
+      ID: 527
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834048
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 526
+      ID: 528
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 834144
@@ -9751,116 +9751,116 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 528 PointerType *compress/flate.InternalError.str
+          Type: 530 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 527 GoStringDataType compress/flate.InternalError.str
+      Data: 529 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 527
+      ID: 529
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1027
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 971
+      ID: 973
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1049
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 877
       Name: context.deadlineExceededError
       GoRuntimeType: 1.478592e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 539
+      ID: 541
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 2
     - __kind: BaseType
-      ID: 540
+      ID: 542
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 2
     - __kind: BaseType
-      ID: 541
+      ID: 543
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1044
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 824
+      ID: 826
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.288576e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1075
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1103
+      ID: 1105
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1079
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1077
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1069
+      ID: 1071
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 542
+      ID: 544
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1092
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1067
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 529
+      ID: 531
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 834624
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 815
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1158
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 643
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 639
+      ID: 641
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.72944e+06
@@ -9871,38 +9871,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 942 ArrayType [5]uint8
+          Type: 944 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 766
+      ID: 768
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 992768
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1037
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 645
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1042
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 912
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 929
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 715
+      ID: 717
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.73232e+06
@@ -9910,21 +9910,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 926 PointerType *crypto/x509.Certificate
+          Type: 928 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 945 BaseType crypto/x509.InvalidReason
+          Type: 947 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 709
+      ID: 711
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.117184e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 711
+      ID: 713
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.598464e+06
@@ -9932,24 +9932,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 926 PointerType *crypto/x509.Certificate
+          Type: 928 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 538
+      ID: 540
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836256
       GoKind: 2
     - __kind: BaseType
-      ID: 945
+      ID: 947
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 590144
       GoKind: 2
     - __kind: StructureType
-      ID: 818
+      ID: 820
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.560352e+06
@@ -9959,13 +9959,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 717
+      ID: 719
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.11744e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 713
+      ID: 715
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.732128e+06
@@ -9973,15 +9973,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 926 PointerType *crypto/x509.Certificate
+          Type: 928 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 926 PointerType *crypto/x509.Certificate
+          Type: 928 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 731
+      ID: 733
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.435008e+06
@@ -9991,7 +9991,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 735
+      ID: 737
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.435168e+06
@@ -10001,55 +10001,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 733
+      ID: 735
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 520
+      ID: 522
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 833568
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 993
+      ID: 995
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 521
+      ID: 523
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 833760
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 597
+      ID: 599
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 804
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 591
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 597
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 593
+      ID: 595
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 593
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1138
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 599
+      ID: 601
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.419008e+06
@@ -10059,19 +10059,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1001
+      ID: 1003
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 705
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 703
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 537
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 836160
@@ -10079,22 +10079,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *encoding/xml.UnmarshalError.str
+          Type: 539 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 536 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 538 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 538
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 708
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1116
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -10111,11 +10111,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 565
+      ID: 567
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 769
+      ID: 771
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -10131,15 +10131,15 @@ Types:
       GoRuntimeType: 584896
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1126
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 773
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 775
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -10155,11 +10155,11 @@ Types:
       GoRuntimeType: 847776
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 629
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 608
+      ID: 610
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.728288e+06
@@ -10167,7 +10167,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 935 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 937 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -10175,25 +10175,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 612
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 941
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 614
+      ID: 616
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.113472e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 943
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 514
+      ID: 516
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 832992
@@ -10201,18 +10201,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 516 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 518 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 515 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 517 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 515
+      ID: 517
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 935
+      ID: 937
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.217952e+06
@@ -10220,7 +10220,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 936 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 938 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10235,7 +10235,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 937 GoSliceHeaderType []float64
+          Type: 939 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -10244,10 +10244,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 938 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 940 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 940 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 942 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 237 GoSliceHeaderType []string
@@ -10261,13 +10261,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 936
+      ID: 938
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586752
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 511
+      ID: 513
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 832896
@@ -10275,18 +10275,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 513 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 515 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 512 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 514 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 512
+      ID: 514
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 517
+      ID: 519
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 833088
@@ -10294,60 +10294,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 519 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 521 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 518 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 520 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 518
+      ID: 520
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1013
+      ID: 1015
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1102
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 727
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 884
+      ID: 886
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1134
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 654
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 659
+      ID: 661
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.116416e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 534
+      ID: 536
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 835296
       GoKind: 2
     - __kind: StructureType
-      ID: 657
+      ID: 659
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.116288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 655
+      ID: 657
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.596544e+06
@@ -10360,7 +10360,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 675
+      ID: 677
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.597344e+06
@@ -10373,7 +10373,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 679
+      ID: 681
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.731552e+06
@@ -10389,7 +10389,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 677
+      ID: 679
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.428928e+06
@@ -10399,7 +10399,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 673
+      ID: 675
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.428608e+06
@@ -10409,14 +10409,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 921
+      ID: 923
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.499552e+06
       GoKind: 21
-      HeaderType: 923 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 925 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 944
+      ID: 946
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.050176e+06
@@ -10431,15 +10431,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 962 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 964 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 962
+      ID: 964
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 687
+      ID: 689
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.597664e+06
@@ -10447,12 +10447,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 921 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 923 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 921 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 923 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 681
+      ID: 683
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.429088e+06
@@ -10462,7 +10462,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 685
+      ID: 687
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.731744e+06
@@ -10473,12 +10473,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 944 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 946 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 944 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 946 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 683
+      ID: 685
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.597504e+06
@@ -10491,7 +10491,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 689
+      ID: 691
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.429248e+06
@@ -10499,9 +10499,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 911 StructureType time.Time
+          Type: 913 StructureType time.Time
     - __kind: StructureType
-      ID: 695
+      ID: 697
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.597984e+06
@@ -10514,7 +10514,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 697
+      ID: 699
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.429568e+06
@@ -10524,7 +10524,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 693
+      ID: 695
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.597824e+06
@@ -10537,7 +10537,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 691
+      ID: 693
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.429408e+06
@@ -10547,7 +10547,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 699
+      ID: 701
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.598144e+06
@@ -10560,7 +10560,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 616
+      ID: 618
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.421248e+06
@@ -10570,11 +10570,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1055
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 618
+      ID: 620
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.421408e+06
@@ -10582,21 +10582,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 616 StructureType github.com/cihub/seelog.baseError
+          Type: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1033
+      ID: 1035
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 991
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1025
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 622
+      ID: 624
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.421728e+06
@@ -10604,13 +10604,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 616 StructureType github.com/cihub/seelog.baseError
+          Type: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1090
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1101
+      ID: 1103
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.10544e+06
@@ -10618,12 +10618,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1087 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1089 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1104
+      ID: 1106
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.130304e+06
@@ -10631,7 +10631,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1087 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1089 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10639,11 +10639,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 993
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 620
+      ID: 622
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.421568e+06
@@ -10651,9 +10651,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 616 StructureType github.com/cihub/seelog.baseError
+          Type: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 624
+      ID: 626
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.421888e+06
@@ -10661,64 +10661,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 616 StructureType github.com/cihub/seelog.baseError
+          Type: 618 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1057
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1098
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1098
+      ID: 1100
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 917
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 830
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 828
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 832
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 834
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1046
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 822
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 630
+      ID: 632
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.422848e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1148
+      ID: 1150
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 888
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 859
+      ID: 861
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.841344e+06
@@ -10734,11 +10734,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 855
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 788
+      ID: 790
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.700992e+06
@@ -10751,7 +10751,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 865
+      ID: 867
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.841792e+06
@@ -10767,13 +10767,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 765
+      ID: 767
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 990080
       GoKind: 8
     - __kind: StructureType
-      ID: 857
+      ID: 859
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.84112e+06
@@ -10789,13 +10789,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 946
+      ID: 948
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 831168
       GoKind: 8
     - __kind: StructureType
-      ID: 855
+      ID: 857
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.840896e+06
@@ -10803,15 +10803,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 946 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 948 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 946 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 948 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 863
+      ID: 865
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.754944e+06
@@ -10824,7 +10824,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 861
+      ID: 863
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.841568e+06
@@ -10840,11 +10840,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1154
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 869
+      ID: 871
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.62256e+06
@@ -10854,19 +10854,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 792
+      ID: 794
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.28256e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 790
+      ID: 792
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.282432e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 867
+      ID: 869
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.755136e+06
@@ -10879,7 +10879,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 547
+      ID: 549
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 838752
@@ -10887,22 +10887,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 549 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 551 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 548 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 550 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 548
+      ID: 550
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 932
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 836
+      ID: 838
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.446848e+06
@@ -10912,7 +10912,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1019
+      ID: 1021
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.676704e+06
@@ -10920,13 +10920,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1045 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1047 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1114
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1045
+      ID: 1047
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.127168e+06
@@ -10939,7 +10939,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1007
+      ID: 1009
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.569152e+06
@@ -10949,19 +10949,19 @@ Types:
           Offset: 0
           Type: 127 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 550
+      ID: 552
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 839328
       GoKind: 10
     - __kind: BaseType
-      ID: 928
+      ID: 930
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.003232e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 894
+      ID: 896
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.879648e+06
@@ -10972,12 +10972,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 928 BaseType golang.org/x/net/http2.ErrCode
+          Type: 930 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 751
+      ID: 753
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.605184e+06
@@ -10985,12 +10985,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 928 BaseType golang.org/x/net/http2.ErrCode
+          Type: 930 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 554
+      ID: 556
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839520
@@ -10998,18 +10998,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 556 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 558 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 555 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 557 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 555
+      ID: 557
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 560
+      ID: 562
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 839712
@@ -11017,18 +11017,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 562 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 564 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 561 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 563 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 561
+      ID: 563
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 559
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 839616
@@ -11036,18 +11036,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 561 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 558 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 560 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 560
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 551
+      ID: 553
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839424
@@ -11055,22 +11055,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 553 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 555 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 552 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 554 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 552
+      ID: 554
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1112
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 755
+      ID: 757
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.447488e+06
@@ -11080,13 +11080,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 563
+      ID: 565
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 839808
       GoKind: 2
     - __kind: StructureType
-      ID: 743
+      ID: 745
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.442528e+06
@@ -11096,11 +11096,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 894
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 917
+      ID: 919
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.907424e+06
@@ -11116,7 +11116,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 745
+      ID: 747
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.604704e+06
@@ -11129,7 +11129,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1059
+      ID: 1061
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.965472e+06
@@ -11137,16 +11137,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1086 GoInterfaceType io.Reader
+          Type: 1088 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1017
+      ID: 1019
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 836
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.566752e+06
@@ -11156,29 +11156,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 981
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 725
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 824
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 892
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 890
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.510272e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 737
+      ID: 739
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.435808e+06
@@ -11188,7 +11188,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 739
+      ID: 741
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.435968e+06
@@ -11198,7 +11198,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 669
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -11272,47 +11272,47 @@ Types:
       GroupType: 309 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 315 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1193
+      ID: 1195
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1194 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1196 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1195 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1201 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1197 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1203 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1227
+      ID: 1229
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1228 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1230 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1229 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1235 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1231 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1237 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1242
+      ID: 1244
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1243 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1245 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1244 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1250 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1246 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1252 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
       ID: 317
       Name: groupReference<int,int>
@@ -11328,19 +11328,19 @@ Types:
       GroupType: 319 StructureType noalg.map.group[int]int
       GroupSliceType: 323 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1257
+      ID: 1259
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1258 PointerType *noalg.map.group[int]interface {}
+          Type: 1260 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1259 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1263 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1261 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1265 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
       ID: 376
       Name: groupReference<int,uint8>
@@ -11384,19 +11384,19 @@ Types:
       GroupType: 343 StructureType noalg.map.group[string][]string
       GroupSliceType: 347 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 953
+      ID: 955
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 954 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 956 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 955 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 959 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 957 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 961 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 333
       Name: groupReference<string,int>
@@ -11538,11 +11538,11 @@ Types:
       GroupType: 386 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 390 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1069
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 760
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11589,11 +11589,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 919
+      ID: 921
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 637
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -11619,29 +11619,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 635
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 967
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 853
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1156
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 849
+      ID: 851
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.475392e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 571
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -11722,7 +11722,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 522
+      ID: 524
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 833952
@@ -11730,18 +11730,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 524 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 526 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 523 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 525 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 523
+      ID: 525
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 806
+      ID: 808
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.558112e+06
@@ -11749,9 +11749,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 918 PointerType *internal/abi.Type
+          Type: 920 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 1166
+      ID: 1168
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.472832e+06
@@ -11764,11 +11764,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1011
+      ID: 1013
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1051
+      ID: 1053
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.189056e+06
@@ -11781,7 +11781,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1086
+      ID: 1088
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.022528e+06
@@ -11794,7 +11794,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1038
+      ID: 1040
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -11820,21 +11820,21 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1009
+      ID: 1011
       Name: io.discard
       GoRuntimeType: 1.461952e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 985
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 849
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1059
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -11902,9 +11902,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1187 GoMapType map[int]*main.deepMap3
+          Type: 1189 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1201
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11916,9 +11916,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1221 GoMapType map[int]*main.deepMap8
+          Type: 1223 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1233
+      ID: 1235
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.184832e+06
@@ -11926,9 +11926,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1236 GoMapType map[int]*main.deepMap9
+          Type: 1238 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1248
+      ID: 1250
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.184704e+06
@@ -11936,7 +11936,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1251 GoMapType map[int]interface {}
+          Type: 1253 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 128
       Name: main.deepPtr1
@@ -11956,9 +11956,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1157 PointerType *main.deepPtr3
+          Type: 1159 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1160
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11970,9 +11970,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1202 PointerType *main.deepPtr8
+          Type: 1204 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1203
+      ID: 1205
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.185984e+06
@@ -11980,9 +11980,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1204 PointerType *main.deepPtr9
+          Type: 1206 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1205
+      ID: 1207
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.185856e+06
@@ -12010,9 +12010,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1181 GoSliceHeaderType []*main.deepSlice3
+          Type: 1183 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1186
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -12024,9 +12024,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1206 GoSliceHeaderType []*main.deepSlice8
+          Type: 1208 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1209
+      ID: 1211
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.187136e+06
@@ -12034,9 +12034,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1212 GoSliceHeaderType []*main.deepSlice9
+          Type: 1214 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1215
+      ID: 1217
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.187008e+06
@@ -12044,7 +12044,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1218 GoSliceHeaderType []interface {}
+          Type: 1220 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 290
       Name: main.emptyStruct
@@ -12062,16 +12062,16 @@ Types:
           Type: 151 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1164 StructureType sync.Mutex
+          Type: 1166 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1167 StructureType sync.Once
+          Type: 1169 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1170 StructureType sync.WaitGroup
+          Type: 1172 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1173 StructureType sync/atomic.Int32
+          Type: 1175 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 151
       Name: main.esotericStack
@@ -12101,7 +12101,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1175
+      ID: 1177
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.411488e+06
@@ -12146,7 +12146,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1177
+      ID: 1179
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.411648e+06
@@ -12166,7 +12166,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1165
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12177,18 +12177,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1160 PointerType *main.stringType1.str
+          Type: 1162 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1159 GoStringDataType main.stringType1.str
+      Data: 1161 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1159
+      ID: 1161
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1161
+      ID: 1163
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -12291,16 +12291,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1178 PointerType **main.t
+          Type: 1180 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1179 GoSliceDataType main.t.array
+      Data: 1181 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1179
+      ID: 1181
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -12501,7 +12501,7 @@ Types:
       TablePtrSliceType: 314 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 309 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1189
+      ID: 1191
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -12514,7 +12514,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1190 PointerType **table<int,*main.deepMap3>
+          Type: 1192 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12533,10 +12533,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1200 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1195 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1202 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1197 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1223
+      ID: 1225
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -12549,7 +12549,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1224 PointerType **table<int,*main.deepMap8>
+          Type: 1226 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12568,10 +12568,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1234 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1229 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1236 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1231 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1238
+      ID: 1240
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -12584,7 +12584,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1239 PointerType **table<int,*main.deepMap9>
+          Type: 1241 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12603,8 +12603,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1249 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1244 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1251 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1246 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 164
       Name: map<int,int>
@@ -12641,7 +12641,7 @@ Types:
       TablePtrSliceType: 322 GoSliceDataType []*table<int,int>.array
       GroupType: 319 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1253
+      ID: 1255
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -12654,7 +12654,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1254 PointerType **table<int,interface {}>
+          Type: 1256 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12673,8 +12673,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1262 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1259 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1264 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1261 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 201
       Name: map<int,uint8>
@@ -12781,7 +12781,7 @@ Types:
       TablePtrSliceType: 346 GoSliceDataType []*table<string,[]string>.array
       GroupType: 343 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 923
+      ID: 925
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -12794,7 +12794,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 924 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 926 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12813,8 +12813,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 958 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 955 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 960 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 957 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 174
       Name: map<string,int>
@@ -13201,26 +13201,26 @@ Types:
       GoKind: 21
       HeaderType: 142 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1187
+      ID: 1189
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.128832e+06
       GoKind: 21
-      HeaderType: 1189 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1191 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1221
+      ID: 1223
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.128192e+06
       GoKind: 21
-      HeaderType: 1223 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1225 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1236
+      ID: 1238
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.128064e+06
       GoKind: 21
-      HeaderType: 1238 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1240 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 162
       Name: map[int]int
@@ -13229,12 +13229,12 @@ Types:
       GoKind: 21
       HeaderType: 164 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1251
+      ID: 1253
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.127936e+06
       GoKind: 21
-      HeaderType: 1253 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1255 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 199
       Name: map[int]uint8
@@ -13321,7 +13321,7 @@ Types:
       GoKind: 21
       HeaderType: 206 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 671
+      ID: 673
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.428128e+06
@@ -13331,7 +13331,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 973
+      ID: 975
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.424928e+06
@@ -13341,11 +13341,11 @@ Types:
           Offset: 0
           Type: 127 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 880
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 943
+      ID: 945
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.595264e+06
@@ -13358,35 +13358,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 906
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1118
+      ID: 1120
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 882
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1130
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1140
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1128
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 839
+      ID: 841
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.113088e+06
@@ -13394,28 +13394,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 841 PointerType *net.UnknownNetworkError.str
+          Type: 843 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 840 GoStringDataType net.UnknownNetworkError.str
+      Data: 842 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 840
+      ID: 842
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 804
+      ID: 806
       Name: net.canceledError
       GoRuntimeType: 1.283584e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1096
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 948
+      ID: 950
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.104736e+06
@@ -13423,7 +13423,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -13434,27 +13434,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1142
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1134
+      ID: 1136
       Name: net.noReadFrom
       GoRuntimeType: 1.113344e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1133
+      ID: 1135
       Name: net.noWriteTo
       GoRuntimeType: 1.113216e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 603
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 603
+      ID: 605
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.728096e+06
@@ -13462,7 +13462,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 931 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 933 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -13470,7 +13470,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1122
+      ID: 1124
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.287744e+06
@@ -13478,12 +13478,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1134 StructureType net.noReadFrom
+          Type: 1136 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1127 PointerType *net.TCPConn
+          Type: 1129 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1120
+      ID: 1122
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.2872e+06
@@ -13491,24 +13491,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1133 StructureType net.noWriteTo
+          Type: 1135 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1127 PointerType *net.TCPConn
+          Type: 1129 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 884
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 908
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 796
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 967
+      ID: 969
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.416448e+06
@@ -13518,19 +13518,19 @@ Types:
           Offset: 0
           Type: 127 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 492
+      ID: 494
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 831648
       GoKind: 10
     - __kind: BaseType
-      ID: 920
+      ID: 922
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 990176
       GoKind: 10
     - __kind: StructureType
-      ID: 579
+      ID: 581
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.726368e+06
@@ -13541,12 +13541,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 920 BaseType net/http.http2ErrCode
+          Type: 922 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 898
+      ID: 900
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.897952e+06
@@ -13557,12 +13557,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 920 BaseType net/http.http2ErrCode
+          Type: 922 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 583
+      ID: 585
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.594784e+06
@@ -13570,16 +13570,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 920 BaseType net/http.http2ErrCode
+          Type: 922 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1031
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 496
+      ID: 498
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 831840
@@ -13587,18 +13587,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 498 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 500 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 497 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 499 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 497
+      ID: 499
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 502
+      ID: 504
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 832032
@@ -13606,18 +13606,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 504 PointerType *net/http.http2headerFieldNameError.str
+          Type: 506 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 503 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 505 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 503
+      ID: 505
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 499
+      ID: 501
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 831936
@@ -13625,32 +13625,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 501 PointerType *net/http.http2headerFieldValueError.str
+          Type: 503 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 500 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 502 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 500
+      ID: 502
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 875
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 800
+      ID: 802
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.282816e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1085
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 493
+      ID: 495
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 831744
@@ -13658,18 +13658,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 495 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 497 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 494 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 496 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 494
+      ID: 496
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 969
+      ID: 971
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.824032e+06
@@ -13677,18 +13677,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1060 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1062 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1061 BaseType time.Duration
+          Type: 1063 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1060
+      ID: 1062
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.415648e+06
@@ -13701,14 +13701,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1048
+      ID: 1050
       Name: net/http.incomparable
       GoRuntimeType: 902848
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 796
+      ID: 798
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.554272e+06
@@ -13718,11 +13718,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1033
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 987
+      ID: 989
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.554112e+06
@@ -13730,9 +13730,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1030 PointerType *net/http.persistConn
+          Type: 1032 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1021
+      ID: 1023
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.799008e+06
@@ -13740,15 +13740,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1048 ArrayType net/http.incomparable
+          Type: 1050 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1049 PointerType *bufio.Reader
+          Type: 1051 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1051 GoInterfaceType io.ReadWriteCloser
+          Type: 1053 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 587
+      ID: 589
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.417408e+06
@@ -13758,17 +13758,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 902
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 873
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.478272e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 798
+      ID: 800
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.554432e+06
@@ -13778,7 +13778,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1063
+      ID: 1065
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.024448e+06
@@ -13786,16 +13786,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 943 GoInterfaceType net.Conn
+          Type: 945 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 576
+      ID: 578
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1085
+      ID: 1087
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.040192e+06
@@ -13803,13 +13803,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1078 PointerType *bufio.Writer
+          Type: 1080 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 999
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 663
+      ID: 665
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.731168e+06
@@ -13825,7 +13825,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 661
+      ID: 663
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.596704e+06
@@ -13838,11 +13838,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1037
+      ID: 1039
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 999
+      ID: 1001
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.598624e+06
@@ -13850,16 +13850,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1036 PointerType *net/smtp.Client
+          Type: 1038 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1038 GoInterfaceType io.WriteCloser
+          Type: 1040 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 649
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 530
+      ID: 532
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 834720
@@ -13867,26 +13867,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 532 PointerType *net/textproto.ProtocolError.str
+          Type: 534 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 531 GoStringDataType net/textproto.ProtocolError.str
+      Data: 533 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 531
+      ID: 533
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 995
+      ID: 997
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 910
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 505
+      ID: 507
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 832608
@@ -13894,18 +13894,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 507 PointerType *net/url.EscapeError.str
+          Type: 509 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 506 GoStringDataType net/url.EscapeError.str
+      Data: 508 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 506
+      ID: 508
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 508
+      ID: 510
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 832704
@@ -13913,13 +13913,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 510 PointerType *net/url.InvalidHostError.str
+          Type: 512 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 509 GoStringDataType net/url.InvalidHostError.str
+      Data: 511 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 509
+      ID: 511
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -13969,32 +13969,32 @@ Types:
       HasCount: true
       Element: 311 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1196
+      ID: 1198
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 681984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1197 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1199 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1230
+      ID: 1232
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1231 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1233 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1245
+      ID: 1247
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1246 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1248 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
       ID: 320
       Name: noalg.[8]struct { key int; elem int }
@@ -14005,14 +14005,14 @@ Types:
       HasCount: true
       Element: 321 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1260
+      ID: 1262
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1261 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1263 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
       ID: 379
       Name: noalg.[8]struct { key int; elem uint8 }
@@ -14041,14 +14041,14 @@ Types:
       HasCount: true
       Element: 345 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 956
+      ID: 958
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 758976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 957 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 959 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 336
       Name: noalg.[8]struct { key string; elem int }
@@ -14199,7 +14199,7 @@ Types:
           Offset: 8
           Type: 310 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1195
+      ID: 1197
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.29408e+06
@@ -14210,9 +14210,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1196 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1198 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1229
+      ID: 1231
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.2928e+06
@@ -14223,9 +14223,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1230 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1232 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1244
+      ID: 1246
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.292544e+06
@@ -14236,7 +14236,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1245 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1247 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
       ID: 319
       Name: noalg.map.group[int]int
@@ -14251,7 +14251,7 @@ Types:
           Offset: 8
           Type: 320 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1259
+      ID: 1261
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.292288e+06
@@ -14262,7 +14262,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1260 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1262 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
       ID: 378
       Name: noalg.map.group[int]uint8
@@ -14303,7 +14303,7 @@ Types:
           Offset: 8
           Type: 344 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 955
+      ID: 957
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.357056e+06
@@ -14314,7 +14314,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 956 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 958 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 335
       Name: noalg.map.group[string]int
@@ -14505,7 +14505,7 @@ Types:
           Offset: 8
           Type: 312 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1197
+      ID: 1199
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.293952e+06
@@ -14516,9 +14516,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1198 PointerType *main.deepMap3
+          Type: 1200 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1231
+      ID: 1233
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.292672e+06
@@ -14529,9 +14529,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1232 PointerType *main.deepMap8
+          Type: 1234 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1246
+      ID: 1248
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.292416e+06
@@ -14542,7 +14542,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1247 PointerType *main.deepMap9
+          Type: 1249 PointerType *main.deepMap9
     - __kind: StructureType
       ID: 321
       Name: noalg.struct { key int; elem int }
@@ -14557,7 +14557,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1261
+      ID: 1263
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.29216e+06
@@ -14609,7 +14609,7 @@ Types:
           Offset: 16
           Type: 237 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 957
+      ID: 959
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.356928e+06
@@ -14620,7 +14620,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 944 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 946 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 337
       Name: noalg.struct { key string; elem int }
@@ -14746,19 +14746,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1148
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 775
+      ID: 777
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 845
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1144
+      ID: 1146
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.358112e+06
@@ -14766,12 +14766,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1150 StructureType os.noReadFrom
+          Type: 1152 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1145 PointerType *os.File
+          Type: 1147 PointerType *os.File
     - __kind: StructureType
-      ID: 1142
+      ID: 1144
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.357312e+06
@@ -14779,36 +14779,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1149 StructureType os.noWriteTo
+          Type: 1151 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1145 PointerType *os.File
+          Type: 1147 PointerType *os.File
     - __kind: StructureType
-      ID: 1150
+      ID: 1152
       Name: os.noReadFrom
       GoRuntimeType: 1.110656e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1149
+      ID: 1151
       Name: os.noWriteTo
       GoRuntimeType: 1.110528e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 810
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 953
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1015
+      ID: 1017
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 812
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.701568e+06
@@ -14821,7 +14821,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 544
+      ID: 546
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 837984
@@ -14829,36 +14829,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 546 PointerType *os/user.UnknownGroupIdError.str
+          Type: 548 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 545 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 547 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 545
+      ID: 547
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 543
+      ID: 545
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 837888
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 573
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 671
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 779
+      ID: 781
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 785
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -14870,7 +14870,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 781
+      ID: 783
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.886816e+06
@@ -14887,9 +14887,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 949 BaseType runtime.boundsErrorCode
+          Type: 951 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 949
+      ID: 951
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585088
@@ -14909,7 +14909,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 845
+      ID: 847
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.751872e+06
@@ -14922,7 +14922,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 759
+      ID: 761
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 988736
@@ -14930,13 +14930,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 761 PointerType *runtime.errorString.str
+          Type: 763 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 760 GoStringDataType runtime.errorString.str
+      Data: 762 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 760
+      ID: 762
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15599,7 +15599,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 762
+      ID: 764
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 988832
@@ -15607,13 +15607,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 764 PointerType *runtime.plainError.str
+          Type: 766 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 763 GoStringDataType runtime.plainError.str
+      Data: 765 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 763
+      ID: 765
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15654,7 +15654,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 567
+      ID: 569
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.594464e+06
@@ -15712,7 +15712,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 787
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -15735,15 +15735,15 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1083
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 987
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 981
+      ID: 983
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.454208e+06
@@ -15759,7 +15759,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1164
+      ID: 1166
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.462752e+06
@@ -15767,12 +15767,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1165 StructureType sync.noCopy
+          Type: 1167 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1166 StructureType internal/sync.Mutex
+          Type: 1168 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1167
+      ID: 1169
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.611808e+06
@@ -15780,15 +15780,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1165 StructureType sync.noCopy
+          Type: 1167 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1168 StructureType sync/atomic.Bool
+          Type: 1170 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1164 StructureType sync.Mutex
+          Type: 1166 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1170
+      ID: 1172
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.611616e+06
@@ -15796,21 +15796,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1165 StructureType sync.noCopy
+          Type: 1167 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1171 StructureType sync/atomic.Uint64
+          Type: 1173 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1165
+      ID: 1167
       Name: sync.noCopy
       GoRuntimeType: 987680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1168
+      ID: 1170
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.463872e+06
@@ -15818,12 +15818,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1169 StructureType sync/atomic.noCopy
+          Type: 1171 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1173
+      ID: 1175
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464032e+06
@@ -15831,12 +15831,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1169 StructureType sync/atomic.noCopy
+          Type: 1171 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1171
+      ID: 1173
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612192e+06
@@ -15844,27 +15844,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1169 StructureType sync/atomic.noCopy
+          Type: 1171 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1172 StructureType sync/atomic.align64
+          Type: 1174 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1172
+      ID: 1174
       Name: sync/atomic.align64
       GoRuntimeType: 987872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1169
+      ID: 1171
       Name: sync/atomic.noCopy
       GoRuntimeType: 987776
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 895
+      ID: 897
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.282176e+06
@@ -15990,7 +15990,7 @@ Types:
           Offset: 16
           Type: 307 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1192
+      ID: 1194
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -16012,9 +16012,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1193 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1195 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1226
+      ID: 1228
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -16036,9 +16036,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1227 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1229 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1241
+      ID: 1243
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -16060,7 +16060,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1242 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1244 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
       ID: 316
       Name: table<int,int>
@@ -16086,7 +16086,7 @@ Types:
           Offset: 16
           Type: 317 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1256
+      ID: 1258
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -16108,7 +16108,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1257 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1259 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
       ID: 375
       Name: table<int,uint8>
@@ -16182,7 +16182,7 @@ Types:
           Offset: 16
           Type: 341 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 952
+      ID: 954
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -16204,7 +16204,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 953 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 955 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 332
       Name: table<string,int>
@@ -16446,11 +16446,11 @@ Types:
           Offset: 16
           Type: 384 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1116
+      ID: 1118
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 838
+      ID: 840
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.705984e+06
@@ -16463,21 +16463,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 1061
+      ID: 1063
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.914272e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 915
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 576
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 911
+      ID: 913
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.371424e+06
@@ -16491,9 +16491,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 912 PointerType *time.Location
+          Type: 914 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 489
+      ID: 491
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 830784
@@ -16501,13 +16501,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 491 PointerType *time.fileSizeError.str
+          Type: 493 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 490 GoStringDataType time.fileSizeError.str
+      Data: 492 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 490
+      ID: 492
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -16554,7 +16554,7 @@ Types:
       GoRuntimeType: 585024
       GoKind: 26
     - __kind: StructureType
-      ID: 931
+      ID: 933
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.06192e+06
@@ -16565,10 +16565,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 932 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 934 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 933 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 935 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -16583,18 +16583,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 934 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 936 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 934
+      ID: 936
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 994400
       GoKind: 9
     - __kind: StructureType
-      ID: 932
+      ID: 934
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.92528e+06
@@ -16619,21 +16619,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 667
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 933
+      ID: 935
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588672
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1110
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 649
+      ID: 651
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.425248e+06
@@ -16643,13 +16643,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 533
+      ID: 535
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 834816
       GoKind: 2
     - __kind: StructureType
-      ID: 815
+      ID: 817
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.70176e+06
@@ -16662,7 +16662,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 767
+      ID: 769
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 993248

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -2343,15 +2343,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80755c..0x80756c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80756c..0x807600
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x807600..0x807670]
@@ -2368,25 +2359,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x807670..0x807780]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80768c..0x8076f8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8076f8..0x807700
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80768c..0x8076f8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8076f8..0x8076fc
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x807780..0x807790]

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,8 +11,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 150 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0x4a6006", Frameless: false}]
+          Type: 167 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0x4a6046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -25,8 +25,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 151 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0x4a6050", Frameless: false}]
+          Type: 168 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0x4a6090", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -38,8 +38,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 146 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4a6513", Frameless: false}]
+          Type: 163 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -52,11 +52,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 149 EventRootType Probe[main.inlined]
+          Type: 166 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4a63ea"
+            - PC: "0x4a642a"
               Frameless: false
-            - PC: "0x4a5dce"
+            - PC: "0x4a5e0e"
               Frameless: false
           Condition: null
     - id: intArg
@@ -69,8 +69,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 138 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4a60ca", Frameless: false}]
+          Type: 155 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0x4a610a", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -82,8 +82,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 141 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4a624a", Frameless: false}]
+          Type: 158 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 144 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4a63c0", Frameless: true}]
+          Type: 161 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0x4a6400", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -108,8 +108,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 140 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4a61ca", Frameless: false}]
+          Type: 157 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
     - id: mapArg
       version: 0
@@ -121,8 +121,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 145 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4a64aa", Frameless: false}]
+          Type: 162 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
     - id: noArgs
       version: 0
@@ -134,8 +134,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 147 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0x4a65ca", Frameless: false}]
+          Type: 164 EventRootType Probe[main.noArgs]
+          InjectionPoints: [{PC: "0x4a660a", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -147,8 +147,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 139 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a614a", Frameless: false}]
+          Type: 156 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -160,8 +160,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 143 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4a634a", Frameless: false}]
+          Type: 160 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -173,8 +173,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 142 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a62ca", Frameless: false}]
+          Type: 159 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -187,31 +187,31 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 148 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0x4a6636", Frameless: false}]
+          Type: 165 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4a6676", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a60c0..0x4a6122]
+      OutOfLinePCRanges: [0x4a6100..0x4a6162]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a60c0..0x4a60d9
+            - Range: 0x4a6100..0x4a6119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4a6140..0x4a61b1]
+      OutOfLinePCRanges: [0x4a6180..0x4a61f1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a6140..0x4a615e
+            - Range: 0x4a6180..0x4a619e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -221,13 +221,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a61c0..0x4a623a]
+      OutOfLinePCRanges: [0x4a6200..0x4a627a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 99 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a61c0..0x4a61de
+            - Range: 0x4a6200..0x4a621e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -239,25 +239,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a6240..0x4a62a7]
+      OutOfLinePCRanges: [0x4a6280..0x4a62e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 100 ArrayType [3]int
           Locations:
-            - Range: 0x4a6240..0x4a62a7
+            - Range: 0x4a6280..0x4a62e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a62c0..0x4a633a]
+      OutOfLinePCRanges: [0x4a6300..0x4a637a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 101 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4a62c0..0x4a62de
+            - Range: 0x4a6300..0x4a631e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -269,77 +269,82 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a6340..0x4a63a7]
+      OutOfLinePCRanges: [0x4a6380..0x4a63e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 102 ArrayType [3]string
           Locations:
-            - Range: 0x4a6340..0x4a63a7
+            - Range: 0x4a6380..0x4a63e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4a63c0..0x4a63c1]
+      OutOfLinePCRanges: [0x4a6400..0x4a6401]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 102 ArrayType [3]string
           Locations:
-            - Range: 0x4a63c0..0x4a63c1
+            - Range: 0x4a6400..0x4a6401
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4a64a0..0x4a64f6]
+      OutOfLinePCRanges: [0x4a64e0..0x4a6536]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 103 GoMapType map[string]int
           Locations:
-            - Range: 0x4a64a0..0x4a64cd
+            - Range: 0x4a64e0..0x4a650d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a6500..0x4a65bb]
+      OutOfLinePCRanges: [0x4a6540..0x4a65fb]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 110 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4a6500..0x4a6533
+            - Range: 0x4a6540..0x4a6573
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a6533..0x4a65bb
+            - Range: 0x4a6573..0x4a65fb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4a65c0..0x4a6613]
+      OutOfLinePCRanges: [0x4a6600..0x4a6653]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4a6620..0x4a6776]
+      OutOfLinePCRanges: [0x4a6660..0x4a6845]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: ~r0
+          Type: 115 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0x4a6660..0x4a6845, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 12
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a63e0..0x4a6442]
+      OutOfLinePCRanges: [0x4a6420..0x4a6482]
       InlinePCRanges:
-        - Ranges: [0x4a5dce..0x4a5e1f]
-          RootRanges: [0x4a5c40..0x4a60aa]
+        - Ranges: [0x4a5e0e..0x4a5e5f]
+          RootRanges: [0x4a5c80..0x4a60ea]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a5dce..0x4a5e1f
+            - Range: 0x4a5e0e..0x4a5e5f
               Pieces: []
-            - Range: 0x4a63e0..0x4a63f9
+            - Range: 0x4a6420..0x4a6439
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -347,13 +352,13 @@ Subprograms:
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4a6006..0x4a6045]
-          RootRanges: [0x4a5c40..0x4a60aa]
+        - Ranges: [0x4a6046..0x4a6085]
+          RootRanges: [0x4a5c80..0x4a60ea]
       Variables:
         - Name: ptr
-          Type: 115 PointerType *****int
+          Type: 120 PointerType *****int
           Locations:
-            - Range: 0x4a5fdf..0x4a602b
+            - Range: 0x4a601f..0x4a606b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -361,79 +366,84 @@ Subprograms:
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4a6050..0x4a608a]
-          RootRanges: [0x4a5c40..0x4a60aa]
+        - Ranges: [0x4a6090..0x4a60ca]
+          RootRanges: [0x4a5c80..0x4a60ea]
       Variables:
         - Name: ptr
-          Type: 117 PointerType **int
+          Type: 122 PointerType **int
           Locations:
-            - Range: 0x4a6050..0x4a608a
+            - Range: 0x4a6090..0x4a60ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 115
+      ID: 120
       Name: '*****int'
+      ByteSize: 8
+      GoRuntimeType: 32992
+      GoKind: 22
+      Pointee: 121 PointerType ****int
+    - __kind: PointerType
+      ID: 121
+      Name: '****int'
       ByteSize: 8
       GoRuntimeType: 32928
       GoKind: 22
-      Pointee: 116 PointerType ****int
+      Pointee: 154 PointerType ***int
     - __kind: PointerType
-      ID: 116
-      Name: '****int'
+      ID: 154
+      Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32864
       GoKind: 22
-      Pointee: 137 PointerType ***int
+      Pointee: 122 PointerType **int
     - __kind: PointerType
-      ID: 137
-      Name: '***int'
+      ID: 122
+      Name: '**int'
       ByteSize: 8
       GoRuntimeType: 32800
       GoKind: 22
-      Pointee: 117 PointerType **int
-    - __kind: PointerType
-      ID: 117
-      Name: '**int'
-      ByteSize: 8
-      GoRuntimeType: 32736
-      GoKind: 22
       Pointee: 93 PointerType *int
     - __kind: PointerType
-      ID: 125
+      ID: 130
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 124 GoSliceDataType []int.array
+      Pointee: 129 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 36384
+      GoRuntimeType: 36448
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 127
+      ID: 132
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 126 GoSliceDataType []string.array
+      Pointee: 131 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 121
+      ID: 126
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []uint8.array
+      Pointee: 125 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 123
+      ID: 128
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 122 GoSliceDataType []uintptr.array
+      Pointee: 127 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 27360
+      GoRuntimeType: 27424
       GoKind: 22
       Pointee: 4 BaseType bool
+    - __kind: PointerType
+      ID: 146
+      Name: '*bucket<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 147 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 106
       Name: '*bucket<string,int>'
@@ -445,26 +455,36 @@ Types:
       ByteSize: 8
       Pointee: 114 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
+      ID: 118
+      Name: '*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 119 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
       ID: 95
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 26272
+      GoRuntimeType: 26336
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 96
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 27232
+      GoRuntimeType: 27296
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 91
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 27296
+      GoRuntimeType: 27360
       GoKind: 22
       Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 144
+      Name: '*hash<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 145 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 104
       Name: '*hash<string,int>'
@@ -476,159 +496,164 @@ Types:
       ByteSize: 8
       Pointee: 112 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
+      ID: 116
+      Name: '*hash<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 117 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
       ID: 93
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 26912
+      GoRuntimeType: 26976
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 26656
+      GoRuntimeType: 26720
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 92
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 26784
+      GoRuntimeType: 26848
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 133
+      ID: 138
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 24672
+      GoRuntimeType: 24736
       GoKind: 22
-      Pointee: 134 StructureType main.bigStruct
+      Pointee: 139 StructureType main.bigStruct
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 27552
+      GoRuntimeType: 27616
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 71072
+      GoRuntimeType: 71392
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 28192
+      GoRuntimeType: 28256
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 28256
+      GoRuntimeType: 28320
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 54112
+      GoRuntimeType: 54336
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 61664
+      GoRuntimeType: 61984
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 108
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 30176
+      GoRuntimeType: 30240
       GoKind: 22
       Pointee: 109 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 28960
+      GoRuntimeType: 29024
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 113824
+      GoRuntimeType: 114336
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 87392
+      GoRuntimeType: 87712
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 26336
+      GoRuntimeType: 26400
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 119
+      ID: 124
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 118 GoStringDataType string.str
+      Pointee: 123 GoStringDataType string.str
     - __kind: PointerType
       ID: 97
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 26976
+      GoRuntimeType: 27040
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 98
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 26592
+      GoRuntimeType: 26656
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 26720
+      GoRuntimeType: 26784
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 94
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 26848
+      GoRuntimeType: 26912
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26464
+      GoRuntimeType: 26528
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 27040
+      GoRuntimeType: 27104
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 150
+      ID: 167
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -636,14 +661,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 115 PointerType *****int
+            Type: 120 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 151
+      ID: 168
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -651,14 +676,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 117 PointerType **int
+            Type: 122 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 146
+      ID: 163
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -673,7 +698,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 149
+      ID: 166
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -688,7 +713,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 138
+      ID: 155
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -703,7 +728,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 141
+      ID: 158
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -718,7 +743,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 140
+      ID: 157
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -733,7 +758,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 145
+      ID: 162
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -748,10 +773,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 147
+      ID: 164
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 139
+      ID: 156
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -766,7 +791,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 144
+      ID: 161
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -781,7 +806,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 143
+      ID: 160
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -796,7 +821,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 142
+      ID: 159
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -811,22 +836,22 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 148
+      ID: 165
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 48256
+      GoRuntimeType: 48480
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 86 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 136
+      ID: 153
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 42592
+      GoRuntimeType: 42720
       GoKind: 17
       Count: 128
       HasCount: true
@@ -835,7 +860,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 47968
+      GoRuntimeType: 48192
       GoKind: 17
       Count: 2
       HasCount: true
@@ -844,7 +869,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 48160
+      GoRuntimeType: 48384
       GoKind: 17
       Count: 2
       HasCount: true
@@ -853,7 +878,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 44224
+      GoRuntimeType: 44448
       GoKind: 17
       Count: 2
       HasCount: true
@@ -862,7 +887,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 50176
+      GoRuntimeType: 50400
       GoKind: 17
       Count: 32
       HasCount: true
@@ -871,7 +896,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 47776
+      GoRuntimeType: 48000
       GoKind: 17
       Count: 32
       HasCount: true
@@ -880,7 +905,7 @@ Types:
       ID: 100
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 42016
+      GoRuntimeType: 42144
       GoKind: 17
       Count: 3
       HasCount: true
@@ -889,7 +914,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 47488
+      GoRuntimeType: 47712
       GoKind: 17
       Count: 3
       HasCount: true
@@ -898,7 +923,7 @@ Types:
       ID: 102
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 42112
+      GoRuntimeType: 42240
       GoKind: 17
       Count: 3
       HasCount: true
@@ -907,7 +932,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 49216
+      GoRuntimeType: 49440
       GoKind: 17
       Count: 4
       HasCount: true
@@ -916,7 +941,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 46720
+      GoRuntimeType: 46944
       GoKind: 17
       Count: 6
       HasCount: true
@@ -925,37 +950,49 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 48064
+      GoRuntimeType: 48288
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 128
+      ID: 133
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 42208
+      GoRuntimeType: 42336
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 131
+      ID: 152
+      Name: '[]bucket<int,main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 144
+      Element: 147 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 136
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 107 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 135
+      ID: 140
       Name: '[]bucket<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 114 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 148
+      Name: '[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 88
+      Element: 119 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 99
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 34528
+      GoRuntimeType: 34592
       GoKind: 23
       RawFields:
         - Name: array
@@ -967,20 +1004,34 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 124 GoSliceDataType []int.array
+      Data: 129 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 124
+      ID: 129
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 129
+      ID: 149
+      Name: '[]key<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 9 BaseType int
+    - __kind: ArrayType
+      ID: 134
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 10 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 141
+      Name: '[]key<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -989,7 +1040,7 @@ Types:
       ID: 101
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 34848
+      GoRuntimeType: 34912
       GoKind: 23
       RawFields:
         - Name: array
@@ -1001,9 +1052,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 126 GoSliceDataType []string.array
+      Data: 131 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 126
+      ID: 131
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -1012,7 +1063,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 34208
+      GoRuntimeType: 34272
       GoKind: 23
       RawFields:
         - Name: array
@@ -1024,9 +1075,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 120 GoSliceDataType []uint8.array
+      Data: 125 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 125
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -1035,7 +1086,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 34656
+      GoRuntimeType: 34720
       GoKind: 23
       RawFields:
         - Name: array
@@ -1047,33 +1098,66 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 122 GoSliceDataType []uintptr.array
+      Data: 127 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 122
+      ID: 127
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 130
+      ID: 135
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 132
+      ID: 150
+      Name: '[]val<main.aStructNotUsedAsAnArgument>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 151 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: ArrayType
+      ID: 137
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 133 PointerType *main.bigStruct
+      Element: 138 PointerType *main.bigStruct
+    - __kind: ArrayType
+      ID: 142
+      Name: '[]val<map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 143 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 39072
+      GoRuntimeType: 39200
       GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 147
+      Name: bucket<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 133 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 149 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 150 ArrayType []val<main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 136
+          Type: 146 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+      KeyType: 9 BaseType int
+      ValueType: 151 StructureType main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 107
       Name: bucket<string,int>
@@ -1081,13 +1165,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 128 ArrayType [8]uint8
+          Type: 133 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 129 ArrayType []key<string>
+          Type: 134 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 130 ArrayType []val<int>
+          Type: 135 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 106 PointerType *bucket<string,int>
@@ -1100,35 +1184,54 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 128 ArrayType [8]uint8
+          Type: 133 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 129 ArrayType []key<string>
+          Type: 134 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 132 ArrayType []val<main.bigStruct>
+          Type: 137 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 113 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 133 PointerType *main.bigStruct
+      ValueType: 138 PointerType *main.bigStruct
+    - __kind: GoHMapBucketType
+      ID: 119
+      Name: bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 88
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 133 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 141 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 142 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 80
+          Type: 118 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      KeyType: 3 BaseType uint8
+      ValueType: 143 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 90
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 38880
+      GoRuntimeType: 39008
       GoKind: 16
     - __kind: BaseType
       ID: 89
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 38816
+      GoRuntimeType: 38944
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 60000
+      GoRuntimeType: 60320
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1141,26 +1244,60 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 38944
+      GoRuntimeType: 39072
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 39008
+      GoRuntimeType: 39136
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 33248
+      GoRuntimeType: 33312
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 52288
+      GoRuntimeType: 52512
       GoKind: 19
+    - __kind: GoHMapHeaderType
+      ID: 145
+      Name: hash<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 146 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 146 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 108 PointerType *runtime.mapextra
+      BucketType: 147 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      BucketsType: 152 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 105
       Name: hash<string,int>
@@ -1194,7 +1331,7 @@ Types:
           Offset: 40
           Type: 108 PointerType *runtime.mapextra
       BucketType: 107 GoHMapBucketType bucket<string,int>
-      BucketsType: 131 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 136 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 112
       Name: hash<string,main.bigStruct>
@@ -1228,36 +1365,70 @@ Types:
           Offset: 40
           Type: 108 PointerType *runtime.mapextra
       BucketType: 114 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 135 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 140 GoSliceDataType []bucket<string,main.bigStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 117
+      Name: hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 118 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 118 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 108 PointerType *runtime.mapextra
+      BucketType: 119 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 148 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 38624
+      GoRuntimeType: 38752
       GoKind: 2
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 38368
+      GoRuntimeType: 38496
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 38496
+      GoRuntimeType: 38624
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 38112
+      GoRuntimeType: 38240
       GoKind: 3
     - __kind: StructureType
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 105024
+      GoRuntimeType: 105536
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1279,7 +1450,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 68800
+      GoRuntimeType: 69120
       GoKind: 25
       RawFields:
         - Name: u
@@ -1289,7 +1460,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 91040
+      GoRuntimeType: 91360
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1305,7 +1476,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 81120
+      GoRuntimeType: 81440
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1318,7 +1489,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 80960
+      GoRuntimeType: 81280
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1331,7 +1502,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 81280
+      GoRuntimeType: 81600
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1343,20 +1514,27 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 58432
+      GoRuntimeType: 58752
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 58336
+      GoRuntimeType: 58656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 134
+      ID: 151
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 64640
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
+    - __kind: StructureType
+      ID: 139
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 112032
+      GoRuntimeType: 112544
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1382,21 +1560,35 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 136 ArrayType [128]uint8
+          Type: 153 ArrayType [128]uint8
+    - __kind: GoMapType
+      ID: 143
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 55680
+      GoKind: 21
+      HeaderType: 145 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 103
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 55552
+      GoRuntimeType: 55776
       GoKind: 21
       HeaderType: 105 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 110
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 55648
+      GoRuntimeType: 55872
       GoKind: 21
       HeaderType: 112 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 115
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 56064
+      GoKind: 21
+      HeaderType: 117 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1416,14 +1608,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 57760
+      GoRuntimeType: 58080
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 132032
+      GoRuntimeType: 132544
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1598,7 +1790,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 67136
+      GoRuntimeType: 67456
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1608,7 +1800,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 110016
+      GoRuntimeType: 110528
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1636,7 +1828,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 78880
+      GoRuntimeType: 79200
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1649,7 +1841,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 98336
+      GoRuntimeType: 98848
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1668,13 +1860,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 50944
+      GoRuntimeType: 51168
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 78720
+      GoRuntimeType: 79040
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1687,7 +1879,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 108704
+      GoRuntimeType: 109216
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1712,13 +1904,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 50848
+      GoRuntimeType: 51072
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 135200
+      GoRuntimeType: 135712
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1938,7 +2130,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 108448
+      GoRuntimeType: 108960
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1963,7 +2155,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 87776
+      GoRuntimeType: 88096
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -1979,7 +2171,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 87584
+      GoRuntimeType: 87904
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -1999,20 +2191,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 50560
+      GoRuntimeType: 50784
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 66752
+      GoRuntimeType: 67072
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 78560
+      GoRuntimeType: 78880
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2025,7 +2217,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 99104
+      GoRuntimeType: 99616
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2044,13 +2236,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 50752
+      GoRuntimeType: 50976
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 53728
+      GoRuntimeType: 53952
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2059,7 +2251,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 76960
+      GoRuntimeType: 77280
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2076,7 +2268,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 39328
+      GoRuntimeType: 39456
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2086,7 +2278,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 39392
+      GoRuntimeType: 39520
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -2096,7 +2288,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 77920
+      GoRuntimeType: 78240
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2109,30 +2301,30 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 63968
+      GoRuntimeType: 64288
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 57664
+      GoRuntimeType: 57984
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 38048
+      GoRuntimeType: 38176
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 119 PointerType *string.str
+          Type: 124 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 118 GoStringDataType string.str
+      Data: 123 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 118
+      ID: 123
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -2140,45 +2332,45 @@ Types:
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 38688
+      GoRuntimeType: 38816
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 38304
+      GoRuntimeType: 38432
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 38432
+      GoRuntimeType: 38560
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 38560
+      GoRuntimeType: 38688
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 38176
+      GoRuntimeType: 38304
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 38752
+      GoRuntimeType: 38880
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 39136
+      GoRuntimeType: 39264
       GoKind: 26
-MaxTypeID: 151
+MaxTypeID: 168
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x573240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,10 +8,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 149 EventRootType Probe[main.PointerChainArg]
+        - ID: 13
+          Type: 150 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6006", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -22,10 +22,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 14}
       events:
-        - ID: 13
-          Type: 150 EventRootType Probe[main.PointerSmallChainArg]
+        - ID: 14
+          Type: 151 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6050", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -49,10 +49,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 148 EventRootType Probe[main.inlined]
+        - ID: 12
+          Type: 149 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a63ea"
               Frameless: false
@@ -175,6 +175,20 @@ Probes:
         - ID: 5
           Type: 142 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a62ca", Frameless: false}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 11
+          Type: 148 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4a6636", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -309,11 +323,16 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
     - ID: 11
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0x4a6620..0x4a6776]
+      InlinePCRanges: []
+      Variables: []
+    - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0x4a63e0..0x4a6442]
       InlinePCRanges:
         - Ranges: [0x4a5dce..0x4a5e1f]
-          RootRanges: [0x4a5c40..0x4a60a5]
+          RootRanges: [0x4a5c40..0x4a60aa]
       Variables:
         - Name: x
           Type: 9 BaseType int
@@ -324,12 +343,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a6006..0x4a6045]
-          RootRanges: [0x4a5c40..0x4a60a5]
+          RootRanges: [0x4a5c40..0x4a60aa]
       Variables:
         - Name: ptr
           Type: 115 PointerType *****int
@@ -338,12 +357,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a6050..0x4a608a]
-          RootRanges: [0x4a5c40..0x4a60a5]
+          RootRanges: [0x4a5c40..0x4a60aa]
       Variables:
         - Name: ptr
           Type: 117 PointerType **int
@@ -357,28 +376,28 @@ Types:
       ID: 115
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 32512
+      GoRuntimeType: 32928
       GoKind: 22
       Pointee: 116 PointerType ****int
     - __kind: PointerType
       ID: 116
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 32448
+      GoRuntimeType: 32864
       GoKind: 22
       Pointee: 137 PointerType ***int
     - __kind: PointerType
       ID: 137
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 32384
+      GoRuntimeType: 32800
       GoKind: 22
       Pointee: 117 PointerType **int
     - __kind: PointerType
       ID: 117
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 32320
+      GoRuntimeType: 32736
       GoKind: 22
       Pointee: 93 PointerType *int
     - __kind: PointerType
@@ -390,7 +409,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 35840
+      GoRuntimeType: 36384
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -412,7 +431,7 @@ Types:
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 26944
+      GoRuntimeType: 27360
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -429,21 +448,21 @@ Types:
       ID: 95
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 25856
+      GoRuntimeType: 26272
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 96
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 26816
+      GoRuntimeType: 27232
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 91
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 26880
+      GoRuntimeType: 27296
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
@@ -460,105 +479,105 @@ Types:
       ID: 93
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 26496
+      GoRuntimeType: 26912
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 26240
+      GoRuntimeType: 26656
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 92
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 26368
+      GoRuntimeType: 26784
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 133
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 24256
+      GoRuntimeType: 24672
       GoKind: 22
       Pointee: 134 StructureType main.bigStruct
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 27136
+      GoRuntimeType: 27552
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 69952
+      GoRuntimeType: 71072
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 27776
+      GoRuntimeType: 28192
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 27840
+      GoRuntimeType: 28256
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 53312
+      GoRuntimeType: 54112
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 60672
+      GoRuntimeType: 61664
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 108
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 29760
+      GoRuntimeType: 30176
       GoKind: 22
       Pointee: 109 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 28544
+      GoRuntimeType: 28960
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 112320
+      GoRuntimeType: 113824
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 86272
+      GoRuntimeType: 87392
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 25920
+      GoRuntimeType: 26336
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -570,46 +589,46 @@ Types:
       ID: 97
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 26560
+      GoRuntimeType: 26976
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 98
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 26176
+      GoRuntimeType: 26592
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 26304
+      GoRuntimeType: 26720
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 94
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 26432
+      GoRuntimeType: 26848
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26048
+      GoRuntimeType: 26464
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 26624
+      GoRuntimeType: 27040
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 149
+      ID: 150
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -620,11 +639,11 @@ Types:
             Type: 115 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 150
+      ID: 151
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -635,7 +654,7 @@ Types:
             Type: 117 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: ptr}
+                  Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -654,7 +673,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 148
+      ID: 149
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -665,7 +684,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -791,11 +810,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 148
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 47456
+      GoRuntimeType: 48256
       GoKind: 17
       Count: 10
       HasCount: true
@@ -804,7 +826,7 @@ Types:
       ID: 136
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 41888
+      GoRuntimeType: 42592
       GoKind: 17
       Count: 128
       HasCount: true
@@ -813,7 +835,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 47168
+      GoRuntimeType: 47968
       GoKind: 17
       Count: 2
       HasCount: true
@@ -822,7 +844,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 47360
+      GoRuntimeType: 48160
       GoKind: 17
       Count: 2
       HasCount: true
@@ -831,7 +853,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 43424
+      GoRuntimeType: 44224
       GoKind: 17
       Count: 2
       HasCount: true
@@ -840,7 +862,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 49376
+      GoRuntimeType: 50176
       GoKind: 17
       Count: 32
       HasCount: true
@@ -849,7 +871,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 46976
+      GoRuntimeType: 47776
       GoKind: 17
       Count: 32
       HasCount: true
@@ -858,7 +880,7 @@ Types:
       ID: 100
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 41408
+      GoRuntimeType: 42016
       GoKind: 17
       Count: 3
       HasCount: true
@@ -867,7 +889,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 46688
+      GoRuntimeType: 47488
       GoKind: 17
       Count: 3
       HasCount: true
@@ -876,7 +898,7 @@ Types:
       ID: 102
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 41504
+      GoRuntimeType: 42112
       GoKind: 17
       Count: 3
       HasCount: true
@@ -885,7 +907,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 48416
+      GoRuntimeType: 49216
       GoKind: 17
       Count: 4
       HasCount: true
@@ -894,7 +916,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 45920
+      GoRuntimeType: 46720
       GoKind: 17
       Count: 6
       HasCount: true
@@ -903,7 +925,7 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 47264
+      GoRuntimeType: 48064
       GoKind: 17
       Count: 8
       HasCount: true
@@ -912,7 +934,7 @@ Types:
       ID: 128
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 41600
+      GoRuntimeType: 42208
       GoKind: 17
       Count: 8
       HasCount: true
@@ -933,7 +955,7 @@ Types:
       ID: 99
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 33984
+      GoRuntimeType: 34528
       GoKind: 23
       RawFields:
         - Name: array
@@ -967,7 +989,7 @@ Types:
       ID: 101
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 34304
+      GoRuntimeType: 34848
       GoKind: 23
       RawFields:
         - Name: array
@@ -990,7 +1012,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 33664
+      GoRuntimeType: 34208
       GoKind: 23
       RawFields:
         - Name: array
@@ -1013,7 +1035,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 34112
+      GoRuntimeType: 34656
       GoKind: 23
       RawFields:
         - Name: array
@@ -1050,7 +1072,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 38464
+      GoRuntimeType: 39072
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 107
@@ -1094,19 +1116,19 @@ Types:
       ID: 90
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 38272
+      GoRuntimeType: 38880
       GoKind: 16
     - __kind: BaseType
       ID: 89
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 38208
+      GoRuntimeType: 38816
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 59008
+      GoRuntimeType: 60000
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1119,25 +1141,25 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 38336
+      GoRuntimeType: 38944
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 38400
+      GoRuntimeType: 39008
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 32704
+      GoRuntimeType: 33248
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 51488
+      GoRuntimeType: 52288
       GoKind: 19
     - __kind: GoHMapHeaderType
       ID: 105
@@ -1211,31 +1233,31 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 38016
+      GoRuntimeType: 38624
       GoKind: 2
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 37760
+      GoRuntimeType: 38368
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 37888
+      GoRuntimeType: 38496
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 37504
+      GoRuntimeType: 38112
       GoKind: 3
     - __kind: StructureType
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 103520
+      GoRuntimeType: 105024
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1257,7 +1279,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 67680
+      GoRuntimeType: 68800
       GoKind: 25
       RawFields:
         - Name: u
@@ -1267,7 +1289,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 89920
+      GoRuntimeType: 91040
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1283,7 +1305,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 80000
+      GoRuntimeType: 81120
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1296,7 +1318,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 79840
+      GoRuntimeType: 80960
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1309,7 +1331,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 80160
+      GoRuntimeType: 81280
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1321,20 +1343,20 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 57440
+      GoRuntimeType: 58432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 57344
+      GoRuntimeType: 58336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 134
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 110528
+      GoRuntimeType: 112032
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1365,14 +1387,14 @@ Types:
       ID: 103
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 54656
+      GoRuntimeType: 55552
       GoKind: 21
       HeaderType: 105 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 110
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 54752
+      GoRuntimeType: 55648
       GoKind: 21
       HeaderType: 112 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: UnresolvedPointeeType
@@ -1394,14 +1416,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 56768
+      GoRuntimeType: 57760
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 130528
+      GoRuntimeType: 132032
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1576,7 +1598,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 66016
+      GoRuntimeType: 67136
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1586,7 +1608,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 108512
+      GoRuntimeType: 110016
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1614,7 +1636,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 77760
+      GoRuntimeType: 78880
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1627,7 +1649,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 96832
+      GoRuntimeType: 98336
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1646,13 +1668,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 50144
+      GoRuntimeType: 50944
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 77600
+      GoRuntimeType: 78720
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1665,7 +1687,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 107200
+      GoRuntimeType: 108704
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1690,13 +1712,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 50048
+      GoRuntimeType: 50848
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 133696
+      GoRuntimeType: 135200
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1916,7 +1938,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 106944
+      GoRuntimeType: 108448
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1941,7 +1963,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 86656
+      GoRuntimeType: 87776
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -1957,7 +1979,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 86464
+      GoRuntimeType: 87584
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -1977,20 +1999,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 49760
+      GoRuntimeType: 50560
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 65632
+      GoRuntimeType: 66752
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 77440
+      GoRuntimeType: 78560
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2003,7 +2025,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 97600
+      GoRuntimeType: 99104
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2022,13 +2044,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 49952
+      GoRuntimeType: 50752
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 52928
+      GoRuntimeType: 53728
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2037,7 +2059,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 75840
+      GoRuntimeType: 76960
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2054,7 +2076,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 38720
+      GoRuntimeType: 39328
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2064,7 +2086,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 38784
+      GoRuntimeType: 39392
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -2074,7 +2096,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 76800
+      GoRuntimeType: 77920
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2087,19 +2109,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 62976
+      GoRuntimeType: 63968
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 56672
+      GoRuntimeType: 57664
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 37440
+      GoRuntimeType: 38048
       GoKind: 24
       RawFields:
         - Name: str
@@ -2118,47 +2140,47 @@ Types:
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 38080
+      GoRuntimeType: 38688
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 37696
+      GoRuntimeType: 38304
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 37824
+      GoRuntimeType: 38432
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 37952
+      GoRuntimeType: 38560
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 37568
+      GoRuntimeType: 38176
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 38144
+      GoRuntimeType: 38752
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 38528
+      GoRuntimeType: 39136
       GoKind: 26
-MaxTypeID: 150
+MaxTypeID: 151
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x572240", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x573240", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,10 +8,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 162 EventRootType Probe[main.PointerChainArg]
+        - ID: 13
+          Type: 163 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8006", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -22,10 +22,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 14}
       events:
-        - ID: 13
-          Type: 163 EventRootType Probe[main.PointerSmallChainArg]
+        - ID: 14
+          Type: 164 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8050", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -49,10 +49,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 161 EventRootType Probe[main.inlined]
+        - ID: 12
+          Type: 162 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a83ea"
               Frameless: false
@@ -175,6 +175,20 @@ Probes:
         - ID: 5
           Type: 155 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a82ca", Frameless: false}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 11
+          Type: 161 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4a8636", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -309,11 +323,16 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
     - ID: 11
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0x4a8620..0x4a878a]
+      InlinePCRanges: []
+      Variables: []
+    - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0x4a83e0..0x4a8442]
       InlinePCRanges:
         - Ranges: [0x4a7dce..0x4a7e1f]
-          RootRanges: [0x4a7c40..0x4a80a5]
+          RootRanges: [0x4a7c40..0x4a80aa]
       Variables:
         - Name: x
           Type: 7 BaseType int
@@ -324,12 +343,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a8006..0x4a8045]
-          RootRanges: [0x4a7c40..0x4a80a5]
+          RootRanges: [0x4a7c40..0x4a80aa]
       Variables:
         - Name: ptr
           Type: 118 PointerType *****int
@@ -338,12 +357,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a8050..0x4a808a]
-          RootRanges: [0x4a7c40..0x4a80a5]
+          RootRanges: [0x4a7c40..0x4a80aa]
       Variables:
         - Name: ptr
           Type: 120 PointerType **int
@@ -357,28 +376,28 @@ Types:
       ID: 118
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 35264
+      GoRuntimeType: 35520
       GoKind: 22
       Pointee: 119 PointerType ****int
     - __kind: PointerType
       ID: 119
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 35200
+      GoRuntimeType: 35456
       GoKind: 22
       Pointee: 150 PointerType ***int
     - __kind: PointerType
       ID: 150
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 35136
+      GoRuntimeType: 35392
       GoKind: 22
       Pointee: 120 PointerType **int
     - __kind: PointerType
       ID: 120
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 35072
+      GoRuntimeType: 35328
       GoKind: 22
       Pointee: 98 PointerType *int
     - __kind: PointerType
@@ -400,7 +419,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 39488
+      GoRuntimeType: 39872
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -422,56 +441,56 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 29568
+      GoRuntimeType: 29824
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 100
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 28480
+      GoRuntimeType: 28736
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 101
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 29440
+      GoRuntimeType: 29696
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 96
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 29504
+      GoRuntimeType: 29760
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 98
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29120
+      GoRuntimeType: 29376
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 28864
+      GoRuntimeType: 29120
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 97
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 28992
+      GoRuntimeType: 29248
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 145
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 26944
+      GoRuntimeType: 27200
       GoKind: 22
       Pointee: 146 StructureType main.bigStruct
     - __kind: PointerType
@@ -498,77 +517,77 @@ Types:
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 29760
+      GoRuntimeType: 30016
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 79104
+      GoRuntimeType: 81024
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 30400
+      GoRuntimeType: 30656
       GoKind: 22
       Pointee: 63 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 30464
+      GoRuntimeType: 30720
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 58240
+      GoRuntimeType: 59264
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 64960
+      GoRuntimeType: 65984
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 31168
+      GoRuntimeType: 31424
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 91072
+      GoRuntimeType: 92992
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 122112
+      GoRuntimeType: 124032
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 96256
+      GoRuntimeType: 98176
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 93
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28544
+      GoRuntimeType: 28800
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -590,46 +609,46 @@ Types:
       ID: 102
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 29184
+      GoRuntimeType: 29440
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 103
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 28800
+      GoRuntimeType: 29056
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 28928
+      GoRuntimeType: 29184
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 99
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29056
+      GoRuntimeType: 29312
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 28672
+      GoRuntimeType: 28928
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 29248
+      GoRuntimeType: 29504
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 162
+      ID: 163
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -640,11 +659,11 @@ Types:
             Type: 118 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 163
+      ID: 164
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -655,7 +674,7 @@ Types:
             Type: 120 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: ptr}
+                  Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -674,7 +693,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 161
+      ID: 162
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -685,7 +704,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -811,10 +830,13 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 161
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 52096
+      GoRuntimeType: 53056
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -822,7 +844,7 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 52000
+      GoRuntimeType: 52960
       GoKind: 17
       Count: 10
       HasCount: true
@@ -831,7 +853,7 @@ Types:
       ID: 149
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 46240
+      GoRuntimeType: 47104
       GoKind: 17
       Count: 128
       HasCount: true
@@ -840,7 +862,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 51616
+      GoRuntimeType: 52576
       GoKind: 17
       Count: 2
       HasCount: true
@@ -849,7 +871,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 51712
+      GoRuntimeType: 52672
       GoKind: 17
       Count: 2
       HasCount: true
@@ -858,7 +880,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 51904
+      GoRuntimeType: 52864
       GoKind: 17
       Count: 2
       HasCount: true
@@ -867,7 +889,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 47776
+      GoRuntimeType: 48736
       GoKind: 17
       Count: 2
       HasCount: true
@@ -876,7 +898,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 54112
+      GoRuntimeType: 55072
       GoKind: 17
       Count: 32
       HasCount: true
@@ -885,7 +907,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 51424
+      GoRuntimeType: 52384
       GoKind: 17
       Count: 32
       HasCount: true
@@ -894,7 +916,7 @@ Types:
       ID: 105
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 45952
+      GoRuntimeType: 46720
       GoKind: 17
       Count: 3
       HasCount: true
@@ -903,7 +925,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 51136
+      GoRuntimeType: 52096
       GoKind: 17
       Count: 3
       HasCount: true
@@ -912,7 +934,7 @@ Types:
       ID: 107
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 46048
+      GoRuntimeType: 46816
       GoKind: 17
       Count: 3
       HasCount: true
@@ -921,7 +943,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 53152
+      GoRuntimeType: 54112
       GoKind: 17
       Count: 4
       HasCount: true
@@ -930,7 +952,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 50368
+      GoRuntimeType: 51328
       GoKind: 17
       Count: 6
       HasCount: true
@@ -939,7 +961,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 51808
+      GoRuntimeType: 52768
       GoKind: 17
       Count: 8
       HasCount: true
@@ -960,7 +982,7 @@ Types:
       ID: 104
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 37696
+      GoRuntimeType: 38080
       GoKind: 23
       RawFields:
         - Name: array
@@ -999,7 +1021,7 @@ Types:
       ID: 106
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 37952
+      GoRuntimeType: 38336
       GoKind: 23
       RawFields:
         - Name: array
@@ -1022,7 +1044,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 37376
+      GoRuntimeType: 37760
       GoKind: 23
       RawFields:
         - Name: array
@@ -1045,7 +1067,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 37824
+      GoRuntimeType: 38208
       GoKind: 23
       RawFields:
         - Name: array
@@ -1068,25 +1090,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 42400
+      GoRuntimeType: 43040
       GoKind: 1
     - __kind: BaseType
       ID: 95
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 42208
+      GoRuntimeType: 42848
       GoKind: 16
     - __kind: BaseType
       ID: 94
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 42144
+      GoRuntimeType: 42784
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 63168
+      GoRuntimeType: 64192
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1099,25 +1121,25 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 42272
+      GoRuntimeType: 42912
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 42336
+      GoRuntimeType: 42976
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 35520
+      GoRuntimeType: 35904
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 56320
+      GoRuntimeType: 57344
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 132
@@ -1151,31 +1173,31 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 41952
+      GoRuntimeType: 42592
       GoKind: 2
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 41696
+      GoRuntimeType: 42336
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 41824
+      GoRuntimeType: 42464
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 41440
+      GoRuntimeType: 42080
       GoKind: 3
     - __kind: StructureType
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 112032
+      GoRuntimeType: 113952
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1197,7 +1219,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 73248
+      GoRuntimeType: 74656
       GoKind: 25
       RawFields:
         - Name: u
@@ -1207,7 +1229,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 99328
+      GoRuntimeType: 101248
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1223,7 +1245,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 89632
+      GoRuntimeType: 91552
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1236,7 +1258,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 89472
+      GoRuntimeType: 91392
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1249,7 +1271,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 89792
+      GoRuntimeType: 91712
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1261,20 +1283,20 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 61600
+      GoRuntimeType: 62624
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 61504
+      GoRuntimeType: 62528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 146
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 119744
+      GoRuntimeType: 121664
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1369,21 +1391,21 @@ Types:
       ID: 108
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 67264
+      GoRuntimeType: 68416
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 113
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 67392
+      GoRuntimeType: 68544
       GoKind: 21
       HeaderType: 115 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
       ID: 143
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 46336
+      GoRuntimeType: 47200
       GoKind: 17
       Count: 8
       HasCount: true
@@ -1392,7 +1414,7 @@ Types:
       ID: 135
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 46144
+      GoRuntimeType: 47008
       GoKind: 17
       Count: 8
       HasCount: true
@@ -1401,7 +1423,7 @@ Types:
       ID: 134
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 74656
+      GoRuntimeType: 76320
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1414,7 +1436,7 @@ Types:
       ID: 142
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 74912
+      GoRuntimeType: 76576
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1427,7 +1449,7 @@ Types:
       ID: 144
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 74784
+      GoRuntimeType: 76448
       GoKind: 25
       RawFields:
         - Name: key
@@ -1440,7 +1462,7 @@ Types:
       ID: 136
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 74528
+      GoRuntimeType: 76192
       GoKind: 25
       RawFields:
         - Name: key
@@ -1468,14 +1490,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 60736
+      GoRuntimeType: 61760
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 141600
+      GoRuntimeType: 143520
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1656,7 +1678,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 71712
+      GoRuntimeType: 73120
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1666,7 +1688,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 117728
+      GoRuntimeType: 119648
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1694,7 +1716,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 87072
+      GoRuntimeType: 88992
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1707,7 +1729,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 104512
+      GoRuntimeType: 106432
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1726,13 +1748,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 54880
+      GoRuntimeType: 55904
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 86912
+      GoRuntimeType: 88832
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1745,7 +1767,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 115904
+      GoRuntimeType: 117824
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1770,13 +1792,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 54784
+      GoRuntimeType: 55808
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 146656
+      GoRuntimeType: 148576
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1999,7 +2021,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 118016
+      GoRuntimeType: 119936
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2027,7 +2049,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 110688
+      GoRuntimeType: 112608
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2049,7 +2071,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 110464
+      GoRuntimeType: 112384
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2071,7 +2093,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 71456
+      GoRuntimeType: 72864
       GoKind: 25
       RawFields:
         - Name: next
@@ -2081,20 +2103,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 54496
+      GoRuntimeType: 55520
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 71328
+      GoRuntimeType: 72736
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 86752
+      GoRuntimeType: 88672
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2107,7 +2129,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 105280
+      GoRuntimeType: 107200
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2126,13 +2148,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 54688
+      GoRuntimeType: 55712
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 57856
+      GoRuntimeType: 58880
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2141,7 +2163,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 85152
+      GoRuntimeType: 87072
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2162,7 +2184,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 42656
+      GoRuntimeType: 43296
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2172,7 +2194,7 @@ Types:
       ID: 71
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 42720
+      GoRuntimeType: 43360
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 77
@@ -2182,7 +2204,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 86112
+      GoRuntimeType: 88032
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2195,19 +2217,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 74272
+      GoRuntimeType: 75680
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 60640
+      GoRuntimeType: 61664
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 41376
+      GoRuntimeType: 42016
       GoKind: 24
       RawFields:
         - Name: str
@@ -2274,45 +2296,45 @@ Types:
       ID: 16
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 42016
+      GoRuntimeType: 42656
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 41632
+      GoRuntimeType: 42272
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 41760
+      GoRuntimeType: 42400
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 41888
+      GoRuntimeType: 42528
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 41504
+      GoRuntimeType: 42144
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 42080
+      GoRuntimeType: 42720
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 42464
+      GoRuntimeType: 43104
       GoKind: 26
-MaxTypeID: 163
+MaxTypeID: 164
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x57e340", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,8 +11,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 163 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0x4a8006", Frameless: false}]
+          Type: 190 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0x4a8046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -25,8 +25,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 164 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0x4a8050", Frameless: false}]
+          Type: 191 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0x4a8090", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -38,8 +38,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 159 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4a8513", Frameless: false}]
+          Type: 186 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0x4a8553", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -52,11 +52,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 162 EventRootType Probe[main.inlined]
+          Type: 189 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4a83ea"
+            - PC: "0x4a842a"
               Frameless: false
-            - PC: "0x4a7dce"
+            - PC: "0x4a7e0e"
               Frameless: false
           Condition: null
     - id: intArg
@@ -69,8 +69,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 151 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4a80ca", Frameless: false}]
+          Type: 178 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0x4a810a", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -82,8 +82,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 154 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4a824a", Frameless: false}]
+          Type: 181 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0x4a828a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 157 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4a83c0", Frameless: true}]
+          Type: 184 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0x4a8400", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -108,8 +108,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 153 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4a81ca", Frameless: false}]
+          Type: 180 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0x4a820a", Frameless: false}]
           Condition: null
     - id: mapArg
       version: 0
@@ -121,8 +121,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 158 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4a84aa", Frameless: false}]
+          Type: 185 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0x4a84ea", Frameless: false}]
           Condition: null
     - id: noArgs
       version: 0
@@ -134,8 +134,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 160 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0x4a85ca", Frameless: false}]
+          Type: 187 EventRootType Probe[main.noArgs]
+          InjectionPoints: [{PC: "0x4a860a", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -147,8 +147,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 152 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a814a", Frameless: false}]
+          Type: 179 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -160,8 +160,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 156 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4a834a", Frameless: false}]
+          Type: 183 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0x4a838a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -173,8 +173,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 155 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a82ca", Frameless: false}]
+          Type: 182 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -187,31 +187,31 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 161 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0x4a8636", Frameless: false}]
+          Type: 188 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a80c0..0x4a8122]
+      OutOfLinePCRanges: [0x4a8100..0x4a8162]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a80c0..0x4a80d9
+            - Range: 0x4a8100..0x4a8119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4a8140..0x4a81b1]
+      OutOfLinePCRanges: [0x4a8180..0x4a81f1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8140..0x4a815e
+            - Range: 0x4a8180..0x4a819e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -221,13 +221,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a81c0..0x4a823a]
+      OutOfLinePCRanges: [0x4a8200..0x4a827a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 104 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a81c0..0x4a81de
+            - Range: 0x4a8200..0x4a821e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -239,25 +239,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a8240..0x4a82a7]
+      OutOfLinePCRanges: [0x4a8280..0x4a82e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 ArrayType [3]int
           Locations:
-            - Range: 0x4a8240..0x4a82a7
+            - Range: 0x4a8280..0x4a82e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a82c0..0x4a833a]
+      OutOfLinePCRanges: [0x4a8300..0x4a837a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 106 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4a82c0..0x4a82de
+            - Range: 0x4a8300..0x4a831e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -269,77 +269,82 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a8340..0x4a83a7]
+      OutOfLinePCRanges: [0x4a8380..0x4a83e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 ArrayType [3]string
           Locations:
-            - Range: 0x4a8340..0x4a83a7
+            - Range: 0x4a8380..0x4a83e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4a83c0..0x4a83c1]
+      OutOfLinePCRanges: [0x4a8400..0x4a8401]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 ArrayType [3]string
           Locations:
-            - Range: 0x4a83c0..0x4a83c1
+            - Range: 0x4a8400..0x4a8401
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4a84a0..0x4a84f6]
+      OutOfLinePCRanges: [0x4a84e0..0x4a8536]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 108 GoMapType map[string]int
           Locations:
-            - Range: 0x4a84a0..0x4a84cd
+            - Range: 0x4a84e0..0x4a850d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a8500..0x4a85bb]
+      OutOfLinePCRanges: [0x4a8540..0x4a85fb]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 113 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4a8500..0x4a8533
+            - Range: 0x4a8540..0x4a8573
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a8533..0x4a85bb
+            - Range: 0x4a8573..0x4a85fb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4a85c0..0x4a8613]
+      OutOfLinePCRanges: [0x4a8600..0x4a8653]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4a8620..0x4a878a]
+      OutOfLinePCRanges: [0x4a8660..0x4a884f]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: ~r0
+          Type: 118 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0x4a8660..0x4a884f, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 12
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a83e0..0x4a8442]
+      OutOfLinePCRanges: [0x4a8420..0x4a8482]
       InlinePCRanges:
-        - Ranges: [0x4a7dce..0x4a7e1f]
-          RootRanges: [0x4a7c40..0x4a80aa]
+        - Ranges: [0x4a7e0e..0x4a7e5f]
+          RootRanges: [0x4a7c80..0x4a80ea]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a7dce..0x4a7e1f
+            - Range: 0x4a7e0e..0x4a7e5f
               Pieces: []
-            - Range: 0x4a83e0..0x4a83f9
+            - Range: 0x4a8420..0x4a8439
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -347,13 +352,13 @@ Subprograms:
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4a8006..0x4a8045]
-          RootRanges: [0x4a7c40..0x4a80aa]
+        - Ranges: [0x4a8046..0x4a8085]
+          RootRanges: [0x4a7c80..0x4a80ea]
       Variables:
         - Name: ptr
-          Type: 118 PointerType *****int
+          Type: 123 PointerType *****int
           Locations:
-            - Range: 0x4a7fdf..0x4a802b
+            - Range: 0x4a801f..0x4a806b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -361,45 +366,50 @@ Subprograms:
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4a8050..0x4a808a]
-          RootRanges: [0x4a7c40..0x4a80aa]
+        - Ranges: [0x4a8090..0x4a80ca]
+          RootRanges: [0x4a7c80..0x4a80ea]
       Variables:
         - Name: ptr
-          Type: 120 PointerType **int
+          Type: 125 PointerType **int
           Locations:
-            - Range: 0x4a8050..0x4a808a
+            - Range: 0x4a8090..0x4a80ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 118
+      ID: 123
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 35520
+      GoRuntimeType: 35552
       GoKind: 22
-      Pointee: 119 PointerType ****int
+      Pointee: 124 PointerType ****int
     - __kind: PointerType
-      ID: 119
+      ID: 124
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 35456
+      GoRuntimeType: 35488
       GoKind: 22
-      Pointee: 150 PointerType ***int
+      Pointee: 177 PointerType ***int
     - __kind: PointerType
-      ID: 150
+      ID: 177
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 35392
+      GoRuntimeType: 35424
       GoKind: 22
-      Pointee: 120 PointerType **int
+      Pointee: 125 PointerType **int
     - __kind: PointerType
-      ID: 120
+      ID: 125
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 35328
+      GoRuntimeType: 35360
       GoKind: 22
       Pointee: 98 PointerType *int
+    - __kind: PointerType
+      ID: 163
+      Name: '**table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 164 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 111
       Name: '**table<string,int>'
@@ -411,88 +421,98 @@ Types:
       ByteSize: 8
       Pointee: 117 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 128
+      ID: 121
+      Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 122 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 133
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 127 GoSliceDataType []int.array
+      Pointee: 132 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 39872
+      GoRuntimeType: 39968
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 130
+      ID: 135
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 129 GoSliceDataType []string.array
+      Pointee: 134 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 124
+      ID: 129
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 123 GoSliceDataType []uint8.array
+      Pointee: 128 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 126
+      ID: 131
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 125 GoSliceDataType []uintptr.array
+      Pointee: 130 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 29824
+      GoRuntimeType: 29856
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 100
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 28736
+      GoRuntimeType: 28768
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 101
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 29696
+      GoRuntimeType: 29728
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 96
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 29760
+      GoRuntimeType: 29792
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 98
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29376
+      GoRuntimeType: 29408
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29120
+      GoRuntimeType: 29152
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 97
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 29248
+      GoRuntimeType: 29280
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 145
+      ID: 150
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 27200
+      GoRuntimeType: 27232
       GoKind: 22
-      Pointee: 146 StructureType main.bigStruct
+      Pointee: 151 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 161
+      Name: '*map<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 162 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 109
       Name: '*map<string,int>'
@@ -504,151 +524,176 @@ Types:
       ByteSize: 8
       Pointee: 115 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 133
+      ID: 119
+      Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 120 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 169
+      Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 170 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: PointerType
+      ID: 138
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 134 StructureType noalg.map.group[string]int
+      Pointee: 139 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 141
+      ID: 146
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 142 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 147 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 156
+      Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 157 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 30016
+      GoRuntimeType: 30048
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 81024
+      GoRuntimeType: 81888
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 30656
+      GoRuntimeType: 30688
       GoKind: 22
       Pointee: 63 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 30720
+      GoRuntimeType: 30752
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 59264
+      GoRuntimeType: 59744
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 65984
+      GoRuntimeType: 66464
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 31424
+      GoRuntimeType: 31456
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 92992
+      GoRuntimeType: 93856
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 124032
+      GoRuntimeType: 124896
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 98176
+      GoRuntimeType: 99040
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 93
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28800
+      GoRuntimeType: 28832
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 122
+      ID: 127
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 121 GoStringDataType string.str
+      Pointee: 126 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 164
+      Name: '*table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 167 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 112
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 131 StructureType table<string,int>
+      Pointee: 136 StructureType table<string,int>
     - __kind: PointerType
       ID: 117
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 139 StructureType table<string,main.bigStruct>
+      Pointee: 144 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 122
+      Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 154 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 102
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 29440
+      GoRuntimeType: 29472
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 103
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29056
+      GoRuntimeType: 29088
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 29184
+      GoRuntimeType: 29216
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 99
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29312
+      GoRuntimeType: 29344
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 28928
+      GoRuntimeType: 28960
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 29504
+      GoRuntimeType: 29536
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 163
+      ID: 190
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -656,14 +701,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 118 PointerType *****int
+            Type: 123 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 164
+      ID: 191
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -671,14 +716,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 120 PointerType **int
+            Type: 125 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 159
+      ID: 186
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -693,7 +738,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 162
+      ID: 189
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -708,7 +753,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 151
+      ID: 178
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -723,7 +768,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 154
+      ID: 181
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -738,7 +783,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 153
+      ID: 180
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -753,7 +798,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 158
+      ID: 185
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -768,10 +813,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 160
+      ID: 187
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 152
+      ID: 179
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -786,7 +831,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 157
+      ID: 184
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -801,7 +846,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 156
+      ID: 183
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -816,7 +861,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 155
+      ID: 182
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -831,12 +876,12 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 161
+      ID: 188
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 53056
+      GoRuntimeType: 53536
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -844,16 +889,16 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 52960
+      GoRuntimeType: 53440
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 90 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 149
+      ID: 176
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 47104
+      GoRuntimeType: 47488
       GoKind: 17
       Count: 128
       HasCount: true
@@ -862,7 +907,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 52576
+      GoRuntimeType: 53056
       GoKind: 17
       Count: 2
       HasCount: true
@@ -871,7 +916,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 52672
+      GoRuntimeType: 53152
       GoKind: 17
       Count: 2
       HasCount: true
@@ -880,7 +925,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 52864
+      GoRuntimeType: 53344
       GoKind: 17
       Count: 2
       HasCount: true
@@ -889,7 +934,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 48736
+      GoRuntimeType: 49216
       GoKind: 17
       Count: 2
       HasCount: true
@@ -898,7 +943,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 55072
+      GoRuntimeType: 55552
       GoKind: 17
       Count: 32
       HasCount: true
@@ -907,7 +952,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 52384
+      GoRuntimeType: 52864
       GoKind: 17
       Count: 32
       HasCount: true
@@ -916,7 +961,7 @@ Types:
       ID: 105
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 46720
+      GoRuntimeType: 47104
       GoKind: 17
       Count: 3
       HasCount: true
@@ -925,7 +970,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 52096
+      GoRuntimeType: 52576
       GoKind: 17
       Count: 3
       HasCount: true
@@ -934,7 +979,7 @@ Types:
       ID: 107
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 46816
+      GoRuntimeType: 47200
       GoKind: 17
       Count: 3
       HasCount: true
@@ -943,7 +988,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 54112
+      GoRuntimeType: 54592
       GoKind: 17
       Count: 4
       HasCount: true
@@ -952,7 +997,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 51328
+      GoRuntimeType: 51808
       GoKind: 17
       Count: 6
       HasCount: true
@@ -961,28 +1006,40 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 52768
+      GoRuntimeType: 53248
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 137
+      ID: 174
+      Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 164 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 142
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 112 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 152
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 117 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 165
+      Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 122 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 104
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 38080
+      GoRuntimeType: 38176
       GoKind: 23
       RawFields:
         - Name: array
@@ -994,25 +1051,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 127 GoSliceDataType []int.array
+      Data: 132 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 127
+      ID: 132
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 175
+      Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
+      DynamicSizeClass: slice
+      ByteSize: 136
+      Element: 170 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoSliceDataType
+      ID: 143
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 134 StructureType noalg.map.group[string]int
+      Element: 139 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 148
+      ID: 153
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 142 StructureType noalg.map.group[string]main.bigStruct
+      Element: 147 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceDataType
+      ID: 166
+      Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
+      DynamicSizeClass: slice
+      ByteSize: 136
+      Element: 157 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -1021,7 +1090,7 @@ Types:
       ID: 106
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 38336
+      GoRuntimeType: 38432
       GoKind: 23
       RawFields:
         - Name: array
@@ -1033,9 +1102,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 129 GoSliceDataType []string.array
+      Data: 134 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 129
+      ID: 134
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -1044,7 +1113,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 37760
+      GoRuntimeType: 37856
       GoKind: 23
       RawFields:
         - Name: array
@@ -1056,9 +1125,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 123 GoSliceDataType []uint8.array
+      Data: 128 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 128
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -1067,7 +1136,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 38208
+      GoRuntimeType: 38304
       GoKind: 23
       RawFields:
         - Name: array
@@ -1079,9 +1148,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 125 GoSliceDataType []uintptr.array
+      Data: 130 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 130
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -1090,25 +1159,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 43040
+      GoRuntimeType: 43200
       GoKind: 1
     - __kind: BaseType
       ID: 95
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 42848
+      GoRuntimeType: 43008
       GoKind: 16
     - __kind: BaseType
       ID: 94
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 42784
+      GoRuntimeType: 42944
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 64192
+      GoRuntimeType: 64672
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1121,83 +1190,111 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 42912
+      GoRuntimeType: 43072
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 42976
+      GoRuntimeType: 43136
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 35904
+      GoRuntimeType: 36000
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 57344
+      GoRuntimeType: 57824
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 132
+      ID: 168
+      Name: groupReference<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 169 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 170 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 175 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+    - __kind: GoSwissMapGroupsType
+      ID: 137
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 133 PointerType *noalg.map.group[string]int
+          Type: 138 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 134 StructureType noalg.map.group[string]int
-      GroupSliceType: 138 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 139 StructureType noalg.map.group[string]int
+      GroupSliceType: 143 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 140
+      ID: 145
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 141 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 146 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 142 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 148 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 147 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 153 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 155
+      Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 156 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 157 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 166 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 42592
+      GoRuntimeType: 42752
       GoKind: 2
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 42336
+      GoRuntimeType: 42496
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 42464
+      GoRuntimeType: 42624
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 42080
+      GoRuntimeType: 42240
       GoKind: 3
     - __kind: StructureType
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 113952
+      GoRuntimeType: 114816
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1219,7 +1316,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 74656
+      GoRuntimeType: 75264
       GoKind: 25
       RawFields:
         - Name: u
@@ -1229,7 +1326,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 101248
+      GoRuntimeType: 102112
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1245,7 +1342,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 91552
+      GoRuntimeType: 92416
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1258,7 +1355,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 91392
+      GoRuntimeType: 92256
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1271,7 +1368,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 91712
+      GoRuntimeType: 92576
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1283,20 +1380,27 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 62624
+      GoRuntimeType: 63104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 62528
+      GoRuntimeType: 63008
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 146
+      ID: 173
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 70912
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
+    - __kind: StructureType
+      ID: 151
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 121664
+      GoRuntimeType: 122528
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1322,7 +1426,39 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 149 ArrayType [128]uint8
+          Type: 176 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 162
+      Name: map<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 163 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 174 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 170 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<string,int>
@@ -1353,8 +1489,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 137 GoSliceDataType []*table<string,int>.array
-      GroupType: 134 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 142 GoSliceDataType []*table<string,int>.array
+      GroupType: 139 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<string,main.bigStruct>
@@ -1385,45 +1521,122 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 147 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 142 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 152 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 147 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 120
+      Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 121 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 165 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 157 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoMapType
+      ID: 160
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 68768
+      GoKind: 21
+      HeaderType: 162 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 108
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 68416
+      GoRuntimeType: 68896
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 113
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 68544
+      GoRuntimeType: 69024
       GoKind: 21
       HeaderType: 115 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 118
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 69280
+      GoKind: 21
+      HeaderType: 120 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 143
+      ID: 171
+      Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 47296
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 172 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: ArrayType
+      ID: 148
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 47200
+      GoRuntimeType: 47584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 144 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 149 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 135
+      ID: 140
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 47008
+      GoRuntimeType: 47392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 136 StructureType noalg.struct { key string; elem int }
+      Element: 141 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 158
+      Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 47776
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 159 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 134
+      ID: 170
+      Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 76672
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 171 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 139
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 76320
+      GoRuntimeType: 76928
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1431,12 +1644,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 135 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 140 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 142
+      ID: 147
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 76576
+      GoRuntimeType: 77184
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1444,12 +1657,38 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 143 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 148 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 144
+      ID: 157
+      Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 77696
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 158 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 172
+      Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 76544
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 173 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: StructureType
+      ID: 149
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 76448
+      GoRuntimeType: 77056
       GoKind: 25
       RawFields:
         - Name: key
@@ -1457,12 +1696,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 145 PointerType *main.bigStruct
+          Type: 150 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 136
+      ID: 141
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 76192
+      GoRuntimeType: 76800
       GoKind: 25
       RawFields:
         - Name: key
@@ -1471,6 +1710,19 @@ Types:
         - Name: elem
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 159
+      Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 77568
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 160 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1490,14 +1742,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 61760
+      GoRuntimeType: 62240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 143520
+      GoRuntimeType: 144384
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1678,7 +1930,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 73120
+      GoRuntimeType: 73728
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1688,7 +1940,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 119648
+      GoRuntimeType: 120512
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1716,7 +1968,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 88992
+      GoRuntimeType: 89856
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1729,7 +1981,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 106432
+      GoRuntimeType: 107296
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1748,13 +2000,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 55904
+      GoRuntimeType: 56384
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 88832
+      GoRuntimeType: 89696
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1767,7 +2019,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 117824
+      GoRuntimeType: 118688
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1792,13 +2044,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 55808
+      GoRuntimeType: 56288
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 148576
+      GoRuntimeType: 149440
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2021,7 +2273,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 119936
+      GoRuntimeType: 120800
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2049,7 +2301,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 112608
+      GoRuntimeType: 113472
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2071,7 +2323,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 112384
+      GoRuntimeType: 113248
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2093,7 +2345,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 72864
+      GoRuntimeType: 73472
       GoKind: 25
       RawFields:
         - Name: next
@@ -2103,20 +2355,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 55520
+      GoRuntimeType: 56000
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 72736
+      GoRuntimeType: 73344
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 88672
+      GoRuntimeType: 89536
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2129,7 +2381,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 107200
+      GoRuntimeType: 108064
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2148,13 +2400,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 55712
+      GoRuntimeType: 56192
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 58880
+      GoRuntimeType: 59360
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2163,7 +2415,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 87072
+      GoRuntimeType: 87936
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2184,7 +2436,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 43296
+      GoRuntimeType: 43456
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2194,7 +2446,7 @@ Types:
       ID: 71
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 43360
+      GoRuntimeType: 43520
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 77
@@ -2204,7 +2456,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 88032
+      GoRuntimeType: 88896
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2217,35 +2469,59 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 75680
+      GoRuntimeType: 76288
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 61664
+      GoRuntimeType: 62144
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 42016
+      GoRuntimeType: 42176
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 122 PointerType *string.str
+          Type: 127 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 121 GoStringDataType string.str
+      Data: 126 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 121
+      ID: 126
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 131
+      ID: 167
+      Name: table<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 168 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+    - __kind: StructureType
+      ID: 136
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -2267,9 +2543,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 132 GoSwissMapGroupsType groupReference<string,int>
+          Type: 137 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 139
+      ID: 144
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -2291,50 +2567,74 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 140 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 145 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 154
+      Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 155 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 16
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 42656
+      GoRuntimeType: 42816
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 42272
+      GoRuntimeType: 42432
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 42400
+      GoRuntimeType: 42560
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 42528
+      GoRuntimeType: 42688
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 42144
+      GoRuntimeType: 42304
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 42720
+      GoRuntimeType: 42880
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 43104
+      GoRuntimeType: 43264
       GoKind: 26
-MaxTypeID: 164
+MaxTypeID: 191
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x57e340", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,8 +11,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 168 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0x4ae606", Frameless: false}]
+          Type: 195 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0x4ae646", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -25,8 +25,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 169 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0x4ae650", Frameless: false}]
+          Type: 196 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0x4ae690", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -38,8 +38,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 164 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4aeb13", Frameless: false}]
+          Type: 191 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0x4aeb53", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -52,11 +52,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 167 EventRootType Probe[main.inlined]
+          Type: 194 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4ae9ea"
+            - PC: "0x4aea2a"
               Frameless: false
-            - PC: "0x4ae3ce"
+            - PC: "0x4ae40e"
               Frameless: false
           Condition: null
     - id: intArg
@@ -69,8 +69,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 156 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4ae6ca", Frameless: false}]
+          Type: 183 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0x4ae70a", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -82,8 +82,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 159 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4ae84a", Frameless: false}]
+          Type: 186 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0x4ae88a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 162 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4ae9c0", Frameless: true}]
+          Type: 189 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0x4aea00", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -108,8 +108,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 158 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4ae7ca", Frameless: false}]
+          Type: 185 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0x4ae80a", Frameless: false}]
           Condition: null
     - id: mapArg
       version: 0
@@ -121,8 +121,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 163 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4aeaaa", Frameless: false}]
+          Type: 190 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0x4aeaea", Frameless: false}]
           Condition: null
     - id: noArgs
       version: 0
@@ -134,8 +134,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 165 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0x4aebca", Frameless: false}]
+          Type: 192 EventRootType Probe[main.noArgs]
+          InjectionPoints: [{PC: "0x4aec0a", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -147,8 +147,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 157 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4ae74a", Frameless: false}]
+          Type: 184 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -160,8 +160,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 161 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4ae94a", Frameless: false}]
+          Type: 188 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0x4ae98a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -173,8 +173,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 160 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4ae8ca", Frameless: false}]
+          Type: 187 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -187,31 +187,31 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 166 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0x4aec36", Frameless: false}]
+          Type: 193 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4aec76", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4ae6c0..0x4ae722]
+      OutOfLinePCRanges: [0x4ae700..0x4ae762]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4ae6c0..0x4ae6d9
+            - Range: 0x4ae700..0x4ae719
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4ae740..0x4ae7b1]
+      OutOfLinePCRanges: [0x4ae780..0x4ae7f1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ae740..0x4ae75e
+            - Range: 0x4ae780..0x4ae79e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -221,13 +221,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4ae7c0..0x4ae83a]
+      OutOfLinePCRanges: [0x4ae800..0x4ae87a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 106 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4ae7c0..0x4ae7de
+            - Range: 0x4ae800..0x4ae81e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -239,25 +239,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4ae840..0x4ae8a7]
+      OutOfLinePCRanges: [0x4ae880..0x4ae8e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 ArrayType [3]int
           Locations:
-            - Range: 0x4ae840..0x4ae8a7
+            - Range: 0x4ae880..0x4ae8e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4ae8c0..0x4ae93a]
+      OutOfLinePCRanges: [0x4ae900..0x4ae97a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4ae8c0..0x4ae8de
+            - Range: 0x4ae900..0x4ae91e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -269,77 +269,82 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4ae940..0x4ae9a7]
+      OutOfLinePCRanges: [0x4ae980..0x4ae9e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 109 ArrayType [3]string
           Locations:
-            - Range: 0x4ae940..0x4ae9a7
+            - Range: 0x4ae980..0x4ae9e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4ae9c0..0x4ae9c1]
+      OutOfLinePCRanges: [0x4aea00..0x4aea01]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 109 ArrayType [3]string
           Locations:
-            - Range: 0x4ae9c0..0x4ae9c1
+            - Range: 0x4aea00..0x4aea01
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4aeaa0..0x4aeaf6]
+      OutOfLinePCRanges: [0x4aeae0..0x4aeb36]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 110 GoMapType map[string]int
           Locations:
-            - Range: 0x4aeaa0..0x4aeacd
+            - Range: 0x4aeae0..0x4aeb0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4aeb00..0x4aebbb]
+      OutOfLinePCRanges: [0x4aeb40..0x4aebfb]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 115 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4aeb00..0x4aeb33
+            - Range: 0x4aeb40..0x4aeb73
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aeb33..0x4aebbb
+            - Range: 0x4aeb73..0x4aebfb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4aebc0..0x4aec13]
+      OutOfLinePCRanges: [0x4aec00..0x4aec53]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4aec20..0x4aed8a]
+      OutOfLinePCRanges: [0x4aec60..0x4aee57]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: ~r0
+          Type: 120 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0x4aec60..0x4aee57, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 12
       Name: main.inlined
-      OutOfLinePCRanges: [0x4ae9e0..0x4aea42]
+      OutOfLinePCRanges: [0x4aea20..0x4aea82]
       InlinePCRanges:
-        - Ranges: [0x4ae3ce..0x4ae40f]
-          RootRanges: [0x4ae240..0x4ae6aa]
+        - Ranges: [0x4ae40e..0x4ae44f]
+          RootRanges: [0x4ae280..0x4ae6ea]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4ae3ce..0x4ae40f
+            - Range: 0x4ae40e..0x4ae44f
               Pieces: []
-            - Range: 0x4ae9e0..0x4ae9f9
+            - Range: 0x4aea20..0x4aea39
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -347,13 +352,13 @@ Subprograms:
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4ae606..0x4ae645]
-          RootRanges: [0x4ae240..0x4ae6aa]
+        - Ranges: [0x4ae646..0x4ae685]
+          RootRanges: [0x4ae280..0x4ae6ea]
       Variables:
         - Name: ptr
-          Type: 120 PointerType *****int
+          Type: 125 PointerType *****int
           Locations:
-            - Range: 0x4ae5df..0x4ae62b
+            - Range: 0x4ae61f..0x4ae66b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -361,43 +366,43 @@ Subprograms:
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4ae650..0x4ae68a]
-          RootRanges: [0x4ae240..0x4ae6aa]
+        - Ranges: [0x4ae690..0x4ae6ca]
+          RootRanges: [0x4ae280..0x4ae6ea]
       Variables:
         - Name: ptr
-          Type: 122 PointerType **int
+          Type: 127 PointerType **int
           Locations:
-            - Range: 0x4ae650..0x4ae68a
+            - Range: 0x4ae690..0x4ae6ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 120
+      ID: 125
       Name: '*****int'
+      ByteSize: 8
+      GoRuntimeType: 36640
+      GoKind: 22
+      Pointee: 126 PointerType ****int
+    - __kind: PointerType
+      ID: 126
+      Name: '****int'
       ByteSize: 8
       GoRuntimeType: 36576
       GoKind: 22
-      Pointee: 121 PointerType ****int
+      Pointee: 182 PointerType ***int
     - __kind: PointerType
-      ID: 121
-      Name: '****int'
+      ID: 182
+      Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36512
       GoKind: 22
-      Pointee: 155 PointerType ***int
+      Pointee: 127 PointerType **int
     - __kind: PointerType
-      ID: 155
-      Name: '***int'
-      ByteSize: 8
-      GoRuntimeType: 36448
-      GoKind: 22
-      Pointee: 122 PointerType **int
-    - __kind: PointerType
-      ID: 122
+      ID: 127
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 36384
+      GoRuntimeType: 36448
       GoKind: 22
       Pointee: 99 PointerType *int
     - __kind: PointerType
@@ -406,6 +411,11 @@ Types:
       ByteSize: 8
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
+    - __kind: PointerType
+      ID: 168
+      Name: '**table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 169 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 113
       Name: '**table<string,int>'
@@ -417,93 +427,103 @@ Types:
       ByteSize: 8
       Pointee: 119 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 131
+      ID: 123
+      Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 124 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 136
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 130 GoSliceDataType []*runtime.p.array
+      Pointee: 135 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 133
+      ID: 138
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 132 GoSliceDataType []int.array
+      Pointee: 137 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 41248
+      GoRuntimeType: 41376
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 135
+      ID: 140
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 134 GoSliceDataType []string.array
+      Pointee: 139 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 126
+      ID: 131
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 125 GoSliceDataType []uint8.array
+      Pointee: 130 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 128
+      ID: 133
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 127 GoSliceDataType []uintptr.array
+      Pointee: 132 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30688
+      GoRuntimeType: 30752
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 102
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 29600
+      GoRuntimeType: 29664
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 103
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 30560
+      GoRuntimeType: 30624
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 98
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 30624
+      GoRuntimeType: 30688
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 30240
+      GoRuntimeType: 30304
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29984
+      GoRuntimeType: 30048
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 100
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 30112
+      GoRuntimeType: 30176
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 150
+      ID: 155
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 28064
+      GoRuntimeType: 28128
       GoKind: 22
-      Pointee: 151 StructureType main.bigStruct
+      Pointee: 156 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 166
+      Name: '*map<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 167 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 111
       Name: '*map<string,int>'
@@ -515,158 +535,183 @@ Types:
       ByteSize: 8
       Pointee: 117 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 138
+      ID: 121
+      Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 122 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 174
+      Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 175 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: PointerType
+      ID: 143
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 139 StructureType noalg.map.group[string]int
+      Pointee: 144 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 146
+      ID: 151
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 147 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 152 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 161
+      Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 162 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 30880
+      GoRuntimeType: 30944
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 83616
+      GoRuntimeType: 84512
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 31520
+      GoRuntimeType: 31584
       GoKind: 22
       Pointee: 66 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 31584
+      GoRuntimeType: 31648
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 61440
+      GoRuntimeType: 61952
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 84256
+      GoRuntimeType: 85152
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 68544
+      GoRuntimeType: 69056
       GoKind: 22
-      Pointee: 129 UnresolvedPointeeType runtime.p
+      Pointee: 134 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 32224
+      GoRuntimeType: 32288
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 96544
+      GoRuntimeType: 97440
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 128128
+      GoRuntimeType: 129024
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 102560
+      GoRuntimeType: 103456
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 95
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 29664
+      GoRuntimeType: 29728
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 124
+      ID: 129
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 123 GoStringDataType string.str
+      Pointee: 128 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 169
+      Name: '*table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 172 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 114
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 136 StructureType table<string,int>
+      Pointee: 141 StructureType table<string,int>
     - __kind: PointerType
       ID: 119
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 144 StructureType table<string,main.bigStruct>
+      Pointee: 149 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 124
+      Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 159 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 104
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 30304
+      GoRuntimeType: 30368
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 105
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29920
+      GoRuntimeType: 29984
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 30048
+      GoRuntimeType: 30112
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 30176
+      GoRuntimeType: 30240
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29792
+      GoRuntimeType: 29856
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 30368
+      GoRuntimeType: 30432
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 168
+      ID: 195
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -674,14 +719,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 120 PointerType *****int
+            Type: 125 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 169
+      ID: 196
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -689,14 +734,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 122 PointerType **int
+            Type: 127 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 164
+      ID: 191
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -711,7 +756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 167
+      ID: 194
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -726,7 +771,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 156
+      ID: 183
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -741,7 +786,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 159
+      ID: 186
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -756,7 +801,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 158
+      ID: 185
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -771,7 +816,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 163
+      ID: 190
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -786,10 +831,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 165
+      ID: 192
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 157
+      ID: 184
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -804,7 +849,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 162
+      ID: 189
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -819,7 +864,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 161
+      ID: 188
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -834,7 +879,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 160
+      ID: 187
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -849,22 +894,22 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 166
+      ID: 193
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 54592
+      GoRuntimeType: 55104
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 93 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 154
+      ID: 181
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 48544
+      GoRuntimeType: 48960
       GoKind: 17
       Count: 128
       HasCount: true
@@ -873,7 +918,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 54208
+      GoRuntimeType: 54720
       GoKind: 17
       Count: 2
       HasCount: true
@@ -882,7 +927,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 54304
+      GoRuntimeType: 54816
       GoKind: 17
       Count: 2
       HasCount: true
@@ -891,7 +936,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 54496
+      GoRuntimeType: 55008
       GoKind: 17
       Count: 2
       HasCount: true
@@ -900,7 +945,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 50176
+      GoRuntimeType: 50688
       GoKind: 17
       Count: 2
       HasCount: true
@@ -909,7 +954,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 56896
+      GoRuntimeType: 57408
       GoKind: 17
       Count: 32
       HasCount: true
@@ -918,7 +963,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 54016
+      GoRuntimeType: 54528
       GoKind: 17
       Count: 32
       HasCount: true
@@ -927,7 +972,7 @@ Types:
       ID: 107
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 48160
+      GoRuntimeType: 48576
       GoKind: 17
       Count: 3
       HasCount: true
@@ -936,7 +981,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 53440
+      GoRuntimeType: 53952
       GoKind: 17
       Count: 3
       HasCount: true
@@ -945,7 +990,7 @@ Types:
       ID: 109
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 48256
+      GoRuntimeType: 48672
       GoKind: 17
       Count: 3
       HasCount: true
@@ -954,7 +999,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 55936
+      GoRuntimeType: 56448
       GoKind: 17
       Count: 4
       HasCount: true
@@ -963,7 +1008,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 52768
+      GoRuntimeType: 53280
       GoKind: 17
       Count: 6
       HasCount: true
@@ -972,7 +1017,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 54400
+      GoRuntimeType: 54912
       GoKind: 17
       Count: 8
       HasCount: true
@@ -981,7 +1026,7 @@ Types:
       ID: 62
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 40800
+      GoRuntimeType: 40928
       GoKind: 23
       RawFields:
         - Name: array
@@ -993,30 +1038,42 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 130 GoSliceDataType []*runtime.p.array
+      Data: 135 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 135
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 142
+      ID: 179
+      Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 169 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 147
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 114 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 152
+      ID: 157
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 119 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 170
+      Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 124 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 106
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 39200
+      GoRuntimeType: 39328
       GoKind: 23
       RawFields:
         - Name: array
@@ -1028,25 +1085,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 132 GoSliceDataType []int.array
+      Data: 137 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 132
+      ID: 137
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 143
+      ID: 180
+      Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
+      DynamicSizeClass: slice
+      ByteSize: 136
+      Element: 175 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoSliceDataType
+      ID: 148
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 139 StructureType noalg.map.group[string]int
+      Element: 144 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 158
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 147 StructureType noalg.map.group[string]main.bigStruct
+      Element: 152 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceDataType
+      ID: 171
+      Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
+      DynamicSizeClass: slice
+      ByteSize: 136
+      Element: 162 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -1055,7 +1124,7 @@ Types:
       ID: 108
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 39456
+      GoRuntimeType: 39584
       GoKind: 23
       RawFields:
         - Name: array
@@ -1067,9 +1136,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 134 GoSliceDataType []string.array
+      Data: 139 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 139
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -1078,7 +1147,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 38880
+      GoRuntimeType: 39008
       GoKind: 23
       RawFields:
         - Name: array
@@ -1090,9 +1159,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 125 GoSliceDataType []uint8.array
+      Data: 130 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 130
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -1101,7 +1170,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 39328
+      GoRuntimeType: 39456
       GoKind: 23
       RawFields:
         - Name: array
@@ -1113,9 +1182,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 127 GoSliceDataType []uintptr.array
+      Data: 132 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 127
+      ID: 132
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -1124,25 +1193,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 44416
+      GoRuntimeType: 44608
       GoKind: 1
     - __kind: BaseType
       ID: 97
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 44224
+      GoRuntimeType: 44416
       GoKind: 16
     - __kind: BaseType
       ID: 96
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 44160
+      GoRuntimeType: 44352
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 66880
+      GoRuntimeType: 67392
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1155,83 +1224,111 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 44288
+      GoRuntimeType: 44480
       GoKind: 13
     - __kind: BaseType
       ID: 15
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 44352
+      GoRuntimeType: 44544
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 36960
+      GoRuntimeType: 37088
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 59264
+      GoRuntimeType: 59776
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 137
+      ID: 173
+      Name: groupReference<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 174 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 175 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 180 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+    - __kind: GoSwissMapGroupsType
+      ID: 142
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 138 PointerType *noalg.map.group[string]int
+          Type: 143 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 139 StructureType noalg.map.group[string]int
-      GroupSliceType: 143 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 144 StructureType noalg.map.group[string]int
+      GroupSliceType: 148 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 145
+      ID: 150
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 146 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 151 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 147 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 153 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 152 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 158 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 160
+      Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 161 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 162 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 171 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 43968
+      GoRuntimeType: 44160
       GoKind: 2
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 43712
+      GoRuntimeType: 43904
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 43840
+      GoRuntimeType: 44032
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 43456
+      GoRuntimeType: 43648
       GoKind: 3
     - __kind: StructureType
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 119168
+      GoRuntimeType: 120064
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1253,7 +1350,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 77248
+      GoRuntimeType: 77888
       GoKind: 25
       RawFields:
         - Name: u
@@ -1263,7 +1360,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 105632
+      GoRuntimeType: 106528
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1279,7 +1376,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 94816
+      GoRuntimeType: 95712
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1292,7 +1389,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 94656
+      GoRuntimeType: 95552
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1305,7 +1402,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 94976
+      GoRuntimeType: 95872
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1317,20 +1414,27 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 65184
+      GoRuntimeType: 65696
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 65088
+      GoRuntimeType: 65600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 151
+      ID: 178
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 73536
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
+    - __kind: StructureType
+      ID: 156
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 126656
+      GoRuntimeType: 127552
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1356,7 +1460,42 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 154 ArrayType [128]uint8
+          Type: 181 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 167
+      Name: map<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 168 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 179 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 175 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 112
       Name: map<string,int>
@@ -1390,8 +1529,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 142 GoSliceDataType []*table<string,int>.array
-      GroupType: 139 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 147 GoSliceDataType []*table<string,int>.array
+      GroupType: 144 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 117
       Name: map<string,main.bigStruct>
@@ -1425,45 +1564,112 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 152 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 147 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 157 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 152 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 122
+      Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 123 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 170 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 162 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoMapType
+      ID: 165
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 71616
+      GoKind: 21
+      HeaderType: 167 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 110
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 71232
+      GoRuntimeType: 71744
       GoKind: 21
       HeaderType: 112 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 115
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 71360
+      GoRuntimeType: 71872
       GoKind: 21
       HeaderType: 117 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 72128
+      GoKind: 21
+      HeaderType: 122 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 148
+      ID: 176
+      Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 48768
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 177 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: ArrayType
+      ID: 153
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 48640
+      GoRuntimeType: 49056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 149 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 154 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 140
+      ID: 145
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 48448
+      GoRuntimeType: 48864
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 141 StructureType noalg.struct { key string; elem int }
+      Element: 146 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 163
+      Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 49248
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 164 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 139
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 78912
+      ID: 175
+      Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 79296
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1471,25 +1677,64 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 140 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 176 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 147
+      ID: 144
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 79552
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 145 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 152
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
+      GoRuntimeType: 79808
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 153 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+    - __kind: StructureType
+      ID: 162
+      Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 80320
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 163 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 177
+      Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
       GoRuntimeType: 79168
       GoKind: 25
       RawFields:
-        - Name: ctrl
+        - Name: key
           Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
+          Type: 7 BaseType int
+        - Name: elem
           Offset: 8
-          Type: 148 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 178 StructureType main.aStructNotUsedAsAnArgument
     - __kind: StructureType
-      ID: 149
+      ID: 154
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 79040
+      GoRuntimeType: 79680
       GoKind: 25
       RawFields:
         - Name: key
@@ -1497,12 +1742,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 150 PointerType *main.bigStruct
+          Type: 155 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 141
+      ID: 146
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 78784
+      GoRuntimeType: 79424
       GoKind: 25
       RawFields:
         - Name: key
@@ -1511,6 +1756,19 @@ Types:
         - Name: elem
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 164
+      Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 80192
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 165 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1530,14 +1788,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 64320
+      GoRuntimeType: 64832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 148928
+      GoRuntimeType: 149824
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1727,7 +1985,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 75712
+      GoRuntimeType: 76352
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1737,7 +1995,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 122336
+      GoRuntimeType: 123232
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1762,7 +2020,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 91936
+      GoRuntimeType: 92832
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1775,7 +2033,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 111008
+      GoRuntimeType: 111904
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1794,13 +2052,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 57728
+      GoRuntimeType: 58240
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 91776
+      GoRuntimeType: 92672
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1813,7 +2071,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 123104
+      GoRuntimeType: 124000
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1838,13 +2096,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 57632
+      GoRuntimeType: 58144
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 152224
+      GoRuntimeType: 153120
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2064,7 +2322,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 122848
+      GoRuntimeType: 123744
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2089,7 +2347,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 118048
+      GoRuntimeType: 118944
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2111,7 +2369,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 117824
+      GoRuntimeType: 118720
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2133,7 +2391,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 91456
+      GoRuntimeType: 92352
       GoKind: 25
       RawFields:
         - Name: next
@@ -2146,24 +2404,24 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 57344
+      GoRuntimeType: 57856
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 75456
+      GoRuntimeType: 76096
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 129
+      ID: 134
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 91616
+      GoRuntimeType: 92512
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2176,7 +2434,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 111968
+      GoRuntimeType: 112864
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2195,13 +2453,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 57536
+      GoRuntimeType: 58048
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 60960
+      GoRuntimeType: 61472
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2210,7 +2468,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 89696
+      GoRuntimeType: 90592
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2231,7 +2489,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 44672
+      GoRuntimeType: 44864
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2241,7 +2499,7 @@ Types:
       ID: 74
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 44736
+      GoRuntimeType: 44928
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 80
@@ -2251,7 +2509,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 90656
+      GoRuntimeType: 91552
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2264,35 +2522,59 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 78272
+      GoRuntimeType: 78912
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 64224
+      GoRuntimeType: 64736
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 43392
+      GoRuntimeType: 43584
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 124 PointerType *string.str
+          Type: 129 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 123 GoStringDataType string.str
+      Data: 128 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 123
+      ID: 128
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 136
+      ID: 172
+      Name: table<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 173 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+    - __kind: StructureType
+      ID: 141
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -2314,9 +2596,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 137 GoSwissMapGroupsType groupReference<string,int>
+          Type: 142 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 144
+      ID: 149
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -2338,52 +2620,76 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 145 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 150 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 159
+      Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 160 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 17
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 44032
+      GoRuntimeType: 44224
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 43648
+      GoRuntimeType: 43840
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 43776
+      GoRuntimeType: 43968
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 43904
+      GoRuntimeType: 44096
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 43520
+      GoRuntimeType: 43712
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 44096
+      GoRuntimeType: 44288
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 44480
+      GoRuntimeType: 44672
       GoKind: 26
-MaxTypeID: 169
+MaxTypeID: 196
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x58c3a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x58d3a0", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,10 +8,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 167 EventRootType Probe[main.PointerChainArg]
+        - ID: 13
+          Type: 168 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae606", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -22,10 +22,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 14}
       events:
-        - ID: 13
-          Type: 168 EventRootType Probe[main.PointerSmallChainArg]
+        - ID: 14
+          Type: 169 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae650", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -49,10 +49,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 166 EventRootType Probe[main.inlined]
+        - ID: 12
+          Type: 167 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae9ea"
               Frameless: false
@@ -175,6 +175,20 @@ Probes:
         - ID: 5
           Type: 160 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4ae8ca", Frameless: false}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 11
+          Type: 166 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4aec36", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -309,11 +323,16 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
     - ID: 11
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0x4aec20..0x4aed8a]
+      InlinePCRanges: []
+      Variables: []
+    - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0x4ae9e0..0x4aea42]
       InlinePCRanges:
         - Ranges: [0x4ae3ce..0x4ae40f]
-          RootRanges: [0x4ae240..0x4ae6a5]
+          RootRanges: [0x4ae240..0x4ae6aa]
       Variables:
         - Name: x
           Type: 7 BaseType int
@@ -324,12 +343,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4ae606..0x4ae645]
-          RootRanges: [0x4ae240..0x4ae6a5]
+          RootRanges: [0x4ae240..0x4ae6aa]
       Variables:
         - Name: ptr
           Type: 120 PointerType *****int
@@ -338,12 +357,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4ae650..0x4ae68a]
-          RootRanges: [0x4ae240..0x4ae6a5]
+          RootRanges: [0x4ae240..0x4ae6aa]
       Variables:
         - Name: ptr
           Type: 122 PointerType **int
@@ -357,28 +376,28 @@ Types:
       ID: 120
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 36320
+      GoRuntimeType: 36576
       GoKind: 22
       Pointee: 121 PointerType ****int
     - __kind: PointerType
       ID: 121
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 36256
+      GoRuntimeType: 36512
       GoKind: 22
       Pointee: 155 PointerType ***int
     - __kind: PointerType
       ID: 155
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 36192
+      GoRuntimeType: 36448
       GoKind: 22
       Pointee: 122 PointerType **int
     - __kind: PointerType
       ID: 122
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 36128
+      GoRuntimeType: 36384
       GoKind: 22
       Pointee: 99 PointerType *int
     - __kind: PointerType
@@ -411,7 +430,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 40864
+      GoRuntimeType: 41248
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -433,56 +452,56 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30432
+      GoRuntimeType: 30688
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 102
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 29344
+      GoRuntimeType: 29600
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 103
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 30304
+      GoRuntimeType: 30560
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 98
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 30368
+      GoRuntimeType: 30624
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29984
+      GoRuntimeType: 30240
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29728
+      GoRuntimeType: 29984
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 100
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 29856
+      GoRuntimeType: 30112
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 150
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 27808
+      GoRuntimeType: 28064
       GoKind: 22
       Pointee: 151 StructureType main.bigStruct
     - __kind: PointerType
@@ -509,84 +528,84 @@ Types:
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 30624
+      GoRuntimeType: 30880
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 81696
+      GoRuntimeType: 83616
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 31264
+      GoRuntimeType: 31520
       GoKind: 22
       Pointee: 66 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 31328
+      GoRuntimeType: 31584
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 60416
+      GoRuntimeType: 61440
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 82336
+      GoRuntimeType: 84256
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 67520
+      GoRuntimeType: 68544
       GoKind: 22
       Pointee: 129 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 31968
+      GoRuntimeType: 32224
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 94624
+      GoRuntimeType: 96544
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 126208
+      GoRuntimeType: 128128
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 100640
+      GoRuntimeType: 102560
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 95
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 29408
+      GoRuntimeType: 29664
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -608,46 +627,46 @@ Types:
       ID: 104
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 30048
+      GoRuntimeType: 30304
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 105
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29664
+      GoRuntimeType: 29920
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 29792
+      GoRuntimeType: 30048
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29920
+      GoRuntimeType: 30176
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29536
+      GoRuntimeType: 29792
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 30112
+      GoRuntimeType: 30368
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 167
+      ID: 168
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -658,11 +677,11 @@ Types:
             Type: 120 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 168
+      ID: 169
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -673,7 +692,7 @@ Types:
             Type: 122 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: ptr}
+                  Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -692,7 +711,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 166
+      ID: 167
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -703,7 +722,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -829,11 +848,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 166
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 53632
+      GoRuntimeType: 54592
       GoKind: 17
       Count: 10
       HasCount: true
@@ -842,7 +864,7 @@ Types:
       ID: 154
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 47680
+      GoRuntimeType: 48544
       GoKind: 17
       Count: 128
       HasCount: true
@@ -851,7 +873,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 53248
+      GoRuntimeType: 54208
       GoKind: 17
       Count: 2
       HasCount: true
@@ -860,7 +882,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 53344
+      GoRuntimeType: 54304
       GoKind: 17
       Count: 2
       HasCount: true
@@ -869,7 +891,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 53536
+      GoRuntimeType: 54496
       GoKind: 17
       Count: 2
       HasCount: true
@@ -878,7 +900,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 49216
+      GoRuntimeType: 50176
       GoKind: 17
       Count: 2
       HasCount: true
@@ -887,7 +909,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 55936
+      GoRuntimeType: 56896
       GoKind: 17
       Count: 32
       HasCount: true
@@ -896,7 +918,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 53056
+      GoRuntimeType: 54016
       GoKind: 17
       Count: 32
       HasCount: true
@@ -905,7 +927,7 @@ Types:
       ID: 107
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 47392
+      GoRuntimeType: 48160
       GoKind: 17
       Count: 3
       HasCount: true
@@ -914,7 +936,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 52480
+      GoRuntimeType: 53440
       GoKind: 17
       Count: 3
       HasCount: true
@@ -923,7 +945,7 @@ Types:
       ID: 109
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 47488
+      GoRuntimeType: 48256
       GoKind: 17
       Count: 3
       HasCount: true
@@ -932,7 +954,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 54976
+      GoRuntimeType: 55936
       GoKind: 17
       Count: 4
       HasCount: true
@@ -941,7 +963,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 51808
+      GoRuntimeType: 52768
       GoKind: 17
       Count: 6
       HasCount: true
@@ -950,7 +972,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 53440
+      GoRuntimeType: 54400
       GoKind: 17
       Count: 8
       HasCount: true
@@ -959,7 +981,7 @@ Types:
       ID: 62
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 40416
+      GoRuntimeType: 40800
       GoKind: 23
       RawFields:
         - Name: array
@@ -994,7 +1016,7 @@ Types:
       ID: 106
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 38816
+      GoRuntimeType: 39200
       GoKind: 23
       RawFields:
         - Name: array
@@ -1033,7 +1055,7 @@ Types:
       ID: 108
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 39072
+      GoRuntimeType: 39456
       GoKind: 23
       RawFields:
         - Name: array
@@ -1056,7 +1078,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 38496
+      GoRuntimeType: 38880
       GoKind: 23
       RawFields:
         - Name: array
@@ -1079,7 +1101,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 38944
+      GoRuntimeType: 39328
       GoKind: 23
       RawFields:
         - Name: array
@@ -1102,25 +1124,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 43776
+      GoRuntimeType: 44416
       GoKind: 1
     - __kind: BaseType
       ID: 97
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 43584
+      GoRuntimeType: 44224
       GoKind: 16
     - __kind: BaseType
       ID: 96
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 43520
+      GoRuntimeType: 44160
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 65856
+      GoRuntimeType: 66880
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1133,25 +1155,25 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 43648
+      GoRuntimeType: 44288
       GoKind: 13
     - __kind: BaseType
       ID: 15
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 43712
+      GoRuntimeType: 44352
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 36576
+      GoRuntimeType: 36960
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 58240
+      GoRuntimeType: 59264
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 137
@@ -1185,31 +1207,31 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 43328
+      GoRuntimeType: 43968
       GoKind: 2
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 43072
+      GoRuntimeType: 43712
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 43200
+      GoRuntimeType: 43840
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 42816
+      GoRuntimeType: 43456
       GoKind: 3
     - __kind: StructureType
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 117248
+      GoRuntimeType: 119168
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1231,7 +1253,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 75840
+      GoRuntimeType: 77248
       GoKind: 25
       RawFields:
         - Name: u
@@ -1241,7 +1263,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 103712
+      GoRuntimeType: 105632
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1257,7 +1279,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 92896
+      GoRuntimeType: 94816
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1270,7 +1292,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 92736
+      GoRuntimeType: 94656
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1283,7 +1305,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 93056
+      GoRuntimeType: 94976
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1295,20 +1317,20 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 64160
+      GoRuntimeType: 65184
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 64064
+      GoRuntimeType: 65088
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 151
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 124736
+      GoRuntimeType: 126656
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1409,21 +1431,21 @@ Types:
       ID: 110
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 70080
+      GoRuntimeType: 71232
       GoKind: 21
       HeaderType: 112 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 115
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 70208
+      GoRuntimeType: 71360
       GoKind: 21
       HeaderType: 117 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
       ID: 148
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 47776
+      GoRuntimeType: 48640
       GoKind: 17
       Count: 8
       HasCount: true
@@ -1432,7 +1454,7 @@ Types:
       ID: 140
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 47584
+      GoRuntimeType: 48448
       GoKind: 17
       Count: 8
       HasCount: true
@@ -1441,7 +1463,7 @@ Types:
       ID: 139
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 77248
+      GoRuntimeType: 78912
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1454,7 +1476,7 @@ Types:
       ID: 147
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 77504
+      GoRuntimeType: 79168
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1467,7 +1489,7 @@ Types:
       ID: 149
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 77376
+      GoRuntimeType: 79040
       GoKind: 25
       RawFields:
         - Name: key
@@ -1480,7 +1502,7 @@ Types:
       ID: 141
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 77120
+      GoRuntimeType: 78784
       GoKind: 25
       RawFields:
         - Name: key
@@ -1508,14 +1530,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 63296
+      GoRuntimeType: 64320
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 147008
+      GoRuntimeType: 148928
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1705,7 +1727,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 74304
+      GoRuntimeType: 75712
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1715,7 +1737,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 120416
+      GoRuntimeType: 122336
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1740,7 +1762,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 90016
+      GoRuntimeType: 91936
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1753,7 +1775,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 109088
+      GoRuntimeType: 111008
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1772,13 +1794,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 56704
+      GoRuntimeType: 57728
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 89856
+      GoRuntimeType: 91776
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1791,7 +1813,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 121184
+      GoRuntimeType: 123104
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1816,13 +1838,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 56608
+      GoRuntimeType: 57632
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 150304
+      GoRuntimeType: 152224
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2042,7 +2064,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 120928
+      GoRuntimeType: 122848
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2067,7 +2089,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 116128
+      GoRuntimeType: 118048
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2089,7 +2111,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 115904
+      GoRuntimeType: 117824
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2111,7 +2133,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 89536
+      GoRuntimeType: 91456
       GoKind: 25
       RawFields:
         - Name: next
@@ -2124,13 +2146,13 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 56320
+      GoRuntimeType: 57344
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 74048
+      GoRuntimeType: 75456
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2141,7 +2163,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 89696
+      GoRuntimeType: 91616
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2154,7 +2176,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 110048
+      GoRuntimeType: 111968
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2173,13 +2195,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 56512
+      GoRuntimeType: 57536
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 59936
+      GoRuntimeType: 60960
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2188,7 +2210,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 87776
+      GoRuntimeType: 89696
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2209,7 +2231,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 44032
+      GoRuntimeType: 44672
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2219,7 +2241,7 @@ Types:
       ID: 74
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 44096
+      GoRuntimeType: 44736
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 80
@@ -2229,7 +2251,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 88736
+      GoRuntimeType: 90656
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2242,19 +2264,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 76864
+      GoRuntimeType: 78272
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 63200
+      GoRuntimeType: 64224
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 42752
+      GoRuntimeType: 43392
       GoKind: 24
       RawFields:
         - Name: str
@@ -2321,45 +2343,45 @@ Types:
       ID: 17
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 43392
+      GoRuntimeType: 44032
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 43008
+      GoRuntimeType: 43648
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 43136
+      GoRuntimeType: 43776
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 43264
+      GoRuntimeType: 43904
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 42880
+      GoRuntimeType: 43520
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 43456
+      GoRuntimeType: 44096
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 43840
+      GoRuntimeType: 44480
       GoKind: 26
-MaxTypeID: 168
+MaxTypeID: 169
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x58c3a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,10 +8,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 150 EventRootType Probe[main.PointerChainArg]
+        - ID: 13
+          Type: 151 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5338", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -22,10 +22,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 14}
       events:
-        - ID: 13
-          Type: 151 EventRootType Probe[main.PointerSmallChainArg]
+        - ID: 14
+          Type: 152 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb5370", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -49,10 +49,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 149 EventRootType Probe[main.inlined]
+        - ID: 12
+          Type: 150 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb56ec"
               Frameless: true
@@ -175,6 +175,20 @@ Probes:
         - ID: 5
           Type: 143 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb55cc", Frameless: true}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 11
+          Type: 149 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb5950", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -309,6 +323,11 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
     - ID: 11
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0xb5940..0xb5a80]
+      InlinePCRanges: []
+      Variables: []
+    - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0xb56e0..0xb5750]
       InlinePCRanges:
@@ -324,7 +343,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -338,7 +357,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -357,28 +376,28 @@ Types:
       ID: 116
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 32480
+      GoRuntimeType: 32896
       GoKind: 22
       Pointee: 117 PointerType ****int
     - __kind: PointerType
       ID: 117
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 32416
+      GoRuntimeType: 32832
       GoKind: 22
       Pointee: 138 PointerType ***int
     - __kind: PointerType
       ID: 138
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 32352
+      GoRuntimeType: 32768
       GoKind: 22
       Pointee: 118 PointerType **int
     - __kind: PointerType
       ID: 118
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 32288
+      GoRuntimeType: 32704
       GoKind: 22
       Pointee: 94 PointerType *int
     - __kind: PointerType
@@ -390,7 +409,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 35808
+      GoRuntimeType: 36352
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -412,7 +431,7 @@ Types:
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 26912
+      GoRuntimeType: 27328
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -429,21 +448,21 @@ Types:
       ID: 96
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 25824
+      GoRuntimeType: 26240
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 97
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 26784
+      GoRuntimeType: 27200
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 92
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 26848
+      GoRuntimeType: 27264
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
@@ -460,105 +479,105 @@ Types:
       ID: 94
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 26464
+      GoRuntimeType: 26880
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 26208
+      GoRuntimeType: 26624
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 93
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 26336
+      GoRuntimeType: 26752
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 134
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 24224
+      GoRuntimeType: 24640
       GoKind: 22
       Pointee: 135 StructureType main.bigStruct
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 27104
+      GoRuntimeType: 27520
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 69824
+      GoRuntimeType: 70944
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 27744
+      GoRuntimeType: 28160
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 27808
+      GoRuntimeType: 28224
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 53184
+      GoRuntimeType: 53984
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 60544
+      GoRuntimeType: 61536
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 109
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 29728
+      GoRuntimeType: 30144
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 28512
+      GoRuntimeType: 28928
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 112192
+      GoRuntimeType: 113696
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 86144
+      GoRuntimeType: 87264
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 25888
+      GoRuntimeType: 26304
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -570,46 +589,46 @@ Types:
       ID: 98
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 26528
+      GoRuntimeType: 26944
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 99
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 26144
+      GoRuntimeType: 26560
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 26272
+      GoRuntimeType: 26688
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 95
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 26400
+      GoRuntimeType: 26816
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26016
+      GoRuntimeType: 26432
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 26592
+      GoRuntimeType: 27008
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 150
+      ID: 151
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -620,11 +639,11 @@ Types:
             Type: 116 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 151
+      ID: 152
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -635,7 +654,7 @@ Types:
             Type: 118 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: ptr}
+                  Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -654,7 +673,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 149
+      ID: 150
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -665,7 +684,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -791,11 +810,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 149
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 47424
+      GoRuntimeType: 48224
       GoKind: 17
       Count: 10
       HasCount: true
@@ -804,7 +826,7 @@ Types:
       ID: 137
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 41856
+      GoRuntimeType: 42560
       GoKind: 17
       Count: 128
       HasCount: true
@@ -813,7 +835,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 47136
+      GoRuntimeType: 47936
       GoKind: 17
       Count: 2
       HasCount: true
@@ -822,7 +844,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 47328
+      GoRuntimeType: 48128
       GoKind: 17
       Count: 2
       HasCount: true
@@ -831,7 +853,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 43392
+      GoRuntimeType: 44192
       GoKind: 17
       Count: 2
       HasCount: true
@@ -840,7 +862,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 49248
+      GoRuntimeType: 50048
       GoKind: 17
       Count: 32
       HasCount: true
@@ -849,7 +871,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 46944
+      GoRuntimeType: 47744
       GoKind: 17
       Count: 32
       HasCount: true
@@ -858,7 +880,7 @@ Types:
       ID: 101
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 41376
+      GoRuntimeType: 41984
       GoKind: 17
       Count: 3
       HasCount: true
@@ -867,7 +889,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 46656
+      GoRuntimeType: 47456
       GoKind: 17
       Count: 3
       HasCount: true
@@ -876,7 +898,7 @@ Types:
       ID: 103
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 41472
+      GoRuntimeType: 42080
       GoKind: 17
       Count: 3
       HasCount: true
@@ -885,7 +907,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 48384
+      GoRuntimeType: 49184
       GoKind: 17
       Count: 4
       HasCount: true
@@ -894,7 +916,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 45888
+      GoRuntimeType: 46688
       GoKind: 17
       Count: 6
       HasCount: true
@@ -903,7 +925,7 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 47232
+      GoRuntimeType: 48032
       GoKind: 17
       Count: 8
       HasCount: true
@@ -912,7 +934,7 @@ Types:
       ID: 129
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 41568
+      GoRuntimeType: 42176
       GoKind: 17
       Count: 8
       HasCount: true
@@ -933,7 +955,7 @@ Types:
       ID: 100
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 33952
+      GoRuntimeType: 34496
       GoKind: 23
       RawFields:
         - Name: array
@@ -967,7 +989,7 @@ Types:
       ID: 102
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 34272
+      GoRuntimeType: 34816
       GoKind: 23
       RawFields:
         - Name: array
@@ -990,7 +1012,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 33632
+      GoRuntimeType: 34176
       GoKind: 23
       RawFields:
         - Name: array
@@ -1013,7 +1035,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 34080
+      GoRuntimeType: 34624
       GoKind: 23
       RawFields:
         - Name: array
@@ -1050,7 +1072,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 38432
+      GoRuntimeType: 39040
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 108
@@ -1094,19 +1116,19 @@ Types:
       ID: 91
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 38240
+      GoRuntimeType: 38848
       GoKind: 16
     - __kind: BaseType
       ID: 90
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 38176
+      GoRuntimeType: 38784
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 58880
+      GoRuntimeType: 59872
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1119,25 +1141,25 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 38304
+      GoRuntimeType: 38912
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 38368
+      GoRuntimeType: 38976
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 32672
+      GoRuntimeType: 33216
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 51360
+      GoRuntimeType: 52160
       GoKind: 19
     - __kind: GoHMapHeaderType
       ID: 106
@@ -1211,37 +1233,37 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 37984
+      GoRuntimeType: 38592
       GoKind: 2
     - __kind: BaseType
       ID: 89
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 37600
+      GoRuntimeType: 38208
       GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 37728
+      GoRuntimeType: 38336
       GoKind: 5
     - __kind: BaseType
       ID: 14
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 37856
+      GoRuntimeType: 38464
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 37472
+      GoRuntimeType: 38080
       GoKind: 3
     - __kind: StructureType
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 103392
+      GoRuntimeType: 104896
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1263,7 +1285,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 67552
+      GoRuntimeType: 68672
       GoKind: 25
       RawFields:
         - Name: u
@@ -1273,7 +1295,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 89792
+      GoRuntimeType: 90912
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1289,7 +1311,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 79872
+      GoRuntimeType: 80992
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1302,7 +1324,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 79712
+      GoRuntimeType: 80832
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1315,7 +1337,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 80032
+      GoRuntimeType: 81152
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1327,20 +1349,20 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 57312
+      GoRuntimeType: 58304
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 57216
+      GoRuntimeType: 58208
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 135
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 110400
+      GoRuntimeType: 111904
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1371,14 +1393,14 @@ Types:
       ID: 104
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 54528
+      GoRuntimeType: 55424
       GoKind: 21
       HeaderType: 106 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 111
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 54624
+      GoRuntimeType: 55520
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: UnresolvedPointeeType
@@ -1400,14 +1422,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 56640
+      GoRuntimeType: 57632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 130400
+      GoRuntimeType: 131904
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1582,7 +1604,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 65888
+      GoRuntimeType: 67008
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1592,7 +1614,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 108384
+      GoRuntimeType: 109888
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1620,7 +1642,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 77632
+      GoRuntimeType: 78752
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1633,7 +1655,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 96704
+      GoRuntimeType: 98208
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1652,13 +1674,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 50016
+      GoRuntimeType: 50816
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 77472
+      GoRuntimeType: 78592
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1671,7 +1693,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 107072
+      GoRuntimeType: 108576
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1696,13 +1718,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 49920
+      GoRuntimeType: 50720
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 133568
+      GoRuntimeType: 135072
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1922,7 +1944,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 106816
+      GoRuntimeType: 108320
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1947,7 +1969,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 86528
+      GoRuntimeType: 87648
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -1963,7 +1985,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 86336
+      GoRuntimeType: 87456
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -1983,20 +2005,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 49632
+      GoRuntimeType: 50432
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 65504
+      GoRuntimeType: 66624
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 77312
+      GoRuntimeType: 78432
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2009,7 +2031,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 97472
+      GoRuntimeType: 98976
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2028,13 +2050,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 49824
+      GoRuntimeType: 50624
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 52800
+      GoRuntimeType: 53600
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2043,7 +2065,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 75712
+      GoRuntimeType: 76832
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2060,7 +2082,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 38688
+      GoRuntimeType: 39296
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2070,7 +2092,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 38752
+      GoRuntimeType: 39360
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -2080,7 +2102,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 76672
+      GoRuntimeType: 77792
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2093,19 +2115,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 62848
+      GoRuntimeType: 63840
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 56544
+      GoRuntimeType: 57536
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 37408
+      GoRuntimeType: 38016
       GoKind: 24
       RawFields:
         - Name: str
@@ -2124,45 +2146,45 @@ Types:
       ID: 12
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 38048
+      GoRuntimeType: 38656
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 37664
+      GoRuntimeType: 38272
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 37792
+      GoRuntimeType: 38400
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 37920
+      GoRuntimeType: 38528
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 37536
+      GoRuntimeType: 38144
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 38112
+      GoRuntimeType: 38720
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 38496
+      GoRuntimeType: 39104
       GoKind: 26
-MaxTypeID: 151
+MaxTypeID: 152
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,8 +11,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 151 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb5338", Frameless: false}]
+          Type: 168 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0xb5388", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -25,8 +25,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 152 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb5370", Frameless: false}]
+          Type: 169 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0xb53c0", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -38,8 +38,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 147 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb5820", Frameless: true}]
+          Type: 164 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0xb5870", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -52,11 +52,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 150 EventRootType Probe[main.inlined]
+          Type: 167 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb56ec"
+            - PC: "0xb573c"
               Frameless: true
-            - PC: "0xb514c"
+            - PC: "0xb519c"
               Frameless: false
           Condition: null
     - id: intArg
@@ -69,8 +69,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 139 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb53cc", Frameless: true}]
+          Type: 156 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0xb541c", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -82,8 +82,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 142 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb554c", Frameless: true}]
+          Type: 159 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0xb559c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 145 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb56d0", Frameless: true}]
+          Type: 162 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0xb5720", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -108,8 +108,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 141 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb54bc", Frameless: true}]
+          Type: 158 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0xb550c", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -121,8 +121,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 146 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb57ac", Frameless: true}]
+          Type: 163 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0xb57fc", Frameless: true}]
           Condition: null
     - id: noArgs
       version: 0
@@ -134,8 +134,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 148 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0xb58dc", Frameless: true}]
+          Type: 165 EventRootType Probe[main.noArgs]
+          InjectionPoints: [{PC: "0xb592c", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -147,8 +147,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 140 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb543c", Frameless: true}]
+          Type: 157 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb548c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -160,8 +160,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 144 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb565c", Frameless: true}]
+          Type: 161 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0xb56ac", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -173,8 +173,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 143 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb55cc", Frameless: true}]
+          Type: 160 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb561c", Frameless: true}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -187,31 +187,31 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 149 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0xb5950", Frameless: true}]
+          Type: 166 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb59a0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb53c0..0xb5430]
+      OutOfLinePCRanges: [0xb5410..0xb5480]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb53c0..0xb53e0
+            - Range: 0xb5410..0xb5430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb5430..0xb54b0]
+      OutOfLinePCRanges: [0xb5480..0xb5500]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb5430..0xb5454
+            - Range: 0xb5480..0xb54a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -221,13 +221,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb54b0..0xb5540]
+      OutOfLinePCRanges: [0xb5500..0xb5590]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb54b0..0xb54d4
+            - Range: 0xb5500..0xb5524
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -239,25 +239,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb5540..0xb55c0]
+      OutOfLinePCRanges: [0xb5590..0xb5610]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 101 ArrayType [3]int
           Locations:
-            - Range: 0xb5540..0xb55c0
+            - Range: 0xb5590..0xb5610
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb55c0..0xb5650]
+      OutOfLinePCRanges: [0xb5610..0xb56a0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 102 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb55c0..0xb55e4
+            - Range: 0xb5610..0xb5634
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -269,77 +269,82 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb5650..0xb56d0]
+      OutOfLinePCRanges: [0xb56a0..0xb5720]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0xb5650..0xb56d0
+            - Range: 0xb56a0..0xb5720
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb56d0..0xb56e0]
+      OutOfLinePCRanges: [0xb5720..0xb5730]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0xb56d0..0xb56e0
+            - Range: 0xb5720..0xb5730
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb57a0..0xb5810]
+      OutOfLinePCRanges: [0xb57f0..0xb5860]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xb57a0..0xb57d8
+            - Range: 0xb57f0..0xb5828
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb5810..0xb58d0]
+      OutOfLinePCRanges: [0xb5860..0xb5920]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb5810..0xb5848
+            - Range: 0xb5860..0xb5898
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb5848..0xb58d0
+            - Range: 0xb5898..0xb5920
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb58d0..0xb5940]
+      OutOfLinePCRanges: [0xb5920..0xb5990]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xb5940..0xb5a80]
+      OutOfLinePCRanges: [0xb5990..0xb5b40]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: ~r0
+          Type: 116 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0xb5990..0xb5b40, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 12
       Name: main.inlined
-      OutOfLinePCRanges: [0xb56e0..0xb5750]
+      OutOfLinePCRanges: [0xb5730..0xb57a0]
       InlinePCRanges:
-        - Ranges: [0xb514c..0xb518c]
-          RootRanges: [0xb4fb0..0xb53c0]
+        - Ranges: [0xb519c..0xb51dc]
+          RootRanges: [0xb5000..0xb5410]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb514c..0xb518c
+            - Range: 0xb519c..0xb51dc
               Pieces: []
-            - Range: 0xb56e0..0xb5700
+            - Range: 0xb5730..0xb5750
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -347,13 +352,13 @@ Subprograms:
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb5338..0xb5368]
-          RootRanges: [0xb4fb0..0xb53c0]
+        - Ranges: [0xb5388..0xb53b8]
+          RootRanges: [0xb5000..0xb5410]
       Variables:
         - Name: ptr
-          Type: 116 PointerType *****int
+          Type: 121 PointerType *****int
           Locations:
-            - Range: 0xb5310..0xb5358
+            - Range: 0xb5360..0xb53a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -361,79 +366,84 @@ Subprograms:
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb5370..0xb53a0]
-          RootRanges: [0xb4fb0..0xb53c0]
+        - Ranges: [0xb53c0..0xb53f0]
+          RootRanges: [0xb5000..0xb5410]
       Variables:
         - Name: ptr
-          Type: 118 PointerType **int
+          Type: 123 PointerType **int
           Locations:
-            - Range: 0xb5370..0xb53a0
+            - Range: 0xb53c0..0xb53f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 116
+      ID: 121
       Name: '*****int'
+      ByteSize: 8
+      GoRuntimeType: 32960
+      GoKind: 22
+      Pointee: 122 PointerType ****int
+    - __kind: PointerType
+      ID: 122
+      Name: '****int'
       ByteSize: 8
       GoRuntimeType: 32896
       GoKind: 22
-      Pointee: 117 PointerType ****int
+      Pointee: 155 PointerType ***int
     - __kind: PointerType
-      ID: 117
-      Name: '****int'
+      ID: 155
+      Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32832
       GoKind: 22
-      Pointee: 138 PointerType ***int
+      Pointee: 123 PointerType **int
     - __kind: PointerType
-      ID: 138
-      Name: '***int'
+      ID: 123
+      Name: '**int'
       ByteSize: 8
       GoRuntimeType: 32768
       GoKind: 22
-      Pointee: 118 PointerType **int
-    - __kind: PointerType
-      ID: 118
-      Name: '**int'
-      ByteSize: 8
-      GoRuntimeType: 32704
-      GoKind: 22
       Pointee: 94 PointerType *int
     - __kind: PointerType
-      ID: 126
+      ID: 131
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 125 GoSliceDataType []int.array
+      Pointee: 130 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 36352
+      GoRuntimeType: 36416
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 128
+      ID: 133
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 127 GoSliceDataType []string.array
+      Pointee: 132 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 122
+      ID: 127
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 121 GoSliceDataType []uint8.array
+      Pointee: 126 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 124
+      ID: 129
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 123 GoSliceDataType []uintptr.array
+      Pointee: 128 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 27328
+      GoRuntimeType: 27392
       GoKind: 22
       Pointee: 4 BaseType bool
+    - __kind: PointerType
+      ID: 147
+      Name: '*bucket<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 148 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 107
       Name: '*bucket<string,int>'
@@ -445,26 +455,36 @@ Types:
       ByteSize: 8
       Pointee: 115 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
+      ID: 119
+      Name: '*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 120 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
       ID: 96
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 26240
+      GoRuntimeType: 26304
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 97
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 27200
+      GoRuntimeType: 27264
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 92
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 27264
+      GoRuntimeType: 27328
       GoKind: 22
       Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 145
+      Name: '*hash<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 146 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 105
       Name: '*hash<string,int>'
@@ -476,159 +496,164 @@ Types:
       ByteSize: 8
       Pointee: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
+      ID: 117
+      Name: '*hash<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 118 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
       ID: 94
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 26880
+      GoRuntimeType: 26944
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 26624
+      GoRuntimeType: 26688
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 93
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 26752
+      GoRuntimeType: 26816
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 134
+      ID: 139
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 24640
+      GoRuntimeType: 24704
       GoKind: 22
-      Pointee: 135 StructureType main.bigStruct
+      Pointee: 140 StructureType main.bigStruct
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 27520
+      GoRuntimeType: 27584
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 70944
+      GoRuntimeType: 71264
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 28160
+      GoRuntimeType: 28224
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 28224
+      GoRuntimeType: 28288
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 53984
+      GoRuntimeType: 54208
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 61536
+      GoRuntimeType: 61856
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 109
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 30144
+      GoRuntimeType: 30208
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 28928
+      GoRuntimeType: 28992
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 113696
+      GoRuntimeType: 114208
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 87264
+      GoRuntimeType: 87584
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 26304
+      GoRuntimeType: 26368
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 120
+      ID: 125
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 119 GoStringDataType string.str
+      Pointee: 124 GoStringDataType string.str
     - __kind: PointerType
       ID: 98
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 26944
+      GoRuntimeType: 27008
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 99
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 26560
+      GoRuntimeType: 26624
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 26688
+      GoRuntimeType: 26752
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 95
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 26816
+      GoRuntimeType: 26880
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26432
+      GoRuntimeType: 26496
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 27008
+      GoRuntimeType: 27072
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 151
+      ID: 168
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -636,14 +661,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 116 PointerType *****int
+            Type: 121 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 152
+      ID: 169
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -651,14 +676,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 118 PointerType **int
+            Type: 123 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 147
+      ID: 164
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -673,7 +698,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 150
+      ID: 167
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -688,7 +713,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 139
+      ID: 156
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -703,7 +728,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 142
+      ID: 159
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -718,7 +743,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 141
+      ID: 158
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -733,7 +758,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 146
+      ID: 163
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -748,10 +773,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 148
+      ID: 165
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 140
+      ID: 157
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -766,7 +791,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 145
+      ID: 162
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -781,7 +806,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 144
+      ID: 161
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -796,7 +821,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 143
+      ID: 160
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -811,22 +836,22 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 149
+      ID: 166
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 48224
+      GoRuntimeType: 48448
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 86 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 137
+      ID: 154
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 42560
+      GoRuntimeType: 42688
       GoKind: 17
       Count: 128
       HasCount: true
@@ -835,7 +860,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 47936
+      GoRuntimeType: 48160
       GoKind: 17
       Count: 2
       HasCount: true
@@ -844,7 +869,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 48128
+      GoRuntimeType: 48352
       GoKind: 17
       Count: 2
       HasCount: true
@@ -853,7 +878,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 44192
+      GoRuntimeType: 44416
       GoKind: 17
       Count: 2
       HasCount: true
@@ -862,7 +887,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 50048
+      GoRuntimeType: 50272
       GoKind: 17
       Count: 32
       HasCount: true
@@ -871,7 +896,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 47744
+      GoRuntimeType: 47968
       GoKind: 17
       Count: 32
       HasCount: true
@@ -880,7 +905,7 @@ Types:
       ID: 101
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 41984
+      GoRuntimeType: 42112
       GoKind: 17
       Count: 3
       HasCount: true
@@ -889,7 +914,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 47456
+      GoRuntimeType: 47680
       GoKind: 17
       Count: 3
       HasCount: true
@@ -898,7 +923,7 @@ Types:
       ID: 103
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 42080
+      GoRuntimeType: 42208
       GoKind: 17
       Count: 3
       HasCount: true
@@ -907,7 +932,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 49184
+      GoRuntimeType: 49408
       GoKind: 17
       Count: 4
       HasCount: true
@@ -916,7 +941,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 46688
+      GoRuntimeType: 46912
       GoKind: 17
       Count: 6
       HasCount: true
@@ -925,37 +950,49 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 48032
+      GoRuntimeType: 48256
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 129
+      ID: 134
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 42176
+      GoRuntimeType: 42304
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 132
+      ID: 153
+      Name: '[]bucket<int,main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 144
+      Element: 148 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 137
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 108 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 136
+      ID: 141
       Name: '[]bucket<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 115 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 149
+      Name: '[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 88
+      Element: 120 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 100
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 34496
+      GoRuntimeType: 34560
       GoKind: 23
       RawFields:
         - Name: array
@@ -967,20 +1004,34 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 125 GoSliceDataType []int.array
+      Data: 130 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 130
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 130
+      ID: 150
+      Name: '[]key<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 9 BaseType int
+    - __kind: ArrayType
+      ID: 135
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 10 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 142
+      Name: '[]key<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -989,7 +1040,7 @@ Types:
       ID: 102
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 34816
+      GoRuntimeType: 34880
       GoKind: 23
       RawFields:
         - Name: array
@@ -1001,9 +1052,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 127 GoSliceDataType []string.array
+      Data: 132 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 127
+      ID: 132
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -1012,7 +1063,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 34176
+      GoRuntimeType: 34240
       GoKind: 23
       RawFields:
         - Name: array
@@ -1024,9 +1075,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 121 GoSliceDataType []uint8.array
+      Data: 126 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 121
+      ID: 126
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -1035,7 +1086,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 34624
+      GoRuntimeType: 34688
       GoKind: 23
       RawFields:
         - Name: array
@@ -1047,33 +1098,66 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 123 GoSliceDataType []uintptr.array
+      Data: 128 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 128
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 131
+      ID: 136
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 133
+      ID: 151
+      Name: '[]val<main.aStructNotUsedAsAnArgument>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 152 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: ArrayType
+      ID: 138
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 134 PointerType *main.bigStruct
+      Element: 139 PointerType *main.bigStruct
+    - __kind: ArrayType
+      ID: 143
+      Name: '[]val<map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 144 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 39040
+      GoRuntimeType: 39168
       GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 148
+      Name: bucket<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 134 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 150 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 151 ArrayType []val<main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 136
+          Type: 147 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+      KeyType: 9 BaseType int
+      ValueType: 152 StructureType main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 108
       Name: bucket<string,int>
@@ -1081,13 +1165,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 129 ArrayType [8]uint8
+          Type: 134 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 130 ArrayType []key<string>
+          Type: 135 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 131 ArrayType []val<int>
+          Type: 136 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 107 PointerType *bucket<string,int>
@@ -1100,35 +1184,54 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 129 ArrayType [8]uint8
+          Type: 134 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 130 ArrayType []key<string>
+          Type: 135 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 133 ArrayType []val<main.bigStruct>
+          Type: 138 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 114 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 134 PointerType *main.bigStruct
+      ValueType: 139 PointerType *main.bigStruct
+    - __kind: GoHMapBucketType
+      ID: 120
+      Name: bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 88
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 134 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 142 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 143 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 80
+          Type: 119 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      KeyType: 3 BaseType uint8
+      ValueType: 144 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 91
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 38848
+      GoRuntimeType: 38976
       GoKind: 16
     - __kind: BaseType
       ID: 90
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 38784
+      GoRuntimeType: 38912
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 59872
+      GoRuntimeType: 60192
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1141,26 +1244,60 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 38912
+      GoRuntimeType: 39040
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 38976
+      GoRuntimeType: 39104
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 33216
+      GoRuntimeType: 33280
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 52160
+      GoRuntimeType: 52384
       GoKind: 19
+    - __kind: GoHMapHeaderType
+      ID: 146
+      Name: hash<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 147 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 147 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 109 PointerType *runtime.mapextra
+      BucketType: 148 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      BucketsType: 153 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 106
       Name: hash<string,int>
@@ -1194,7 +1331,7 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 108 GoHMapBucketType bucket<string,int>
-      BucketsType: 132 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 137 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 113
       Name: hash<string,main.bigStruct>
@@ -1228,42 +1365,76 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 115 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 136 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 141 GoSliceDataType []bucket<string,main.bigStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 118
+      Name: hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 119 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 119 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 109 PointerType *runtime.mapextra
+      BucketType: 120 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 149 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 38592
+      GoRuntimeType: 38720
       GoKind: 2
     - __kind: BaseType
       ID: 89
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 38208
+      GoRuntimeType: 38336
       GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 38336
+      GoRuntimeType: 38464
       GoKind: 5
     - __kind: BaseType
       ID: 14
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 38464
+      GoRuntimeType: 38592
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 38080
+      GoRuntimeType: 38208
       GoKind: 3
     - __kind: StructureType
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 104896
+      GoRuntimeType: 105408
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1285,7 +1456,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 68672
+      GoRuntimeType: 68992
       GoKind: 25
       RawFields:
         - Name: u
@@ -1295,7 +1466,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 90912
+      GoRuntimeType: 91232
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1311,7 +1482,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 80992
+      GoRuntimeType: 81312
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1324,7 +1495,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 80832
+      GoRuntimeType: 81152
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1337,7 +1508,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 81152
+      GoRuntimeType: 81472
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1349,20 +1520,27 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 58304
+      GoRuntimeType: 58624
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 58208
+      GoRuntimeType: 58528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 135
+      ID: 152
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 64512
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
+    - __kind: StructureType
+      ID: 140
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 111904
+      GoRuntimeType: 112416
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1388,21 +1566,35 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 137 ArrayType [128]uint8
+          Type: 154 ArrayType [128]uint8
+    - __kind: GoMapType
+      ID: 144
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 55552
+      GoKind: 21
+      HeaderType: 146 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 104
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 55424
+      GoRuntimeType: 55648
       GoKind: 21
       HeaderType: 106 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 111
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 55520
+      GoRuntimeType: 55744
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 116
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 55936
+      GoKind: 21
+      HeaderType: 118 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1422,14 +1614,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 57632
+      GoRuntimeType: 57952
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 131904
+      GoRuntimeType: 132416
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1604,7 +1796,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 67008
+      GoRuntimeType: 67328
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1614,7 +1806,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 109888
+      GoRuntimeType: 110400
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1642,7 +1834,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 78752
+      GoRuntimeType: 79072
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1655,7 +1847,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 98208
+      GoRuntimeType: 98720
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1674,13 +1866,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 50816
+      GoRuntimeType: 51040
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 78592
+      GoRuntimeType: 78912
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1693,7 +1885,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 108576
+      GoRuntimeType: 109088
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1718,13 +1910,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 50720
+      GoRuntimeType: 50944
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 135072
+      GoRuntimeType: 135584
       GoKind: 25
       RawFields:
         - Name: g0
@@ -1944,7 +2136,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 108320
+      GoRuntimeType: 108832
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -1969,7 +2161,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 87648
+      GoRuntimeType: 87968
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -1985,7 +2177,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 87456
+      GoRuntimeType: 87776
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2005,20 +2197,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 50432
+      GoRuntimeType: 50656
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 66624
+      GoRuntimeType: 66944
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 78432
+      GoRuntimeType: 78752
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2031,7 +2223,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 98976
+      GoRuntimeType: 99488
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2050,13 +2242,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 50624
+      GoRuntimeType: 50848
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 53600
+      GoRuntimeType: 53824
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2065,7 +2257,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 76832
+      GoRuntimeType: 77152
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2082,7 +2274,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 39296
+      GoRuntimeType: 39424
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2092,7 +2284,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 39360
+      GoRuntimeType: 39488
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -2102,7 +2294,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 77792
+      GoRuntimeType: 78112
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2115,30 +2307,30 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 63840
+      GoRuntimeType: 64160
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 57536
+      GoRuntimeType: 57856
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 38016
+      GoRuntimeType: 38144
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 120 PointerType *string.str
+          Type: 125 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 119 GoStringDataType string.str
+      Data: 124 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 119
+      ID: 124
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -2146,45 +2338,45 @@ Types:
       ID: 12
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 38656
+      GoRuntimeType: 38784
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 38272
+      GoRuntimeType: 38400
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 38400
+      GoRuntimeType: 38528
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 38528
+      GoRuntimeType: 38656
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 38144
+      GoRuntimeType: 38272
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 38720
+      GoRuntimeType: 38848
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 39104
+      GoRuntimeType: 39232
       GoKind: 26
-MaxTypeID: 152
+MaxTypeID: 169
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,10 +8,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 163 EventRootType Probe[main.PointerChainArg]
+        - ID: 13
+          Type: 164 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb51cc", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -22,10 +22,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 14}
       events:
-        - ID: 13
-          Type: 164 EventRootType Probe[main.PointerSmallChainArg]
+        - ID: 14
+          Type: 165 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb5204", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,7 +39,7 @@ Probes:
       events:
         - ID: 9
           Type: 160 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb5690", Frameless: true}]
+          InjectionPoints: [{PC: "0xb56a0", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -49,12 +49,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 162 EventRootType Probe[main.inlined]
+        - ID: 12
+          Type: 163 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb555c"
+            - PC: "0xb556c"
               Frameless: true
             - PC: "0xb4fec"
               Frameless: false
@@ -70,7 +70,7 @@ Probes:
       events:
         - ID: 1
           Type: 152 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb525c", Frameless: true}]
+          InjectionPoints: [{PC: "0xb526c", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -83,7 +83,7 @@ Probes:
       events:
         - ID: 4
           Type: 155 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb53cc", Frameless: true}]
+          InjectionPoints: [{PC: "0xb53dc", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -96,7 +96,7 @@ Probes:
       events:
         - ID: 7
           Type: 158 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb5540", Frameless: true}]
+          InjectionPoints: [{PC: "0xb5550", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -109,7 +109,7 @@ Probes:
       events:
         - ID: 3
           Type: 154 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb534c", Frameless: true}]
+          InjectionPoints: [{PC: "0xb535c", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -122,7 +122,7 @@ Probes:
       events:
         - ID: 8
           Type: 159 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb561c", Frameless: true}]
+          InjectionPoints: [{PC: "0xb562c", Frameless: true}]
           Condition: null
     - id: noArgs
       version: 0
@@ -135,7 +135,7 @@ Probes:
       events:
         - ID: 10
           Type: 161 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0xb574c", Frameless: true}]
+          InjectionPoints: [{PC: "0xb575c", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -148,7 +148,7 @@ Probes:
       events:
         - ID: 2
           Type: 153 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb52cc", Frameless: true}]
+          InjectionPoints: [{PC: "0xb52dc", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -161,7 +161,7 @@ Probes:
       events:
         - ID: 6
           Type: 157 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb54cc", Frameless: true}]
+          InjectionPoints: [{PC: "0xb54dc", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -174,30 +174,44 @@ Probes:
       events:
         - ID: 5
           Type: 156 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb544c", Frameless: true}]
+          InjectionPoints: [{PC: "0xb545c", Frameless: true}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 11
+          Type: 162 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb57d0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb5250..0xb52c0]
+      OutOfLinePCRanges: [0xb5260..0xb52d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb5250..0xb5270
+            - Range: 0xb5260..0xb5280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb52c0..0xb5340]
+      OutOfLinePCRanges: [0xb52d0..0xb5350]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb52c0..0xb52e4
+            - Range: 0xb52d0..0xb52f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -207,13 +221,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb5340..0xb53c0]
+      OutOfLinePCRanges: [0xb5350..0xb53d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb5340..0xb5364
+            - Range: 0xb5350..0xb5374
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -225,25 +239,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb53c0..0xb5440]
+      OutOfLinePCRanges: [0xb53d0..0xb5450]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 106 ArrayType [3]int
           Locations:
-            - Range: 0xb53c0..0xb5440
+            - Range: 0xb53d0..0xb5450
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb5440..0xb54c0]
+      OutOfLinePCRanges: [0xb5450..0xb54d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb5440..0xb5464
+            - Range: 0xb5450..0xb5474
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -255,81 +269,86 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb54c0..0xb5540]
+      OutOfLinePCRanges: [0xb54d0..0xb5550]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0xb54c0..0xb5540
+            - Range: 0xb54d0..0xb5550
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb5540..0xb5550]
+      OutOfLinePCRanges: [0xb5550..0xb5560]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0xb5540..0xb5550
+            - Range: 0xb5550..0xb5560
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb5610..0xb5680]
+      OutOfLinePCRanges: [0xb5620..0xb5690]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xb5610..0xb5648
+            - Range: 0xb5620..0xb5658
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb5680..0xb5740]
+      OutOfLinePCRanges: [0xb5690..0xb5750]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 114 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb5680..0xb56b8
+            - Range: 0xb5690..0xb56c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb56b8..0xb5740
+            - Range: 0xb56c8..0xb5750
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb5740..0xb57b0]
+      OutOfLinePCRanges: [0xb5750..0xb57c0]
       InlinePCRanges: []
       Variables: []
     - ID: 11
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0xb57c0..0xb5900]
+      InlinePCRanges: []
+      Variables: []
+    - ID: 12
       Name: main.inlined
-      OutOfLinePCRanges: [0xb5550..0xb55c0]
+      OutOfLinePCRanges: [0xb5560..0xb55d0]
       InlinePCRanges:
         - Ranges: [0xb4fec..0xb5028]
-          RootRanges: [0xb4e50..0xb5250]
+          RootRanges: [0xb4e50..0xb5260]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0xb4fec..0xb5028
               Pieces: []
-            - Range: 0xb5550..0xb5570
+            - Range: 0xb5560..0xb5580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xb51cc..0xb51fc]
-          RootRanges: [0xb4e50..0xb5250]
+          RootRanges: [0xb4e50..0xb5260]
       Variables:
         - Name: ptr
           Type: 119 PointerType *****int
@@ -338,12 +357,12 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xb5204..0xb5234]
-          RootRanges: [0xb4e50..0xb5250]
+          RootRanges: [0xb4e50..0xb5260]
       Variables:
         - Name: ptr
           Type: 121 PointerType **int
@@ -357,28 +376,28 @@ Types:
       ID: 119
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 35232
+      GoRuntimeType: 35488
       GoKind: 22
       Pointee: 120 PointerType ****int
     - __kind: PointerType
       ID: 120
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 35168
+      GoRuntimeType: 35424
       GoKind: 22
       Pointee: 151 PointerType ***int
     - __kind: PointerType
       ID: 151
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 35104
+      GoRuntimeType: 35360
       GoKind: 22
       Pointee: 121 PointerType **int
     - __kind: PointerType
       ID: 121
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 35040
+      GoRuntimeType: 35296
       GoKind: 22
       Pointee: 99 PointerType *int
     - __kind: PointerType
@@ -400,7 +419,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 39456
+      GoRuntimeType: 39840
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -422,56 +441,56 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 29536
+      GoRuntimeType: 29792
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 101
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 28448
+      GoRuntimeType: 28704
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 102
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 29408
+      GoRuntimeType: 29664
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 97
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 29472
+      GoRuntimeType: 29728
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29088
+      GoRuntimeType: 29344
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 28832
+      GoRuntimeType: 29088
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 98
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 28960
+      GoRuntimeType: 29216
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 146
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 26912
+      GoRuntimeType: 27168
       GoKind: 22
       Pointee: 147 StructureType main.bigStruct
     - __kind: PointerType
@@ -498,77 +517,77 @@ Types:
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 29728
+      GoRuntimeType: 29984
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 78976
+      GoRuntimeType: 80896
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 30368
+      GoRuntimeType: 30624
       GoKind: 22
       Pointee: 63 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 30432
+      GoRuntimeType: 30688
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 58112
+      GoRuntimeType: 59136
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 64832
+      GoRuntimeType: 65856
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 31136
+      GoRuntimeType: 31392
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 90944
+      GoRuntimeType: 92864
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 121984
+      GoRuntimeType: 123904
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 96128
+      GoRuntimeType: 98048
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 93
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28512
+      GoRuntimeType: 28768
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -590,46 +609,46 @@ Types:
       ID: 103
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 29152
+      GoRuntimeType: 29408
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 104
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 28768
+      GoRuntimeType: 29024
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 28896
+      GoRuntimeType: 29152
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 100
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29024
+      GoRuntimeType: 29280
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 28640
+      GoRuntimeType: 28896
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 29216
+      GoRuntimeType: 29472
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 163
+      ID: 164
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -640,11 +659,11 @@ Types:
             Type: 119 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 164
+      ID: 165
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -655,7 +674,7 @@ Types:
             Type: 121 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: ptr}
+                  Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -674,7 +693,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 162
+      ID: 163
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -685,7 +704,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -811,10 +830,13 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 162
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 51968
+      GoRuntimeType: 52928
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -822,7 +844,7 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 51872
+      GoRuntimeType: 52832
       GoKind: 17
       Count: 10
       HasCount: true
@@ -831,7 +853,7 @@ Types:
       ID: 150
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 46208
+      GoRuntimeType: 47072
       GoKind: 17
       Count: 128
       HasCount: true
@@ -840,7 +862,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 51488
+      GoRuntimeType: 52448
       GoKind: 17
       Count: 2
       HasCount: true
@@ -849,7 +871,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 51584
+      GoRuntimeType: 52544
       GoKind: 17
       Count: 2
       HasCount: true
@@ -858,7 +880,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 51776
+      GoRuntimeType: 52736
       GoKind: 17
       Count: 2
       HasCount: true
@@ -867,7 +889,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 47744
+      GoRuntimeType: 48704
       GoKind: 17
       Count: 2
       HasCount: true
@@ -876,7 +898,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 53984
+      GoRuntimeType: 54944
       GoKind: 17
       Count: 32
       HasCount: true
@@ -885,7 +907,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 51296
+      GoRuntimeType: 52256
       GoKind: 17
       Count: 32
       HasCount: true
@@ -894,7 +916,7 @@ Types:
       ID: 106
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 45920
+      GoRuntimeType: 46688
       GoKind: 17
       Count: 3
       HasCount: true
@@ -903,7 +925,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 51008
+      GoRuntimeType: 51968
       GoKind: 17
       Count: 3
       HasCount: true
@@ -912,7 +934,7 @@ Types:
       ID: 108
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 46016
+      GoRuntimeType: 46784
       GoKind: 17
       Count: 3
       HasCount: true
@@ -921,7 +943,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 53120
+      GoRuntimeType: 54080
       GoKind: 17
       Count: 4
       HasCount: true
@@ -930,7 +952,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 50240
+      GoRuntimeType: 51200
       GoKind: 17
       Count: 6
       HasCount: true
@@ -939,7 +961,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 51680
+      GoRuntimeType: 52640
       GoKind: 17
       Count: 8
       HasCount: true
@@ -960,7 +982,7 @@ Types:
       ID: 105
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 37664
+      GoRuntimeType: 38048
       GoKind: 23
       RawFields:
         - Name: array
@@ -999,7 +1021,7 @@ Types:
       ID: 107
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 37920
+      GoRuntimeType: 38304
       GoKind: 23
       RawFields:
         - Name: array
@@ -1022,7 +1044,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 37344
+      GoRuntimeType: 37728
       GoKind: 23
       RawFields:
         - Name: array
@@ -1045,7 +1067,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 37792
+      GoRuntimeType: 38176
       GoKind: 23
       RawFields:
         - Name: array
@@ -1068,25 +1090,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 42368
+      GoRuntimeType: 43008
       GoKind: 1
     - __kind: BaseType
       ID: 96
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 42176
+      GoRuntimeType: 42816
       GoKind: 16
     - __kind: BaseType
       ID: 95
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 42112
+      GoRuntimeType: 42752
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 63040
+      GoRuntimeType: 64064
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1099,25 +1121,25 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 42240
+      GoRuntimeType: 42880
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 42304
+      GoRuntimeType: 42944
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 35488
+      GoRuntimeType: 35872
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 56192
+      GoRuntimeType: 57216
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 133
@@ -1151,37 +1173,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 41920
+      GoRuntimeType: 42560
       GoKind: 2
     - __kind: BaseType
       ID: 94
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 41536
+      GoRuntimeType: 42176
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 41664
+      GoRuntimeType: 42304
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 41792
+      GoRuntimeType: 42432
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 41408
+      GoRuntimeType: 42048
       GoKind: 3
     - __kind: StructureType
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 111904
+      GoRuntimeType: 113824
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1203,7 +1225,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 73120
+      GoRuntimeType: 74528
       GoKind: 25
       RawFields:
         - Name: u
@@ -1213,7 +1235,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 99200
+      GoRuntimeType: 101120
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1229,7 +1251,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 89504
+      GoRuntimeType: 91424
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1242,7 +1264,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 89344
+      GoRuntimeType: 91264
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1255,7 +1277,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 89664
+      GoRuntimeType: 91584
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1267,20 +1289,20 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 61472
+      GoRuntimeType: 62496
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 61376
+      GoRuntimeType: 62400
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 147
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 119616
+      GoRuntimeType: 121536
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1375,21 +1397,21 @@ Types:
       ID: 109
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 67136
+      GoRuntimeType: 68288
       GoKind: 21
       HeaderType: 111 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 114
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 67264
+      GoRuntimeType: 68416
       GoKind: 21
       HeaderType: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
       ID: 144
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 46304
+      GoRuntimeType: 47168
       GoKind: 17
       Count: 8
       HasCount: true
@@ -1398,7 +1420,7 @@ Types:
       ID: 136
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 46112
+      GoRuntimeType: 46976
       GoKind: 17
       Count: 8
       HasCount: true
@@ -1407,7 +1429,7 @@ Types:
       ID: 135
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 74528
+      GoRuntimeType: 76192
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1420,7 +1442,7 @@ Types:
       ID: 143
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 74784
+      GoRuntimeType: 76448
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1433,7 +1455,7 @@ Types:
       ID: 145
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 74656
+      GoRuntimeType: 76320
       GoKind: 25
       RawFields:
         - Name: key
@@ -1446,7 +1468,7 @@ Types:
       ID: 137
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 74400
+      GoRuntimeType: 76064
       GoKind: 25
       RawFields:
         - Name: key
@@ -1474,14 +1496,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 60608
+      GoRuntimeType: 61632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 141472
+      GoRuntimeType: 143392
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1662,7 +1684,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 71584
+      GoRuntimeType: 72992
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1672,7 +1694,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 117600
+      GoRuntimeType: 119520
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1700,7 +1722,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 86944
+      GoRuntimeType: 88864
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1713,7 +1735,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 104384
+      GoRuntimeType: 106304
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1732,13 +1754,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 54752
+      GoRuntimeType: 55776
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 86784
+      GoRuntimeType: 88704
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1751,7 +1773,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 115776
+      GoRuntimeType: 117696
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1776,13 +1798,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 54656
+      GoRuntimeType: 55680
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 146528
+      GoRuntimeType: 148448
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2005,7 +2027,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 117888
+      GoRuntimeType: 119808
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2033,7 +2055,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 110560
+      GoRuntimeType: 112480
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2055,7 +2077,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 110336
+      GoRuntimeType: 112256
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2077,7 +2099,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 71328
+      GoRuntimeType: 72736
       GoKind: 25
       RawFields:
         - Name: next
@@ -2087,20 +2109,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 54368
+      GoRuntimeType: 55392
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 71200
+      GoRuntimeType: 72608
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 86624
+      GoRuntimeType: 88544
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2113,7 +2135,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 105152
+      GoRuntimeType: 107072
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2132,13 +2154,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 54560
+      GoRuntimeType: 55584
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 57728
+      GoRuntimeType: 58752
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2147,7 +2169,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 85024
+      GoRuntimeType: 86944
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2168,7 +2190,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 42624
+      GoRuntimeType: 43264
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2178,7 +2200,7 @@ Types:
       ID: 71
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 42688
+      GoRuntimeType: 43328
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 77
@@ -2188,7 +2210,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 85984
+      GoRuntimeType: 87904
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2201,19 +2223,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 74144
+      GoRuntimeType: 75552
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 60512
+      GoRuntimeType: 61536
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 41344
+      GoRuntimeType: 41984
       GoKind: 24
       RawFields:
         - Name: str
@@ -2280,45 +2302,45 @@ Types:
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 41984
+      GoRuntimeType: 42624
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 41600
+      GoRuntimeType: 42240
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 41728
+      GoRuntimeType: 42368
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 41856
+      GoRuntimeType: 42496
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 41472
+      GoRuntimeType: 42112
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 42048
+      GoRuntimeType: 42688
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 42432
+      GoRuntimeType: 43072
       GoKind: 26
-MaxTypeID: 164
+MaxTypeID: 165
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191340", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,8 +11,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 164 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb51cc", Frameless: false}]
+          Type: 191 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0xb520c", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -25,8 +25,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 165 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb5204", Frameless: false}]
+          Type: 192 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0xb5244", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -38,8 +38,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 160 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb56a0", Frameless: true}]
+          Type: 187 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0xb56e0", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -52,11 +52,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 163 EventRootType Probe[main.inlined]
+          Type: 190 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb556c"
+            - PC: "0xb55ac"
               Frameless: true
-            - PC: "0xb4fec"
+            - PC: "0xb502c"
               Frameless: false
           Condition: null
     - id: intArg
@@ -69,8 +69,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 152 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb526c", Frameless: true}]
+          Type: 179 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0xb52ac", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -82,8 +82,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 155 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb53dc", Frameless: true}]
+          Type: 182 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0xb541c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 158 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb5550", Frameless: true}]
+          Type: 185 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0xb5590", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -108,8 +108,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 154 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb535c", Frameless: true}]
+          Type: 181 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0xb539c", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -121,8 +121,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 159 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb562c", Frameless: true}]
+          Type: 186 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0xb566c", Frameless: true}]
           Condition: null
     - id: noArgs
       version: 0
@@ -134,8 +134,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 161 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0xb575c", Frameless: true}]
+          Type: 188 EventRootType Probe[main.noArgs]
+          InjectionPoints: [{PC: "0xb579c", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -147,8 +147,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 153 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb52dc", Frameless: true}]
+          Type: 180 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb531c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -160,8 +160,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 157 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb54dc", Frameless: true}]
+          Type: 184 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0xb551c", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -173,8 +173,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 156 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb545c", Frameless: true}]
+          Type: 183 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb549c", Frameless: true}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -187,31 +187,31 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 162 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0xb57d0", Frameless: true}]
+          Type: 189 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb5810", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb5260..0xb52d0]
+      OutOfLinePCRanges: [0xb52a0..0xb5310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb5260..0xb5280
+            - Range: 0xb52a0..0xb52c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb52d0..0xb5350]
+      OutOfLinePCRanges: [0xb5310..0xb5390]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb52d0..0xb52f4
+            - Range: 0xb5310..0xb5334
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -221,13 +221,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb5350..0xb53d0]
+      OutOfLinePCRanges: [0xb5390..0xb5410]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb5350..0xb5374
+            - Range: 0xb5390..0xb53b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -239,25 +239,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb53d0..0xb5450]
+      OutOfLinePCRanges: [0xb5410..0xb5490]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 106 ArrayType [3]int
           Locations:
-            - Range: 0xb53d0..0xb5450
+            - Range: 0xb5410..0xb5490
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb5450..0xb54d0]
+      OutOfLinePCRanges: [0xb5490..0xb5510]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb5450..0xb5474
+            - Range: 0xb5490..0xb54b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -269,77 +269,82 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb54d0..0xb5550]
+      OutOfLinePCRanges: [0xb5510..0xb5590]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0xb54d0..0xb5550
+            - Range: 0xb5510..0xb5590
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb5550..0xb5560]
+      OutOfLinePCRanges: [0xb5590..0xb55a0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0xb5550..0xb5560
+            - Range: 0xb5590..0xb55a0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb5620..0xb5690]
+      OutOfLinePCRanges: [0xb5660..0xb56d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xb5620..0xb5658
+            - Range: 0xb5660..0xb5698
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb5690..0xb5750]
+      OutOfLinePCRanges: [0xb56d0..0xb5790]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 114 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb5690..0xb56c8
+            - Range: 0xb56d0..0xb5708
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb56c8..0xb5750
+            - Range: 0xb5708..0xb5790
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb5750..0xb57c0]
+      OutOfLinePCRanges: [0xb5790..0xb5800]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xb57c0..0xb5900]
+      OutOfLinePCRanges: [0xb5800..0xb59c0]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: ~r0
+          Type: 119 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0xb5800..0xb59c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 12
       Name: main.inlined
-      OutOfLinePCRanges: [0xb5560..0xb55d0]
+      OutOfLinePCRanges: [0xb55a0..0xb5610]
       InlinePCRanges:
-        - Ranges: [0xb4fec..0xb5028]
-          RootRanges: [0xb4e50..0xb5260]
+        - Ranges: [0xb502c..0xb5068]
+          RootRanges: [0xb4e90..0xb52a0]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb4fec..0xb5028
+            - Range: 0xb502c..0xb5068
               Pieces: []
-            - Range: 0xb5560..0xb5580
+            - Range: 0xb55a0..0xb55c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -347,13 +352,13 @@ Subprograms:
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb51cc..0xb51fc]
-          RootRanges: [0xb4e50..0xb5260]
+        - Ranges: [0xb520c..0xb523c]
+          RootRanges: [0xb4e90..0xb52a0]
       Variables:
         - Name: ptr
-          Type: 119 PointerType *****int
+          Type: 124 PointerType *****int
           Locations:
-            - Range: 0xb51a4..0xb51ec
+            - Range: 0xb51e4..0xb522c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -361,45 +366,50 @@ Subprograms:
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb5204..0xb5234]
-          RootRanges: [0xb4e50..0xb5260]
+        - Ranges: [0xb5244..0xb5274]
+          RootRanges: [0xb4e90..0xb52a0]
       Variables:
         - Name: ptr
-          Type: 121 PointerType **int
+          Type: 126 PointerType **int
           Locations:
-            - Range: 0xb5204..0xb5234
+            - Range: 0xb5244..0xb5274
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 119
+      ID: 124
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 35488
+      GoRuntimeType: 35520
       GoKind: 22
-      Pointee: 120 PointerType ****int
+      Pointee: 125 PointerType ****int
     - __kind: PointerType
-      ID: 120
+      ID: 125
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 35424
+      GoRuntimeType: 35456
       GoKind: 22
-      Pointee: 151 PointerType ***int
+      Pointee: 178 PointerType ***int
     - __kind: PointerType
-      ID: 151
+      ID: 178
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 35360
+      GoRuntimeType: 35392
       GoKind: 22
-      Pointee: 121 PointerType **int
+      Pointee: 126 PointerType **int
     - __kind: PointerType
-      ID: 121
+      ID: 126
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 35296
+      GoRuntimeType: 35328
       GoKind: 22
       Pointee: 99 PointerType *int
+    - __kind: PointerType
+      ID: 164
+      Name: '**table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 165 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 112
       Name: '**table<string,int>'
@@ -411,88 +421,98 @@ Types:
       ByteSize: 8
       Pointee: 118 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 129
+      ID: 122
+      Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 123 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 134
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 128 GoSliceDataType []int.array
+      Pointee: 133 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 39840
+      GoRuntimeType: 39936
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 131
+      ID: 136
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 130 GoSliceDataType []string.array
+      Pointee: 135 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 125
+      ID: 130
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 124 GoSliceDataType []uint8.array
+      Pointee: 129 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 127
+      ID: 132
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 126 GoSliceDataType []uintptr.array
+      Pointee: 131 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 29792
+      GoRuntimeType: 29824
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 101
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 28704
+      GoRuntimeType: 28736
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 102
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 29664
+      GoRuntimeType: 29696
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 97
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 29728
+      GoRuntimeType: 29760
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29344
+      GoRuntimeType: 29376
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29088
+      GoRuntimeType: 29120
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 98
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 29216
+      GoRuntimeType: 29248
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 146
+      ID: 151
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 27168
+      GoRuntimeType: 27200
       GoKind: 22
-      Pointee: 147 StructureType main.bigStruct
+      Pointee: 152 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 162
+      Name: '*map<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 163 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 110
       Name: '*map<string,int>'
@@ -504,151 +524,176 @@ Types:
       ByteSize: 8
       Pointee: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 134
+      ID: 120
+      Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 121 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 170
+      Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 171 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: PointerType
+      ID: 139
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 135 StructureType noalg.map.group[string]int
+      Pointee: 140 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 142
+      ID: 147
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 143 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 148 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 157
+      Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 158 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 29984
+      GoRuntimeType: 30016
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 80896
+      GoRuntimeType: 81760
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 30624
+      GoRuntimeType: 30656
       GoKind: 22
       Pointee: 63 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 30688
+      GoRuntimeType: 30720
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 59136
+      GoRuntimeType: 59616
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 65856
+      GoRuntimeType: 66336
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 31392
+      GoRuntimeType: 31424
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 92864
+      GoRuntimeType: 93728
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 123904
+      GoRuntimeType: 124768
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 98048
+      GoRuntimeType: 98912
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 93
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28768
+      GoRuntimeType: 28800
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 123
+      ID: 128
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 122 GoStringDataType string.str
+      Pointee: 127 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 165
+      Name: '*table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 168 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 113
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 132 StructureType table<string,int>
+      Pointee: 137 StructureType table<string,int>
     - __kind: PointerType
       ID: 118
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 140 StructureType table<string,main.bigStruct>
+      Pointee: 145 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 123
+      Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 155 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 103
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 29408
+      GoRuntimeType: 29440
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 104
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29024
+      GoRuntimeType: 29056
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 29152
+      GoRuntimeType: 29184
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 100
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29280
+      GoRuntimeType: 29312
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 28896
+      GoRuntimeType: 28928
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 29472
+      GoRuntimeType: 29504
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 164
+      ID: 191
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -656,14 +701,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 119 PointerType *****int
+            Type: 124 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 165
+      ID: 192
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -671,14 +716,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 121 PointerType **int
+            Type: 126 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 160
+      ID: 187
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -693,7 +738,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 163
+      ID: 190
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -708,7 +753,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 152
+      ID: 179
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -723,7 +768,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 155
+      ID: 182
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -738,7 +783,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 154
+      ID: 181
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -753,7 +798,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 159
+      ID: 186
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -768,10 +813,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 161
+      ID: 188
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 153
+      ID: 180
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -786,7 +831,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 158
+      ID: 185
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -801,7 +846,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 157
+      ID: 184
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -816,7 +861,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 156
+      ID: 183
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -831,12 +876,12 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 162
+      ID: 189
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 52928
+      GoRuntimeType: 53408
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -844,16 +889,16 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 52832
+      GoRuntimeType: 53312
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 90 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 150
+      ID: 177
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 47072
+      GoRuntimeType: 47456
       GoKind: 17
       Count: 128
       HasCount: true
@@ -862,7 +907,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 52448
+      GoRuntimeType: 52928
       GoKind: 17
       Count: 2
       HasCount: true
@@ -871,7 +916,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 52544
+      GoRuntimeType: 53024
       GoKind: 17
       Count: 2
       HasCount: true
@@ -880,7 +925,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 52736
+      GoRuntimeType: 53216
       GoKind: 17
       Count: 2
       HasCount: true
@@ -889,7 +934,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 48704
+      GoRuntimeType: 49184
       GoKind: 17
       Count: 2
       HasCount: true
@@ -898,7 +943,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 54944
+      GoRuntimeType: 55424
       GoKind: 17
       Count: 32
       HasCount: true
@@ -907,7 +952,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 52256
+      GoRuntimeType: 52736
       GoKind: 17
       Count: 32
       HasCount: true
@@ -916,7 +961,7 @@ Types:
       ID: 106
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 46688
+      GoRuntimeType: 47072
       GoKind: 17
       Count: 3
       HasCount: true
@@ -925,7 +970,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 51968
+      GoRuntimeType: 52448
       GoKind: 17
       Count: 3
       HasCount: true
@@ -934,7 +979,7 @@ Types:
       ID: 108
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 46784
+      GoRuntimeType: 47168
       GoKind: 17
       Count: 3
       HasCount: true
@@ -943,7 +988,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 54080
+      GoRuntimeType: 54560
       GoKind: 17
       Count: 4
       HasCount: true
@@ -952,7 +997,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 51200
+      GoRuntimeType: 51680
       GoKind: 17
       Count: 6
       HasCount: true
@@ -961,28 +1006,40 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 52640
+      GoRuntimeType: 53120
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 175
+      Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 165 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 143
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 113 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 148
+      ID: 153
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 118 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 166
+      Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 123 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 105
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 38048
+      GoRuntimeType: 38144
       GoKind: 23
       RawFields:
         - Name: array
@@ -994,25 +1051,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 128 GoSliceDataType []int.array
+      Data: 133 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 133
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 176
+      Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
+      DynamicSizeClass: slice
+      ByteSize: 136
+      Element: 171 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoSliceDataType
+      ID: 144
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 135 StructureType noalg.map.group[string]int
+      Element: 140 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 154
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 143 StructureType noalg.map.group[string]main.bigStruct
+      Element: 148 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceDataType
+      ID: 167
+      Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
+      DynamicSizeClass: slice
+      ByteSize: 136
+      Element: 158 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -1021,7 +1090,7 @@ Types:
       ID: 107
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 38304
+      GoRuntimeType: 38400
       GoKind: 23
       RawFields:
         - Name: array
@@ -1033,9 +1102,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 130 GoSliceDataType []string.array
+      Data: 135 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 135
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -1044,7 +1113,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 37728
+      GoRuntimeType: 37824
       GoKind: 23
       RawFields:
         - Name: array
@@ -1056,9 +1125,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 124 GoSliceDataType []uint8.array
+      Data: 129 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 124
+      ID: 129
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -1067,7 +1136,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 38176
+      GoRuntimeType: 38272
       GoKind: 23
       RawFields:
         - Name: array
@@ -1079,9 +1148,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 126 GoSliceDataType []uintptr.array
+      Data: 131 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 126
+      ID: 131
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -1090,25 +1159,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 43008
+      GoRuntimeType: 43168
       GoKind: 1
     - __kind: BaseType
       ID: 96
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 42816
+      GoRuntimeType: 42976
       GoKind: 16
     - __kind: BaseType
       ID: 95
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 42752
+      GoRuntimeType: 42912
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 64064
+      GoRuntimeType: 64544
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1121,89 +1190,117 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 42880
+      GoRuntimeType: 43040
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 42944
+      GoRuntimeType: 43104
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 35872
+      GoRuntimeType: 35968
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 57216
+      GoRuntimeType: 57696
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 133
+      ID: 169
+      Name: groupReference<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 170 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 171 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 176 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+    - __kind: GoSwissMapGroupsType
+      ID: 138
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 134 PointerType *noalg.map.group[string]int
+          Type: 139 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 135 StructureType noalg.map.group[string]int
-      GroupSliceType: 139 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 140 StructureType noalg.map.group[string]int
+      GroupSliceType: 144 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 141
+      ID: 146
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 142 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 147 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 143 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 149 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 148 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 154 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 156
+      Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 157 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 158 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 167 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 42560
+      GoRuntimeType: 42720
       GoKind: 2
     - __kind: BaseType
       ID: 94
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 42176
+      GoRuntimeType: 42336
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 42304
+      GoRuntimeType: 42464
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 42432
+      GoRuntimeType: 42592
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 42048
+      GoRuntimeType: 42208
       GoKind: 3
     - __kind: StructureType
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 113824
+      GoRuntimeType: 114688
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1225,7 +1322,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 74528
+      GoRuntimeType: 75136
       GoKind: 25
       RawFields:
         - Name: u
@@ -1235,7 +1332,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 101120
+      GoRuntimeType: 101984
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1251,7 +1348,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 91424
+      GoRuntimeType: 92288
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1264,7 +1361,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 91264
+      GoRuntimeType: 92128
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1277,7 +1374,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 91584
+      GoRuntimeType: 92448
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1289,20 +1386,27 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 62496
+      GoRuntimeType: 62976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 62400
+      GoRuntimeType: 62880
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 147
+      ID: 174
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 70784
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
+    - __kind: StructureType
+      ID: 152
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 121536
+      GoRuntimeType: 122400
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1328,7 +1432,39 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 150 ArrayType [128]uint8
+          Type: 177 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 163
+      Name: map<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 164 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 175 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 171 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 111
       Name: map<string,int>
@@ -1359,8 +1495,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 138 GoSliceDataType []*table<string,int>.array
-      GroupType: 135 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 143 GoSliceDataType []*table<string,int>.array
+      GroupType: 140 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 116
       Name: map<string,main.bigStruct>
@@ -1391,45 +1527,122 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 148 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 143 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 153 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 148 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 121
+      Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 122 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 166 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 158 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoMapType
+      ID: 161
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 68640
+      GoKind: 21
+      HeaderType: 163 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 109
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 68288
+      GoRuntimeType: 68768
       GoKind: 21
       HeaderType: 111 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 114
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 68416
+      GoRuntimeType: 68896
       GoKind: 21
       HeaderType: 116 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 119
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 69152
+      GoKind: 21
+      HeaderType: 121 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 144
+      ID: 172
+      Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 47264
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 173 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: ArrayType
+      ID: 149
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 47168
+      GoRuntimeType: 47552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 145 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 150 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 136
+      ID: 141
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 46976
+      GoRuntimeType: 47360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 137 StructureType noalg.struct { key string; elem int }
+      Element: 142 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 159
+      Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 47744
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 160 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 135
+      ID: 171
+      Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 76544
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 172 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 140
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 76192
+      GoRuntimeType: 76800
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1437,12 +1650,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 136 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 141 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 143
+      ID: 148
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 76448
+      GoRuntimeType: 77056
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1450,12 +1663,38 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 144 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 149 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 145
+      ID: 158
+      Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 77568
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 159 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 173
+      Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 76416
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 174 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: StructureType
+      ID: 150
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 76320
+      GoRuntimeType: 76928
       GoKind: 25
       RawFields:
         - Name: key
@@ -1463,12 +1702,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 146 PointerType *main.bigStruct
+          Type: 151 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 137
+      ID: 142
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 76064
+      GoRuntimeType: 76672
       GoKind: 25
       RawFields:
         - Name: key
@@ -1477,6 +1716,19 @@ Types:
         - Name: elem
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 160
+      Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 77440
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 161 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1496,14 +1748,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 61632
+      GoRuntimeType: 62112
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 143392
+      GoRuntimeType: 144256
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1684,7 +1936,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 72992
+      GoRuntimeType: 73600
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1694,7 +1946,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 119520
+      GoRuntimeType: 120384
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1722,7 +1974,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 88864
+      GoRuntimeType: 89728
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1735,7 +1987,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 106304
+      GoRuntimeType: 107168
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1754,13 +2006,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 55776
+      GoRuntimeType: 56256
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 88704
+      GoRuntimeType: 89568
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1773,7 +2025,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 117696
+      GoRuntimeType: 118560
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1798,13 +2050,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 55680
+      GoRuntimeType: 56160
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 148448
+      GoRuntimeType: 149312
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2027,7 +2279,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 119808
+      GoRuntimeType: 120672
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2055,7 +2307,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 112480
+      GoRuntimeType: 113344
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2077,7 +2329,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 112256
+      GoRuntimeType: 113120
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2099,7 +2351,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 72736
+      GoRuntimeType: 73344
       GoKind: 25
       RawFields:
         - Name: next
@@ -2109,20 +2361,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 55392
+      GoRuntimeType: 55872
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 72608
+      GoRuntimeType: 73216
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 88544
+      GoRuntimeType: 89408
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2135,7 +2387,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 107072
+      GoRuntimeType: 107936
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2154,13 +2406,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 55584
+      GoRuntimeType: 56064
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 58752
+      GoRuntimeType: 59232
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2169,7 +2421,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 86944
+      GoRuntimeType: 87808
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2190,7 +2442,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 43264
+      GoRuntimeType: 43424
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2200,7 +2452,7 @@ Types:
       ID: 71
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 43328
+      GoRuntimeType: 43488
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 77
@@ -2210,7 +2462,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 87904
+      GoRuntimeType: 88768
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2223,35 +2475,59 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 75552
+      GoRuntimeType: 76160
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 61536
+      GoRuntimeType: 62016
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 41984
+      GoRuntimeType: 42144
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 123 PointerType *string.str
+          Type: 128 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 122 GoStringDataType string.str
+      Data: 127 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 122
+      ID: 127
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 132
+      ID: 168
+      Name: table<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 169 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+    - __kind: StructureType
+      ID: 137
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -2273,9 +2549,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 133 GoSwissMapGroupsType groupReference<string,int>
+          Type: 138 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 140
+      ID: 145
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -2297,50 +2573,74 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 141 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 146 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 155
+      Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 156 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 42624
+      GoRuntimeType: 42784
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 42240
+      GoRuntimeType: 42400
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 42368
+      GoRuntimeType: 42528
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 42496
+      GoRuntimeType: 42656
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 42112
+      GoRuntimeType: 42272
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 42688
+      GoRuntimeType: 42848
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 43072
+      GoRuntimeType: 43232
       GoKind: 26
-MaxTypeID: 165
+MaxTypeID: 192
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191340", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,10 +8,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 168 EventRootType Probe[main.PointerChainArg]
+        - ID: 13
+          Type: 169 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7d60", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -22,10 +22,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 14}
       events:
-        - ID: 13
-          Type: 169 EventRootType Probe[main.PointerSmallChainArg]
+        - ID: 14
+          Type: 170 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7d94", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -49,10 +49,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 167 EventRootType Probe[main.inlined]
+        - ID: 12
+          Type: 168 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb80bc"
               Frameless: true
@@ -175,6 +175,20 @@ Probes:
         - ID: 5
           Type: 161 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb7fbc", Frameless: true}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 11
+          Type: 167 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb8310", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -309,6 +323,11 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
     - ID: 11
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0xb8300..0xb8440]
+      InlinePCRanges: []
+      Variables: []
+    - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0xb80b0..0xb8120]
       InlinePCRanges:
@@ -324,7 +343,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -338,7 +357,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -357,28 +376,28 @@ Types:
       ID: 121
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 36288
+      GoRuntimeType: 36544
       GoKind: 22
       Pointee: 122 PointerType ****int
     - __kind: PointerType
       ID: 122
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 36224
+      GoRuntimeType: 36480
       GoKind: 22
       Pointee: 156 PointerType ***int
     - __kind: PointerType
       ID: 156
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 36160
+      GoRuntimeType: 36416
       GoKind: 22
       Pointee: 123 PointerType **int
     - __kind: PointerType
       ID: 123
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 36096
+      GoRuntimeType: 36352
       GoKind: 22
       Pointee: 100 PointerType *int
     - __kind: PointerType
@@ -411,7 +430,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 40832
+      GoRuntimeType: 41216
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -433,56 +452,56 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30400
+      GoRuntimeType: 30656
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 103
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 29312
+      GoRuntimeType: 29568
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 104
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 30272
+      GoRuntimeType: 30528
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 99
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 30336
+      GoRuntimeType: 30592
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
       ID: 100
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29952
+      GoRuntimeType: 30208
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29696
+      GoRuntimeType: 29952
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 102
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 29824
+      GoRuntimeType: 30080
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 151
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 27776
+      GoRuntimeType: 28032
       GoKind: 22
       Pointee: 152 StructureType main.bigStruct
     - __kind: PointerType
@@ -509,84 +528,84 @@ Types:
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 30592
+      GoRuntimeType: 30848
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 81568
+      GoRuntimeType: 83488
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 31232
+      GoRuntimeType: 31488
       GoKind: 22
       Pointee: 66 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 31296
+      GoRuntimeType: 31552
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 60288
+      GoRuntimeType: 61312
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 82208
+      GoRuntimeType: 84128
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 67392
+      GoRuntimeType: 68416
       GoKind: 22
       Pointee: 130 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 31936
+      GoRuntimeType: 32192
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 94496
+      GoRuntimeType: 96416
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 126080
+      GoRuntimeType: 128000
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 100512
+      GoRuntimeType: 102432
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 95
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 29376
+      GoRuntimeType: 29632
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -608,46 +627,46 @@ Types:
       ID: 105
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 30016
+      GoRuntimeType: 30272
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 106
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29632
+      GoRuntimeType: 29888
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 29760
+      GoRuntimeType: 30016
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29888
+      GoRuntimeType: 30144
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29504
+      GoRuntimeType: 29760
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 30080
+      GoRuntimeType: 30336
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 168
+      ID: 169
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -658,11 +677,11 @@ Types:
             Type: 121 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 169
+      ID: 170
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -673,7 +692,7 @@ Types:
             Type: 123 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: ptr}
+                  Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -692,7 +711,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 167
+      ID: 168
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -703,7 +722,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -829,11 +848,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 167
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 53504
+      GoRuntimeType: 54464
       GoKind: 17
       Count: 10
       HasCount: true
@@ -842,7 +864,7 @@ Types:
       ID: 155
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 47648
+      GoRuntimeType: 48512
       GoKind: 17
       Count: 128
       HasCount: true
@@ -851,7 +873,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 53120
+      GoRuntimeType: 54080
       GoKind: 17
       Count: 2
       HasCount: true
@@ -860,7 +882,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 53216
+      GoRuntimeType: 54176
       GoKind: 17
       Count: 2
       HasCount: true
@@ -869,7 +891,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 53408
+      GoRuntimeType: 54368
       GoKind: 17
       Count: 2
       HasCount: true
@@ -878,7 +900,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 49184
+      GoRuntimeType: 50144
       GoKind: 17
       Count: 2
       HasCount: true
@@ -887,7 +909,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 55808
+      GoRuntimeType: 56768
       GoKind: 17
       Count: 32
       HasCount: true
@@ -896,7 +918,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 52928
+      GoRuntimeType: 53888
       GoKind: 17
       Count: 32
       HasCount: true
@@ -905,7 +927,7 @@ Types:
       ID: 108
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 47360
+      GoRuntimeType: 48128
       GoKind: 17
       Count: 3
       HasCount: true
@@ -914,7 +936,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 52352
+      GoRuntimeType: 53312
       GoKind: 17
       Count: 3
       HasCount: true
@@ -923,7 +945,7 @@ Types:
       ID: 110
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 47456
+      GoRuntimeType: 48224
       GoKind: 17
       Count: 3
       HasCount: true
@@ -932,7 +954,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 54944
+      GoRuntimeType: 55904
       GoKind: 17
       Count: 4
       HasCount: true
@@ -941,7 +963,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 51680
+      GoRuntimeType: 52640
       GoKind: 17
       Count: 6
       HasCount: true
@@ -950,7 +972,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 53312
+      GoRuntimeType: 54272
       GoKind: 17
       Count: 8
       HasCount: true
@@ -959,7 +981,7 @@ Types:
       ID: 62
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 40384
+      GoRuntimeType: 40768
       GoKind: 23
       RawFields:
         - Name: array
@@ -994,7 +1016,7 @@ Types:
       ID: 107
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 38784
+      GoRuntimeType: 39168
       GoKind: 23
       RawFields:
         - Name: array
@@ -1033,7 +1055,7 @@ Types:
       ID: 109
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 39040
+      GoRuntimeType: 39424
       GoKind: 23
       RawFields:
         - Name: array
@@ -1056,7 +1078,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 38464
+      GoRuntimeType: 38848
       GoKind: 23
       RawFields:
         - Name: array
@@ -1079,7 +1101,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 38912
+      GoRuntimeType: 39296
       GoKind: 23
       RawFields:
         - Name: array
@@ -1102,25 +1124,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 43744
+      GoRuntimeType: 44384
       GoKind: 1
     - __kind: BaseType
       ID: 98
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 43552
+      GoRuntimeType: 44192
       GoKind: 16
     - __kind: BaseType
       ID: 97
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 43488
+      GoRuntimeType: 44128
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 65728
+      GoRuntimeType: 66752
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1133,25 +1155,25 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 43616
+      GoRuntimeType: 44256
       GoKind: 13
     - __kind: BaseType
       ID: 16
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 43680
+      GoRuntimeType: 44320
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 36544
+      GoRuntimeType: 36928
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 58112
+      GoRuntimeType: 59136
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 138
@@ -1185,37 +1207,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 43296
+      GoRuntimeType: 43936
       GoKind: 2
     - __kind: BaseType
       ID: 96
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 42912
+      GoRuntimeType: 43552
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 43040
+      GoRuntimeType: 43680
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 43168
+      GoRuntimeType: 43808
       GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 42784
+      GoRuntimeType: 43424
       GoKind: 3
     - __kind: StructureType
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 117120
+      GoRuntimeType: 119040
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1237,7 +1259,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 75712
+      GoRuntimeType: 77120
       GoKind: 25
       RawFields:
         - Name: u
@@ -1247,7 +1269,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 103584
+      GoRuntimeType: 105504
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1263,7 +1285,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 92768
+      GoRuntimeType: 94688
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1276,7 +1298,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 92608
+      GoRuntimeType: 94528
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1289,7 +1311,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 92928
+      GoRuntimeType: 94848
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1301,20 +1323,20 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 64032
+      GoRuntimeType: 65056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 63936
+      GoRuntimeType: 64960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 152
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 124608
+      GoRuntimeType: 126528
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1415,21 +1437,21 @@ Types:
       ID: 111
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 69952
+      GoRuntimeType: 71104
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 116
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 70080
+      GoRuntimeType: 71232
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
       ID: 149
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 47744
+      GoRuntimeType: 48608
       GoKind: 17
       Count: 8
       HasCount: true
@@ -1438,7 +1460,7 @@ Types:
       ID: 141
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 47552
+      GoRuntimeType: 48416
       GoKind: 17
       Count: 8
       HasCount: true
@@ -1447,7 +1469,7 @@ Types:
       ID: 140
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 77120
+      GoRuntimeType: 78784
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1460,7 +1482,7 @@ Types:
       ID: 148
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 77376
+      GoRuntimeType: 79040
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1473,7 +1495,7 @@ Types:
       ID: 150
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 77248
+      GoRuntimeType: 78912
       GoKind: 25
       RawFields:
         - Name: key
@@ -1486,7 +1508,7 @@ Types:
       ID: 142
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 76992
+      GoRuntimeType: 78656
       GoKind: 25
       RawFields:
         - Name: key
@@ -1514,14 +1536,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 63168
+      GoRuntimeType: 64192
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 146880
+      GoRuntimeType: 148800
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1711,7 +1733,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 74176
+      GoRuntimeType: 75584
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1721,7 +1743,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 120288
+      GoRuntimeType: 122208
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1746,7 +1768,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 89888
+      GoRuntimeType: 91808
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1759,7 +1781,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 108960
+      GoRuntimeType: 110880
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1778,13 +1800,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 56576
+      GoRuntimeType: 57600
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 89728
+      GoRuntimeType: 91648
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1797,7 +1819,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 121056
+      GoRuntimeType: 122976
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1822,13 +1844,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 56480
+      GoRuntimeType: 57504
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 150176
+      GoRuntimeType: 152096
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2048,7 +2070,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 120800
+      GoRuntimeType: 122720
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2073,7 +2095,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 116000
+      GoRuntimeType: 117920
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2095,7 +2117,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 115776
+      GoRuntimeType: 117696
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2117,7 +2139,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 89408
+      GoRuntimeType: 91328
       GoKind: 25
       RawFields:
         - Name: next
@@ -2130,13 +2152,13 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 56192
+      GoRuntimeType: 57216
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 73920
+      GoRuntimeType: 75328
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -2147,7 +2169,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 89568
+      GoRuntimeType: 91488
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2160,7 +2182,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 109920
+      GoRuntimeType: 111840
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2179,13 +2201,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 56384
+      GoRuntimeType: 57408
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 59808
+      GoRuntimeType: 60832
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2194,7 +2216,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 87648
+      GoRuntimeType: 89568
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2215,7 +2237,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 44000
+      GoRuntimeType: 44640
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2225,7 +2247,7 @@ Types:
       ID: 74
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 44064
+      GoRuntimeType: 44704
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 80
@@ -2235,7 +2257,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 88608
+      GoRuntimeType: 90528
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2248,19 +2270,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 76736
+      GoRuntimeType: 78144
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 63072
+      GoRuntimeType: 64096
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 42720
+      GoRuntimeType: 43360
       GoKind: 24
       RawFields:
         - Name: str
@@ -2327,45 +2349,45 @@ Types:
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 43360
+      GoRuntimeType: 44000
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 42976
+      GoRuntimeType: 43616
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 43104
+      GoRuntimeType: 43744
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 43232
+      GoRuntimeType: 43872
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 42848
+      GoRuntimeType: 43488
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 43424
+      GoRuntimeType: 44064
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 43808
+      GoRuntimeType: 44448
       GoKind: 26
-MaxTypeID: 169
+MaxTypeID: 170
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1a13a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,8 +11,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 169 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb7d60", Frameless: false}]
+          Type: 196 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0xb7da0", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -25,8 +25,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 170 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb7d94", Frameless: false}]
+          Type: 197 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0xb7dd4", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -38,8 +38,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 165 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb81f0", Frameless: true}]
+          Type: 192 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0xb8230", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -52,11 +52,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 168 EventRootType Probe[main.inlined]
+          Type: 195 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb80bc"
+            - PC: "0xb80fc"
               Frameless: true
-            - PC: "0xb7b88"
+            - PC: "0xb7bc8"
               Frameless: false
           Condition: null
     - id: intArg
@@ -69,8 +69,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 157 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb7dec", Frameless: true}]
+          Type: 184 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0xb7e2c", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -82,8 +82,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 160 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb7f4c", Frameless: true}]
+          Type: 187 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0xb7f8c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 163 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb80a0", Frameless: true}]
+          Type: 190 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0xb80e0", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -108,8 +108,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 159 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb7ecc", Frameless: true}]
+          Type: 186 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0xb7f0c", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -121,8 +121,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 164 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb817c", Frameless: true}]
+          Type: 191 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0xb81bc", Frameless: true}]
           Condition: null
     - id: noArgs
       version: 0
@@ -134,8 +134,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 166 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0xb829c", Frameless: true}]
+          Type: 193 EventRootType Probe[main.noArgs]
+          InjectionPoints: [{PC: "0xb82dc", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -147,8 +147,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 158 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb7e5c", Frameless: true}]
+          Type: 185 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7e9c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -160,8 +160,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 162 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb803c", Frameless: true}]
+          Type: 189 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0xb807c", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -173,8 +173,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 161 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb7fbc", Frameless: true}]
+          Type: 188 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb7ffc", Frameless: true}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -187,31 +187,31 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 167 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0xb8310", Frameless: true}]
+          Type: 194 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb8350", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb7de0..0xb7e50]
+      OutOfLinePCRanges: [0xb7e20..0xb7e90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb7de0..0xb7e00
+            - Range: 0xb7e20..0xb7e40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb7e50..0xb7ec0]
+      OutOfLinePCRanges: [0xb7e90..0xb7f00]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb7e50..0xb7e74
+            - Range: 0xb7e90..0xb7eb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -221,13 +221,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb7ec0..0xb7f40]
+      OutOfLinePCRanges: [0xb7f00..0xb7f80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb7ec0..0xb7ee4
+            - Range: 0xb7f00..0xb7f24
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -239,25 +239,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb7f40..0xb7fb0]
+      OutOfLinePCRanges: [0xb7f80..0xb7ff0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]int
           Locations:
-            - Range: 0xb7f40..0xb7fb0
+            - Range: 0xb7f80..0xb7ff0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb7fb0..0xb8030]
+      OutOfLinePCRanges: [0xb7ff0..0xb8070]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 109 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb7fb0..0xb7fd4
+            - Range: 0xb7ff0..0xb8014
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -269,77 +269,82 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb8030..0xb80a0]
+      OutOfLinePCRanges: [0xb8070..0xb80e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0xb8030..0xb80a0
+            - Range: 0xb8070..0xb80e0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb80a0..0xb80b0]
+      OutOfLinePCRanges: [0xb80e0..0xb80f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0xb80a0..0xb80b0
+            - Range: 0xb80e0..0xb80f0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb8170..0xb81e0]
+      OutOfLinePCRanges: [0xb81b0..0xb8220]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xb8170..0xb81a4
+            - Range: 0xb81b0..0xb81e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb81e0..0xb8290]
+      OutOfLinePCRanges: [0xb8220..0xb82d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb81e0..0xb8218
+            - Range: 0xb8220..0xb8258
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb8218..0xb8290
+            - Range: 0xb8258..0xb82d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb8290..0xb8300]
+      OutOfLinePCRanges: [0xb82d0..0xb8340]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xb8300..0xb8440]
+      OutOfLinePCRanges: [0xb8340..0xb84f0]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: ~r0
+          Type: 121 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0xb8340..0xb84f0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
     - ID: 12
       Name: main.inlined
-      OutOfLinePCRanges: [0xb80b0..0xb8120]
+      OutOfLinePCRanges: [0xb80f0..0xb8160]
       InlinePCRanges:
-        - Ranges: [0xb7b88..0xb7bbc]
-          RootRanges: [0xb7a00..0xb7de0]
+        - Ranges: [0xb7bc8..0xb7bfc]
+          RootRanges: [0xb7a40..0xb7e20]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb7b88..0xb7bbc
+            - Range: 0xb7bc8..0xb7bfc
               Pieces: []
-            - Range: 0xb80b0..0xb80d0
+            - Range: 0xb80f0..0xb8110
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -347,13 +352,13 @@ Subprograms:
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb7d60..0xb7d8c]
-          RootRanges: [0xb7a00..0xb7de0]
+        - Ranges: [0xb7da0..0xb7dcc]
+          RootRanges: [0xb7a40..0xb7e20]
       Variables:
         - Name: ptr
-          Type: 121 PointerType *****int
+          Type: 126 PointerType *****int
           Locations:
-            - Range: 0xb7d38..0xb7d7c
+            - Range: 0xb7d78..0xb7dbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -361,43 +366,43 @@ Subprograms:
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb7d94..0xb7dc0]
-          RootRanges: [0xb7a00..0xb7de0]
+        - Ranges: [0xb7dd4..0xb7e00]
+          RootRanges: [0xb7a40..0xb7e20]
       Variables:
         - Name: ptr
-          Type: 123 PointerType **int
+          Type: 128 PointerType **int
           Locations:
-            - Range: 0xb7d94..0xb7dc0
+            - Range: 0xb7dd4..0xb7e00
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 121
+      ID: 126
       Name: '*****int'
+      ByteSize: 8
+      GoRuntimeType: 36608
+      GoKind: 22
+      Pointee: 127 PointerType ****int
+    - __kind: PointerType
+      ID: 127
+      Name: '****int'
       ByteSize: 8
       GoRuntimeType: 36544
       GoKind: 22
-      Pointee: 122 PointerType ****int
+      Pointee: 183 PointerType ***int
     - __kind: PointerType
-      ID: 122
-      Name: '****int'
+      ID: 183
+      Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36480
       GoKind: 22
-      Pointee: 156 PointerType ***int
+      Pointee: 128 PointerType **int
     - __kind: PointerType
-      ID: 156
-      Name: '***int'
-      ByteSize: 8
-      GoRuntimeType: 36416
-      GoKind: 22
-      Pointee: 123 PointerType **int
-    - __kind: PointerType
-      ID: 123
+      ID: 128
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 36352
+      GoRuntimeType: 36416
       GoKind: 22
       Pointee: 100 PointerType *int
     - __kind: PointerType
@@ -406,6 +411,11 @@ Types:
       ByteSize: 8
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
+    - __kind: PointerType
+      ID: 169
+      Name: '**table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 170 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 114
       Name: '**table<string,int>'
@@ -417,93 +427,103 @@ Types:
       ByteSize: 8
       Pointee: 120 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 132
+      ID: 124
+      Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 125 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 137
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 131 GoSliceDataType []*runtime.p.array
+      Pointee: 136 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 134
+      ID: 139
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 133 GoSliceDataType []int.array
+      Pointee: 138 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 41216
+      GoRuntimeType: 41344
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 136
+      ID: 141
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 135 GoSliceDataType []string.array
+      Pointee: 140 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 127
+      ID: 132
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 126 GoSliceDataType []uint8.array
+      Pointee: 131 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 129
+      ID: 134
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 128 GoSliceDataType []uintptr.array
+      Pointee: 133 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30656
+      GoRuntimeType: 30720
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 103
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 29568
+      GoRuntimeType: 29632
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 104
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 30528
+      GoRuntimeType: 30592
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 99
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 30592
+      GoRuntimeType: 30656
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
       ID: 100
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 30208
+      GoRuntimeType: 30272
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29952
+      GoRuntimeType: 30016
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 102
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 30080
+      GoRuntimeType: 30144
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 151
+      ID: 156
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 28032
+      GoRuntimeType: 28096
       GoKind: 22
-      Pointee: 152 StructureType main.bigStruct
+      Pointee: 157 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 167
+      Name: '*map<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 168 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 112
       Name: '*map<string,int>'
@@ -515,158 +535,183 @@ Types:
       ByteSize: 8
       Pointee: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 139
+      ID: 122
+      Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 123 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 175
+      Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 176 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: PointerType
+      ID: 144
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 140 StructureType noalg.map.group[string]int
+      Pointee: 145 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 147
+      ID: 152
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 148 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 153 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 162
+      Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 163 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 30848
+      GoRuntimeType: 30912
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 83488
+      GoRuntimeType: 84384
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 31488
+      GoRuntimeType: 31552
       GoKind: 22
       Pointee: 66 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 31552
+      GoRuntimeType: 31616
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 61312
+      GoRuntimeType: 61824
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 84128
+      GoRuntimeType: 85024
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 68416
+      GoRuntimeType: 68928
       GoKind: 22
-      Pointee: 130 UnresolvedPointeeType runtime.p
+      Pointee: 135 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 32192
+      GoRuntimeType: 32256
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 96416
+      GoRuntimeType: 97312
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 128000
+      GoRuntimeType: 128896
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 102432
+      GoRuntimeType: 103328
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 95
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 29632
+      GoRuntimeType: 29696
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 125
+      ID: 130
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 124 GoStringDataType string.str
+      Pointee: 129 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 170
+      Name: '*table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 173 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 115
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 137 StructureType table<string,int>
+      Pointee: 142 StructureType table<string,int>
     - __kind: PointerType
       ID: 120
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 145 StructureType table<string,main.bigStruct>
+      Pointee: 150 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 125
+      Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 160 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 30272
+      GoRuntimeType: 30336
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 106
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29888
+      GoRuntimeType: 29952
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 30016
+      GoRuntimeType: 30080
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 30144
+      GoRuntimeType: 30208
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29760
+      GoRuntimeType: 29824
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 30336
+      GoRuntimeType: 30400
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 169
+      ID: 196
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -674,14 +719,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 121 PointerType *****int
+            Type: 126 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 170
+      ID: 197
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -689,14 +734,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 123 PointerType **int
+            Type: 128 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 165
+      ID: 192
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -711,7 +756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 168
+      ID: 195
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -726,7 +771,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 157
+      ID: 184
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -741,7 +786,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 160
+      ID: 187
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -756,7 +801,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 159
+      ID: 186
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -771,7 +816,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 164
+      ID: 191
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -786,10 +831,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 166
+      ID: 193
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 158
+      ID: 185
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -804,7 +849,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 163
+      ID: 190
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -819,7 +864,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 162
+      ID: 189
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -834,7 +879,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 161
+      ID: 188
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -849,22 +894,22 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 167
+      ID: 194
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 54464
+      GoRuntimeType: 54976
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 93 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 155
+      ID: 182
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 48512
+      GoRuntimeType: 48928
       GoKind: 17
       Count: 128
       HasCount: true
@@ -873,7 +918,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 54080
+      GoRuntimeType: 54592
       GoKind: 17
       Count: 2
       HasCount: true
@@ -882,7 +927,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 54176
+      GoRuntimeType: 54688
       GoKind: 17
       Count: 2
       HasCount: true
@@ -891,7 +936,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 54368
+      GoRuntimeType: 54880
       GoKind: 17
       Count: 2
       HasCount: true
@@ -900,7 +945,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 50144
+      GoRuntimeType: 50656
       GoKind: 17
       Count: 2
       HasCount: true
@@ -909,7 +954,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 56768
+      GoRuntimeType: 57280
       GoKind: 17
       Count: 32
       HasCount: true
@@ -918,7 +963,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 53888
+      GoRuntimeType: 54400
       GoKind: 17
       Count: 32
       HasCount: true
@@ -927,7 +972,7 @@ Types:
       ID: 108
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 48128
+      GoRuntimeType: 48544
       GoKind: 17
       Count: 3
       HasCount: true
@@ -936,7 +981,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 53312
+      GoRuntimeType: 53824
       GoKind: 17
       Count: 3
       HasCount: true
@@ -945,7 +990,7 @@ Types:
       ID: 110
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 48224
+      GoRuntimeType: 48640
       GoKind: 17
       Count: 3
       HasCount: true
@@ -954,7 +999,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 55904
+      GoRuntimeType: 56416
       GoKind: 17
       Count: 4
       HasCount: true
@@ -963,7 +1008,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 52640
+      GoRuntimeType: 53152
       GoKind: 17
       Count: 6
       HasCount: true
@@ -972,7 +1017,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 54272
+      GoRuntimeType: 54784
       GoKind: 17
       Count: 8
       HasCount: true
@@ -981,7 +1026,7 @@ Types:
       ID: 62
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 40768
+      GoRuntimeType: 40896
       GoKind: 23
       RawFields:
         - Name: array
@@ -993,30 +1038,42 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 131 GoSliceDataType []*runtime.p.array
+      Data: 136 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 131
+      ID: 136
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 143
+      ID: 180
+      Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 170 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 148
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 115 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 158
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 120 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 171
+      Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 125 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 107
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 39168
+      GoRuntimeType: 39296
       GoKind: 23
       RawFields:
         - Name: array
@@ -1028,25 +1085,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 133 GoSliceDataType []int.array
+      Data: 138 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 133
+      ID: 138
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 181
+      Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
+      DynamicSizeClass: slice
+      ByteSize: 136
+      Element: 176 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoSliceDataType
+      ID: 149
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 140 StructureType noalg.map.group[string]int
+      Element: 145 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 154
+      ID: 159
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: slice
       ByteSize: 200
-      Element: 148 StructureType noalg.map.group[string]main.bigStruct
+      Element: 153 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceDataType
+      ID: 172
+      Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
+      DynamicSizeClass: slice
+      ByteSize: 136
+      Element: 163 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -1055,7 +1124,7 @@ Types:
       ID: 109
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 39424
+      GoRuntimeType: 39552
       GoKind: 23
       RawFields:
         - Name: array
@@ -1067,9 +1136,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 135 GoSliceDataType []string.array
+      Data: 140 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 135
+      ID: 140
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -1078,7 +1147,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 38848
+      GoRuntimeType: 38976
       GoKind: 23
       RawFields:
         - Name: array
@@ -1090,9 +1159,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 126 GoSliceDataType []uint8.array
+      Data: 131 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 126
+      ID: 131
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -1101,7 +1170,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 39296
+      GoRuntimeType: 39424
       GoKind: 23
       RawFields:
         - Name: array
@@ -1113,9 +1182,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 128 GoSliceDataType []uintptr.array
+      Data: 133 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 133
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -1124,25 +1193,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 44384
+      GoRuntimeType: 44576
       GoKind: 1
     - __kind: BaseType
       ID: 98
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 44192
+      GoRuntimeType: 44384
       GoKind: 16
     - __kind: BaseType
       ID: 97
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 44128
+      GoRuntimeType: 44320
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 66752
+      GoRuntimeType: 67264
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1155,89 +1224,117 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 44256
+      GoRuntimeType: 44448
       GoKind: 13
     - __kind: BaseType
       ID: 16
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 44320
+      GoRuntimeType: 44512
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 36928
+      GoRuntimeType: 37056
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 59136
+      GoRuntimeType: 59648
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 138
+      ID: 174
+      Name: groupReference<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 175 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 176 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 181 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+    - __kind: GoSwissMapGroupsType
+      ID: 143
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 139 PointerType *noalg.map.group[string]int
+          Type: 144 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 140 StructureType noalg.map.group[string]int
-      GroupSliceType: 144 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 145 StructureType noalg.map.group[string]int
+      GroupSliceType: 149 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 146
+      ID: 151
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 147 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 152 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 148 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 154 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 153 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 159 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 161
+      Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 162 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 163 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 172 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 43936
+      GoRuntimeType: 44128
       GoKind: 2
     - __kind: BaseType
       ID: 96
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 43552
+      GoRuntimeType: 43744
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 43680
+      GoRuntimeType: 43872
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 43808
+      GoRuntimeType: 44000
       GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 43424
+      GoRuntimeType: 43616
       GoKind: 3
     - __kind: StructureType
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 119040
+      GoRuntimeType: 119936
       GoKind: 25
       RawFields:
         - Name: buf
@@ -1259,7 +1356,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 77120
+      GoRuntimeType: 77760
       GoKind: 25
       RawFields:
         - Name: u
@@ -1269,7 +1366,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 105504
+      GoRuntimeType: 106400
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1285,7 +1382,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 94688
+      GoRuntimeType: 95584
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1298,7 +1395,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 94528
+      GoRuntimeType: 95424
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1311,7 +1408,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 94848
+      GoRuntimeType: 95744
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1323,20 +1420,27 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 65056
+      GoRuntimeType: 65568
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 64960
+      GoRuntimeType: 65472
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 152
+      ID: 179
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 73408
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
+    - __kind: StructureType
+      ID: 157
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 126528
+      GoRuntimeType: 127424
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1362,7 +1466,42 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 155 ArrayType [128]uint8
+          Type: 182 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 168
+      Name: map<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 169 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 180 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 176 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 113
       Name: map<string,int>
@@ -1396,8 +1535,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 143 GoSliceDataType []*table<string,int>.array
-      GroupType: 140 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 148 GoSliceDataType []*table<string,int>.array
+      GroupType: 145 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 118
       Name: map<string,main.bigStruct>
@@ -1431,45 +1570,112 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 153 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 148 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 158 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 153 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 123
+      Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 124 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 171 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 163 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoMapType
+      ID: 166
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 71488
+      GoKind: 21
+      HeaderType: 168 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 111
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 71104
+      GoRuntimeType: 71616
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 116
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 71232
+      GoRuntimeType: 71744
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 121
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 72000
+      GoKind: 21
+      HeaderType: 123 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 149
+      ID: 177
+      Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 48736
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 178 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: ArrayType
+      ID: 154
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 48608
+      GoRuntimeType: 49024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 150 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 155 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 141
+      ID: 146
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 48416
+      GoRuntimeType: 48832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 142 StructureType noalg.struct { key string; elem int }
+      Element: 147 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 164
+      Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 49216
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 165 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 140
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 78784
+      ID: 176
+      Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 79168
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1477,25 +1683,64 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 141 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 177 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 148
+      ID: 145
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 79424
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 146 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 153
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
+      GoRuntimeType: 79680
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 154 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+    - __kind: StructureType
+      ID: 163
+      Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 80192
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 164 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 178
+      Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
       GoRuntimeType: 79040
       GoKind: 25
       RawFields:
-        - Name: ctrl
+        - Name: key
           Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
+          Type: 7 BaseType int
+        - Name: elem
           Offset: 8
-          Type: 149 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 179 StructureType main.aStructNotUsedAsAnArgument
     - __kind: StructureType
-      ID: 150
+      ID: 155
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 78912
+      GoRuntimeType: 79552
       GoKind: 25
       RawFields:
         - Name: key
@@ -1503,12 +1748,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 151 PointerType *main.bigStruct
+          Type: 156 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 142
+      ID: 147
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 78656
+      GoRuntimeType: 79296
       GoKind: 25
       RawFields:
         - Name: key
@@ -1517,6 +1762,19 @@ Types:
         - Name: elem
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 165
+      Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 80064
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 166 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1536,14 +1794,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 64192
+      GoRuntimeType: 64704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 148800
+      GoRuntimeType: 149696
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1733,7 +1991,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 75584
+      GoRuntimeType: 76224
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -1743,7 +2001,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 122208
+      GoRuntimeType: 123104
       GoKind: 25
       RawFields:
         - Name: sp
@@ -1768,7 +2026,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 91808
+      GoRuntimeType: 92704
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -1781,7 +2039,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 110880
+      GoRuntimeType: 111776
       GoKind: 25
       RawFields:
         - Name: stack
@@ -1800,13 +2058,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 57600
+      GoRuntimeType: 58112
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 91648
+      GoRuntimeType: 92544
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -1819,7 +2077,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 122976
+      GoRuntimeType: 123872
       GoKind: 25
       RawFields:
         - Name: fn
@@ -1844,13 +2102,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 57504
+      GoRuntimeType: 58016
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 152096
+      GoRuntimeType: 152992
       GoKind: 25
       RawFields:
         - Name: g0
@@ -2070,7 +2328,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 122720
+      GoRuntimeType: 123616
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -2095,7 +2353,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 117920
+      GoRuntimeType: 118816
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -2117,7 +2375,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 117696
+      GoRuntimeType: 118592
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -2139,7 +2397,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 91328
+      GoRuntimeType: 92224
       GoKind: 25
       RawFields:
         - Name: next
@@ -2152,24 +2410,24 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 57216
+      GoRuntimeType: 57728
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 75328
+      GoRuntimeType: 75968
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 130
+      ID: 135
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 91488
+      GoRuntimeType: 92384
       GoKind: 25
       RawFields:
         - Name: entries
@@ -2182,7 +2440,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 111840
+      GoRuntimeType: 112736
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -2201,13 +2459,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 57408
+      GoRuntimeType: 57920
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 60832
+      GoRuntimeType: 61344
       GoKind: 17
       Count: 2
       HasCount: true
@@ -2216,7 +2474,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 89568
+      GoRuntimeType: 90464
       GoKind: 25
       RawFields:
         - Name: lo
@@ -2237,7 +2495,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 44640
+      GoRuntimeType: 44832
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -2247,7 +2505,7 @@ Types:
       ID: 74
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 44704
+      GoRuntimeType: 44896
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 80
@@ -2257,7 +2515,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 90528
+      GoRuntimeType: 91424
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -2270,35 +2528,59 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 78144
+      GoRuntimeType: 78784
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 64096
+      GoRuntimeType: 64608
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 43360
+      GoRuntimeType: 43552
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 125 PointerType *string.str
+          Type: 130 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 124 GoStringDataType string.str
+      Data: 129 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 124
+      ID: 129
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 137
+      ID: 173
+      Name: table<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 174 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+    - __kind: StructureType
+      ID: 142
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -2320,9 +2602,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 138 GoSwissMapGroupsType groupReference<string,int>
+          Type: 143 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 145
+      ID: 150
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -2344,50 +2626,74 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 146 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 151 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 160
+      Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 161 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 44000
+      GoRuntimeType: 44192
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 43616
+      GoRuntimeType: 43808
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 43744
+      GoRuntimeType: 43936
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 43872
+      GoRuntimeType: 44064
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 43488
+      GoRuntimeType: 43680
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 44064
+      GoRuntimeType: 44256
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 44448
+      GoRuntimeType: 44640
       GoKind: 26
-MaxTypeID: 170
+MaxTypeID: 197
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1a13a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -29,7 +29,8 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )
 		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 137, available: )
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
 		Arg: ptr: *****int (declared at line 0, available: [113-113])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -1,37 +1,39 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
-		Arg: ptr: *****int (declared at line 0, available: [112-112])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
-		Arg: ptr: **int (declared at line 0, available: [116-116])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
-		Arg: x: int (declared at line 0, available: [76-77])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 137, available: )
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
+		Arg: ptr: *****int (declared at line 0, available: [113-113])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]
+		Arg: ptr: **int (declared at line 0, available: [117-117])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [77:79]
+		Arg: x: int (declared at line 0, available: [77-78])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
@@ -29,7 +29,8 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
 		Arg: ptr: *****int (declared at line 0, available: [113-113])
 	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
@@ -1,37 +1,38 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
-		Arg: ptr: *****int (declared at line 0, available: [112-112])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
-		Arg: ptr: **int (declared at line 0, available: [116-116])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
-		Arg: x: int (declared at line 0, available: [76-77])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
+		Arg: ptr: *****int (declared at line 0, available: [113-113])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]
+		Arg: ptr: **int (declared at line 0, available: [117-117])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [77:79]
+		Arg: x: int (declared at line 0, available: [77-78])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
@@ -29,7 +29,8 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
 		Arg: ptr: *****int (declared at line 0, available: [113-113])
 	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
@@ -1,37 +1,38 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
-		Arg: ptr: *****int (declared at line 0, available: [112-112])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
-		Arg: ptr: **int (declared at line 0, available: [116-116])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
-		Arg: x: int (declared at line 0, available: [76-77])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
+		Arg: ptr: *****int (declared at line 0, available: [113-113])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]
+		Arg: ptr: **int (declared at line 0, available: [117-117])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [77:79]
+		Arg: x: int (declared at line 0, available: [77-78])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -29,7 +29,8 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )
 		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 137, available: )
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
 		Arg: ptr: *****int (declared at line 0, available: [113-113])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -1,37 +1,39 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
-		Arg: ptr: *****int (declared at line 0, available: [112-112])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
-		Arg: ptr: **int (declared at line 0, available: [116-116])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
-		Arg: x: int (declared at line 0, available: [76-77])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 137, available: )
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
+		Arg: ptr: *****int (declared at line 0, available: [113-113])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]
+		Arg: ptr: **int (declared at line 0, available: [117-117])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [77:79]
+		Arg: x: int (declared at line 0, available: [77-78])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
@@ -29,7 +29,8 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
 		Arg: ptr: *****int (declared at line 0, available: [113-113])
 	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
@@ -1,37 +1,38 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
-		Arg: ptr: *****int (declared at line 0, available: [112-112])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
-		Arg: ptr: **int (declared at line 0, available: [116-116])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
-		Arg: x: int (declared at line 0, available: [76-77])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
+		Arg: ptr: *****int (declared at line 0, available: [113-113])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]
+		Arg: ptr: **int (declared at line 0, available: [117-117])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [77:79]
+		Arg: x: int (declared at line 0, available: [77-78])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
@@ -29,7 +29,8 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )
 	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
 		Arg: ptr: *****int (declared at line 0, available: [113-113])
 	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
@@ -1,37 +1,38 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
-		Arg: ptr: *****int (declared at line 0, available: [112-112])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
-		Arg: ptr: **int (declared at line 0, available: [116-116])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
-		Arg: x: int (declared at line 0, available: [76-77])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [112:113]
+		Arg: ptr: *****int (declared at line 0, available: [113-113])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [116:117]
+		Arg: ptr: **int (declared at line 0, available: [117-117])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [77:79]
+		Arg: x: int (declared at line 0, available: [77-78])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,31 +1,33 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 137, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -29,5 +29,6 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )
 		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 137, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -29,4 +29,5 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,31 +1,32 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -29,4 +29,5 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,31 +1,32 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,31 +1,33 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 137, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -29,5 +29,6 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )
 		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 137, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -29,4 +29,5 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,31 +1,32 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -29,4 +29,5 @@ Package: main
 	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
 		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
 	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:144]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 134, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,31 +1,32 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:41]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-40])
-		Var: &ptr1: **int (declared at line 32, available: [14-40])
-		Var: &ptr2: ***int (declared at line 33, available: [14-40])
-		Var: &ptr3: ****int (declared at line 34, available: [14-40])
+		Var: &val: *int (declared at line 31, available: [14-41])
+		Var: &ptr1: **int (declared at line 32, available: [14-41])
+		Var: &ptr2: ***int (declared at line 33, available: [14-41])
+		Var: &ptr3: ****int (declared at line 34, available: [14-41])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
-		Arg: s: string (declared at line 48, available: [48-49])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
-		Arg: s: []int (declared at line 53, available: [53-54])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
-		Arg: s: [3]int (declared at line 58, available: [58-60])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
-		Arg: s: []string (declared at line 63, available: [63-64])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
-		Arg: s: [3]string (declared at line 68, available: [68-70])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
-		Arg: s: [3]string (declared at line 73, available: [74-74])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
-		Arg: f: func(int) (declared at line 81, available: [81-82])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
-		Arg: m: map[string]int (declared at line 86, available: [86-87])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
-		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [120:122]
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [49:51]
+		Arg: s: string (declared at line 49, available: [49-50])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [54:56]
+		Arg: s: []int (declared at line 54, available: [54-55])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [59:61]
+		Arg: s: [3]int (declared at line 59, available: [59-61])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [64:66]
+		Arg: s: []string (declared at line 64, available: [64-65])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [69:71]
+		Arg: s: [3]string (declared at line 69, available: [69-71])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:75]
+		Arg: s: [3]string (declared at line 74, available: [75-75])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [82:84]
+		Arg: f: func(int) (declared at line 82, available: [82-83])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [87:89]
+		Arg: m: map[string]int (declared at line 87, available: [87-88])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [104:110]
+		Arg: m: map[string]main.bigStruct (declared at line 104, available: [104-110])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123]
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [134:143]

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.PointerChainArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 112
+            "lineNumber": 113
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.PointerSmallChainArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 116
+            "lineNumber": 117
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.bigMapArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 103
+            "lineNumber": 104
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -18,7 +18,7 @@
           {
             "function": "main.inlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 77
+            "lineNumber": 78
           },
           {
             "function": "main.main",
@@ -75,12 +75,12 @@
           {
             "function": "main.inlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 76
+            "lineNumber": 77
           },
           {
             "function": "main.funcArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 43
+            "lineNumber": 44
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 58
+            "lineNumber": 59
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArgFrameless",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 74
+            "lineNumber": 75
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 53
+            "lineNumber": 54
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/noArgs.json
+++ b/pkg/dyninst/testdata/decoded/simple/noArgs.json
@@ -18,7 +18,7 @@
           {
             "function": "main.noArgs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 120
+            "lineNumber": 121
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 48
+            "lineNumber": 49
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 68
+            "lineNumber": 69
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 63
+            "lineNumber": 64
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.mapArg",
+      "method": "main.usesMapsOfMapsThatDoNotAppearAsArguments",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.mapArg",
+            "function": "main.usesMapsOfMapsThatDoNotAppearAsArguments",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 87
+            "lineNumber": 134
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 29
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -37,31 +37,14 @@
           }
         ],
         "probe": {
-          "id": "mapArg",
+          "id": "usesMapsOfMapsThatDoNotAppearAsArguments",
           "location": {
-            "method": "main.mapArg"
+            "method": "main.usesMapsOfMapsThatDoNotAppearAsArguments"
           }
         },
         "captures": {
           "entry": {
-            "arguments": {
-              "m": {
-                "type": "map[string]int",
-                "size": "1",
-                "entries": [
-                  [
-                    {
-                      "type": "string",
-                      "value": "a"
-                    },
-                    {
-                      "type": "int",
-                      "value": "1"
-                    }
-                  ]
-                ]
-              }
-            }
+            "arguments": {}
           }
         }
       }

--- a/pkg/dyninst/testprogs/progs/simple/main.go
+++ b/pkg/dyninst/testprogs/progs/simple/main.go
@@ -131,7 +131,7 @@ type aStructNotUsedAsAnArgument struct {
 // the completion of internals of map types. This test reproduced that bug.
 //
 //go:noinline
-func usesMapsOfMapsThatDoNotAppearAsArguments() {
+func usesMapsOfMapsThatDoNotAppearAsArguments() map[byte]map[int]aStructNotUsedAsAnArgument {
 	// The bug required a map of maps. We make a new type here to ensure
 	// that it's not a map type that could possibly exist elsewhere.
 	m := map[string]map[int]aStructNotUsedAsAnArgument{
@@ -139,5 +139,8 @@ func usesMapsOfMapsThatDoNotAppearAsArguments() {
 	}
 	if m["b"] != nil {
 		m["b"][0] = aStructNotUsedAsAnArgument{a: 2}
+	}
+	return map[byte]map[int]aStructNotUsedAsAnArgument{
+		'a': m["a"],
 	}
 }

--- a/pkg/dyninst/testprogs/progs/simple/main.go
+++ b/pkg/dyninst/testprogs/progs/simple/main.go
@@ -37,6 +37,7 @@ func main() {
 	PointerChainArg(ptr5)
 	PointerSmallChainArg(ptr2)
 	noArgs()
+	usesMapsOfMapsThatDoNotAppearAsArguments()
 }
 
 //go:noinline
@@ -119,4 +120,24 @@ func PointerSmallChainArg(ptr **int) {
 //go:noinline
 func noArgs() {
 	fmt.Println("noArgs")
+}
+
+type aStructNotUsedAsAnArgument struct {
+	a int
+}
+
+// This test tickles a bug where we didn't explore variable types when we
+// but we were adding them. At that point we violated an invariant regarding
+// the completion of internals of map types. This test reproduced that bug.
+//
+//go:noinline
+func usesMapsOfMapsThatDoNotAppearAsArguments() {
+	// The bug required a map of maps. We make a new type here to ensure
+	// that it's not a map type that could possibly exist elsewhere.
+	m := map[string]map[int]aStructNotUsedAsAnArgument{
+		"a": {0: aStructNotUsedAsAnArgument{a: 1}},
+	}
+	if m["b"] != nil {
+		m["b"][0] = aStructNotUsedAsAnArgument{a: 2}
+	}
 }

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -72,3 +72,8 @@ probes:
   captureSnapshot: true
   where:
     methodName: main.noArgs
+- id: usesMapsOfMapsThatDoNotAppearAsArguments
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments


### PR DESCRIPTION
### What does this PR do?

This PR fixes issues in irgen found in real-world binaries from testing. In particular:

* it stops exploring local variables (we don't capture them)
* it always runs type expansion on all types (at least to a level of 0) -- this more deeply upholds an invariant
* it allows and warns about bogus DW_AT_GO_runtime_type dwarf attributes

### Motivation

The ir generation needs to succeed on all the binaries we can find. This fixes issues found with real binaries.

### Describe how you validated your changes

Added automated testing and ran the generation on real, large binaries.

