### PR TITLE
[CNM-4740] Add feature_traceroute_enabled to inventory agent.

### DIFF
--- a/comp/metadata/inventoryagent/README.md
+++ b/comp/metadata/inventoryagent/README.md
@@ -61,6 +61,7 @@ The payload is a JSON dict with the following fields
      (see: `process_config.container_collection.enabled`)
   - `feature_networks_enabled` - **bool**: True if the Network Performance Monitoring is enabled (see:
     `network_config.enabled` config option in `system-probe.yaml`).
+  - `feature_traceroute_enabled` - **bool**: True if the Traceroute module is enabled in the System Probe (see: `traceroute.enabled` config option in `system-probe.yaml`).
   - `feature_oom_kill_enabled` - **bool**: True if the OOM Kill check is enabled for System Probe (see: `system_probe_config.enable_oom_kill` config option in `system-probe.yaml`).
   - `feature_tcp_queue_length_enabled` - **bool**: True if TCP Queue Length check is enabled in System Probe (see: `system_probe_config.enable_tcp_queue_length` config option in `system-probe.yaml`).
   - `system_probe_telemetry_enabled` - **bool**: True if Telemetry is enabled in the System Probe (see: `system_probe_config.telemetry_enabled` config option in `system-probe.yaml`).
@@ -158,6 +159,7 @@ Here an example of an inventory payload:
         "feature_cws_enabled": false,
         "feature_logs_enabled": true,
         "feature_networks_enabled": false,
+        "feature_traceroute_enabled": false,
         "feature_process_enabled": false,
         "feature_remote_configuration_enabled": false,
         "flavor": "agent",

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -323,6 +323,7 @@ func (ia *inventoryagent) fetchSystemProbeMetadata() {
 	ia.data["feature_networks_enabled"] = sysProbeConf.GetBool("network_config.enabled")
 	ia.data["feature_networks_http_enabled"] = sysProbeConf.GetBool("service_monitoring_config.http.enabled")
 	ia.data["feature_networks_https_enabled"] = sysProbeConf.GetBool("service_monitoring_config.tls.native.enabled")
+	ia.data["feature_traceroute_enabled"] = sysProbeConf.GetBool("traceroute.enabled")
 
 	ia.data["feature_usm_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enabled")
 	ia.data["feature_usm_kafka_enabled"] = sysProbeConf.GetBool("service_monitoring_config.kafka.enabled")

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -120,6 +120,7 @@ func TestInitData(t *testing.T) {
 		"runtime_security_config.activity_dump.enabled":        true,
 		"runtime_security_config.remote_configuration.enabled": true,
 		"network_config.enabled":                               true,
+		"traceroute.enabled":                                   true,
 		"service_monitoring_config.enable_http_monitoring":     true,
 		"service_monitoring_config.tls.native.enabled":         true,
 		"service_monitoring_config.enabled":                    true,
@@ -219,6 +220,7 @@ func TestInitData(t *testing.T) {
 		"feature_networks_enabled":                     true,
 		"feature_networks_http_enabled":                true,
 		"feature_networks_https_enabled":               true,
+		"feature_traceroute_enabled":                   true,
 		"feature_usm_enabled":                          true,
 		"feature_usm_kafka_enabled":                    true,
 		"feature_usm_postgres_enabled":                 true,
@@ -497,6 +499,7 @@ func TestFetchSystemProbeAgent(t *testing.T) {
 	assert.False(t, ia.data["feature_networks_enabled"].(bool))
 	assert.True(t, ia.data["feature_networks_http_enabled"].(bool))
 	assert.True(t, ia.data["feature_networks_https_enabled"].(bool))
+	assert.False(t, ia.data["feature_traceroute_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_kafka_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_postgres_enabled"].(bool))
@@ -554,6 +557,7 @@ func TestFetchSystemProbeAgent(t *testing.T) {
 	assert.False(t, ia.data["feature_networks_enabled"].(bool))
 	assert.False(t, ia.data["feature_networks_http_enabled"].(bool))
 	assert.False(t, ia.data["feature_networks_https_enabled"].(bool))
+	assert.False(t, ia.data["feature_traceroute_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_kafka_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_postgres_enabled"].(bool))
@@ -603,6 +607,9 @@ network_config:
   enable_protocol_classification: true
   enable_gateway_lookup: true
   enable_root_netns: true
+
+traceroute:
+  enabled: true
 
 service_monitoring_config:
   http:
@@ -661,6 +668,7 @@ gpu_monitoring:
 	assert.True(t, ia.data["feature_networks_enabled"].(bool))
 	assert.True(t, ia.data["feature_networks_http_enabled"].(bool))
 	assert.True(t, ia.data["feature_networks_https_enabled"].(bool))
+	assert.True(t, ia.data["feature_traceroute_enabled"].(bool))
 	assert.True(t, ia.data["feature_usm_enabled"].(bool))
 	assert.True(t, ia.data["feature_usm_kafka_enabled"].(bool))
 	assert.True(t, ia.data["feature_usm_postgres_enabled"].(bool))

--- a/test/new-e2e/tests/agent-configuration/inventory/inventory_agent_test.go
+++ b/test/new-e2e/tests/agent-configuration/inventory/inventory_agent_test.go
@@ -32,6 +32,7 @@ func (v *inventoryAgentSuite) TestInventoryDefaultConfig() {
 	assert.Contains(v.T(), inventory, `"feature_logs_enabled": false`)
 	assert.Contains(v.T(), inventory, `"feature_process_enabled": false`)
 	assert.Contains(v.T(), inventory, `"feature_networks_enabled": false`)
+	assert.Contains(v.T(), inventory, `"feature_traceroute_enabled": false`)
 	assert.Contains(v.T(), inventory, `"feature_cspm_enabled": false`)
 	assert.Contains(v.T(), inventory, `"feature_cws_enabled": false`)
 	assert.Contains(v.T(), inventory, `"feature_usm_enabled": false`)
@@ -51,6 +52,8 @@ compliance_config:
 service_monitoring_config:
   enabled: true
 network_config:
+  enabled: true
+traceroute:
   enabled: true`
 
 	agentOptions := []agentparams.Option{
@@ -65,6 +68,7 @@ network_config:
 	assert.Contains(v.T(), inventory, `"feature_logs_enabled": true`)
 	assert.Contains(v.T(), inventory, `"feature_process_enabled": true`)
 	assert.Contains(v.T(), inventory, `"feature_networks_enabled": true`)
+	assert.Contains(v.T(), inventory, `"feature_traceroute_enabled": true`)
 	assert.Contains(v.T(), inventory, `"feature_cspm_enabled": true`)
 	assert.Contains(v.T(), inventory, `"feature_cws_enabled": true`)
 	assert.Contains(v.T(), inventory, `"feature_usm_enabled": true`)


### PR DESCRIPTION
### What does this PR do?
Add feature_traceroute_enabled to inventory agent.

### Motivation
To allow Synthetics to filter by agents which support Network Tests by using the fleet automation /agents endpoint.

### Describe how you validated your changes
Built and ran agent in docker and validated with `agent diagnose show-metadata inventory-agent`.

Then, after updating the `datadog_agent` schema in https://github.com/DataDog/infrastructure-resources/pull/2347 and deploying it in staging, validated with DDSQL Editor:

<img width="1180" height="636" alt="image" src="https://github.com/user-attachments/assets/26c58d76-a7c6-4a7a-88fa-0b6b52cb69a2" />

And after adding traceroute:enabled to `system-probe.yaml` and restarting agent:

<img width="1188" height="631" alt="image" src="https://github.com/user-attachments/assets/e7357534-776a-4c7f-b6c2-823882fec7da" />
 



### Additional Notes
