### PR TITLE
[Backport 7.71.x] dyninst/irgen: fix issues found in the wild (#41091)

### DIFF
--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -3,268 +3,313 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a6046.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[*****int]
+	Call 4a 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6006]
-	PrepareEventRoot 4e 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6046]
+	PrepareEventRoot 60 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6046.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 52 02 00 00 // ProcessType[**int]
+	Call 5c 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6050]
-	PrepareEventRoot 4f 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6090]
+	PrepareEventRoot 61 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7a 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call f5 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a64f3]
-	PrepareEventRoot 4c 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6553]
+	PrepareEventRoot 5d 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@4a63ca]
-	PrepareEventRoot 4d 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@4a5dce]
-	PrepareEventRoot 4d 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@4a60aa]
-	PrepareEventRoot 44 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@4a642a]
+	PrepareEventRoot 5f 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@4a5e0e]
+	PrepareEventRoot 5f 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a610a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@4a610a]
+	PrepareEventRoot 55 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a610a.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a622a]
-	PrepareEventRoot 47 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a628a]
+	PrepareEventRoot 58 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 02 00 00 // ProcessType[[3]string]
+	Call da 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a63a0]
-	PrepareEventRoot 4a 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
+	PrepareEventRoot 5b 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ec 02 00 00 // ProcessType[[]int]
+	Call 1a 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a61aa]
-	PrepareEventRoot 46 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a620a]
+	PrepareEventRoot 57 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 74 03 00 00 // ProcessType[map[string]int]
+	Call ef 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@4a648a]
-	PrepareEventRoot 4b 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4a64ea]
+	PrepareEventRoot 5c 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	Return 
-// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 80 03 00 00 // ProcessType[string]
+	Call 01 04 00 00 // ProcessType[string]
 	Return 
-// 0x1c9: ProcessEvent[Probe[main.stringArg]@4a612a]
-	PrepareEventRoot 45 00 00 00 11 00 00 00 
-	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot 56 00 00 00 11 00 00 00 
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
-// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 02 00 00 // ProcessType[[3]string]
+	Call da 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4a632a]
-	PrepareEventRoot 49 00 00 00 31 00 00 00 
-	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
+	PrepareEventRoot 5a 00 00 00 31 00 00 00 
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	Return 
-// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 06 03 00 00 // ProcessType[[]string]
+	Call 34 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4a62aa]
-	PrepareEventRoot 48 00 00 00 19 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
+	PrepareEventRoot 59 00 00 00 19 00 00 00 
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	Return 
-// 0x240: ProcessType[*****int]
-	ProcessPointer 32 00 00 00 
+// 0x240: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6616]
+	PrepareEventRoot 5e 00 00 00 00 00 00 00 
 	Return 
-// 0x246: ProcessType[****int]
-	ProcessPointer 42 00 00 00 
+// 0x24a: ProcessType[*****int]
+	ProcessPointer 37 00 00 00 
 	Return 
-// 0x24c: ProcessType[***int]
-	ProcessPointer 33 00 00 00 
+// 0x250: ProcessType[****int]
+	ProcessPointer 53 00 00 00 
 	Return 
-// 0x252: ProcessType[**int]
+// 0x256: ProcessType[***int]
+	ProcessPointer 38 00 00 00 
+	Return 
+// 0x25c: ProcessType[**int]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x258: ProcessType[*bool]
+// 0x262: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x25e: ProcessType[*bucket<string,int>]
+// 0x268: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 4d 00 00 00 
+	Return 
+// 0x26e: ProcessType[*bucket<string,int>]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x264: ProcessType[*bucket<string,main.bigStruct>]
+// 0x274: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x26a: ProcessType[*error]
+// 0x27a: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 35 00 00 00 
+	Return 
+// 0x280: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x270: ProcessType[*float32]
+// 0x286: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x276: ProcessType[*float64]
+// 0x28c: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x27c: ProcessType[*int]
+// 0x292: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x282: ProcessType[*int32]
+// 0x298: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x288: ProcessType[*int64]
+// 0x29e: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x28e: ProcessType[*main.bigStruct]
-	ProcessPointer 40 00 00 00 
+// 0x2a4: ProcessType[*main.bigStruct]
+	ProcessPointer 45 00 00 00 
 	Return 
-// 0x294: ProcessType[*runtime.mapextra]
+// 0x2aa: ProcessType[*runtime.mapextra]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x29a: ProcessType[*string]
+// 0x2b0: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2a0: ProcessType[*uint]
+// 0x2b6: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*uint16]
+// 0x2bc: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint32]
+// 0x2c2: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint64]
+// 0x2c8: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uint8]
+// 0x2ce: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x2be: ProcessType[*uintptr]
+// 0x2d4: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x2c4: ProcessType[[3]string]
+// 0x2da: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 80 03 00 00 // ProcessType[string]
+	Call 01 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2d4: ProcessType[[]bucket<string,int>.array]
+// 0x2ea: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 2c 03 00 00 // ProcessType[bucket<string,int>]
+	Call 6a 03 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2e0: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x2f6: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 41 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 75 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2ec: ProcessType[[]int]
-	ProcessSlice 36 00 00 00 08 00 00 00 
+// 0x302: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 8a 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2f6: ProcessType[[]key<string>]
+// 0x30e: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 9f 03 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x31a: ProcessType[[]int]
+	ProcessSlice 3b 00 00 00 08 00 00 00 
+	Return 
+// 0x324: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 80 03 00 00 // ProcessType[string]
+	Call 01 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x306: ProcessType[[]string]
-	ProcessSlice 38 00 00 00 10 00 00 00 
+// 0x334: ProcessType[[]string]
+	ProcessSlice 3d 00 00 00 10 00 00 00 
 	Return 
-// 0x310: ProcessType[[]string.array]
+// 0x33e: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 80 03 00 00 // ProcessType[string]
+	Call 01 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x31c: ProcessType[[]val<main.bigStruct>]
+// 0x34a: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 8e 02 00 00 // ProcessType[*main.bigStruct]
+	Call a4 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x32c: ProcessType[bucket<string,int>]
+// 0x35a: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call e9 03 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x36a: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 88 00 00 00 
+	Call 68 02 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x375: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f6 02 00 00 // ProcessType[[]key<string>]
+	Call 24 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5e 02 00 00 // ProcessType[*bucket<string,int>]
+	Call 6e 02 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x341: ProcessType[bucket<string,main.bigStruct>]
+// 0x38a: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f6 02 00 00 // ProcessType[[]key<string>]
-	Call 1c 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 64 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 24 03 00 00 // ProcessType[[]key<string>]
+	Call 4a 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 74 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x356: ProcessType[error]
+// 0x39f: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 5a 03 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 7a 02 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x3af: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x358: ProcessType[hash<string,int>]
-	ProcessGoHmap 3d 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x3b1: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 52 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x366: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 41 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x3bf: ProcessType[hash<string,int>]
+	ProcessGoHmap 42 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x374: ProcessType[map[string]int]
+// 0x3cd: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 46 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x3db: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 4e 00 00 00 58 00 00 00 08 09 10 18 
+	Return 
+// 0x3e9: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 4b 00 00 00 
+	Return 
+// 0x3ef: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
 	Return 
-// 0x37a: ProcessType[map[string]main.bigStruct]
+// 0x3f5: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x380: ProcessType[string]
-	ProcessString 34 00 00 00 
+// 0x3fb: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x401: ProcessType[string]
+	ProcessString 39 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -285,12 +330,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 600
-ID: 6 Len: 8 Enqueue: 696
+ID: 5 Len: 8 Enqueue: 610
+ID: 6 Len: 8 Enqueue: 718
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 702
+ID: 8 Len: 8 Enqueue: 724
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 896
+ID: 10 Len: 16 Enqueue: 1025
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -298,65 +343,83 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 854
+ID: 18 Len: 16 Enqueue: 943
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 642
-ID: 21 Len: 8 Enqueue: 684
-ID: 22 Len: 8 Enqueue: 666
+ID: 20 Len: 8 Enqueue: 664
+ID: 21 Len: 8 Enqueue: 706
+ID: 22 Len: 8 Enqueue: 688
 ID: 23 Len: 8 Enqueue: 0
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 630
-ID: 26 Len: 8 Enqueue: 648
-ID: 27 Len: 8 Enqueue: 636
-ID: 28 Len: 8 Enqueue: 690
-ID: 29 Len: 8 Enqueue: 618
-ID: 30 Len: 8 Enqueue: 624
-ID: 31 Len: 8 Enqueue: 672
-ID: 32 Len: 8 Enqueue: 678
-ID: 33 Len: 24 Enqueue: 748
+ID: 25 Len: 8 Enqueue: 652
+ID: 26 Len: 8 Enqueue: 670
+ID: 27 Len: 8 Enqueue: 658
+ID: 28 Len: 8 Enqueue: 712
+ID: 29 Len: 8 Enqueue: 640
+ID: 30 Len: 8 Enqueue: 646
+ID: 31 Len: 8 Enqueue: 694
+ID: 32 Len: 8 Enqueue: 700
+ID: 33 Len: 24 Enqueue: 794
 ID: 34 Len: 24 Enqueue: 0
-ID: 35 Len: 24 Enqueue: 774
-ID: 36 Len: 48 Enqueue: 708
-ID: 37 Len: 8 Enqueue: 884
+ID: 35 Len: 24 Enqueue: 820
+ID: 36 Len: 48 Enqueue: 730
+ID: 37 Len: 8 Enqueue: 1007
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 48 Enqueue: 856
-ID: 40 Len: 8 Enqueue: 606
-ID: 41 Len: 208 Enqueue: 812
-ID: 42 Len: 8 Enqueue: 660
+ID: 39 Len: 48 Enqueue: 959
+ID: 40 Len: 8 Enqueue: 622
+ID: 41 Len: 208 Enqueue: 885
+ID: 42 Len: 8 Enqueue: 682
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 8 Enqueue: 890
+ID: 44 Len: 8 Enqueue: 1013
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 48 Enqueue: 870
-ID: 47 Len: 8 Enqueue: 612
-ID: 48 Len: 208 Enqueue: 833
-ID: 49 Len: 8 Enqueue: 576
-ID: 50 Len: 8 Enqueue: 582
-ID: 51 Len: 8 Enqueue: 594
-ID: 52 Len: 2048 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 2048 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 2048 Enqueue: 784
-ID: 57 Len: 8 Enqueue: 0
+ID: 46 Len: 48 Enqueue: 973
+ID: 47 Len: 8 Enqueue: 628
+ID: 48 Len: 208 Enqueue: 906
+ID: 49 Len: 8 Enqueue: 1019
+ID: 50 Len: 8 Enqueue: 0
+ID: 51 Len: 48 Enqueue: 987
+ID: 52 Len: 8 Enqueue: 634
+ID: 53 Len: 88 Enqueue: 927
+ID: 54 Len: 8 Enqueue: 586
+ID: 55 Len: 8 Enqueue: 592
+ID: 56 Len: 8 Enqueue: 604
+ID: 57 Len: 2048 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 128 Enqueue: 758
-ID: 60 Len: 64 Enqueue: 0
-ID: 61 Len: 2048 Enqueue: 724
-ID: 62 Len: 64 Enqueue: 796
-ID: 63 Len: 8 Enqueue: 654
-ID: 64 Len: 184 Enqueue: 0
-ID: 65 Len: 2048 Enqueue: 736
-ID: 66 Len: 8 Enqueue: 588
-ID: 67 Len: 128 Enqueue: 0
-ID: 68 Len: 9 Enqueue: 0
-ID: 69 Len: 17 Enqueue: 0
-ID: 70 Len: 25 Enqueue: 0
-ID: 71 Len: 25 Enqueue: 0
-ID: 72 Len: 25 Enqueue: 0
-ID: 73 Len: 49 Enqueue: 0
-ID: 74 Len: 49 Enqueue: 0
-ID: 75 Len: 9 Enqueue: 0
-ID: 76 Len: 9 Enqueue: 0
-ID: 77 Len: 9 Enqueue: 0
-ID: 78 Len: 9 Enqueue: 0
-ID: 79 Len: 9 Enqueue: 0
+ID: 59 Len: 2048 Enqueue: 0
+ID: 60 Len: 8 Enqueue: 0
+ID: 61 Len: 2048 Enqueue: 830
+ID: 62 Len: 8 Enqueue: 0
+ID: 63 Len: 8 Enqueue: 0
+ID: 64 Len: 128 Enqueue: 804
+ID: 65 Len: 64 Enqueue: 0
+ID: 66 Len: 2048 Enqueue: 758
+ID: 67 Len: 64 Enqueue: 842
+ID: 68 Len: 8 Enqueue: 676
+ID: 69 Len: 184 Enqueue: 0
+ID: 70 Len: 2048 Enqueue: 770
+ID: 71 Len: 8 Enqueue: 0
+ID: 72 Len: 64 Enqueue: 858
+ID: 73 Len: 8 Enqueue: 1001
+ID: 74 Len: 8 Enqueue: 0
+ID: 75 Len: 48 Enqueue: 945
+ID: 76 Len: 8 Enqueue: 616
+ID: 77 Len: 144 Enqueue: 874
+ID: 78 Len: 2048 Enqueue: 782
+ID: 79 Len: 64 Enqueue: 0
+ID: 80 Len: 64 Enqueue: 0
+ID: 81 Len: 8 Enqueue: 0
+ID: 82 Len: 2048 Enqueue: 746
+ID: 83 Len: 8 Enqueue: 598
+ID: 84 Len: 128 Enqueue: 0
+ID: 85 Len: 9 Enqueue: 0
+ID: 86 Len: 17 Enqueue: 0
+ID: 87 Len: 25 Enqueue: 0
+ID: 88 Len: 25 Enqueue: 0
+ID: 89 Len: 25 Enqueue: 0
+ID: 90 Len: 49 Enqueue: 0
+ID: 91 Len: 49 Enqueue: 0
+ID: 92 Len: 9 Enqueue: 0
+ID: 93 Len: 9 Enqueue: 0
+ID: 94 Len: 0 Enqueue: 0
+ID: 95 Len: 9 Enqueue: 0
+ID: 96 Len: 9 Enqueue: 0
+ID: 97 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -3,293 +3,356 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a8046.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[*****int]
+	Call 4a 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8006]
-	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8046]
+	PrepareEventRoot 72 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8046.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8090.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 52 02 00 00 // ProcessType[**int]
+	Call 5c 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8050]
-	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8090]
+	PrepareEventRoot 73 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8090.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a84f3.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 56 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call c6 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a84f3]
-	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a84f3.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a8553]
+	PrepareEventRoot 6f 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0x4a83ca.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@4a83ca]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a83ca.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@4a7dce]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a80aa.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@4a80aa]
-	PrepareEventRoot 4c 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a80aa.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@4a842a]
+	PrepareEventRoot 71 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a822a.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@4a7e0e]
+	PrepareEventRoot 71 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a810a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@4a810a]
+	PrepareEventRoot 67 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a810a.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a828a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a822a]
-	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a822a.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a828a]
+	PrepareEventRoot 6a 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a828a.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 02 00 00 // ProcessType[[3]string]
+	Call d4 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a83a0]
-	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83a0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8400]
+	PrepareEventRoot 6d 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a81aa.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e6 02 00 00 // ProcessType[[]int]
+	Call 14 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a81aa]
-	PrepareEventRoot 4e 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a81aa.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a820a]
+	PrepareEventRoot 69 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a848a.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 50 03 00 00 // ProcessType[map[string]int]
+	Call c0 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@4a848a]
-	PrepareEventRoot 53 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a848a.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4a84ea]
+	PrepareEventRoot 6e 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	Return 
-// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4a812a.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 44 04 00 00 // ProcessType[string]
 	Return 
-// 0x1c9: ProcessEvent[Probe[main.stringArg]@4a812a]
-	PrepareEventRoot 4d 00 00 00 11 00 00 00 
-	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a812a.expr[0]]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot 68 00 00 00 11 00 00 00 
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	Return 
-// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4a832a.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 02 00 00 // ProcessType[[3]string]
+	Call d4 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4a832a]
-	PrepareEventRoot 51 00 00 00 31 00 00 00 
-	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a832a.expr[0]]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4a838a]
+	PrepareEventRoot 6c 00 00 00 31 00 00 00 
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
 	Return 
-// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 08 03 00 00 // ProcessType[[]string]
+	Call 42 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4a82aa]
-	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4a830a]
+	PrepareEventRoot 6b 00 00 00 19 00 00 00 
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	Return 
-// 0x240: ProcessType[*****int]
-	ProcessPointer 30 00 00 00 
+// 0x240: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8616]
+	PrepareEventRoot 70 00 00 00 00 00 00 00 
 	Return 
-// 0x246: ProcessType[****int]
-	ProcessPointer 4a 00 00 00 
+// 0x24a: ProcessType[*****int]
+	ProcessPointer 35 00 00 00 
 	Return 
-// 0x24c: ProcessType[***int]
-	ProcessPointer 31 00 00 00 
+// 0x250: ProcessType[****int]
+	ProcessPointer 65 00 00 00 
 	Return 
-// 0x252: ProcessType[**int]
+// 0x256: ProcessType[***int]
+	ProcessPointer 36 00 00 00 
+	Return 
+// 0x25c: ProcessType[**int]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x258: ProcessType[*bool]
+// 0x262: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x25e: ProcessType[*error]
+// 0x268: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x264: ProcessType[*float32]
+// 0x26e: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x26a: ProcessType[*float64]
+// 0x274: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x270: ProcessType[*int]
+// 0x27a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x276: ProcessType[*int32]
+// 0x280: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x27c: ProcessType[*int64]
+// 0x286: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 47 00 00 00 
+// 0x28c: ProcessType[*main.bigStruct]
+	ProcessPointer 4c 00 00 00 
 	Return 
-// 0x288: ProcessType[*string]
+// 0x292: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 38 00 00 00 
+// 0x298: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 5c 00 00 00 
 	Return 
-// 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 40 00 00 00 
+// 0x29e: ProcessType[*table<string,int>]
+	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x29a: ProcessType[*uint]
+// 0x2a4: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 45 00 00 00 
+	Return 
+// 0x2aa: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 4f 00 00 00 
+	Return 
+// 0x2b0: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x2a0: ProcessType[*uint16]
+// 0x2b6: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*uint32]
+// 0x2bc: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint64]
+// 0x2c2: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint8]
+// 0x2c8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uintptr]
+// 0x2ce: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x2be: ProcessType[[3]string]
+// 0x2d4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 44 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2ce: ProcessType[[]*table<string,int>.array]
+// 0x2e4: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 8e 02 00 00 // ProcessType[*table<string,int>]
+	Call 98 02 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2da: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x2f0: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 94 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 9e 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2e6: ProcessType[[]int]
-	ProcessSlice 34 00 00 00 08 00 00 00 
-	Return 
-// 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
+// 0x2fc: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7c 03 00 00 // ProcessType[noalg.map.group[string]int]
+	Call a4 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x308: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call aa 02 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x314: ProcessType[[]int]
+	ProcessSlice 39 00 00 00 08 00 00 00 
+	Return 
+// 0x31e: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 02 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x2fc: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x32a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 87 03 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 0d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x308: ProcessType[[]string]
-	ProcessSlice 36 00 00 00 10 00 00 00 
-	Return 
-// 0x312: ProcessType[[]string.array]
+// 0x336: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 18 04 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x342: ProcessType[[]string]
+	ProcessSlice 3b 00 00 00 10 00 00 00 
+	Return 
+// 0x34c: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 44 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x31e: ProcessType[error]
+// 0x358: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 3f 00 00 00 c8 00 00 00 00 08 
+// 0x35a: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups 64 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
+// 0x366: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 44 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 3e 00 00 00 3b 00 00 00 10 18 
+// 0x372: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 4e 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 48 00 00 00 43 00 00 00 10 18 
+// 0x37e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups 5b 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x350: ProcessType[map[string]int]
+// 0x38a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap 63 00 00 00 5f 00 00 00 10 18 
+	Return 
+// 0x396: ProcessType[map<string,int>]
+	ProcessGoSwissMap 43 00 00 00 40 00 00 00 10 18 
+	Return 
+// 0x3a2: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4d 00 00 00 48 00 00 00 10 18 
+	Return 
+// 0x3ae: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap 5a 00 00 00 52 00 00 00 10 18 
+	Return 
+// 0x3ba: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 57 00 00 00 
+	Return 
+// 0x3c0: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
 	Return 
-// 0x356: ProcessType[map[string]main.bigStruct]
+// 0x3c6: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 2c 00 00 00 
 	Return 
-// 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x3cc: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 31 00 00 00 
+	Return 
+// 0x3d2: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 92 03 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 23 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36c: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x3e2: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a2 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 33 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x37c: ProcessType[noalg.map.group[string]int]
+// 0x3f2: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call 39 04 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x402: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call e2 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x387: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x40d: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call d2 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x392: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call a8 03 00 00 // ProcessType[string]
+// 0x418: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	IncrementOutputOffset 08 00 00 00 
+	Call f2 03 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Return 
+// 0x423: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 44 04 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 82 02 00 00 // ProcessType[*main.bigStruct]
+	Call 8c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x3a2: ProcessType[noalg.struct { key string; elem int }]
-	Call a8 03 00 00 // ProcessType[string]
+// 0x433: ProcessType[noalg.struct { key string; elem int }]
+	Call 44 04 00 00 // ProcessType[string]
 	Return 
-// 0x3a8: ProcessType[string]
-	ProcessString 32 00 00 00 
+// 0x439: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	IncrementOutputOffset 08 00 00 00 
+	Call ba 03 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3ae: ProcessType[table<string,int>]
+// 0x444: ProcessType[string]
+	ProcessString 37 00 00 00 
+	Return 
+// 0x44a: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 20 03 00 00 // ProcessType[groupReference<string,int>]
+	Call 5a 03 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x3b9: ProcessType[table<string,main.bigStruct>]
+// 0x455: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2c 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 66 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x460: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 72 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x46b: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 7e 03 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -310,86 +373,114 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 690
+ID: 5 Len: 8 Enqueue: 712
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 936
+ID: 9 Len: 16 Enqueue: 1092
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 600
+ID: 11 Len: 8 Enqueue: 610
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 798
+ID: 13 Len: 16 Enqueue: 856
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 696
-ID: 20 Len: 8 Enqueue: 630
-ID: 21 Len: 8 Enqueue: 678
-ID: 22 Len: 8 Enqueue: 648
+ID: 19 Len: 8 Enqueue: 718
+ID: 20 Len: 8 Enqueue: 640
+ID: 21 Len: 8 Enqueue: 700
+ID: 22 Len: 8 Enqueue: 658
 ID: 23 Len: 8 Enqueue: 0
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 618
-ID: 26 Len: 8 Enqueue: 636
-ID: 27 Len: 8 Enqueue: 624
-ID: 28 Len: 8 Enqueue: 684
-ID: 29 Len: 8 Enqueue: 606
-ID: 30 Len: 8 Enqueue: 612
-ID: 31 Len: 8 Enqueue: 666
-ID: 32 Len: 8 Enqueue: 672
-ID: 33 Len: 24 Enqueue: 742
+ID: 25 Len: 8 Enqueue: 628
+ID: 26 Len: 8 Enqueue: 646
+ID: 27 Len: 8 Enqueue: 634
+ID: 28 Len: 8 Enqueue: 706
+ID: 29 Len: 8 Enqueue: 616
+ID: 30 Len: 8 Enqueue: 622
+ID: 31 Len: 8 Enqueue: 688
+ID: 32 Len: 8 Enqueue: 694
+ID: 33 Len: 24 Enqueue: 788
 ID: 34 Len: 24 Enqueue: 0
-ID: 35 Len: 24 Enqueue: 776
-ID: 36 Len: 48 Enqueue: 702
-ID: 37 Len: 8 Enqueue: 848
+ID: 35 Len: 24 Enqueue: 834
+ID: 36 Len: 48 Enqueue: 724
+ID: 37 Len: 8 Enqueue: 960
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 48 Enqueue: 824
+ID: 39 Len: 48 Enqueue: 918
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 654
-ID: 42 Len: 8 Enqueue: 854
+ID: 41 Len: 8 Enqueue: 670
+ID: 42 Len: 8 Enqueue: 966
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 48 Enqueue: 836
+ID: 44 Len: 48 Enqueue: 930
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 660
-ID: 47 Len: 8 Enqueue: 576
-ID: 48 Len: 8 Enqueue: 582
-ID: 49 Len: 8 Enqueue: 594
-ID: 50 Len: 2048 Enqueue: 0
-ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 2048 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 2048 Enqueue: 786
-ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 32 Enqueue: 942
-ID: 57 Len: 16 Enqueue: 800
+ID: 46 Len: 8 Enqueue: 676
+ID: 47 Len: 8 Enqueue: 972
+ID: 48 Len: 8 Enqueue: 0
+ID: 49 Len: 48 Enqueue: 942
+ID: 50 Len: 8 Enqueue: 0
+ID: 51 Len: 8 Enqueue: 682
+ID: 52 Len: 8 Enqueue: 586
+ID: 53 Len: 8 Enqueue: 592
+ID: 54 Len: 8 Enqueue: 604
+ID: 55 Len: 2048 Enqueue: 0
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 2048 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 200 Enqueue: 892
-ID: 60 Len: 192 Enqueue: 876
-ID: 61 Len: 24 Enqueue: 930
-ID: 62 Len: 8192 Enqueue: 718
-ID: 63 Len: 2048 Enqueue: 752
-ID: 64 Len: 32 Enqueue: 953
-ID: 65 Len: 16 Enqueue: 812
-ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 200 Enqueue: 903
-ID: 68 Len: 192 Enqueue: 860
-ID: 69 Len: 24 Enqueue: 914
-ID: 70 Len: 8 Enqueue: 642
-ID: 71 Len: 184 Enqueue: 0
-ID: 72 Len: 8192 Enqueue: 730
-ID: 73 Len: 2048 Enqueue: 764
-ID: 74 Len: 8 Enqueue: 588
-ID: 75 Len: 128 Enqueue: 0
-ID: 76 Len: 9 Enqueue: 0
-ID: 77 Len: 17 Enqueue: 0
-ID: 78 Len: 25 Enqueue: 0
-ID: 79 Len: 25 Enqueue: 0
-ID: 80 Len: 25 Enqueue: 0
-ID: 81 Len: 49 Enqueue: 0
-ID: 82 Len: 49 Enqueue: 0
-ID: 83 Len: 9 Enqueue: 0
-ID: 84 Len: 9 Enqueue: 0
-ID: 85 Len: 9 Enqueue: 0
-ID: 86 Len: 9 Enqueue: 0
-ID: 87 Len: 9 Enqueue: 0
+ID: 59 Len: 2048 Enqueue: 844
+ID: 60 Len: 8 Enqueue: 0
+ID: 61 Len: 32 Enqueue: 1109
+ID: 62 Len: 16 Enqueue: 870
+ID: 63 Len: 8 Enqueue: 0
+ID: 64 Len: 200 Enqueue: 1026
+ID: 65 Len: 192 Enqueue: 994
+ID: 66 Len: 24 Enqueue: 1075
+ID: 67 Len: 8192 Enqueue: 752
+ID: 68 Len: 2048 Enqueue: 798
+ID: 69 Len: 32 Enqueue: 1120
+ID: 70 Len: 16 Enqueue: 882
+ID: 71 Len: 8 Enqueue: 0
+ID: 72 Len: 200 Enqueue: 1037
+ID: 73 Len: 192 Enqueue: 978
+ID: 74 Len: 24 Enqueue: 1059
+ID: 75 Len: 8 Enqueue: 652
+ID: 76 Len: 184 Enqueue: 0
+ID: 77 Len: 8192 Enqueue: 764
+ID: 78 Len: 2048 Enqueue: 810
+ID: 79 Len: 32 Enqueue: 1131
+ID: 80 Len: 16 Enqueue: 894
+ID: 81 Len: 8 Enqueue: 0
+ID: 82 Len: 136 Enqueue: 1048
+ID: 83 Len: 128 Enqueue: 1010
+ID: 84 Len: 16 Enqueue: 1081
+ID: 85 Len: 8 Enqueue: 954
+ID: 86 Len: 8 Enqueue: 0
+ID: 87 Len: 48 Enqueue: 906
+ID: 88 Len: 8 Enqueue: 0
+ID: 89 Len: 8 Enqueue: 664
+ID: 90 Len: 8192 Enqueue: 776
+ID: 91 Len: 2048 Enqueue: 822
+ID: 92 Len: 32 Enqueue: 1098
+ID: 93 Len: 16 Enqueue: 858
+ID: 94 Len: 8 Enqueue: 0
+ID: 95 Len: 136 Enqueue: 0
+ID: 96 Len: 128 Enqueue: 0
+ID: 97 Len: 16 Enqueue: 0
+ID: 98 Len: 8 Enqueue: 0
+ID: 99 Len: 8192 Enqueue: 740
+ID: 100 Len: 2048 Enqueue: 0
+ID: 101 Len: 8 Enqueue: 598
+ID: 102 Len: 128 Enqueue: 0
+ID: 103 Len: 9 Enqueue: 0
+ID: 104 Len: 17 Enqueue: 0
+ID: 105 Len: 25 Enqueue: 0
+ID: 106 Len: 25 Enqueue: 0
+ID: 107 Len: 25 Enqueue: 0
+ID: 108 Len: 49 Enqueue: 0
+ID: 109 Len: 49 Enqueue: 0
+ID: 110 Len: 9 Enqueue: 0
+ID: 111 Len: 9 Enqueue: 0
+ID: 112 Len: 0 Enqueue: 0
+ID: 113 Len: 9 Enqueue: 0
+ID: 114 Len: 9 Enqueue: 0
+ID: 115 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -3,293 +3,356 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4ae646.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[*****int]
+	Call 4a 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae606]
-	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae646]
+	PrepareEventRoot 72 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae646.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae690.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 52 02 00 00 // ProcessType[**int]
+	Call 5c 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae650]
-	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae690]
+	PrepareEventRoot 73 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae690.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4aeaf3.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 56 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call c6 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeaf3]
-	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4aeaf3.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeb53]
+	PrepareEventRoot 6f 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0x4ae9ca.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@4ae9ca]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae9ca.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@4ae3ce]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0x4ae6aa.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@4ae6aa]
-	PrepareEventRoot 4c 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4ae6aa.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@4aea2a]
+	PrepareEventRoot 71 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4ae82a.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@4ae40e]
+	PrepareEventRoot 71 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4ae70a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@4ae70a]
+	PrepareEventRoot 67 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4ae70a.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4ae88a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@4ae82a]
-	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae82a.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4ae88a]
+	PrepareEventRoot 6a 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae88a.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4ae9a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 02 00 00 // ProcessType[[3]string]
+	Call d4 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4ae9a0]
-	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4ae9a0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4aea00]
+	PrepareEventRoot 6d 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4ae7aa.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e6 02 00 00 // ProcessType[[]int]
+	Call 14 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4ae7aa]
-	PrepareEventRoot 4e 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae7aa.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4ae80a]
+	PrepareEventRoot 69 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4aea8a.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 50 03 00 00 // ProcessType[map[string]int]
+	Call c0 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@4aea8a]
-	PrepareEventRoot 53 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aea8a.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4aeaea]
+	PrepareEventRoot 6e 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	Return 
-// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4ae72a.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 44 04 00 00 // ProcessType[string]
 	Return 
-// 0x1c9: ProcessEvent[Probe[main.stringArg]@4ae72a]
-	PrepareEventRoot 4d 00 00 00 11 00 00 00 
-	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae72a.expr[0]]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot 68 00 00 00 11 00 00 00 
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	Return 
-// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4ae92a.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 02 00 00 // ProcessType[[3]string]
+	Call d4 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4ae92a]
-	PrepareEventRoot 51 00 00 00 31 00 00 00 
-	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae92a.expr[0]]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4ae98a]
+	PrepareEventRoot 6c 00 00 00 31 00 00 00 
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
 	Return 
-// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4ae8aa.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 08 03 00 00 // ProcessType[[]string]
+	Call 42 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4ae8aa]
-	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae8aa.expr[0]]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4ae90a]
+	PrepareEventRoot 6b 00 00 00 19 00 00 00 
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	Return 
-// 0x240: ProcessType[*****int]
-	ProcessPointer 30 00 00 00 
+// 0x240: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec16]
+	PrepareEventRoot 70 00 00 00 00 00 00 00 
 	Return 
-// 0x246: ProcessType[****int]
-	ProcessPointer 4a 00 00 00 
+// 0x24a: ProcessType[*****int]
+	ProcessPointer 35 00 00 00 
 	Return 
-// 0x24c: ProcessType[***int]
-	ProcessPointer 31 00 00 00 
+// 0x250: ProcessType[****int]
+	ProcessPointer 65 00 00 00 
 	Return 
-// 0x252: ProcessType[**int]
+// 0x256: ProcessType[***int]
+	ProcessPointer 36 00 00 00 
+	Return 
+// 0x25c: ProcessType[**int]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x258: ProcessType[*bool]
+// 0x262: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x25e: ProcessType[*error]
+// 0x268: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x264: ProcessType[*float32]
+// 0x26e: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x26a: ProcessType[*float64]
+// 0x274: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x270: ProcessType[*int]
+// 0x27a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x276: ProcessType[*int32]
+// 0x280: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x27c: ProcessType[*int64]
+// 0x286: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 47 00 00 00 
+// 0x28c: ProcessType[*main.bigStruct]
+	ProcessPointer 4c 00 00 00 
 	Return 
-// 0x288: ProcessType[*string]
+// 0x292: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 38 00 00 00 
+// 0x298: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 5c 00 00 00 
 	Return 
-// 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 40 00 00 00 
+// 0x29e: ProcessType[*table<string,int>]
+	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x29a: ProcessType[*uint]
+// 0x2a4: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 45 00 00 00 
+	Return 
+// 0x2aa: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 4f 00 00 00 
+	Return 
+// 0x2b0: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x2a0: ProcessType[*uint16]
+// 0x2b6: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*uint32]
+// 0x2bc: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint64]
+// 0x2c2: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint8]
+// 0x2c8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uintptr]
+// 0x2ce: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x2be: ProcessType[[3]string]
+// 0x2d4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 44 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2ce: ProcessType[[]*table<string,int>.array]
+// 0x2e4: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 8e 02 00 00 // ProcessType[*table<string,int>]
+	Call 98 02 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2da: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x2f0: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 94 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 9e 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2e6: ProcessType[[]int]
-	ProcessSlice 34 00 00 00 08 00 00 00 
-	Return 
-// 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
+// 0x2fc: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7c 03 00 00 // ProcessType[noalg.map.group[string]int]
+	Call a4 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x308: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call aa 02 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x314: ProcessType[[]int]
+	ProcessSlice 39 00 00 00 08 00 00 00 
+	Return 
+// 0x31e: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 02 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x2fc: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x32a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 87 03 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 0d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x308: ProcessType[[]string]
-	ProcessSlice 36 00 00 00 10 00 00 00 
-	Return 
-// 0x312: ProcessType[[]string.array]
+// 0x336: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 18 04 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x342: ProcessType[[]string]
+	ProcessSlice 3b 00 00 00 10 00 00 00 
+	Return 
+// 0x34c: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 44 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x31e: ProcessType[error]
+// 0x358: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 3f 00 00 00 c8 00 00 00 00 08 
+// 0x35a: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups 64 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
+// 0x366: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 44 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 3e 00 00 00 3b 00 00 00 10 18 
+// 0x372: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 4e 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 48 00 00 00 43 00 00 00 10 18 
+// 0x37e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups 5b 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x350: ProcessType[map[string]int]
+// 0x38a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap 63 00 00 00 5f 00 00 00 10 18 
+	Return 
+// 0x396: ProcessType[map<string,int>]
+	ProcessGoSwissMap 43 00 00 00 40 00 00 00 10 18 
+	Return 
+// 0x3a2: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4d 00 00 00 48 00 00 00 10 18 
+	Return 
+// 0x3ae: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap 5a 00 00 00 52 00 00 00 10 18 
+	Return 
+// 0x3ba: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 57 00 00 00 
+	Return 
+// 0x3c0: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
 	Return 
-// 0x356: ProcessType[map[string]main.bigStruct]
+// 0x3c6: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 2c 00 00 00 
 	Return 
-// 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x3cc: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 31 00 00 00 
+	Return 
+// 0x3d2: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 92 03 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 23 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36c: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x3e2: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a2 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 33 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x37c: ProcessType[noalg.map.group[string]int]
+// 0x3f2: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call 39 04 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x402: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call e2 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x387: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x40d: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call d2 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x392: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call a8 03 00 00 // ProcessType[string]
+// 0x418: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	IncrementOutputOffset 08 00 00 00 
+	Call f2 03 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Return 
+// 0x423: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 44 04 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 82 02 00 00 // ProcessType[*main.bigStruct]
+	Call 8c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x3a2: ProcessType[noalg.struct { key string; elem int }]
-	Call a8 03 00 00 // ProcessType[string]
+// 0x433: ProcessType[noalg.struct { key string; elem int }]
+	Call 44 04 00 00 // ProcessType[string]
 	Return 
-// 0x3a8: ProcessType[string]
-	ProcessString 32 00 00 00 
+// 0x439: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	IncrementOutputOffset 08 00 00 00 
+	Call ba 03 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3ae: ProcessType[table<string,int>]
+// 0x444: ProcessType[string]
+	ProcessString 37 00 00 00 
+	Return 
+// 0x44a: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 20 03 00 00 // ProcessType[groupReference<string,int>]
+	Call 5a 03 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x3b9: ProcessType[table<string,main.bigStruct>]
+// 0x455: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2c 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 66 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x460: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 72 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x46b: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 7e 03 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -310,86 +373,114 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 690
+ID: 5 Len: 8 Enqueue: 712
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 936
+ID: 9 Len: 16 Enqueue: 1092
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 600
+ID: 11 Len: 8 Enqueue: 610
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 798
+ID: 13 Len: 16 Enqueue: 856
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 696
-ID: 20 Len: 8 Enqueue: 630
-ID: 21 Len: 8 Enqueue: 678
-ID: 22 Len: 8 Enqueue: 648
+ID: 19 Len: 8 Enqueue: 718
+ID: 20 Len: 8 Enqueue: 640
+ID: 21 Len: 8 Enqueue: 700
+ID: 22 Len: 8 Enqueue: 658
 ID: 23 Len: 8 Enqueue: 0
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 618
-ID: 26 Len: 8 Enqueue: 624
-ID: 27 Len: 8 Enqueue: 636
-ID: 28 Len: 8 Enqueue: 684
-ID: 29 Len: 8 Enqueue: 606
-ID: 30 Len: 8 Enqueue: 612
-ID: 31 Len: 8 Enqueue: 666
-ID: 32 Len: 8 Enqueue: 672
-ID: 33 Len: 24 Enqueue: 742
+ID: 25 Len: 8 Enqueue: 628
+ID: 26 Len: 8 Enqueue: 634
+ID: 27 Len: 8 Enqueue: 646
+ID: 28 Len: 8 Enqueue: 706
+ID: 29 Len: 8 Enqueue: 616
+ID: 30 Len: 8 Enqueue: 622
+ID: 31 Len: 8 Enqueue: 688
+ID: 32 Len: 8 Enqueue: 694
+ID: 33 Len: 24 Enqueue: 788
 ID: 34 Len: 24 Enqueue: 0
-ID: 35 Len: 24 Enqueue: 776
-ID: 36 Len: 48 Enqueue: 702
-ID: 37 Len: 8 Enqueue: 848
+ID: 35 Len: 24 Enqueue: 834
+ID: 36 Len: 48 Enqueue: 724
+ID: 37 Len: 8 Enqueue: 960
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 48 Enqueue: 824
+ID: 39 Len: 48 Enqueue: 918
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 654
-ID: 42 Len: 8 Enqueue: 854
+ID: 41 Len: 8 Enqueue: 670
+ID: 42 Len: 8 Enqueue: 966
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 48 Enqueue: 836
+ID: 44 Len: 48 Enqueue: 930
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 660
-ID: 47 Len: 8 Enqueue: 576
-ID: 48 Len: 8 Enqueue: 582
-ID: 49 Len: 8 Enqueue: 594
-ID: 50 Len: 2048 Enqueue: 0
-ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 2048 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 2048 Enqueue: 786
-ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 32 Enqueue: 942
-ID: 57 Len: 16 Enqueue: 800
+ID: 46 Len: 8 Enqueue: 676
+ID: 47 Len: 8 Enqueue: 972
+ID: 48 Len: 8 Enqueue: 0
+ID: 49 Len: 48 Enqueue: 942
+ID: 50 Len: 8 Enqueue: 0
+ID: 51 Len: 8 Enqueue: 682
+ID: 52 Len: 8 Enqueue: 586
+ID: 53 Len: 8 Enqueue: 592
+ID: 54 Len: 8 Enqueue: 604
+ID: 55 Len: 2048 Enqueue: 0
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 2048 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 200 Enqueue: 892
-ID: 60 Len: 192 Enqueue: 876
-ID: 61 Len: 24 Enqueue: 930
-ID: 62 Len: 8192 Enqueue: 718
-ID: 63 Len: 2048 Enqueue: 752
-ID: 64 Len: 32 Enqueue: 953
-ID: 65 Len: 16 Enqueue: 812
-ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 200 Enqueue: 903
-ID: 68 Len: 192 Enqueue: 860
-ID: 69 Len: 24 Enqueue: 914
-ID: 70 Len: 8 Enqueue: 642
-ID: 71 Len: 184 Enqueue: 0
-ID: 72 Len: 8192 Enqueue: 730
-ID: 73 Len: 2048 Enqueue: 764
-ID: 74 Len: 8 Enqueue: 588
-ID: 75 Len: 128 Enqueue: 0
-ID: 76 Len: 9 Enqueue: 0
-ID: 77 Len: 17 Enqueue: 0
-ID: 78 Len: 25 Enqueue: 0
-ID: 79 Len: 25 Enqueue: 0
-ID: 80 Len: 25 Enqueue: 0
-ID: 81 Len: 49 Enqueue: 0
-ID: 82 Len: 49 Enqueue: 0
-ID: 83 Len: 9 Enqueue: 0
-ID: 84 Len: 9 Enqueue: 0
-ID: 85 Len: 9 Enqueue: 0
-ID: 86 Len: 9 Enqueue: 0
-ID: 87 Len: 9 Enqueue: 0
+ID: 59 Len: 2048 Enqueue: 844
+ID: 60 Len: 8 Enqueue: 0
+ID: 61 Len: 32 Enqueue: 1109
+ID: 62 Len: 16 Enqueue: 870
+ID: 63 Len: 8 Enqueue: 0
+ID: 64 Len: 200 Enqueue: 1026
+ID: 65 Len: 192 Enqueue: 994
+ID: 66 Len: 24 Enqueue: 1075
+ID: 67 Len: 8192 Enqueue: 752
+ID: 68 Len: 2048 Enqueue: 798
+ID: 69 Len: 32 Enqueue: 1120
+ID: 70 Len: 16 Enqueue: 882
+ID: 71 Len: 8 Enqueue: 0
+ID: 72 Len: 200 Enqueue: 1037
+ID: 73 Len: 192 Enqueue: 978
+ID: 74 Len: 24 Enqueue: 1059
+ID: 75 Len: 8 Enqueue: 652
+ID: 76 Len: 184 Enqueue: 0
+ID: 77 Len: 8192 Enqueue: 764
+ID: 78 Len: 2048 Enqueue: 810
+ID: 79 Len: 32 Enqueue: 1131
+ID: 80 Len: 16 Enqueue: 894
+ID: 81 Len: 8 Enqueue: 0
+ID: 82 Len: 136 Enqueue: 1048
+ID: 83 Len: 128 Enqueue: 1010
+ID: 84 Len: 16 Enqueue: 1081
+ID: 85 Len: 8 Enqueue: 954
+ID: 86 Len: 8 Enqueue: 0
+ID: 87 Len: 48 Enqueue: 906
+ID: 88 Len: 8 Enqueue: 0
+ID: 89 Len: 8 Enqueue: 664
+ID: 90 Len: 8192 Enqueue: 776
+ID: 91 Len: 2048 Enqueue: 822
+ID: 92 Len: 32 Enqueue: 1098
+ID: 93 Len: 16 Enqueue: 858
+ID: 94 Len: 8 Enqueue: 0
+ID: 95 Len: 136 Enqueue: 0
+ID: 96 Len: 128 Enqueue: 0
+ID: 97 Len: 16 Enqueue: 0
+ID: 98 Len: 8 Enqueue: 0
+ID: 99 Len: 8192 Enqueue: 740
+ID: 100 Len: 2048 Enqueue: 0
+ID: 101 Len: 8 Enqueue: 598
+ID: 102 Len: 128 Enqueue: 0
+ID: 103 Len: 9 Enqueue: 0
+ID: 104 Len: 17 Enqueue: 0
+ID: 105 Len: 25 Enqueue: 0
+ID: 106 Len: 25 Enqueue: 0
+ID: 107 Len: 25 Enqueue: 0
+ID: 108 Len: 49 Enqueue: 0
+ID: 109 Len: 49 Enqueue: 0
+ID: 110 Len: 9 Enqueue: 0
+ID: 111 Len: 9 Enqueue: 0
+ID: 112 Len: 0 Enqueue: 0
+ID: 113 Len: 9 Enqueue: 0
+ID: 114 Len: 9 Enqueue: 0
+ID: 115 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -3,268 +3,313 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5388.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[*****int]
+	Call 4a 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5338]
-	PrepareEventRoot 4f 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5388]
+	PrepareEventRoot 61 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5388.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 52 02 00 00 // ProcessType[**int]
+	Call 5c 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5370]
-	PrepareEventRoot 50 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b53c0]
+	PrepareEventRoot 62 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5870.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7a 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call f5 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@b5820]
-	PrepareEventRoot 4d 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b5870]
+	PrepareEventRoot 5e 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5870.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@b56ec]
-	PrepareEventRoot 4e 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@b514c]
-	PrepareEventRoot 4e 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb573c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@b53cc]
-	PrepareEventRoot 45 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@b573c]
+	PrepareEventRoot 60 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb573c.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@b519c]
+	PrepareEventRoot 60 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb541c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@b541c]
+	PrepareEventRoot 56 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb541c.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb559c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@b554c]
-	PrepareEventRoot 48 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b559c]
+	PrepareEventRoot 59 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb559c.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 02 00 00 // ProcessType[[3]string]
+	Call da 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b56d0]
-	PrepareEventRoot 4b 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
+	PrepareEventRoot 5c 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb550c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ec 02 00 00 // ProcessType[[]int]
+	Call 1a 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b54bc]
-	PrepareEventRoot 47 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b550c]
+	PrepareEventRoot 58 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb550c.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb57fc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 74 03 00 00 // ProcessType[map[string]int]
+	Call ef 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@b57ac]
-	PrepareEventRoot 4c 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b57fc]
+	PrepareEventRoot 5d 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57fc.expr[0]]
 	Return 
-// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb548c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 80 03 00 00 // ProcessType[string]
+	Call 01 04 00 00 // ProcessType[string]
 	Return 
-// 0x1c9: ProcessEvent[Probe[main.stringArg]@b543c]
-	PrepareEventRoot 46 00 00 00 11 00 00 00 
-	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@b548c]
+	PrepareEventRoot 57 00 00 00 11 00 00 00 
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb548c.expr[0]]
 	Return 
-// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb56ac.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 02 00 00 // ProcessType[[3]string]
+	Call da 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b565c]
-	PrepareEventRoot 4a 00 00 00 31 00 00 00 
-	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b56ac]
+	PrepareEventRoot 5b 00 00 00 31 00 00 00 
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb56ac.expr[0]]
 	Return 
-// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb561c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 06 03 00 00 // ProcessType[[]string]
+	Call 34 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b55cc]
-	PrepareEventRoot 49 00 00 00 19 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b561c]
+	PrepareEventRoot 5a 00 00 00 19 00 00 00 
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb561c.expr[0]]
 	Return 
-// 0x240: ProcessType[*****int]
-	ProcessPointer 33 00 00 00 
+// 0x240: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5930]
+	PrepareEventRoot 5f 00 00 00 00 00 00 00 
 	Return 
-// 0x246: ProcessType[****int]
-	ProcessPointer 43 00 00 00 
+// 0x24a: ProcessType[*****int]
+	ProcessPointer 38 00 00 00 
 	Return 
-// 0x24c: ProcessType[***int]
-	ProcessPointer 34 00 00 00 
+// 0x250: ProcessType[****int]
+	ProcessPointer 54 00 00 00 
 	Return 
-// 0x252: ProcessType[**int]
+// 0x256: ProcessType[***int]
+	ProcessPointer 39 00 00 00 
+	Return 
+// 0x25c: ProcessType[**int]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x258: ProcessType[*bool]
+// 0x262: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x25e: ProcessType[*bucket<string,int>]
+// 0x268: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 4e 00 00 00 
+	Return 
+// 0x26e: ProcessType[*bucket<string,int>]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x264: ProcessType[*bucket<string,main.bigStruct>]
+// 0x274: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x26a: ProcessType[*error]
+// 0x27a: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 36 00 00 00 
+	Return 
+// 0x280: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x270: ProcessType[*float32]
+// 0x286: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x276: ProcessType[*float64]
+// 0x28c: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x27c: ProcessType[*int]
+// 0x292: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x282: ProcessType[*int32]
+// 0x298: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x288: ProcessType[*int64]
+// 0x29e: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x28e: ProcessType[*main.bigStruct]
-	ProcessPointer 41 00 00 00 
+// 0x2a4: ProcessType[*main.bigStruct]
+	ProcessPointer 46 00 00 00 
 	Return 
-// 0x294: ProcessType[*runtime.mapextra]
+// 0x2aa: ProcessType[*runtime.mapextra]
 	ProcessPointer 2c 00 00 00 
 	Return 
-// 0x29a: ProcessType[*string]
+// 0x2b0: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2a0: ProcessType[*uint]
+// 0x2b6: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*uint16]
+// 0x2bc: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint32]
+// 0x2c2: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint64]
+// 0x2c8: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uint8]
+// 0x2ce: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x2be: ProcessType[*uintptr]
+// 0x2d4: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x2c4: ProcessType[[3]string]
+// 0x2da: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 80 03 00 00 // ProcessType[string]
+	Call 01 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2d4: ProcessType[[]bucket<string,int>.array]
+// 0x2ea: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 2c 03 00 00 // ProcessType[bucket<string,int>]
+	Call 6a 03 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2e0: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x2f6: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 41 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 75 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2ec: ProcessType[[]int]
-	ProcessSlice 37 00 00 00 08 00 00 00 
+// 0x302: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 8a 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2f6: ProcessType[[]key<string>]
+// 0x30e: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 9f 03 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x31a: ProcessType[[]int]
+	ProcessSlice 3c 00 00 00 08 00 00 00 
+	Return 
+// 0x324: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 80 03 00 00 // ProcessType[string]
+	Call 01 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x306: ProcessType[[]string]
-	ProcessSlice 39 00 00 00 10 00 00 00 
+// 0x334: ProcessType[[]string]
+	ProcessSlice 3e 00 00 00 10 00 00 00 
 	Return 
-// 0x310: ProcessType[[]string.array]
+// 0x33e: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 80 03 00 00 // ProcessType[string]
+	Call 01 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x31c: ProcessType[[]val<main.bigStruct>]
+// 0x34a: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 8e 02 00 00 // ProcessType[*main.bigStruct]
+	Call a4 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x32c: ProcessType[bucket<string,int>]
+// 0x35a: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call e9 03 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x36a: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 88 00 00 00 
+	Call 68 02 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x375: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f6 02 00 00 // ProcessType[[]key<string>]
+	Call 24 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5e 02 00 00 // ProcessType[*bucket<string,int>]
+	Call 6e 02 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x341: ProcessType[bucket<string,main.bigStruct>]
+// 0x38a: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call f6 02 00 00 // ProcessType[[]key<string>]
-	Call 1c 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 64 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 24 03 00 00 // ProcessType[[]key<string>]
+	Call 4a 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 74 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x356: ProcessType[error]
+// 0x39f: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 5a 03 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 7a 02 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x3af: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x358: ProcessType[hash<string,int>]
-	ProcessGoHmap 3e 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x3b1: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 53 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x366: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 42 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x3bf: ProcessType[hash<string,int>]
+	ProcessGoHmap 43 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x374: ProcessType[map[string]int]
+// 0x3cd: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 47 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x3db: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 4f 00 00 00 58 00 00 00 08 09 10 18 
+	Return 
+// 0x3e9: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 4c 00 00 00 
+	Return 
+// 0x3ef: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x37a: ProcessType[map[string]main.bigStruct]
+// 0x3f5: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 2f 00 00 00 
 	Return 
-// 0x380: ProcessType[string]
-	ProcessString 35 00 00 00 
+// 0x3fb: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 34 00 00 00 
+	Return 
+// 0x401: ProcessType[string]
+	ProcessString 3a 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -285,12 +330,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 600
-ID: 6 Len: 8 Enqueue: 696
+ID: 5 Len: 8 Enqueue: 610
+ID: 6 Len: 8 Enqueue: 718
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 702
+ID: 8 Len: 8 Enqueue: 724
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 896
+ID: 10 Len: 16 Enqueue: 1025
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -298,66 +343,84 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 854
+ID: 18 Len: 16 Enqueue: 943
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 642
-ID: 21 Len: 8 Enqueue: 684
-ID: 22 Len: 8 Enqueue: 666
+ID: 20 Len: 8 Enqueue: 664
+ID: 21 Len: 8 Enqueue: 706
+ID: 22 Len: 8 Enqueue: 688
 ID: 23 Len: 2 Enqueue: 0
 ID: 24 Len: 8 Enqueue: 0
 ID: 25 Len: 16 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 630
-ID: 27 Len: 8 Enqueue: 648
-ID: 28 Len: 8 Enqueue: 636
-ID: 29 Len: 8 Enqueue: 690
-ID: 30 Len: 8 Enqueue: 618
-ID: 31 Len: 8 Enqueue: 624
-ID: 32 Len: 8 Enqueue: 672
-ID: 33 Len: 8 Enqueue: 678
-ID: 34 Len: 24 Enqueue: 748
+ID: 26 Len: 8 Enqueue: 652
+ID: 27 Len: 8 Enqueue: 670
+ID: 28 Len: 8 Enqueue: 658
+ID: 29 Len: 8 Enqueue: 712
+ID: 30 Len: 8 Enqueue: 640
+ID: 31 Len: 8 Enqueue: 646
+ID: 32 Len: 8 Enqueue: 694
+ID: 33 Len: 8 Enqueue: 700
+ID: 34 Len: 24 Enqueue: 794
 ID: 35 Len: 24 Enqueue: 0
-ID: 36 Len: 24 Enqueue: 774
-ID: 37 Len: 48 Enqueue: 708
-ID: 38 Len: 8 Enqueue: 884
+ID: 36 Len: 24 Enqueue: 820
+ID: 37 Len: 48 Enqueue: 730
+ID: 38 Len: 8 Enqueue: 1007
 ID: 39 Len: 8 Enqueue: 0
-ID: 40 Len: 48 Enqueue: 856
-ID: 41 Len: 8 Enqueue: 606
-ID: 42 Len: 208 Enqueue: 812
-ID: 43 Len: 8 Enqueue: 660
+ID: 40 Len: 48 Enqueue: 959
+ID: 41 Len: 8 Enqueue: 622
+ID: 42 Len: 208 Enqueue: 885
+ID: 43 Len: 8 Enqueue: 682
 ID: 44 Len: 8 Enqueue: 0
-ID: 45 Len: 8 Enqueue: 890
+ID: 45 Len: 8 Enqueue: 1013
 ID: 46 Len: 8 Enqueue: 0
-ID: 47 Len: 48 Enqueue: 870
-ID: 48 Len: 8 Enqueue: 612
-ID: 49 Len: 208 Enqueue: 833
-ID: 50 Len: 8 Enqueue: 576
-ID: 51 Len: 8 Enqueue: 582
-ID: 52 Len: 8 Enqueue: 594
-ID: 53 Len: 2048 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 0
-ID: 55 Len: 2048 Enqueue: 0
-ID: 56 Len: 8 Enqueue: 0
-ID: 57 Len: 2048 Enqueue: 784
-ID: 58 Len: 8 Enqueue: 0
+ID: 47 Len: 48 Enqueue: 973
+ID: 48 Len: 8 Enqueue: 628
+ID: 49 Len: 208 Enqueue: 906
+ID: 50 Len: 8 Enqueue: 1019
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 48 Enqueue: 987
+ID: 53 Len: 8 Enqueue: 634
+ID: 54 Len: 88 Enqueue: 927
+ID: 55 Len: 8 Enqueue: 586
+ID: 56 Len: 8 Enqueue: 592
+ID: 57 Len: 8 Enqueue: 604
+ID: 58 Len: 2048 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
-ID: 60 Len: 128 Enqueue: 758
-ID: 61 Len: 64 Enqueue: 0
-ID: 62 Len: 2048 Enqueue: 724
-ID: 63 Len: 64 Enqueue: 796
-ID: 64 Len: 8 Enqueue: 654
-ID: 65 Len: 184 Enqueue: 0
-ID: 66 Len: 2048 Enqueue: 736
-ID: 67 Len: 8 Enqueue: 588
-ID: 68 Len: 128 Enqueue: 0
-ID: 69 Len: 9 Enqueue: 0
-ID: 70 Len: 17 Enqueue: 0
-ID: 71 Len: 25 Enqueue: 0
-ID: 72 Len: 25 Enqueue: 0
-ID: 73 Len: 25 Enqueue: 0
-ID: 74 Len: 49 Enqueue: 0
-ID: 75 Len: 49 Enqueue: 0
-ID: 76 Len: 9 Enqueue: 0
-ID: 77 Len: 9 Enqueue: 0
-ID: 78 Len: 9 Enqueue: 0
-ID: 79 Len: 9 Enqueue: 0
-ID: 80 Len: 9 Enqueue: 0
+ID: 60 Len: 2048 Enqueue: 0
+ID: 61 Len: 8 Enqueue: 0
+ID: 62 Len: 2048 Enqueue: 830
+ID: 63 Len: 8 Enqueue: 0
+ID: 64 Len: 8 Enqueue: 0
+ID: 65 Len: 128 Enqueue: 804
+ID: 66 Len: 64 Enqueue: 0
+ID: 67 Len: 2048 Enqueue: 758
+ID: 68 Len: 64 Enqueue: 842
+ID: 69 Len: 8 Enqueue: 676
+ID: 70 Len: 184 Enqueue: 0
+ID: 71 Len: 2048 Enqueue: 770
+ID: 72 Len: 8 Enqueue: 0
+ID: 73 Len: 64 Enqueue: 858
+ID: 74 Len: 8 Enqueue: 1001
+ID: 75 Len: 8 Enqueue: 0
+ID: 76 Len: 48 Enqueue: 945
+ID: 77 Len: 8 Enqueue: 616
+ID: 78 Len: 144 Enqueue: 874
+ID: 79 Len: 2048 Enqueue: 782
+ID: 80 Len: 64 Enqueue: 0
+ID: 81 Len: 64 Enqueue: 0
+ID: 82 Len: 8 Enqueue: 0
+ID: 83 Len: 2048 Enqueue: 746
+ID: 84 Len: 8 Enqueue: 598
+ID: 85 Len: 128 Enqueue: 0
+ID: 86 Len: 9 Enqueue: 0
+ID: 87 Len: 17 Enqueue: 0
+ID: 88 Len: 25 Enqueue: 0
+ID: 89 Len: 25 Enqueue: 0
+ID: 90 Len: 25 Enqueue: 0
+ID: 91 Len: 49 Enqueue: 0
+ID: 92 Len: 49 Enqueue: 0
+ID: 93 Len: 9 Enqueue: 0
+ID: 94 Len: 9 Enqueue: 0
+ID: 95 Len: 0 Enqueue: 0
+ID: 96 Len: 9 Enqueue: 0
+ID: 97 Len: 9 Enqueue: 0
+ID: 98 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -3,293 +3,356 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb520c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[*****int]
+	Call 4a 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b51cc]
-	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b520c]
+	PrepareEventRoot 73 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb520c.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5244.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 52 02 00 00 // ProcessType[**int]
+	Call 5c 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5204]
-	PrepareEventRoot 58 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5244]
+	PrepareEventRoot 74 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5244.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb56d0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 56 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call c6 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@b5690]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b56d0]
+	PrepareEventRoot 70 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb56d0.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@b555c]
-	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@b4fec]
-	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb559c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@b525c]
-	PrepareEventRoot 4d 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@b559c]
+	PrepareEventRoot 72 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb559c.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@b502c]
+	PrepareEventRoot 72 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb529c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@b529c]
+	PrepareEventRoot 68 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb529c.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb540c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@b53cc]
-	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b540c]
+	PrepareEventRoot 6b 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb540c.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5580.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 02 00 00 // ProcessType[[3]string]
+	Call d4 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5540]
-	PrepareEventRoot 53 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5580]
+	PrepareEventRoot 6e 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5580.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb538c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e6 02 00 00 // ProcessType[[]int]
+	Call 14 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b534c]
-	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b538c]
+	PrepareEventRoot 6a 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb538c.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb565c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 50 03 00 00 // ProcessType[map[string]int]
+	Call c0 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@b561c]
-	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b565c]
+	PrepareEventRoot 6f 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb565c.expr[0]]
 	Return 
-// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb530c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 44 04 00 00 // ProcessType[string]
 	Return 
-// 0x1c9: ProcessEvent[Probe[main.stringArg]@b52cc]
-	PrepareEventRoot 4e 00 00 00 11 00 00 00 
-	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@b530c]
+	PrepareEventRoot 69 00 00 00 11 00 00 00 
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb530c.expr[0]]
 	Return 
-// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb550c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 02 00 00 // ProcessType[[3]string]
+	Call d4 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b54cc]
-	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b550c]
+	PrepareEventRoot 6d 00 00 00 31 00 00 00 
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb550c.expr[0]]
 	Return 
-// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb548c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 08 03 00 00 // ProcessType[[]string]
+	Call 42 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b544c]
-	PrepareEventRoot 51 00 00 00 19 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b548c]
+	PrepareEventRoot 6c 00 00 00 19 00 00 00 
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb548c.expr[0]]
 	Return 
-// 0x240: ProcessType[*****int]
-	ProcessPointer 31 00 00 00 
+// 0x240: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5790]
+	PrepareEventRoot 71 00 00 00 00 00 00 00 
 	Return 
-// 0x246: ProcessType[****int]
-	ProcessPointer 4b 00 00 00 
+// 0x24a: ProcessType[*****int]
+	ProcessPointer 36 00 00 00 
 	Return 
-// 0x24c: ProcessType[***int]
-	ProcessPointer 32 00 00 00 
+// 0x250: ProcessType[****int]
+	ProcessPointer 66 00 00 00 
 	Return 
-// 0x252: ProcessType[**int]
+// 0x256: ProcessType[***int]
+	ProcessPointer 37 00 00 00 
+	Return 
+// 0x25c: ProcessType[**int]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x258: ProcessType[*bool]
+// 0x262: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x25e: ProcessType[*error]
+// 0x268: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x264: ProcessType[*float32]
+// 0x26e: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x26a: ProcessType[*float64]
+// 0x274: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x270: ProcessType[*int]
+// 0x27a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x276: ProcessType[*int32]
+// 0x280: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x27c: ProcessType[*int64]
+// 0x286: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 48 00 00 00 
+// 0x28c: ProcessType[*main.bigStruct]
+	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x288: ProcessType[*string]
+// 0x292: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 39 00 00 00 
+// 0x298: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 41 00 00 00 
+// 0x29e: ProcessType[*table<string,int>]
+	ProcessPointer 3e 00 00 00 
 	Return 
-// 0x29a: ProcessType[*uint]
+// 0x2a4: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 46 00 00 00 
+	Return 
+// 0x2aa: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 50 00 00 00 
+	Return 
+// 0x2b0: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2a0: ProcessType[*uint16]
+// 0x2b6: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*uint32]
+// 0x2bc: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint64]
+// 0x2c2: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint8]
+// 0x2c8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uintptr]
+// 0x2ce: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x2be: ProcessType[[3]string]
+// 0x2d4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 44 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2ce: ProcessType[[]*table<string,int>.array]
+// 0x2e4: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 8e 02 00 00 // ProcessType[*table<string,int>]
+	Call 98 02 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2da: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x2f0: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 94 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 9e 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2e6: ProcessType[[]int]
-	ProcessSlice 35 00 00 00 08 00 00 00 
-	Return 
-// 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
+// 0x2fc: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7c 03 00 00 // ProcessType[noalg.map.group[string]int]
+	Call a4 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x308: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call aa 02 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x314: ProcessType[[]int]
+	ProcessSlice 3a 00 00 00 08 00 00 00 
+	Return 
+// 0x31e: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 02 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x2fc: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x32a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 87 03 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 0d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x308: ProcessType[[]string]
-	ProcessSlice 37 00 00 00 10 00 00 00 
-	Return 
-// 0x312: ProcessType[[]string.array]
+// 0x336: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 18 04 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x342: ProcessType[[]string]
+	ProcessSlice 3c 00 00 00 10 00 00 00 
+	Return 
+// 0x34c: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 44 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x31e: ProcessType[error]
+// 0x358: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 40 00 00 00 c8 00 00 00 00 08 
+// 0x35a: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups 65 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
+// 0x366: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 45 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 3f 00 00 00 3c 00 00 00 10 18 
+// 0x372: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 4f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 49 00 00 00 44 00 00 00 10 18 
+// 0x37e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups 5c 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x350: ProcessType[map[string]int]
+// 0x38a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap 64 00 00 00 60 00 00 00 10 18 
+	Return 
+// 0x396: ProcessType[map<string,int>]
+	ProcessGoSwissMap 44 00 00 00 41 00 00 00 10 18 
+	Return 
+// 0x3a2: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4e 00 00 00 49 00 00 00 10 18 
+	Return 
+// 0x3ae: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap 5b 00 00 00 53 00 00 00 10 18 
+	Return 
+// 0x3ba: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 58 00 00 00 
+	Return 
+// 0x3c0: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x356: ProcessType[map[string]main.bigStruct]
+// 0x3c6: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x3cc: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x3d2: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 92 03 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 23 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36c: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x3e2: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a2 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 33 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x37c: ProcessType[noalg.map.group[string]int]
+// 0x3f2: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call 39 04 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x402: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call e2 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x387: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x40d: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call d2 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x392: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call a8 03 00 00 // ProcessType[string]
+// 0x418: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	IncrementOutputOffset 08 00 00 00 
+	Call f2 03 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Return 
+// 0x423: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 44 04 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 82 02 00 00 // ProcessType[*main.bigStruct]
+	Call 8c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x3a2: ProcessType[noalg.struct { key string; elem int }]
-	Call a8 03 00 00 // ProcessType[string]
+// 0x433: ProcessType[noalg.struct { key string; elem int }]
+	Call 44 04 00 00 // ProcessType[string]
 	Return 
-// 0x3a8: ProcessType[string]
-	ProcessString 33 00 00 00 
+// 0x439: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	IncrementOutputOffset 08 00 00 00 
+	Call ba 03 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3ae: ProcessType[table<string,int>]
+// 0x444: ProcessType[string]
+	ProcessString 38 00 00 00 
+	Return 
+// 0x44a: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 20 03 00 00 // ProcessType[groupReference<string,int>]
+	Call 5a 03 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x3b9: ProcessType[table<string,main.bigStruct>]
+// 0x455: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2c 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 66 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x460: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 72 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x46b: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 7e 03 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -310,87 +373,115 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 690
+ID: 5 Len: 8 Enqueue: 712
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 936
+ID: 9 Len: 16 Enqueue: 1092
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 600
+ID: 11 Len: 8 Enqueue: 610
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 798
+ID: 14 Len: 16 Enqueue: 856
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 696
-ID: 20 Len: 8 Enqueue: 630
-ID: 21 Len: 8 Enqueue: 678
-ID: 22 Len: 8 Enqueue: 648
+ID: 19 Len: 8 Enqueue: 718
+ID: 20 Len: 8 Enqueue: 640
+ID: 21 Len: 8 Enqueue: 700
+ID: 22 Len: 8 Enqueue: 658
 ID: 23 Len: 2 Enqueue: 0
 ID: 24 Len: 8 Enqueue: 0
 ID: 25 Len: 16 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 618
-ID: 27 Len: 8 Enqueue: 636
-ID: 28 Len: 8 Enqueue: 624
-ID: 29 Len: 8 Enqueue: 684
-ID: 30 Len: 8 Enqueue: 606
-ID: 31 Len: 8 Enqueue: 612
-ID: 32 Len: 8 Enqueue: 666
-ID: 33 Len: 8 Enqueue: 672
-ID: 34 Len: 24 Enqueue: 742
+ID: 26 Len: 8 Enqueue: 628
+ID: 27 Len: 8 Enqueue: 646
+ID: 28 Len: 8 Enqueue: 634
+ID: 29 Len: 8 Enqueue: 706
+ID: 30 Len: 8 Enqueue: 616
+ID: 31 Len: 8 Enqueue: 622
+ID: 32 Len: 8 Enqueue: 688
+ID: 33 Len: 8 Enqueue: 694
+ID: 34 Len: 24 Enqueue: 788
 ID: 35 Len: 24 Enqueue: 0
-ID: 36 Len: 24 Enqueue: 776
-ID: 37 Len: 48 Enqueue: 702
-ID: 38 Len: 8 Enqueue: 848
+ID: 36 Len: 24 Enqueue: 834
+ID: 37 Len: 48 Enqueue: 724
+ID: 38 Len: 8 Enqueue: 960
 ID: 39 Len: 8 Enqueue: 0
-ID: 40 Len: 48 Enqueue: 824
+ID: 40 Len: 48 Enqueue: 918
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 654
-ID: 43 Len: 8 Enqueue: 854
+ID: 42 Len: 8 Enqueue: 670
+ID: 43 Len: 8 Enqueue: 966
 ID: 44 Len: 8 Enqueue: 0
-ID: 45 Len: 48 Enqueue: 836
+ID: 45 Len: 48 Enqueue: 930
 ID: 46 Len: 8 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 660
-ID: 48 Len: 8 Enqueue: 576
-ID: 49 Len: 8 Enqueue: 582
-ID: 50 Len: 8 Enqueue: 594
-ID: 51 Len: 2048 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 0
-ID: 53 Len: 2048 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 0
-ID: 55 Len: 2048 Enqueue: 786
-ID: 56 Len: 8 Enqueue: 0
-ID: 57 Len: 32 Enqueue: 942
-ID: 58 Len: 16 Enqueue: 800
+ID: 47 Len: 8 Enqueue: 676
+ID: 48 Len: 8 Enqueue: 972
+ID: 49 Len: 8 Enqueue: 0
+ID: 50 Len: 48 Enqueue: 942
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 8 Enqueue: 682
+ID: 53 Len: 8 Enqueue: 586
+ID: 54 Len: 8 Enqueue: 592
+ID: 55 Len: 8 Enqueue: 604
+ID: 56 Len: 2048 Enqueue: 0
+ID: 57 Len: 8 Enqueue: 0
+ID: 58 Len: 2048 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
-ID: 60 Len: 200 Enqueue: 892
-ID: 61 Len: 192 Enqueue: 876
-ID: 62 Len: 24 Enqueue: 930
-ID: 63 Len: 8192 Enqueue: 718
-ID: 64 Len: 2048 Enqueue: 752
-ID: 65 Len: 32 Enqueue: 953
-ID: 66 Len: 16 Enqueue: 812
-ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 200 Enqueue: 903
-ID: 69 Len: 192 Enqueue: 860
-ID: 70 Len: 24 Enqueue: 914
-ID: 71 Len: 8 Enqueue: 642
-ID: 72 Len: 184 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 730
-ID: 74 Len: 2048 Enqueue: 764
-ID: 75 Len: 8 Enqueue: 588
-ID: 76 Len: 128 Enqueue: 0
-ID: 77 Len: 9 Enqueue: 0
-ID: 78 Len: 17 Enqueue: 0
-ID: 79 Len: 25 Enqueue: 0
-ID: 80 Len: 25 Enqueue: 0
-ID: 81 Len: 25 Enqueue: 0
-ID: 82 Len: 49 Enqueue: 0
-ID: 83 Len: 49 Enqueue: 0
-ID: 84 Len: 9 Enqueue: 0
-ID: 85 Len: 9 Enqueue: 0
-ID: 86 Len: 9 Enqueue: 0
-ID: 87 Len: 9 Enqueue: 0
-ID: 88 Len: 9 Enqueue: 0
+ID: 60 Len: 2048 Enqueue: 844
+ID: 61 Len: 8 Enqueue: 0
+ID: 62 Len: 32 Enqueue: 1109
+ID: 63 Len: 16 Enqueue: 870
+ID: 64 Len: 8 Enqueue: 0
+ID: 65 Len: 200 Enqueue: 1026
+ID: 66 Len: 192 Enqueue: 994
+ID: 67 Len: 24 Enqueue: 1075
+ID: 68 Len: 8192 Enqueue: 752
+ID: 69 Len: 2048 Enqueue: 798
+ID: 70 Len: 32 Enqueue: 1120
+ID: 71 Len: 16 Enqueue: 882
+ID: 72 Len: 8 Enqueue: 0
+ID: 73 Len: 200 Enqueue: 1037
+ID: 74 Len: 192 Enqueue: 978
+ID: 75 Len: 24 Enqueue: 1059
+ID: 76 Len: 8 Enqueue: 652
+ID: 77 Len: 184 Enqueue: 0
+ID: 78 Len: 8192 Enqueue: 764
+ID: 79 Len: 2048 Enqueue: 810
+ID: 80 Len: 32 Enqueue: 1131
+ID: 81 Len: 16 Enqueue: 894
+ID: 82 Len: 8 Enqueue: 0
+ID: 83 Len: 136 Enqueue: 1048
+ID: 84 Len: 128 Enqueue: 1010
+ID: 85 Len: 16 Enqueue: 1081
+ID: 86 Len: 8 Enqueue: 954
+ID: 87 Len: 8 Enqueue: 0
+ID: 88 Len: 48 Enqueue: 906
+ID: 89 Len: 8 Enqueue: 0
+ID: 90 Len: 8 Enqueue: 664
+ID: 91 Len: 8192 Enqueue: 776
+ID: 92 Len: 2048 Enqueue: 822
+ID: 93 Len: 32 Enqueue: 1098
+ID: 94 Len: 16 Enqueue: 858
+ID: 95 Len: 8 Enqueue: 0
+ID: 96 Len: 136 Enqueue: 0
+ID: 97 Len: 128 Enqueue: 0
+ID: 98 Len: 16 Enqueue: 0
+ID: 99 Len: 8 Enqueue: 0
+ID: 100 Len: 8192 Enqueue: 740
+ID: 101 Len: 2048 Enqueue: 0
+ID: 102 Len: 8 Enqueue: 598
+ID: 103 Len: 128 Enqueue: 0
+ID: 104 Len: 9 Enqueue: 0
+ID: 105 Len: 17 Enqueue: 0
+ID: 106 Len: 25 Enqueue: 0
+ID: 107 Len: 25 Enqueue: 0
+ID: 108 Len: 25 Enqueue: 0
+ID: 109 Len: 49 Enqueue: 0
+ID: 110 Len: 49 Enqueue: 0
+ID: 111 Len: 9 Enqueue: 0
+ID: 112 Len: 9 Enqueue: 0
+ID: 113 Len: 0 Enqueue: 0
+ID: 114 Len: 9 Enqueue: 0
+ID: 115 Len: 9 Enqueue: 0
+ID: 116 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -3,293 +3,356 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb7da0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[*****int]
+	Call 4a 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7d60]
-	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7da0]
+	PrepareEventRoot 73 00 00 00 09 00 00 00 
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7da0.expr[0]]
 	Return 
-// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7dd4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 52 02 00 00 // ProcessType[**int]
+	Call 5c 02 00 00 // ProcessType[**int]
 	Return 
-// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7d94]
-	PrepareEventRoot 58 00 00 00 09 00 00 00 
-	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7dd4]
+	PrepareEventRoot 74 00 00 00 09 00 00 00 
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7dd4.expr[0]]
 	Return 
-// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb8230.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 56 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call c6 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x72: ProcessEvent[Probe[main.bigMapArg]@b81f0]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b8230]
+	PrepareEventRoot 70 00 00 00 09 00 00 00 
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8230.expr[0]]
 	Return 
-// 0x81: ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x97: ProcessEvent[Probe[main.inlined]@b80bc]
-	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
-	Return 
-// 0xa6: ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xb6: ProcessEvent[Probe[main.inlined]@b7b88]
-	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
-	Return 
-// 0xc5: ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb80fc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xdb: ProcessEvent[Probe[main.intArg]@b7dec]
-	PrepareEventRoot 4d 00 00 00 09 00 00 00 
-	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
+// 0x97: ProcessEvent[Probe[main.inlined]@b80fc]
+	PrepareEventRoot 72 00 00 00 09 00 00 00 
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb80fc.expr[0]]
 	Return 
-// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb7f4c.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xb6: ProcessEvent[Probe[main.inlined]@b7bc8]
+	PrepareEventRoot 72 00 00 00 09 00 00 00 
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
+	Return 
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb7e2c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xdb: ProcessEvent[Probe[main.intArg]@b7e2c]
+	PrepareEventRoot 68 00 00 00 09 00 00 00 
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb7e2c.expr[0]]
+	Return 
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb7f8c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x106: ProcessEvent[Probe[main.intArrayArg]@b7f4c]
-	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f4c.expr[0]]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b7f8c]
+	PrepareEventRoot 6b 00 00 00 19 00 00 00 
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f8c.expr[0]]
 	Return 
-// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 02 00 00 // ProcessType[[3]string]
+	Call d4 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80a0]
-	PrepareEventRoot 53 00 00 00 31 00 00 00 
-	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80a0.expr[0]]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80e0]
+	PrepareEventRoot 6e 00 00 00 31 00 00 00 
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	Return 
-// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb7ecc.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb7f0c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e6 02 00 00 // ProcessType[[]int]
+	Call 14 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b7ecc]
-	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7ecc.expr[0]]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b7f0c]
+	PrepareEventRoot 6a 00 00 00 19 00 00 00 
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7f0c.expr[0]]
 	Return 
-// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb817c.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb81bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 50 03 00 00 // ProcessType[map[string]int]
+	Call c0 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x198: ProcessEvent[Probe[main.mapArg]@b817c]
-	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb817c.expr[0]]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b81bc]
+	PrepareEventRoot 6f 00 00 00 09 00 00 00 
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb81bc.expr[0]]
 	Return 
-// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb7e5c.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb7e9c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 44 04 00 00 // ProcessType[string]
 	Return 
-// 0x1c9: ProcessEvent[Probe[main.stringArg]@b7e5c]
-	PrepareEventRoot 4e 00 00 00 11 00 00 00 
-	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7e5c.expr[0]]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@b7e9c]
+	PrepareEventRoot 69 00 00 00 11 00 00 00 
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7e9c.expr[0]]
 	Return 
-// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb803c.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb807c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 02 00 00 // ProcessType[[3]string]
+	Call d4 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b803c]
-	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb803c.expr[0]]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b807c]
+	PrepareEventRoot 6d 00 00 00 31 00 00 00 
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb807c.expr[0]]
 	Return 
-// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb7ffc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 08 03 00 00 // ProcessType[[]string]
+	Call 42 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b7fbc]
-	PrepareEventRoot 51 00 00 00 19 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b7ffc]
+	PrepareEventRoot 6c 00 00 00 19 00 00 00 
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7ffc.expr[0]]
 	Return 
-// 0x240: ProcessType[*****int]
-	ProcessPointer 31 00 00 00 
+// 0x240: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b82e0]
+	PrepareEventRoot 71 00 00 00 00 00 00 00 
 	Return 
-// 0x246: ProcessType[****int]
-	ProcessPointer 4b 00 00 00 
+// 0x24a: ProcessType[*****int]
+	ProcessPointer 36 00 00 00 
 	Return 
-// 0x24c: ProcessType[***int]
-	ProcessPointer 32 00 00 00 
+// 0x250: ProcessType[****int]
+	ProcessPointer 66 00 00 00 
 	Return 
-// 0x252: ProcessType[**int]
+// 0x256: ProcessType[***int]
+	ProcessPointer 37 00 00 00 
+	Return 
+// 0x25c: ProcessType[**int]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x258: ProcessType[*bool]
+// 0x262: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x25e: ProcessType[*error]
+// 0x268: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x264: ProcessType[*float32]
+// 0x26e: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x26a: ProcessType[*float64]
+// 0x274: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x270: ProcessType[*int]
+// 0x27a: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x276: ProcessType[*int32]
+// 0x280: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x27c: ProcessType[*int64]
+// 0x286: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 48 00 00 00 
+// 0x28c: ProcessType[*main.bigStruct]
+	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x288: ProcessType[*string]
+// 0x292: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 39 00 00 00 
+// 0x298: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 41 00 00 00 
+// 0x29e: ProcessType[*table<string,int>]
+	ProcessPointer 3e 00 00 00 
 	Return 
-// 0x29a: ProcessType[*uint]
+// 0x2a4: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 46 00 00 00 
+	Return 
+// 0x2aa: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 50 00 00 00 
+	Return 
+// 0x2b0: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2a0: ProcessType[*uint16]
+// 0x2b6: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*uint32]
+// 0x2bc: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint64]
+// 0x2c2: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint8]
+// 0x2c8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uintptr]
+// 0x2ce: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x2be: ProcessType[[3]string]
+// 0x2d4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 44 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2ce: ProcessType[[]*table<string,int>.array]
+// 0x2e4: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 8e 02 00 00 // ProcessType[*table<string,int>]
+	Call 98 02 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2da: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x2f0: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 94 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 9e 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2e6: ProcessType[[]int]
-	ProcessSlice 35 00 00 00 08 00 00 00 
-	Return 
-// 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
+// 0x2fc: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7c 03 00 00 // ProcessType[noalg.map.group[string]int]
+	Call a4 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x308: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call aa 02 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x314: ProcessType[[]int]
+	ProcessSlice 3a 00 00 00 08 00 00 00 
+	Return 
+// 0x31e: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 02 04 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x2fc: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x32a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 87 03 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 0d 04 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x308: ProcessType[[]string]
-	ProcessSlice 37 00 00 00 10 00 00 00 
-	Return 
-// 0x312: ProcessType[[]string.array]
+// 0x336: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call a8 03 00 00 // ProcessType[string]
+	Call 18 04 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x342: ProcessType[[]string]
+	ProcessSlice 3c 00 00 00 10 00 00 00 
+	Return 
+// 0x34c: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 44 04 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x31e: ProcessType[error]
+// 0x358: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 40 00 00 00 c8 00 00 00 00 08 
+// 0x35a: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups 65 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
+// 0x366: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 45 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 3f 00 00 00 3c 00 00 00 10 18 
+// 0x372: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 4f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 49 00 00 00 44 00 00 00 10 18 
+// 0x37e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups 5c 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x350: ProcessType[map[string]int]
+// 0x38a: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap 64 00 00 00 60 00 00 00 10 18 
+	Return 
+// 0x396: ProcessType[map<string,int>]
+	ProcessGoSwissMap 44 00 00 00 41 00 00 00 10 18 
+	Return 
+// 0x3a2: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4e 00 00 00 49 00 00 00 10 18 
+	Return 
+// 0x3ae: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap 5b 00 00 00 53 00 00 00 10 18 
+	Return 
+// 0x3ba: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 58 00 00 00 
+	Return 
+// 0x3c0: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x356: ProcessType[map[string]main.bigStruct]
+// 0x3c6: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x3cc: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x3d2: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 92 03 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 23 04 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36c: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x3e2: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a2 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 33 04 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x37c: ProcessType[noalg.map.group[string]int]
+// 0x3f2: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call 39 04 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x402: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call e2 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x387: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x40d: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call d2 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x392: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call a8 03 00 00 // ProcessType[string]
+// 0x418: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	IncrementOutputOffset 08 00 00 00 
+	Call f2 03 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Return 
+// 0x423: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 44 04 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 82 02 00 00 // ProcessType[*main.bigStruct]
+	Call 8c 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x3a2: ProcessType[noalg.struct { key string; elem int }]
-	Call a8 03 00 00 // ProcessType[string]
+// 0x433: ProcessType[noalg.struct { key string; elem int }]
+	Call 44 04 00 00 // ProcessType[string]
 	Return 
-// 0x3a8: ProcessType[string]
-	ProcessString 33 00 00 00 
+// 0x439: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	IncrementOutputOffset 08 00 00 00 
+	Call ba 03 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x3ae: ProcessType[table<string,int>]
+// 0x444: ProcessType[string]
+	ProcessString 38 00 00 00 
+	Return 
+// 0x44a: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 20 03 00 00 // ProcessType[groupReference<string,int>]
+	Call 5a 03 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x3b9: ProcessType[table<string,main.bigStruct>]
+// 0x455: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2c 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 66 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x460: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 72 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x46b: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 7e 03 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -310,87 +373,115 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 690
+ID: 5 Len: 8 Enqueue: 712
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 936
+ID: 9 Len: 16 Enqueue: 1092
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 600
+ID: 11 Len: 8 Enqueue: 610
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 798
+ID: 14 Len: 16 Enqueue: 856
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 696
-ID: 20 Len: 8 Enqueue: 630
-ID: 21 Len: 8 Enqueue: 678
-ID: 22 Len: 8 Enqueue: 648
+ID: 19 Len: 8 Enqueue: 718
+ID: 20 Len: 8 Enqueue: 640
+ID: 21 Len: 8 Enqueue: 700
+ID: 22 Len: 8 Enqueue: 658
 ID: 23 Len: 2 Enqueue: 0
 ID: 24 Len: 8 Enqueue: 0
 ID: 25 Len: 16 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 618
-ID: 27 Len: 8 Enqueue: 624
-ID: 28 Len: 8 Enqueue: 684
-ID: 29 Len: 8 Enqueue: 636
-ID: 30 Len: 8 Enqueue: 606
-ID: 31 Len: 8 Enqueue: 612
-ID: 32 Len: 8 Enqueue: 666
-ID: 33 Len: 8 Enqueue: 672
-ID: 34 Len: 24 Enqueue: 742
+ID: 26 Len: 8 Enqueue: 628
+ID: 27 Len: 8 Enqueue: 634
+ID: 28 Len: 8 Enqueue: 706
+ID: 29 Len: 8 Enqueue: 646
+ID: 30 Len: 8 Enqueue: 616
+ID: 31 Len: 8 Enqueue: 622
+ID: 32 Len: 8 Enqueue: 688
+ID: 33 Len: 8 Enqueue: 694
+ID: 34 Len: 24 Enqueue: 788
 ID: 35 Len: 24 Enqueue: 0
-ID: 36 Len: 24 Enqueue: 776
-ID: 37 Len: 48 Enqueue: 702
-ID: 38 Len: 8 Enqueue: 848
+ID: 36 Len: 24 Enqueue: 834
+ID: 37 Len: 48 Enqueue: 724
+ID: 38 Len: 8 Enqueue: 960
 ID: 39 Len: 8 Enqueue: 0
-ID: 40 Len: 48 Enqueue: 824
+ID: 40 Len: 48 Enqueue: 918
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 654
-ID: 43 Len: 8 Enqueue: 854
+ID: 42 Len: 8 Enqueue: 670
+ID: 43 Len: 8 Enqueue: 966
 ID: 44 Len: 8 Enqueue: 0
-ID: 45 Len: 48 Enqueue: 836
+ID: 45 Len: 48 Enqueue: 930
 ID: 46 Len: 8 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 660
-ID: 48 Len: 8 Enqueue: 576
-ID: 49 Len: 8 Enqueue: 582
-ID: 50 Len: 8 Enqueue: 594
-ID: 51 Len: 2048 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 0
-ID: 53 Len: 2048 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 0
-ID: 55 Len: 2048 Enqueue: 786
-ID: 56 Len: 8 Enqueue: 0
-ID: 57 Len: 32 Enqueue: 942
-ID: 58 Len: 16 Enqueue: 800
+ID: 47 Len: 8 Enqueue: 676
+ID: 48 Len: 8 Enqueue: 972
+ID: 49 Len: 8 Enqueue: 0
+ID: 50 Len: 48 Enqueue: 942
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 8 Enqueue: 682
+ID: 53 Len: 8 Enqueue: 586
+ID: 54 Len: 8 Enqueue: 592
+ID: 55 Len: 8 Enqueue: 604
+ID: 56 Len: 2048 Enqueue: 0
+ID: 57 Len: 8 Enqueue: 0
+ID: 58 Len: 2048 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
-ID: 60 Len: 200 Enqueue: 892
-ID: 61 Len: 192 Enqueue: 876
-ID: 62 Len: 24 Enqueue: 930
-ID: 63 Len: 8192 Enqueue: 718
-ID: 64 Len: 2048 Enqueue: 752
-ID: 65 Len: 32 Enqueue: 953
-ID: 66 Len: 16 Enqueue: 812
-ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 200 Enqueue: 903
-ID: 69 Len: 192 Enqueue: 860
-ID: 70 Len: 24 Enqueue: 914
-ID: 71 Len: 8 Enqueue: 642
-ID: 72 Len: 184 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 730
-ID: 74 Len: 2048 Enqueue: 764
-ID: 75 Len: 8 Enqueue: 588
-ID: 76 Len: 128 Enqueue: 0
-ID: 77 Len: 9 Enqueue: 0
-ID: 78 Len: 17 Enqueue: 0
-ID: 79 Len: 25 Enqueue: 0
-ID: 80 Len: 25 Enqueue: 0
-ID: 81 Len: 25 Enqueue: 0
-ID: 82 Len: 49 Enqueue: 0
-ID: 83 Len: 49 Enqueue: 0
-ID: 84 Len: 9 Enqueue: 0
-ID: 85 Len: 9 Enqueue: 0
-ID: 86 Len: 9 Enqueue: 0
-ID: 87 Len: 9 Enqueue: 0
-ID: 88 Len: 9 Enqueue: 0
+ID: 60 Len: 2048 Enqueue: 844
+ID: 61 Len: 8 Enqueue: 0
+ID: 62 Len: 32 Enqueue: 1109
+ID: 63 Len: 16 Enqueue: 870
+ID: 64 Len: 8 Enqueue: 0
+ID: 65 Len: 200 Enqueue: 1026
+ID: 66 Len: 192 Enqueue: 994
+ID: 67 Len: 24 Enqueue: 1075
+ID: 68 Len: 8192 Enqueue: 752
+ID: 69 Len: 2048 Enqueue: 798
+ID: 70 Len: 32 Enqueue: 1120
+ID: 71 Len: 16 Enqueue: 882
+ID: 72 Len: 8 Enqueue: 0
+ID: 73 Len: 200 Enqueue: 1037
+ID: 74 Len: 192 Enqueue: 978
+ID: 75 Len: 24 Enqueue: 1059
+ID: 76 Len: 8 Enqueue: 652
+ID: 77 Len: 184 Enqueue: 0
+ID: 78 Len: 8192 Enqueue: 764
+ID: 79 Len: 2048 Enqueue: 810
+ID: 80 Len: 32 Enqueue: 1131
+ID: 81 Len: 16 Enqueue: 894
+ID: 82 Len: 8 Enqueue: 0
+ID: 83 Len: 136 Enqueue: 1048
+ID: 84 Len: 128 Enqueue: 1010
+ID: 85 Len: 16 Enqueue: 1081
+ID: 86 Len: 8 Enqueue: 954
+ID: 87 Len: 8 Enqueue: 0
+ID: 88 Len: 48 Enqueue: 906
+ID: 89 Len: 8 Enqueue: 0
+ID: 90 Len: 8 Enqueue: 664
+ID: 91 Len: 8192 Enqueue: 776
+ID: 92 Len: 2048 Enqueue: 822
+ID: 93 Len: 32 Enqueue: 1098
+ID: 94 Len: 16 Enqueue: 858
+ID: 95 Len: 8 Enqueue: 0
+ID: 96 Len: 136 Enqueue: 0
+ID: 97 Len: 128 Enqueue: 0
+ID: 98 Len: 16 Enqueue: 0
+ID: 99 Len: 8 Enqueue: 0
+ID: 100 Len: 8192 Enqueue: 740
+ID: 101 Len: 2048 Enqueue: 0
+ID: 102 Len: 8 Enqueue: 598
+ID: 103 Len: 128 Enqueue: 0
+ID: 104 Len: 9 Enqueue: 0
+ID: 105 Len: 17 Enqueue: 0
+ID: 106 Len: 25 Enqueue: 0
+ID: 107 Len: 25 Enqueue: 0
+ID: 108 Len: 25 Enqueue: 0
+ID: 109 Len: 49 Enqueue: 0
+ID: 110 Len: 49 Enqueue: 0
+ID: 111 Len: 9 Enqueue: 0
+ID: 112 Len: 9 Enqueue: 0
+ID: 113 Len: 0 Enqueue: 0
+ID: 114 Len: 9 Enqueue: 0
+ID: 115 Len: 9 Enqueue: 0
+ID: 116 Len: 9 Enqueue: 0

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -1,105 +1,110 @@
-LocatePC: 0x4a60a0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:42
-LocatePC: 0x4a60d1
-	fmt.Println@fmt/print.go:314
+LocatePC: 0x4a6100
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
-LocatePC: 0x4a6120
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-LocatePC: 0x4a6158
+LocatePC: 0x4a6131
 	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+LocatePC: 0x4a6180
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-LocatePC: 0x4a61a0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-LocatePC: 0x4a61dd
+LocatePC: 0x4a61b8
 	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+LocatePC: 0x4a6200
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-LocatePC: 0x4a6220
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-LocatePC: 0x4a6253
+LocatePC: 0x4a623d
+	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+LocatePC: 0x4a6280
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0x4a62a0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-LocatePC: 0x4a62dd
-	fmt.Println@fmt/print.go:314
+LocatePC: 0x4a62b3
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0x4a6300
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-LocatePC: 0x4a6320
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-LocatePC: 0x4a6353
+LocatePC: 0x4a633d
+	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+LocatePC: 0x4a6380
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0x4a63a0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0x4a63a0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0x4a6480
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-LocatePC: 0x4a64ab
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0x4a63b3
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0x4a6400
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+LocatePC: 0x4a6400
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
 LocatePC: 0x4a64e0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-LocatePC: 0x4a653d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:107
-LocatePC: 0x4a63c0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4a63f1
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0x4a650b
 	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+LocatePC: 0x4a6540
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+LocatePC: 0x4a659d
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+LocatePC: 0x4a6600
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+LocatePC: 0x4a66f2
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0x4a6420
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
-LocatePC: 0x4a5dce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0x4a6451
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+LocatePC: 0x4a5e0e
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4a5df6
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0x4a5e36
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4a6006
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+LocatePC: 0x4a6046
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4a6025
+LocatePC: 0x4a6065
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4a6050
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+LocatePC: 0x4a6090
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0x4a606d
+LocatePC: 0x4a60ad
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0x4a6050
+FunctionLines: 0x4a6090
 	fmt.Println
-		[0x4a5dfc, 0x4a5e1f) fmt.Println@fmt/print.go:314
-		[0x4a601d, 0x4a6045) fmt.Println@fmt/print.go:314
-		[0x4a6067, 0x4a608a) fmt.Println@fmt/print.go:314
+		[0x4a5e3c, 0x4a5e5f) fmt.Println@fmt/print.go:314
+		[0x4a605d, 0x4a6085) fmt.Println@fmt/print.go:314
+		[0x4a60a7, 0x4a60ca) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0x4a5c5d, 0x4a5c64) fmt.Scanln@fmt/scan.go:70
-		[0x4a5c65, 0x4a5c78) fmt.Scanln@fmt/scan.go:70
+		[0x4a5c9d, 0x4a5ca4) fmt.Scanln@fmt/scan.go:70
+		[0x4a5ca5, 0x4a5cb8) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4a6006, 0x4a601d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0x4a6046, 0x4a605d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.PointerSmallChainArg
-		[0x4a6050, 0x4a6067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0x4a6090, 0x4a60a7) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.inlined
-		[0x4a5dce, 0x4a5dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+		[0x4a5e0e, 0x4a5e3c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main
-		[0x4a5c40, 0x4a5c5d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0x4a5c64, 0x4a5c65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0x4a5c78, 0x4a5c7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0x4a5c7d, 0x4a5cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0x4a5cbd, 0x4a5ccc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0x4a5ccc, 0x4a5cdd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0x4a5cdd, 0x4a5d0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0x4a5d0d, 0x4a5d2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0x4a5d2c, 0x4a5d7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0x4a5d7d, 0x4a5da5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0x4a5da5, 0x4a5dcd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0x4a5dcd, 0x4a5dce) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0x4a5e1f, 0x4a5e2b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0x4a5e2b, 0x4a5e67) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0x4a5e67, 0x4a5f05) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0x4a5f05, 0x4a5f20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0x4a5f20, 0x4a5f5b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0x4a5f5b, 0x4a5f95) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0x4a5f95, 0x4a5fd3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0x4a5fd3, 0x4a6005) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0x4a6005, 0x4a6006) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0x4a6045, 0x4a6050) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0x4a608a, 0x4a6093) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4a6093, 0x4a609d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a5c80, 0x4a5c9d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a5ca4, 0x4a5ca5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0x4a5cb8, 0x4a5cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0x4a5cbd, 0x4a5cfd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0x4a5cfd, 0x4a5d0c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0x4a5d0c, 0x4a5d1d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0x4a5d1d, 0x4a5d4d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0x4a5d4d, 0x4a5d6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0x4a5d6c, 0x4a5dbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0x4a5dbd, 0x4a5de5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0x4a5de5, 0x4a5e0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0x4a5e0d, 0x4a5e0e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0x4a5e5f, 0x4a5e6b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0x4a5e6b, 0x4a5ea7) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0x4a5ea7, 0x4a5f45) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0x4a5f45, 0x4a5f60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0x4a5f60, 0x4a5f9b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0x4a5f9b, 0x4a5fd5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0x4a5fd5, 0x4a6013) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0x4a6013, 0x4a6045) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0x4a6045, 0x4a6046) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0x4a6085, 0x4a6090) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0x4a60ca, 0x4a60cf) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0x4a60cf, 0x4a60d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4a60d8, 0x4a60e5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
@@ -1,105 +1,110 @@
-LocatePC: 0x4a80a0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:42
-LocatePC: 0x4a80d1
-	fmt.Println@fmt/print.go:314
+LocatePC: 0x4a8100
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
-LocatePC: 0x4a8120
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-LocatePC: 0x4a8158
+LocatePC: 0x4a8131
 	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+LocatePC: 0x4a8180
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-LocatePC: 0x4a81a0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-LocatePC: 0x4a81dd
+LocatePC: 0x4a81b8
 	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+LocatePC: 0x4a8200
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-LocatePC: 0x4a8220
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-LocatePC: 0x4a8253
+LocatePC: 0x4a823d
+	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+LocatePC: 0x4a8280
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0x4a82a0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-LocatePC: 0x4a82dd
-	fmt.Println@fmt/print.go:314
+LocatePC: 0x4a82b3
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0x4a8300
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-LocatePC: 0x4a8320
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-LocatePC: 0x4a8353
+LocatePC: 0x4a833d
+	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+LocatePC: 0x4a8380
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0x4a83a0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0x4a83a0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0x4a8480
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-LocatePC: 0x4a84ab
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0x4a83b3
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0x4a8400
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+LocatePC: 0x4a8400
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
 LocatePC: 0x4a84e0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-LocatePC: 0x4a853d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:107
-LocatePC: 0x4a83c0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4a83f1
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0x4a850b
 	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+LocatePC: 0x4a8540
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+LocatePC: 0x4a859d
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+LocatePC: 0x4a8600
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+LocatePC: 0x4a86f7
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0x4a8420
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
-LocatePC: 0x4a7dce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0x4a8451
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+LocatePC: 0x4a7e0e
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4a7df6
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0x4a7e36
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4a8006
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+LocatePC: 0x4a8046
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4a8025
+LocatePC: 0x4a8065
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4a8050
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+LocatePC: 0x4a8090
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0x4a806d
+LocatePC: 0x4a80ad
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0x4a8050
+FunctionLines: 0x4a8090
 	fmt.Println
-		[0x4a7dfc, 0x4a7e1f) fmt.Println@fmt/print.go:314
-		[0x4a801d, 0x4a8045) fmt.Println@fmt/print.go:314
-		[0x4a8067, 0x4a808a) fmt.Println@fmt/print.go:314
+		[0x4a7e3c, 0x4a7e5f) fmt.Println@fmt/print.go:314
+		[0x4a805d, 0x4a8085) fmt.Println@fmt/print.go:314
+		[0x4a80a7, 0x4a80ca) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0x4a7c5d, 0x4a7c64) fmt.Scanln@fmt/scan.go:70
-		[0x4a7c65, 0x4a7c78) fmt.Scanln@fmt/scan.go:70
+		[0x4a7c9d, 0x4a7ca4) fmt.Scanln@fmt/scan.go:70
+		[0x4a7ca5, 0x4a7cb8) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4a8006, 0x4a801d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0x4a8046, 0x4a805d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.PointerSmallChainArg
-		[0x4a8050, 0x4a8067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0x4a8090, 0x4a80a7) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.inlined
-		[0x4a7dce, 0x4a7dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+		[0x4a7e0e, 0x4a7e3c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main
-		[0x4a7c40, 0x4a7c5d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0x4a7c64, 0x4a7c65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0x4a7c78, 0x4a7c7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0x4a7c7d, 0x4a7cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0x4a7cbd, 0x4a7ccc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0x4a7ccc, 0x4a7cdd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0x4a7cdd, 0x4a7d0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0x4a7d0d, 0x4a7d2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0x4a7d2c, 0x4a7d7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0x4a7d7d, 0x4a7da5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0x4a7da5, 0x4a7dcd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0x4a7dcd, 0x4a7dce) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0x4a7e1f, 0x4a7e2b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0x4a7e2b, 0x4a7e67) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0x4a7e67, 0x4a7f05) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0x4a7f05, 0x4a7f20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0x4a7f20, 0x4a7f5b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0x4a7f5b, 0x4a7f95) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0x4a7f95, 0x4a7fd3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0x4a7fd3, 0x4a8005) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0x4a8005, 0x4a8006) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0x4a8045, 0x4a8050) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0x4a808a, 0x4a8093) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4a8093, 0x4a809d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a7c80, 0x4a7c9d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a7ca4, 0x4a7ca5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0x4a7cb8, 0x4a7cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0x4a7cbd, 0x4a7cfd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0x4a7cfd, 0x4a7d0c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0x4a7d0c, 0x4a7d1d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0x4a7d1d, 0x4a7d4d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0x4a7d4d, 0x4a7d6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0x4a7d6c, 0x4a7dbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0x4a7dbd, 0x4a7de5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0x4a7de5, 0x4a7e0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0x4a7e0d, 0x4a7e0e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0x4a7e5f, 0x4a7e6b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0x4a7e6b, 0x4a7ea7) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0x4a7ea7, 0x4a7f45) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0x4a7f45, 0x4a7f60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0x4a7f60, 0x4a7f9b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0x4a7f9b, 0x4a7fd5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0x4a7fd5, 0x4a8013) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0x4a8013, 0x4a8045) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0x4a8045, 0x4a8046) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0x4a8085, 0x4a8090) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0x4a80ca, 0x4a80cf) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0x4a80cf, 0x4a80d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4a80d8, 0x4a80e5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
@@ -1,106 +1,111 @@
-LocatePC: 0x4ae6a0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:42
-LocatePC: 0x4ae6d1
-	fmt.Println@fmt/print.go:314
+LocatePC: 0x4ae700
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
-LocatePC: 0x4ae720
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-LocatePC: 0x4ae758
+LocatePC: 0x4ae731
 	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+LocatePC: 0x4ae780
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-LocatePC: 0x4ae7a0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-LocatePC: 0x4ae7dd
+LocatePC: 0x4ae7b8
 	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+LocatePC: 0x4ae800
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-LocatePC: 0x4ae820
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-LocatePC: 0x4ae853
+LocatePC: 0x4ae83d
+	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+LocatePC: 0x4ae880
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0x4ae8a0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-LocatePC: 0x4ae8dd
-	fmt.Println@fmt/print.go:314
+LocatePC: 0x4ae8b3
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0x4ae900
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-LocatePC: 0x4ae920
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-LocatePC: 0x4ae953
+LocatePC: 0x4ae93d
+	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+LocatePC: 0x4ae980
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0x4ae9a0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0x4ae9a0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0x4aea80
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-LocatePC: 0x4aeaab
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0x4ae9b3
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0x4aea00
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+LocatePC: 0x4aea00
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
 LocatePC: 0x4aeae0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-LocatePC: 0x4aeb3d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:107
-LocatePC: 0x4ae9c0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0x4ae9f1
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0x4aeb0b
 	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+LocatePC: 0x4aeb40
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+LocatePC: 0x4aeb9d
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+LocatePC: 0x4aec00
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+LocatePC: 0x4aecfb
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0x4aea20
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
-LocatePC: 0x4ae3ce
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0x4aea51
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+LocatePC: 0x4ae40e
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4ae3ee
+LocatePC: 0x4ae42e
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0x4ae606
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+LocatePC: 0x4ae646
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4ae625
+LocatePC: 0x4ae665
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0x4ae650
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+LocatePC: 0x4ae690
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0x4ae66d
+LocatePC: 0x4ae6ad
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0x4ae650
+FunctionLines: 0x4ae690
 	fmt.Println
-		[0x4ae3ec, 0x4ae40f) fmt.Println@fmt/print.go:314
-		[0x4ae61d, 0x4ae645) fmt.Println@fmt/print.go:314
-		[0x4ae667, 0x4ae68a) fmt.Println@fmt/print.go:314
+		[0x4ae42c, 0x4ae44f) fmt.Println@fmt/print.go:314
+		[0x4ae65d, 0x4ae685) fmt.Println@fmt/print.go:314
+		[0x4ae6a7, 0x4ae6ca) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0x4ae25d, 0x4ae264) fmt.Scanln@fmt/scan.go:70
-		[0x4ae265, 0x4ae278) fmt.Scanln@fmt/scan.go:70
+		[0x4ae29d, 0x4ae2a4) fmt.Scanln@fmt/scan.go:70
+		[0x4ae2a5, 0x4ae2b8) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4ae606, 0x4ae61d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0x4ae646, 0x4ae65d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.PointerSmallChainArg
-		[0x4ae650, 0x4ae667) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0x4ae690, 0x4ae6a7) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.inlined
-		[0x4ae3ce, 0x4ae3ec) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+		[0x4ae40e, 0x4ae42c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main
-		[0x4ae240, 0x4ae25d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0x4ae264, 0x4ae265) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0x4ae278, 0x4ae27d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0x4ae27d, 0x4ae2bd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0x4ae2bd, 0x4ae2cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0x4ae2cc, 0x4ae2dd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0x4ae2dd, 0x4ae30d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0x4ae30d, 0x4ae32c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0x4ae32c, 0x4ae37d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0x4ae37d, 0x4ae3a5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0x4ae3a5, 0x4ae3cd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0x4ae3cd, 0x4ae3ce) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0x4ae40f, 0x4ae420) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0x4ae420, 0x4ae460) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0x4ae460, 0x4ae505) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0x4ae505, 0x4ae520) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0x4ae520, 0x4ae55b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0x4ae55b, 0x4ae595) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0x4ae595, 0x4ae5d3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0x4ae5d3, 0x4ae605) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0x4ae605, 0x4ae606) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0x4ae645, 0x4ae650) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0x4ae68a, 0x4ae693) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0x4ae693, 0x4ae69d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4ae280, 0x4ae29d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4ae2a4, 0x4ae2a5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0x4ae2b8, 0x4ae2bd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0x4ae2bd, 0x4ae2fd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0x4ae2fd, 0x4ae30c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0x4ae30c, 0x4ae31d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0x4ae31d, 0x4ae34d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0x4ae34d, 0x4ae36c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0x4ae36c, 0x4ae3bd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0x4ae3bd, 0x4ae3e5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0x4ae3e5, 0x4ae40d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0x4ae40d, 0x4ae40e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0x4ae44f, 0x4ae460) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0x4ae460, 0x4ae4a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0x4ae4a0, 0x4ae545) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0x4ae545, 0x4ae560) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0x4ae560, 0x4ae59b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0x4ae59b, 0x4ae5d5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0x4ae5d5, 0x4ae613) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0x4ae613, 0x4ae645) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0x4ae645, 0x4ae646) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0x4ae685, 0x4ae690) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0x4ae6ca, 0x4ae6cf) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0x4ae6cf, 0x4ae6d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0x4ae6d8, 0x4ae6e5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -1,108 +1,113 @@
-LocatePC: 0xb53c0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:42
-LocatePC: 0xb53f8
-	fmt.Println@fmt/print.go:314
+LocatePC: 0xb5410
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
-LocatePC: 0xb5430
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-LocatePC: 0xb5470
+LocatePC: 0xb5448
 	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+LocatePC: 0xb5480
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-LocatePC: 0xb54b0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-LocatePC: 0xb54f8
+LocatePC: 0xb54c0
 	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+LocatePC: 0xb5500
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-LocatePC: 0xb5540
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-LocatePC: 0xb5580
+LocatePC: 0xb5548
 	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+LocatePC: 0xb5590
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0xb55c0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-LocatePC: 0xb5608
+LocatePC: 0xb55d0
 	fmt.Println@fmt/print.go:314
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0xb5610
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-LocatePC: 0xb5650
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-LocatePC: 0xb5690
+LocatePC: 0xb5658
 	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+LocatePC: 0xb56a0
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0xb56d0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0xb56d8
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0xb57a0
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-LocatePC: 0xb57d8
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
-LocatePC: 0xb5810
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-LocatePC: 0xb5870
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:107
 LocatePC: 0xb56e0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
-LocatePC: 0xb5718
 	fmt.Println@fmt/print.go:314
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0xb5720
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+LocatePC: 0xb5728
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+LocatePC: 0xb57f0
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0xb5828
+	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+LocatePC: 0xb5860
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+LocatePC: 0xb58c0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+LocatePC: 0xb5920
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+LocatePC: 0xb59f8
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0xb5730
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
-LocatePC: 0xb514c
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0xb5768
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+LocatePC: 0xb519c
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb516c
+LocatePC: 0xb51bc
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb5338
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb5350
-	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb5370
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
-	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0xb5388
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+LocatePC: 0xb53a0
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+LocatePC: 0xb53c0
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb5370
+LocatePC: 0xb53d8
+	fmt.Println@fmt/print.go:314
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+FunctionLines: 0xb53c0
 	fmt.Println
-		[0xb5168, 0xb518c) fmt.Println@fmt/print.go:314
-		[0xb5348, 0xb5368) fmt.Println@fmt/print.go:314
-		[0xb5380, 0xb53a0) fmt.Println@fmt/print.go:314
+		[0xb51b8, 0xb51dc) fmt.Println@fmt/print.go:314
+		[0xb5398, 0xb53b8) fmt.Println@fmt/print.go:314
+		[0xb53d0, 0xb53f0) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0xb4fd0, 0xb4fd8) fmt.Scanln@fmt/scan.go:70
-		[0xb4fdc, 0xb4ff4) fmt.Scanln@fmt/scan.go:70
+		[0xb5020, 0xb5028) fmt.Scanln@fmt/scan.go:70
+		[0xb502c, 0xb5044) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb5338, 0xb5348) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0xb5388, 0xb5398) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.PointerSmallChainArg
-		[0xb5370, 0xb5380) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0xb53c0, 0xb53d0) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.inlined
-		[0xb514c, 0xb5168) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+		[0xb519c, 0xb51b8) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main
-		[0xb4fb0, 0xb4fd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0xb4fd8, 0xb4fdc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0xb4ff4, 0xb4ff8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0xb4ff8, 0xb5028) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0xb5028, 0xb503c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0xb503c, 0xb504c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0xb504c, 0xb5078) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0xb5078, 0xb5094) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0xb5094, 0xb50e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0xb50e0, 0xb5114) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0xb5114, 0xb5148) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0xb5148, 0xb514c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb518c, 0xb5198) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb5198, 0xb51cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb51cc, 0xb5250) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb5250, 0xb5268) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb5268, 0xb529c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb529c, 0xb52d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb52d0, 0xb5304) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb5304, 0xb5334) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb5334, 0xb5338) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb5368, 0xb5370) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb53a0, 0xb53ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb53ac, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb5000, 0xb5020) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb5028, 0xb502c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0xb5044, 0xb5048) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0xb5048, 0xb5078) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0xb5078, 0xb508c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0xb508c, 0xb509c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0xb509c, 0xb50c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0xb50c8, 0xb50e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0xb50e4, 0xb5130) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0xb5130, 0xb5164) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0xb5164, 0xb5198) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0xb5198, 0xb519c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0xb51dc, 0xb51e8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb51e8, 0xb521c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb521c, 0xb52a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb52a0, 0xb52b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb52b8, 0xb52ec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb52ec, 0xb5320) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb5320, 0xb5354) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb5354, 0xb5384) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb5384, 0xb5388) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb53b8, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb53f0, 0xb53f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb53f4, 0xb5400) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb5400, 0xb5410) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
@@ -1,108 +1,113 @@
-LocatePC: 0xb5250
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:42
-LocatePC: 0xb5288
-	fmt.Println@fmt/print.go:314
+LocatePC: 0xb5290
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
-LocatePC: 0xb52c0
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-LocatePC: 0xb5300
+LocatePC: 0xb52c8
 	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+LocatePC: 0xb5300
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
 LocatePC: 0xb5340
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-LocatePC: 0xb5380
 	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+LocatePC: 0xb5380
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
 LocatePC: 0xb53c0
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-LocatePC: 0xb5400
 	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+LocatePC: 0xb5400
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
 LocatePC: 0xb5440
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-LocatePC: 0xb5480
 	fmt.Println@fmt/print.go:314
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0xb5480
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
 LocatePC: 0xb54c0
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-LocatePC: 0xb5500
 	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+LocatePC: 0xb5500
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
 LocatePC: 0xb5540
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0xb5548
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0xb5610
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-LocatePC: 0xb5648
 	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
-LocatePC: 0xb5680
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-LocatePC: 0xb56e0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:107
-LocatePC: 0xb5550
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0xb5580
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
 LocatePC: 0xb5588
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+LocatePC: 0xb5650
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0xb5688
 	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+LocatePC: 0xb56c0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+LocatePC: 0xb5720
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:108
+LocatePC: 0xb5780
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+LocatePC: 0xb5860
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0xb5590
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
-LocatePC: 0xb4fec
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0xb55c8
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+LocatePC: 0xb502c
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb500a
+LocatePC: 0xb504a
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb51cc
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+LocatePC: 0xb520c
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb51e4
+LocatePC: 0xb5224
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb5204
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+LocatePC: 0xb5244
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0xb521c
+LocatePC: 0xb525c
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb5204
+FunctionLines: 0xb5244
 	fmt.Println
-		[0xb5008, 0xb5028) fmt.Println@fmt/print.go:314
-		[0xb51dc, 0xb51fc) fmt.Println@fmt/print.go:314
-		[0xb5214, 0xb5234) fmt.Println@fmt/print.go:314
+		[0xb5048, 0xb5068) fmt.Println@fmt/print.go:314
+		[0xb521c, 0xb523c) fmt.Println@fmt/print.go:314
+		[0xb5254, 0xb5274) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0xb4e70, 0xb4e78) fmt.Scanln@fmt/scan.go:70
-		[0xb4e7c, 0xb4e94) fmt.Scanln@fmt/scan.go:70
+		[0xb4eb0, 0xb4eb8) fmt.Scanln@fmt/scan.go:70
+		[0xb4ebc, 0xb4ed4) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb51cc, 0xb51dc) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0xb520c, 0xb521c) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.PointerSmallChainArg
-		[0xb5204, 0xb5214) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0xb5244, 0xb5254) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.inlined
-		[0xb4fec, 0xb5008) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+		[0xb502c, 0xb5048) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main
-		[0xb4e50, 0xb4e70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0xb4e78, 0xb4e7c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0xb4e94, 0xb4e98) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0xb4e98, 0xb4ec8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0xb4ec8, 0xb4edc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0xb4edc, 0xb4eec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0xb4eec, 0xb4f18) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0xb4f18, 0xb4f34) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0xb4f34, 0xb4f80) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0xb4f80, 0xb4fb4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0xb4fb4, 0xb4fe8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0xb4fe8, 0xb4fec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb5028, 0xb5034) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb5034, 0xb5068) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb5068, 0xb50e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb50e4, 0xb50fc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb50fc, 0xb5130) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb5130, 0xb5164) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb5164, 0xb5198) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb5198, 0xb51c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb51c8, 0xb51cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb51fc, 0xb5204) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb5234, 0xb5240) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb5240, 0xb5250) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb4e90, 0xb4eb0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb4eb8, 0xb4ebc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0xb4ed4, 0xb4ed8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0xb4ed8, 0xb4f08) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0xb4f08, 0xb4f1c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0xb4f1c, 0xb4f2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0xb4f2c, 0xb4f58) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0xb4f58, 0xb4f74) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0xb4f74, 0xb4fc0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0xb4fc0, 0xb4ff4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0xb4ff4, 0xb5028) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0xb5028, 0xb502c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0xb5068, 0xb5074) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb5074, 0xb50a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb50a8, 0xb5124) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb5124, 0xb513c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb513c, 0xb5170) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb5170, 0xb51a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb51a4, 0xb51d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb51d8, 0xb5208) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb5208, 0xb520c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb523c, 0xb5244) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb5274, 0xb5278) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb5278, 0xb5284) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb5284, 0xb5290) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
@@ -1,108 +1,113 @@
-LocatePC: 0xb7de0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:42
-LocatePC: 0xb7e18
-	fmt.Println@fmt/print.go:314
+LocatePC: 0xb7e20
 	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
-LocatePC: 0xb7e50
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-LocatePC: 0xb7e88
+LocatePC: 0xb7e58
 	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:44
+LocatePC: 0xb7e90
 	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-LocatePC: 0xb7ec0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-LocatePC: 0xb7f00
+LocatePC: 0xb7ec8
 	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+LocatePC: 0xb7f00
 	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
 LocatePC: 0xb7f40
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-LocatePC: 0xb7f78
 	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+LocatePC: 0xb7f80
 	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-LocatePC: 0xb7fb0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-LocatePC: 0xb7ff0
+LocatePC: 0xb7fb8
 	fmt.Println@fmt/print.go:314
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+LocatePC: 0xb7ff0
 	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
 LocatePC: 0xb8030
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-LocatePC: 0xb8068
 	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+LocatePC: 0xb8070
 	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-LocatePC: 0xb80a0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
 LocatePC: 0xb80a8
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-LocatePC: 0xb8170
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-LocatePC: 0xb81a8
 	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
-LocatePC: 0xb81e0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-LocatePC: 0xb8238
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
-LocatePC: 0xb80b0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+LocatePC: 0xb80e0
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
 LocatePC: 0xb80e8
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:74
+LocatePC: 0xb81b0
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0xb81e8
 	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+LocatePC: 0xb8220
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:103
+LocatePC: 0xb8278
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:104
+LocatePC: 0xb82d0
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+LocatePC: 0xb83a8
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+LocatePC: 0xb80f0
 	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
-LocatePC: 0xb7b88
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0xb8128
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
+LocatePC: 0xb7bc8
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb7ba2
+LocatePC: 0xb7be2
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb7d60
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+LocatePC: 0xb7da0
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb7d76
+LocatePC: 0xb7db6
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb7d94
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+LocatePC: 0xb7dd4
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0xb7daa
+LocatePC: 0xb7dea
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb7d94
+FunctionLines: 0xb7dd4
 	fmt.Println
-		[0xb7b9c, 0xb7bbc) fmt.Println@fmt/print.go:314
-		[0xb7d6c, 0xb7d8c) fmt.Println@fmt/print.go:314
-		[0xb7da0, 0xb7dc0) fmt.Println@fmt/print.go:314
+		[0xb7bdc, 0xb7bfc) fmt.Println@fmt/print.go:314
+		[0xb7dac, 0xb7dcc) fmt.Println@fmt/print.go:314
+		[0xb7de0, 0xb7e00) fmt.Println@fmt/print.go:314
 	fmt.Scanln
-		[0xb7a20, 0xb7a28) fmt.Scanln@fmt/scan.go:70
-		[0xb7a2c, 0xb7a44) fmt.Scanln@fmt/scan.go:70
+		[0xb7a60, 0xb7a68) fmt.Scanln@fmt/scan.go:70
+		[0xb7a6c, 0xb7a84) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb7d60, 0xb7d6c) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0xb7da0, 0xb7dac) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
 	main.PointerSmallChainArg
-		[0xb7d94, 0xb7da0) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0xb7dd4, 0xb7de0) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 	main.inlined
-		[0xb7b88, 0xb7b9c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+		[0xb7bc8, 0xb7bdc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:77
 	main.main
-		[0xb7a00, 0xb7a20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
-		[0xb7a28, 0xb7a2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
-		[0xb7a44, 0xb7a48) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
-		[0xb7a48, 0xb7a74) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
-		[0xb7a74, 0xb7a88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
-		[0xb7a88, 0xb7a98) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
-		[0xb7a98, 0xb7ac0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
-		[0xb7ac0, 0xb7adc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
-		[0xb7adc, 0xb7b1c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
-		[0xb7b1c, 0xb7b50) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
-		[0xb7b50, 0xb7b84) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
-		[0xb7b84, 0xb7b88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb7bbc, 0xb7bc8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb7bc8, 0xb7bfc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb7bfc, 0xb7c78) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb7c78, 0xb7c90) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb7c90, 0xb7cc4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb7cc4, 0xb7cf8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb7cf8, 0xb7d2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb7d2c, 0xb7d5c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb7d5c, 0xb7d60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb7d8c, 0xb7d94) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb7dc0, 0xb7dcc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb7dcc, 0xb7de0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb7a40, 0xb7a60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb7a68, 0xb7a6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0xb7a84, 0xb7a88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0xb7a88, 0xb7ab4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0xb7ab4, 0xb7ac8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0xb7ac8, 0xb7ad8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0xb7ad8, 0xb7b00) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0xb7b00, 0xb7b1c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0xb7b1c, 0xb7b5c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0xb7b5c, 0xb7b90) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0xb7b90, 0xb7bc4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0xb7bc4, 0xb7bc8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0xb7bfc, 0xb7c08) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb7c08, 0xb7c3c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb7c3c, 0xb7cb8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb7cb8, 0xb7cd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb7cd0, 0xb7d04) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb7d04, 0xb7d38) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb7d38, 0xb7d6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb7d6c, 0xb7d9c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb7d9c, 0xb7da0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb7dcc, 0xb7dd4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb7e00, 0xb7e04) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb7e04, 0xb7e10) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb7e10, 0xb7e20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001afc0"
+- offset: "0x0000fc80"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006060"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001b7a0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00005ec0"
+  ptrToThis: "0x000060a0"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001d3c0"
+- offset: "0x00011500"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006a20"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001dea0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006940"
+  ptrToThis: "0x00006a60"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001e740"
+- offset: "0x00011f40"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006da0"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001f240"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006ca0"
+  ptrToThis: "0x00006de0"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001af40"
+- offset: "0x0000fc00"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006040"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001b720"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00005ea0"
+  ptrToThis: "0x00006080"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001d340"
+- offset: "0x00011480"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006a00"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001de20"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006920"
+  ptrToThis: "0x00006a40"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,10 +1,22 @@
-- offset: "0x0001e6c0"
+- offset: "0x00011ec0"
+  size: 8
+  kind: struct
+  nameEntry: main.aStructNotUsedAsAnArgument
+  name: main.aStructNotUsedAsAnArgument
+  pkg: main
+  ptrToThis: "0x00006d80"
+  struct:
+    fields:
+    - name: a
+      type: int
+      offset: 0
+- offset: "0x0001f1c0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006c80"
+  ptrToThis: "0x00006dc0"
   struct:
     fields:
     - name: Field1 (exported)

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 124 EventRootType Probe[main.HandleHTTP]
+          Type: 118 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 125 EventRootType Probe[main.LookAtTheRequest]
+          Type: 119 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -72,29 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0xd59848..0xd59881
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 41 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd59958..0xd5997a
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd5997a..0xd59a5c
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 43 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0xd597c0..0xd59a5c
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd59b20..0xd59be5]
@@ -113,10 +90,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 121
+      ID: 115
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []string.array
+      Pointee: 114 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -125,29 +102,22 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 93
+      ID: 87
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 94 GoHMapBucketType bucket<string,[]string>
+      Pointee: 88 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 114
+      ID: 108
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 115 GoHMapBucketType bucket<string,string>
+      Pointee: 109 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 41
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.17632e+06
-      GoKind: 22
-      Pointee: 42 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 103
+      ID: 97
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 104 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 98 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -170,29 +140,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 39
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.187104e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 47
+      ID: 41
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.396768e+06
       GoKind: 22
-      Pointee: 48 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 91
+      ID: 85
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 92 GoHMapHeaderType hash<string,[]string>
+      Pointee: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 112
+      ID: 106
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 113 GoHMapHeaderType hash<string,string>
+      Pointee: 107 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -229,12 +192,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 101
+      ID: 95
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 102 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 96 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -243,47 +206,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 106
+      ID: 100
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 107 UnresolvedPointeeType net/http.Response
+      Pointee: 101 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 84
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.876224e+06
       GoKind: 22
-      Pointee: 85 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 109
+      ID: 103
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 110 UnresolvedPointeeType net/http.pattern
+      Pointee: 104 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 86
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.117184e+06
       GoKind: 22
-      Pointee: 87 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 88
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 89 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 95
+      ID: 89
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 379904
       GoKind: 22
-      Pointee: 96 UnresolvedPointeeType runtime.mapextra
+      Pointee: 90 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -292,115 +255,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 46
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 45 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 53
+      ID: 47
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.532416e+06
       GoKind: 22
-      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 67
+      ID: 61
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656736e+06
       GoKind: 22
-      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 49
+      ID: 43
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.532032e+06
       GoKind: 22
-      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 59
+      ID: 53
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.655968e+06
       GoKind: 22
-      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 73
+      ID: 67
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726624e+06
       GoKind: 22
-      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 61
+      ID: 55
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.65616e+06
       GoKind: 22
-      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 57
+      ID: 51
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.655776e+06
       GoKind: 22
-      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 69
+      ID: 63
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.726176e+06
       GoKind: 22
-      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 77
+      ID: 71
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.794496e+06
       GoKind: 22
-      Pointee: 78 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 71
+      ID: 65
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.7264e+06
       GoKind: 22
-      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 55
+      ID: 49
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.532608e+06
       GoKind: 22
-      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 51
+      ID: 45
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.532224e+06
       GoKind: 22
-      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 63
+      ID: 57
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656352e+06
       GoKind: 22
-      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 75
+      ID: 69
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726848e+06
       GoKind: 22
-      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 65
+      ID: 59
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656544e+06
       GoKind: 22
-      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -444,12 +407,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 105
+      ID: 99
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: EventRootType
-      ID: 124
+      ID: 118
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -473,7 +436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 125
+      ID: 119
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -488,7 +451,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 116
+      ID: 110
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -497,24 +460,24 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 113
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 94 GoHMapBucketType bucket<string,[]string>
+      Element: 88 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 117
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 115 GoHMapBucketType bucket<string,string>
+      Element: 109 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 117
+      ID: 111
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 93
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -529,21 +492,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 120 GoSliceDataType []string.array
+      Data: 114 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 114
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 118
+      ID: 112
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 99 GoSliceHeaderType []string
+      Element: 93 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 122
+      ID: 116
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -556,47 +519,43 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 94
+      ID: 88
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 116 ArrayType [8]uint8
+          Type: 110 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 117 ArrayType []key<string>
+          Type: 111 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 118 ArrayType []val<[]string>
+          Type: 112 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 93 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 99 GoSliceHeaderType []string
+      ValueType: 93 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 115
+      ID: 109
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 116 ArrayType [8]uint8
+          Type: 110 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 117 ArrayType []key<string>
+          Type: 111 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 122 ArrayType []val<string>
+          Type: 116 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 114 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: UnresolvedPointeeType
-      ID: 42
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -610,7 +569,7 @@ Types:
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 108
+      ID: 102
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215552e+06
@@ -622,23 +581,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 43
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.708256e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 44 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 44
-      Name: context.emptyCtx
-      GoRuntimeType: 1.43472e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 104
+      ID: 98
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -667,17 +611,13 @@ Types:
       GoRuntimeType: 543264
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 98
+      ID: 92
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 73
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.265696e+06
@@ -690,11 +630,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 48
+      ID: 42
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 92
+      ID: 86
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -715,20 +655,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 93 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 93 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 95 PointerType *runtime.mapextra
-      BucketType: 94 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 119 GoSliceDataType []bucket<string,[]string>.array
+          Type: 89 PointerType *runtime.mapextra
+      BucketType: 88 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 113 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 113
+      ID: 107
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -749,18 +689,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 114 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 114 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 95 PointerType *runtime.mapextra
-      BucketType: 115 GoHMapBucketType bucket<string,string>
-      BucketsType: 123 GoSliceDataType []bucket<string,string>.array
+          Type: 89 PointerType *runtime.mapextra
+      BucketType: 109 GoHMapBucketType bucket<string,string>
+      BucketsType: 117 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -792,7 +732,7 @@ Types:
       GoRuntimeType: 542368
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 97
+      ID: 91
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.092864e+06
@@ -805,18 +745,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 111
+      ID: 105
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 113 GoHMapHeaderType hash<string,string>
+      HeaderType: 107 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 102
+      ID: 96
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 82
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.006528e+06
@@ -829,7 +769,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.00512e+06
@@ -842,14 +782,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 90
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.963712e+06
       GoKind: 21
-      HeaderType: 92 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 83
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.005248e+06
@@ -862,7 +802,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.005504e+06
@@ -886,7 +826,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 88 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -898,19 +838,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 90 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 97 GoInterfaceType io.ReadCloser
+          Type: 91 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 98 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 92 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 99 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -919,16 +859,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 100 GoMapType net/url.Values
+          Type: 94 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 100 GoMapType net/url.Values
+          Type: 94 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 101 PointerType *mime/multipart.Form
+          Type: 95 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 90 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -937,30 +877,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 103 PointerType *crypto/tls.ConnectionState
+          Type: 97 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 105 GoChannelType <-chan struct {}
+          Type: 99 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 106 PointerType *net/http.Response
+          Type: 100 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 108 GoInterfaceType context.Context
+          Type: 102 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 109 PointerType *net/http.pattern
+          Type: 103 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 99 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 111 GoMapType map[string]string
+          Type: 105 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 107
+      ID: 101
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -977,30 +917,30 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 85
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 110
+      ID: 104
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 87
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 89
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 100
+      ID: 94
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.71184e+06
       GoKind: 21
-      HeaderType: 92 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 96
+      ID: 90
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -1012,17 +952,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 46 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 45 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 45
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 54
+      ID: 48
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.855808e+06
@@ -1030,12 +970,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 68
+      ID: 62
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.931104e+06
@@ -1043,15 +983,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 50
+      ID: 44
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.855296e+06
@@ -1059,12 +999,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 60
+      ID: 54
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.929952e+06
@@ -1072,15 +1012,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 74
+      ID: 68
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999552e+06
@@ -1088,18 +1028,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 62
+      ID: 56
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.93024e+06
@@ -1107,15 +1047,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 58
+      ID: 52
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.929664e+06
@@ -1123,15 +1063,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 70
+      ID: 64
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.998912e+06
@@ -1139,18 +1079,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 78
+      ID: 72
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.058656e+06
@@ -1158,21 +1098,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 72
+      ID: 66
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999232e+06
@@ -1180,18 +1120,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 56
+      ID: 50
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.856064e+06
@@ -1199,12 +1139,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 52
+      ID: 46
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.855552e+06
@@ -1212,12 +1152,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 64
+      ID: 58
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.930528e+06
@@ -1225,15 +1165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 76
+      ID: 70
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999872e+06
@@ -1241,18 +1181,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 66
+      ID: 60
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.930816e+06
@@ -1260,13 +1200,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -1309,6 +1249,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543392
       GoKind: 26
-MaxTypeID: 125
+MaxTypeID: 119
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 132 EventRootType Probe[main.HandleHTTP]
+          Type: 126 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 133 EventRootType Probe[main.LookAtTheRequest]
+          Type: 127 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -72,29 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0xd313e8..0xd31421
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 41 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd314f7..0xd31512
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd31512..0xd315f9
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 43 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0xd31360..0xd315f9
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd316c0..0xd31785]
@@ -113,20 +90,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 93
+      ID: 87
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 94 PointerType *table<string,[]string>
+      Pointee: 88 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 112
+      ID: 106
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 113 PointerType *table<string,string>
+      Pointee: 107 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 123
+      ID: 117
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 122 GoSliceDataType []string.array
+      Pointee: 116 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -135,19 +112,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 41
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.316768e+06
-      GoKind: 22
-      Pointee: 42 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 101
+      ID: 95
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 102 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 96 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -170,19 +140,12 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 39
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.32752e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 47
+      ID: 41
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.577632e+06
       GoKind: 22
-      Pointee: 48 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -219,22 +182,22 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 91
+      ID: 85
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 92 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 110
+      ID: 104
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 111 GoSwissMapHeaderType map<string,string>
+      Pointee: 105 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 99
+      ID: 93
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 100 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 94 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -243,50 +206,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 104
+      ID: 98
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 105 UnresolvedPointeeType net/http.Response
+      Pointee: 99 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 84
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.045344e+06
       GoKind: 22
-      Pointee: 85 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 107
+      ID: 101
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 108 UnresolvedPointeeType net/http.pattern
+      Pointee: 102 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 86
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.254144e+06
       GoKind: 22
-      Pointee: 87 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 88
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 89 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 116
+      ID: 110
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 117 StructureType noalg.map.group[string][]string
+      Pointee: 111 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 126
+      ID: 120
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 127 StructureType noalg.map.group[string]string
+      Pointee: 121 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -295,125 +258,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 46
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 45 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 53
+      ID: 47
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.716704e+06
       GoKind: 22
-      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 67
+      ID: 61
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774624e+06
       GoKind: 22
-      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 49
+      ID: 43
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.71632e+06
       GoKind: 22
-      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 59
+      ID: 53
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773856e+06
       GoKind: 22
-      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 73
+      ID: 67
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845888e+06
       GoKind: 22
-      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 61
+      ID: 55
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774048e+06
       GoKind: 22
-      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 57
+      ID: 51
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.773664e+06
       GoKind: 22
-      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 69
+      ID: 63
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.84544e+06
       GoKind: 22
-      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 77
+      ID: 71
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.918112e+06
       GoKind: 22
-      Pointee: 78 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 71
+      ID: 65
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845664e+06
       GoKind: 22
-      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 55
+      ID: 49
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.716896e+06
       GoKind: 22
-      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 51
+      ID: 45
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.716512e+06
       GoKind: 22
-      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 63
+      ID: 57
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.77424e+06
       GoKind: 22
-      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 75
+      ID: 69
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.846112e+06
       GoKind: 22
-      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 65
+      ID: 59
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774432e+06
       GoKind: 22
-      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 94
+      ID: 88
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 114 StructureType table<string,[]string>
+      Pointee: 108 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 113
+      ID: 107
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 124 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -457,12 +420,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 103
+      ID: 97
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: EventRootType
-      ID: 132
+      ID: 126
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -486,7 +449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 133
+      ID: 127
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -501,27 +464,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 114
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 94 PointerType *table<string,[]string>
+      Element: 88 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 124
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 113 PointerType *table<string,string>
+      Element: 107 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 121
+      ID: 115
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 117 StructureType noalg.map.group[string][]string
+      Element: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 131
+      ID: 125
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 127 StructureType noalg.map.group[string]string
+      Element: 121 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 91
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -536,9 +499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 122 GoSliceDataType []string.array
+      Data: 116 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 122
+      ID: 116
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -548,10 +511,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 591392
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 42
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -565,7 +524,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 106
+      ID: 100
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298688e+06
@@ -577,23 +536,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 43
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.827296e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 44 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 44
-      Name: context.emptyCtx
-      GoRuntimeType: 1.618752e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 102
+      ID: 96
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -622,17 +566,13 @@ Types:
       GoRuntimeType: 591328
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 96
+      ID: 90
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 73
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.440512e+06
@@ -645,37 +585,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 48
+      ID: 42
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 115
+      ID: 109
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 116 PointerType *noalg.map.group[string][]string
+          Type: 110 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 117 StructureType noalg.map.group[string][]string
-      GroupSliceType: 121 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
+      GroupSliceType: 115 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 125
+      ID: 119
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 126 PointerType *noalg.map.group[string]string
+          Type: 120 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 127 StructureType noalg.map.group[string]string
-      GroupSliceType: 131 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 121 StructureType noalg.map.group[string]string
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -707,7 +647,7 @@ Types:
       GoRuntimeType: 590432
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 95
+      ID: 89
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.130304e+06
@@ -720,7 +660,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 92
+      ID: 86
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -733,7 +673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 93 PointerType **table<string,[]string>
+          Type: 87 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -749,10 +689,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 120 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 117 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 114 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 111
+      ID: 105
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -765,7 +705,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 112 PointerType **table<string,string>
+          Type: 106 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -781,21 +721,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 130 GoSliceDataType []*table<string,string>.array
-      GroupType: 127 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,string>.array
+      GroupType: 121 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 109
+      ID: 103
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.149376e+06
       GoKind: 21
-      HeaderType: 111 GoSwissMapHeaderType map<string,string>
+      HeaderType: 105 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 100
+      ID: 94
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 82
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.04576e+06
@@ -808,7 +748,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.044352e+06
@@ -821,14 +761,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 90
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.148192e+06
       GoKind: 21
-      HeaderType: 92 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 83
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.04448e+06
@@ -841,7 +781,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.044736e+06
@@ -865,7 +805,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 88 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -877,19 +817,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 90 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 95 GoInterfaceType io.ReadCloser
+          Type: 89 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 96 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 90 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 97 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -898,16 +838,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 98 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 98 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 99 PointerType *mime/multipart.Form
+          Type: 93 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 90 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -916,30 +856,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 101 PointerType *crypto/tls.ConnectionState
+          Type: 95 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 103 GoChannelType <-chan struct {}
+          Type: 97 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 104 PointerType *net/http.Response
+          Type: 98 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 106 GoInterfaceType context.Context
+          Type: 100 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 107 PointerType *net/http.pattern
+          Type: 101 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 97 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 109 GoMapType map[string]string
+          Type: 103 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 105
+      ID: 99
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -956,48 +896,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 85
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 108
+      ID: 102
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 87
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 89
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 98
+      ID: 92
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.9208e+06
       GoKind: 21
-      HeaderType: 92 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 118
+      ID: 112
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 119 StructureType noalg.struct { key string; elem []string }
+      Element: 113 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 128
+      ID: 122
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 129 StructureType noalg.struct { key string; elem string }
+      Element: 123 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 117
+      ID: 111
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -1008,9 +948,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 118 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 112 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 127
+      ID: 121
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -1021,9 +961,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 128 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 122 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 119
+      ID: 113
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -1034,9 +974,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 97 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 129
+      ID: 123
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -1057,17 +997,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 46 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 45 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 45
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 54
+      ID: 48
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.982976e+06
@@ -1075,12 +1015,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 68
+      ID: 62
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.06032e+06
@@ -1088,15 +1028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 50
+      ID: 44
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.982464e+06
@@ -1104,12 +1044,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 60
+      ID: 54
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059168e+06
@@ -1117,15 +1057,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 74
+      ID: 68
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129376e+06
@@ -1133,18 +1073,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 62
+      ID: 56
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059456e+06
@@ -1152,15 +1092,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 58
+      ID: 52
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.05888e+06
@@ -1168,15 +1108,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 70
+      ID: 64
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.128736e+06
@@ -1184,18 +1124,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 78
+      ID: 72
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.191008e+06
@@ -1203,21 +1143,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 72
+      ID: 66
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129056e+06
@@ -1225,18 +1165,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 56
+      ID: 50
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.983232e+06
@@ -1244,12 +1184,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 52
+      ID: 46
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.98272e+06
@@ -1257,12 +1197,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 64
+      ID: 58
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059744e+06
@@ -1270,15 +1210,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 76
+      ID: 70
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129696e+06
@@ -1286,18 +1226,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 66
+      ID: 60
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.060032e+06
@@ -1305,15 +1245,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 114
+      ID: 108
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -1335,9 +1275,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 115 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 109 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 124
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -1359,7 +1299,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 125 GoSwissMapGroupsType groupReference<string,string>
+          Type: 119 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -1402,6 +1342,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591456
       GoKind: 26
-MaxTypeID: 133
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 130 EventRootType Probe[main.HandleHTTP]
+          Type: 126 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 131 EventRootType Probe[main.LookAtTheRequest]
+          Type: 127 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
 Subprograms:
@@ -72,22 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0xd363c8..0xd36401
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 41 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd364d7..0xd364f2
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd364f2..0xd365d9
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd366a0..0xd36765]
@@ -106,20 +90,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 91
+      ID: 87
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 92 PointerType *table<string,[]string>
+      Pointee: 88 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 110
+      ID: 106
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 111 PointerType *table<string,string>
+      Pointee: 107 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 121
+      ID: 117
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []string.array
+      Pointee: 116 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -128,19 +112,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 41
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.321376e+06
-      GoKind: 22
-      Pointee: 42 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 99
+      ID: 95
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 100 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 96 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -163,19 +140,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 39
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.33264e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 45
+      ID: 41
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.582816e+06
       GoKind: 22
-      Pointee: 46 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -212,22 +182,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 89
+      ID: 85
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 90 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 108
+      ID: 104
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 109 GoSwissMapHeaderType map<string,string>
+      Pointee: 105 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 97
+      ID: 93
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 98 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 94 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -236,50 +206,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 102
+      ID: 98
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.7584e+06
       GoKind: 22
-      Pointee: 103 UnresolvedPointeeType net/http.Response
+      Pointee: 99 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 82
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.053472e+06
       GoKind: 22
-      Pointee: 83 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 105
+      ID: 101
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642688e+06
       GoKind: 22
-      Pointee: 106 UnresolvedPointeeType net/http.pattern
+      Pointee: 102 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 84
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.27712e+06
       GoKind: 22
-      Pointee: 85 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 86
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 87 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 114
+      ID: 110
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 115 StructureType noalg.map.group[string][]string
+      Pointee: 111 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 124
+      ID: 120
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 125 StructureType noalg.map.group[string]string
+      Pointee: 121 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -288,125 +258,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 44
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 43 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 51
+      ID: 47
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.722368e+06
       GoKind: 22
-      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 65
+      ID: 61
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781632e+06
       GoKind: 22
-      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 47
+      ID: 43
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.721984e+06
       GoKind: 22
-      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 57
+      ID: 53
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.780864e+06
       GoKind: 22
-      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 71
+      ID: 67
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853888e+06
       GoKind: 22
-      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 59
+      ID: 55
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781056e+06
       GoKind: 22
-      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 55
+      ID: 51
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.780672e+06
       GoKind: 22
-      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 67
+      ID: 63
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.85344e+06
       GoKind: 22
-      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 75
+      ID: 71
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.925792e+06
       GoKind: 22
-      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 69
+      ID: 65
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853664e+06
       GoKind: 22
-      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 53
+      ID: 49
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.72256e+06
       GoKind: 22
-      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 49
+      ID: 45
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.722176e+06
       GoKind: 22
-      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 61
+      ID: 57
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.781248e+06
       GoKind: 22
-      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 73
+      ID: 69
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.854112e+06
       GoKind: 22
-      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 63
+      ID: 59
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.78144e+06
       GoKind: 22
-      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 92
+      ID: 88
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 112 StructureType table<string,[]string>
+      Pointee: 108 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 111
+      ID: 107
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 122 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -450,12 +420,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 101
+      ID: 97
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
     - __kind: EventRootType
-      ID: 130
+      ID: 126
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -479,7 +449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 131
+      ID: 127
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -494,27 +464,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 114
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 92 PointerType *table<string,[]string>
+      Element: 88 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 124
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 111 PointerType *table<string,string>
+      Element: 107 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 115
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 115 StructureType noalg.map.group[string][]string
+      Element: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 129
+      ID: 125
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 125 StructureType noalg.map.group[string]string
+      Element: 121 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 91
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -529,9 +499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 120 GoSliceDataType []string.array
+      Data: 116 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 116
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -541,10 +511,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 595232
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 42
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -558,7 +524,7 @@ Types:
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 104
+      ID: 100
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.3032e+06
@@ -571,7 +537,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 100
+      ID: 96
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -600,17 +566,13 @@ Types:
       GoRuntimeType: 595168
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 94
+      ID: 90
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 705088
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 77
+      ID: 73
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.445024e+06
@@ -623,37 +585,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 46
+      ID: 42
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 113
+      ID: 109
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 114 PointerType *noalg.map.group[string][]string
+          Type: 110 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 115 StructureType noalg.map.group[string][]string
-      GroupSliceType: 119 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
+      GroupSliceType: 115 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 123
+      ID: 119
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 124 PointerType *noalg.map.group[string]string
+          Type: 120 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 125 StructureType noalg.map.group[string]string
-      GroupSliceType: 129 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 121 StructureType noalg.map.group[string]string
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -685,7 +647,7 @@ Types:
       GoRuntimeType: 594272
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 93
+      ID: 89
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.135168e+06
@@ -698,7 +660,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 90
+      ID: 86
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -711,7 +673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 91 PointerType **table<string,[]string>
+          Type: 87 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -730,10 +692,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 118 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 115 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 114 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 109
+      ID: 105
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -746,7 +708,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 110 PointerType **table<string,string>
+          Type: 106 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -765,21 +727,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 128 GoSliceDataType []*table<string,string>.array
-      GroupType: 125 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,string>.array
+      GroupType: 121 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 107
+      ID: 103
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.15424e+06
       GoKind: 21
-      HeaderType: 109 GoSwissMapHeaderType map<string,string>
+      HeaderType: 105 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 98
+      ID: 94
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.05008e+06
@@ -792,7 +754,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 78
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.048544e+06
@@ -805,14 +767,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 88
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.15504e+06
       GoKind: 21
-      HeaderType: 90 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.048672e+06
@@ -825,7 +787,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.048928e+06
@@ -849,7 +811,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 86 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -861,19 +823,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 88 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 93 GoInterfaceType io.ReadCloser
+          Type: 89 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 94 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 90 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 95 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -882,16 +844,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 96 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 96 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 97 PointerType *mime/multipart.Form
+          Type: 93 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 88 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -900,30 +862,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 99 PointerType *crypto/tls.ConnectionState
+          Type: 95 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 101 GoChannelType <-chan struct {}
+          Type: 97 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 102 PointerType *net/http.Response
+          Type: 98 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 104 GoInterfaceType context.Context
+          Type: 100 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 105 PointerType *net/http.pattern
+          Type: 101 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 95 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 107 GoMapType map[string]string
+          Type: 103 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 103
+      ID: 99
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -940,48 +902,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 83
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 106
+      ID: 102
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 85
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 87
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 96
+      ID: 92
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.92848e+06
       GoKind: 21
-      HeaderType: 90 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 116
+      ID: 112
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 117 StructureType noalg.struct { key string; elem []string }
+      Element: 113 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 126
+      ID: 122
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 127 StructureType noalg.struct { key string; elem string }
+      Element: 123 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 115
+      ID: 111
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -992,9 +954,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 116 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 112 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 125
+      ID: 121
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -1005,9 +967,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 126 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 122 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 117
+      ID: 113
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -1018,9 +980,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 95 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 127
+      ID: 123
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -1041,17 +1003,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 44 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 43 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 43
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 52
+      ID: 48
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.991456e+06
@@ -1059,12 +1021,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 66
+      ID: 62
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.067584e+06
@@ -1072,15 +1034,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 48
+      ID: 44
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.990944e+06
@@ -1088,12 +1050,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 58
+      ID: 54
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.066432e+06
@@ -1101,15 +1063,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 72
+      ID: 68
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.137312e+06
@@ -1117,18 +1079,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 60
+      ID: 56
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.06672e+06
@@ -1136,15 +1098,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 56
+      ID: 52
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.066144e+06
@@ -1152,15 +1114,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 68
+      ID: 64
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.136672e+06
@@ -1168,18 +1130,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 76
+      ID: 72
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.199296e+06
@@ -1187,21 +1149,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 70
+      ID: 66
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136992e+06
@@ -1209,18 +1171,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 54
+      ID: 50
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.991712e+06
@@ -1228,12 +1190,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 50
+      ID: 46
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.9912e+06
@@ -1241,12 +1203,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 62
+      ID: 58
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.067008e+06
@@ -1254,15 +1216,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 74
+      ID: 70
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.137632e+06
@@ -1270,18 +1232,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 64
+      ID: 60
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.067296e+06
@@ -1289,15 +1251,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 112
+      ID: 108
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -1319,9 +1281,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 113 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 109 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 122
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -1343,7 +1305,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 123 GoSwissMapGroupsType groupReference<string,string>
+          Type: 119 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -1386,6 +1348,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595296
       GoKind: 26
-MaxTypeID: 131
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18bb880", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 124 EventRootType Probe[main.HandleHTTP]
+          Type: 118 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff40", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 125 EventRootType Probe[main.LookAtTheRequest]
+          Type: 119 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e025c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -72,29 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0x8dffa8..0x8dffd8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 41 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x8e007c..0x8e0098
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8e0098..0x8e0170
-              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 43 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0x8dff30..0x8e0170
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8e0250..0x8e0310]
@@ -113,10 +90,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 121
+      ID: 115
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []string.array
+      Pointee: 114 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -125,29 +102,22 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 93
+      ID: 87
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 94 GoHMapBucketType bucket<string,[]string>
+      Pointee: 88 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 114
+      ID: 108
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 115 GoHMapBucketType bucket<string,string>
+      Pointee: 109 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 41
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.176896e+06
-      GoKind: 22
-      Pointee: 42 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 103
+      ID: 97
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 104 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 98 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -170,29 +140,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 39
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.18768e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 47
+      ID: 41
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.397152e+06
       GoKind: 22
-      Pointee: 48 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 91
+      ID: 85
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 92 GoHMapHeaderType hash<string,[]string>
+      Pointee: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 112
+      ID: 106
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 113 GoHMapHeaderType hash<string,string>
+      Pointee: 107 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -229,12 +192,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 101
+      ID: 95
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 102 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 96 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -243,47 +206,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 106
+      ID: 100
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 107 UnresolvedPointeeType net/http.Response
+      Pointee: 101 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 84
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.8768e+06
       GoKind: 22
-      Pointee: 85 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 109
+      ID: 103
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 110 UnresolvedPointeeType net/http.pattern
+      Pointee: 104 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 86
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.11776e+06
       GoKind: 22
-      Pointee: 87 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 88
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 89 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 95
+      ID: 89
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 380000
       GoKind: 22
-      Pointee: 96 UnresolvedPointeeType runtime.mapextra
+      Pointee: 90 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -292,115 +255,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 46
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 45 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 53
+      ID: 47
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.5328e+06
       GoKind: 22
-      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 67
+      ID: 61
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.657312e+06
       GoKind: 22
-      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 49
+      ID: 43
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.532416e+06
       GoKind: 22
-      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 59
+      ID: 53
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656544e+06
       GoKind: 22
-      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 73
+      ID: 67
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.7272e+06
       GoKind: 22
-      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 61
+      ID: 55
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656736e+06
       GoKind: 22
-      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 57
+      ID: 51
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.656352e+06
       GoKind: 22
-      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 69
+      ID: 63
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.726752e+06
       GoKind: 22
-      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 77
+      ID: 71
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.795072e+06
       GoKind: 22
-      Pointee: 78 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 71
+      ID: 65
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726976e+06
       GoKind: 22
-      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 55
+      ID: 49
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.532992e+06
       GoKind: 22
-      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 51
+      ID: 45
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.532608e+06
       GoKind: 22
-      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 63
+      ID: 57
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656928e+06
       GoKind: 22
-      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 75
+      ID: 69
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.727424e+06
       GoKind: 22
-      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 65
+      ID: 59
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.65712e+06
       GoKind: 22
-      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -444,12 +407,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 105
+      ID: 99
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: EventRootType
-      ID: 124
+      ID: 118
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -473,7 +436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 125
+      ID: 119
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -488,7 +451,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 116
+      ID: 110
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -497,24 +460,24 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 113
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 94 GoHMapBucketType bucket<string,[]string>
+      Element: 88 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 117
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 115 GoHMapBucketType bucket<string,string>
+      Element: 109 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 117
+      ID: 111
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 93
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -529,21 +492,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 120 GoSliceDataType []string.array
+      Data: 114 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 114
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 118
+      ID: 112
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 99 GoSliceHeaderType []string
+      Element: 93 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 122
+      ID: 116
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -556,47 +519,43 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 94
+      ID: 88
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 116 ArrayType [8]uint8
+          Type: 110 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 117 ArrayType []key<string>
+          Type: 111 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 118 ArrayType []val<[]string>
+          Type: 112 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 93 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 99 GoSliceHeaderType []string
+      ValueType: 93 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 115
+      ID: 109
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 116 ArrayType [8]uint8
+          Type: 110 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 117 ArrayType []key<string>
+          Type: 111 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 122 ArrayType []val<string>
+          Type: 116 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 114 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: UnresolvedPointeeType
-      ID: 42
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -610,7 +569,7 @@ Types:
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 108
+      ID: 102
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215776e+06
@@ -622,23 +581,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 43
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.708832e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 44 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 44
-      Name: context.emptyCtx
-      GoRuntimeType: 1.435104e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 104
+      ID: 98
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -667,17 +611,13 @@ Types:
       GoRuntimeType: 543488
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 98
+      ID: 92
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 73
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.26592e+06
@@ -690,11 +630,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 48
+      ID: 42
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 92
+      ID: 86
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -715,20 +655,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 93 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 93 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 95 PointerType *runtime.mapextra
-      BucketType: 94 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 119 GoSliceDataType []bucket<string,[]string>.array
+          Type: 89 PointerType *runtime.mapextra
+      BucketType: 88 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 113 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 113
+      ID: 107
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -749,18 +689,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 114 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 114 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 95 PointerType *runtime.mapextra
-      BucketType: 115 GoHMapBucketType bucket<string,string>
-      BucketsType: 123 GoSliceDataType []bucket<string,string>.array
+          Type: 89 PointerType *runtime.mapextra
+      BucketType: 109 GoHMapBucketType bucket<string,string>
+      BucketsType: 117 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -792,7 +732,7 @@ Types:
       GoRuntimeType: 542592
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 97
+      ID: 91
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.093088e+06
@@ -805,18 +745,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 111
+      ID: 105
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 113 GoHMapHeaderType hash<string,string>
+      HeaderType: 107 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 102
+      ID: 96
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 82
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.006752e+06
@@ -829,7 +769,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.005344e+06
@@ -842,14 +782,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 90
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.964288e+06
       GoKind: 21
-      HeaderType: 92 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 83
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.005472e+06
@@ -862,7 +802,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.005728e+06
@@ -886,7 +826,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 88 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -898,19 +838,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 90 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 97 GoInterfaceType io.ReadCloser
+          Type: 91 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 98 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 92 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 99 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -919,16 +859,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 100 GoMapType net/url.Values
+          Type: 94 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 100 GoMapType net/url.Values
+          Type: 94 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 101 PointerType *mime/multipart.Form
+          Type: 95 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 90 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -937,30 +877,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 103 PointerType *crypto/tls.ConnectionState
+          Type: 97 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 105 GoChannelType <-chan struct {}
+          Type: 99 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 106 PointerType *net/http.Response
+          Type: 100 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 108 GoInterfaceType context.Context
+          Type: 102 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 109 PointerType *net/http.pattern
+          Type: 103 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 99 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 111 GoMapType map[string]string
+          Type: 105 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 107
+      ID: 101
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -977,30 +917,30 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 85
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 110
+      ID: 104
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 87
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 89
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 100
+      ID: 94
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.712416e+06
       GoKind: 21
-      HeaderType: 92 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 96
+      ID: 90
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -1012,17 +952,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 46 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 45 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 45
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 54
+      ID: 48
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.856384e+06
@@ -1030,12 +970,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 68
+      ID: 62
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.93168e+06
@@ -1043,15 +983,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 50
+      ID: 44
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.855872e+06
@@ -1059,12 +999,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 60
+      ID: 54
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.930528e+06
@@ -1072,15 +1012,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 74
+      ID: 68
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.000128e+06
@@ -1088,18 +1028,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 62
+      ID: 56
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.930816e+06
@@ -1107,15 +1047,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 58
+      ID: 52
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.93024e+06
@@ -1123,15 +1063,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 70
+      ID: 64
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.999488e+06
@@ -1139,18 +1079,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 78
+      ID: 72
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.059232e+06
@@ -1158,21 +1098,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 72
+      ID: 66
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999808e+06
@@ -1180,18 +1120,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 56
+      ID: 50
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.85664e+06
@@ -1199,12 +1139,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 52
+      ID: 46
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.856128e+06
@@ -1212,12 +1152,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 64
+      ID: 58
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.931104e+06
@@ -1225,15 +1165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 76
+      ID: 70
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.000448e+06
@@ -1241,18 +1181,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 66
+      ID: 60
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.931392e+06
@@ -1260,13 +1200,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -1309,6 +1249,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543616
       GoKind: 26
-MaxTypeID: 125
+MaxTypeID: 119
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 132 EventRootType Probe[main.HandleHTTP]
+          Type: 126 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0ca0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 133 EventRootType Probe[main.LookAtTheRequest]
+          Type: 127 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0f9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -72,29 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0x8a0d08..0x8a0d38
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 41 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x8a0ddc..0x8a0df0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8a0df0..0x8a0ec0
-              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 43 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0x8a0c90..0x8a0ec0
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8a0f90..0x8a1040]
@@ -113,20 +90,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 93
+      ID: 87
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 94 PointerType *table<string,[]string>
+      Pointee: 88 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 112
+      ID: 106
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 113 PointerType *table<string,string>
+      Pointee: 107 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 123
+      ID: 117
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 122 GoSliceDataType []string.array
+      Pointee: 116 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -135,19 +112,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 41
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.316032e+06
-      GoKind: 22
-      Pointee: 42 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 101
+      ID: 95
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 102 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 96 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -170,19 +140,12 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 39
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.326784e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 47
+      ID: 41
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.57712e+06
       GoKind: 22
-      Pointee: 48 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -219,22 +182,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 91
+      ID: 85
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 92 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 110
+      ID: 104
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 111 GoSwissMapHeaderType map<string,string>
+      Pointee: 105 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 99
+      ID: 93
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 100 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 94 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -243,50 +206,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 104
+      ID: 98
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 105 UnresolvedPointeeType net/http.Response
+      Pointee: 99 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 84
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.044608e+06
       GoKind: 22
-      Pointee: 85 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 107
+      ID: 101
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 108 UnresolvedPointeeType net/http.pattern
+      Pointee: 102 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 86
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.253408e+06
       GoKind: 22
-      Pointee: 87 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 88
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 89 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 116
+      ID: 110
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 117 StructureType noalg.map.group[string][]string
+      Pointee: 111 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 126
+      ID: 120
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 127 StructureType noalg.map.group[string]string
+      Pointee: 121 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -295,125 +258,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 46
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 45 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 53
+      ID: 47
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.716192e+06
       GoKind: 22
-      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 67
+      ID: 61
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774112e+06
       GoKind: 22
-      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 49
+      ID: 43
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.715808e+06
       GoKind: 22
-      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 59
+      ID: 53
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773344e+06
       GoKind: 22
-      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 73
+      ID: 67
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845376e+06
       GoKind: 22
-      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 61
+      ID: 55
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.773536e+06
       GoKind: 22
-      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 57
+      ID: 51
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.773152e+06
       GoKind: 22
-      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 69
+      ID: 63
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.844928e+06
       GoKind: 22
-      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 77
+      ID: 71
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.917376e+06
       GoKind: 22
-      Pointee: 78 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 71
+      ID: 65
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845152e+06
       GoKind: 22
-      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 55
+      ID: 49
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.716384e+06
       GoKind: 22
-      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 51
+      ID: 45
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.716e+06
       GoKind: 22
-      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 63
+      ID: 57
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773728e+06
       GoKind: 22
-      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 75
+      ID: 69
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.8456e+06
       GoKind: 22
-      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 65
+      ID: 59
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.77392e+06
       GoKind: 22
-      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 94
+      ID: 88
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 114 StructureType table<string,[]string>
+      Pointee: 108 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 113
+      ID: 107
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 124 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -457,12 +420,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 103
+      ID: 97
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: EventRootType
-      ID: 132
+      ID: 126
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -486,7 +449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 133
+      ID: 127
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -501,27 +464,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 114
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 94 PointerType *table<string,[]string>
+      Element: 88 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 124
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 113 PointerType *table<string,string>
+      Element: 107 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 121
+      ID: 115
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 117 StructureType noalg.map.group[string][]string
+      Element: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 131
+      ID: 125
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 127 StructureType noalg.map.group[string]string
+      Element: 121 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 91
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -536,9 +499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 122 GoSliceDataType []string.array
+      Data: 116 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 122
+      ID: 116
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -548,10 +511,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 591200
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 42
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -565,7 +524,7 @@ Types:
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 106
+      ID: 100
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298016e+06
@@ -577,23 +536,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 43
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.826784e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 44 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 44
-      Name: context.emptyCtx
-      GoRuntimeType: 1.61824e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 102
+      ID: 96
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -622,17 +566,13 @@ Types:
       GoRuntimeType: 591136
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 96
+      ID: 90
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 73
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.43984e+06
@@ -645,37 +585,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 48
+      ID: 42
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 115
+      ID: 109
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 116 PointerType *noalg.map.group[string][]string
+          Type: 110 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 117 StructureType noalg.map.group[string][]string
-      GroupSliceType: 121 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
+      GroupSliceType: 115 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 125
+      ID: 119
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 126 PointerType *noalg.map.group[string]string
+          Type: 120 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 127 StructureType noalg.map.group[string]string
-      GroupSliceType: 131 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 121 StructureType noalg.map.group[string]string
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -707,7 +647,7 @@ Types:
       GoRuntimeType: 590240
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 95
+      ID: 89
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.129632e+06
@@ -720,7 +660,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 92
+      ID: 86
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -733,7 +673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 93 PointerType **table<string,[]string>
+          Type: 87 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -749,10 +689,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 120 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 117 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 114 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 111
+      ID: 105
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -765,7 +705,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 112 PointerType **table<string,string>
+          Type: 106 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -781,21 +721,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 130 GoSliceDataType []*table<string,string>.array
-      GroupType: 127 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,string>.array
+      GroupType: 121 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 109
+      ID: 103
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.148704e+06
       GoKind: 21
-      HeaderType: 111 GoSwissMapHeaderType map<string,string>
+      HeaderType: 105 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 100
+      ID: 94
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 82
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.045088e+06
@@ -808,7 +748,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.04368e+06
@@ -821,14 +761,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 90
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.147456e+06
       GoKind: 21
-      HeaderType: 92 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 83
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.043808e+06
@@ -841,7 +781,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.044064e+06
@@ -865,7 +805,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 88 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -877,19 +817,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 90 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 95 GoInterfaceType io.ReadCloser
+          Type: 89 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 96 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 90 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 97 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -898,16 +838,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 98 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 98 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 99 PointerType *mime/multipart.Form
+          Type: 93 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 90 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -916,30 +856,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 101 PointerType *crypto/tls.ConnectionState
+          Type: 95 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 103 GoChannelType <-chan struct {}
+          Type: 97 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 104 PointerType *net/http.Response
+          Type: 98 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 106 GoInterfaceType context.Context
+          Type: 100 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 107 PointerType *net/http.pattern
+          Type: 101 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 97 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 109 GoMapType map[string]string
+          Type: 103 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 105
+      ID: 99
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -956,48 +896,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 85
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 108
+      ID: 102
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 87
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 89
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 98
+      ID: 92
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.920064e+06
       GoKind: 21
-      HeaderType: 92 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 118
+      ID: 112
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 119 StructureType noalg.struct { key string; elem []string }
+      Element: 113 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 128
+      ID: 122
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 129 StructureType noalg.struct { key string; elem string }
+      Element: 123 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 117
+      ID: 111
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -1008,9 +948,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 118 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 112 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 127
+      ID: 121
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -1021,9 +961,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 128 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 122 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 119
+      ID: 113
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -1034,9 +974,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 97 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 129
+      ID: 123
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -1057,17 +997,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 46 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 45 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 45
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 54
+      ID: 48
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.98224e+06
@@ -1075,12 +1015,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 68
+      ID: 62
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059584e+06
@@ -1088,15 +1028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 50
+      ID: 44
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.981728e+06
@@ -1104,12 +1044,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 60
+      ID: 54
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.058432e+06
@@ -1117,15 +1057,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 74
+      ID: 68
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12864e+06
@@ -1133,18 +1073,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 62
+      ID: 56
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.05872e+06
@@ -1152,15 +1092,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 58
+      ID: 52
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.058144e+06
@@ -1168,15 +1108,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 70
+      ID: 64
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.128e+06
@@ -1184,18 +1124,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 78
+      ID: 72
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.190272e+06
@@ -1203,21 +1143,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 72
+      ID: 66
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12832e+06
@@ -1225,18 +1165,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 56
+      ID: 50
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.982496e+06
@@ -1244,12 +1184,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 52
+      ID: 46
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.981984e+06
@@ -1257,12 +1197,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 64
+      ID: 58
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059008e+06
@@ -1270,15 +1210,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 76
+      ID: 70
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12896e+06
@@ -1286,18 +1226,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 82 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 66
+      ID: 60
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059296e+06
@@ -1305,15 +1245,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 79 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 83 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 114
+      ID: 108
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -1335,9 +1275,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 115 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 109 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 124
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -1359,7 +1299,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 125 GoSwissMapGroupsType groupReference<string,string>
+          Type: 119 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -1402,6 +1342,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591264
       GoKind: 26
-MaxTypeID: 133
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 130 EventRootType Probe[main.HandleHTTP]
+          Type: 126 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859980", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 131 EventRootType Probe[main.LookAtTheRequest]
+          Type: 127 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c5c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -72,22 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: span
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-          Locations:
-            - Range: 0x8599e4..0x859a14
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: '&buf'
-          Type: 41 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x859aa0..0x859ab8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x859ab8..0x859b80
-              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x859c50..0x859cf0]
@@ -106,20 +90,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 91
+      ID: 87
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 92 PointerType *table<string,[]string>
+      Pointee: 88 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 110
+      ID: 106
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 111 PointerType *table<string,string>
+      Pointee: 107 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 121
+      ID: 117
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 120 GoSliceDataType []string.array
+      Pointee: 116 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -128,19 +112,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 41
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.320608e+06
-      GoKind: 22
-      Pointee: 42 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 99
+      ID: 95
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 100 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 96 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -163,19 +140,12 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 39
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.331872e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 45
+      ID: 41
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.582272e+06
       GoKind: 22
-      Pointee: 46 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -212,22 +182,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 89
+      ID: 85
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 90 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 108
+      ID: 104
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 109 GoSwissMapHeaderType map<string,string>
+      Pointee: 105 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 97
+      ID: 93
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 98 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 94 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -236,50 +206,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 102
+      ID: 98
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.757856e+06
       GoKind: 22
-      Pointee: 103 UnresolvedPointeeType net/http.Response
+      Pointee: 99 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 82
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.052704e+06
       GoKind: 22
-      Pointee: 83 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 105
+      ID: 101
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642144e+06
       GoKind: 22
-      Pointee: 106 UnresolvedPointeeType net/http.pattern
+      Pointee: 102 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 84
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.276352e+06
       GoKind: 22
-      Pointee: 85 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 86
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 87 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 114
+      ID: 110
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 115 StructureType noalg.map.group[string][]string
+      Pointee: 111 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 124
+      ID: 120
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 125 StructureType noalg.map.group[string]string
+      Pointee: 121 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -288,125 +258,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 44
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 43 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 51
+      ID: 47
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.721824e+06
       GoKind: 22
-      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 65
+      ID: 61
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781088e+06
       GoKind: 22
-      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 47
+      ID: 43
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.72144e+06
       GoKind: 22
-      Pointee: 48 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 57
+      ID: 53
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.78032e+06
       GoKind: 22
-      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 71
+      ID: 67
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853344e+06
       GoKind: 22
-      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 59
+      ID: 55
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.780512e+06
       GoKind: 22
-      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 55
+      ID: 51
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.780128e+06
       GoKind: 22
-      Pointee: 56 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 67
+      ID: 63
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.852896e+06
       GoKind: 22
-      Pointee: 68 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 75
+      ID: 71
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.925024e+06
       GoKind: 22
-      Pointee: 76 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 69
+      ID: 65
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.85312e+06
       GoKind: 22
-      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 53
+      ID: 49
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.722016e+06
       GoKind: 22
-      Pointee: 54 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 49
+      ID: 45
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.721632e+06
       GoKind: 22
-      Pointee: 50 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 61
+      ID: 57
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.780704e+06
       GoKind: 22
-      Pointee: 62 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 73
+      ID: 69
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853568e+06
       GoKind: 22
-      Pointee: 74 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 63
+      ID: 59
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.780896e+06
       GoKind: 22
-      Pointee: 64 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 92
+      ID: 88
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 112 StructureType table<string,[]string>
+      Pointee: 108 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 111
+      ID: 107
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 122 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -450,12 +420,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 101
+      ID: 97
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
     - __kind: EventRootType
-      ID: 130
+      ID: 126
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -479,7 +449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 131
+      ID: 127
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -494,27 +464,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 114
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 92 PointerType *table<string,[]string>
+      Element: 88 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 124
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 111 PointerType *table<string,string>
+      Element: 107 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 115
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 115 StructureType noalg.map.group[string][]string
+      Element: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 129
+      ID: 125
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 125 StructureType noalg.map.group[string]string
+      Element: 121 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 91
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -529,9 +499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 120 GoSliceDataType []string.array
+      Data: 116 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 116
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -541,10 +511,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 595008
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 42
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -558,7 +524,7 @@ Types:
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 104
+      ID: 100
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.302496e+06
@@ -571,7 +537,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 100
+      ID: 96
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -600,17 +566,13 @@ Types:
       GoRuntimeType: 594944
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 94
+      ID: 90
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 704864
       GoKind: 19
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 77
+      ID: 73
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.44432e+06
@@ -623,37 +585,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 46
+      ID: 42
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 113
+      ID: 109
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 114 PointerType *noalg.map.group[string][]string
+          Type: 110 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 115 StructureType noalg.map.group[string][]string
-      GroupSliceType: 119 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
+      GroupSliceType: 115 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 123
+      ID: 119
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 124 PointerType *noalg.map.group[string]string
+          Type: 120 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 125 StructureType noalg.map.group[string]string
-      GroupSliceType: 129 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 121 StructureType noalg.map.group[string]string
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -685,7 +647,7 @@ Types:
       GoRuntimeType: 594048
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 93
+      ID: 89
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.134464e+06
@@ -698,7 +660,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 90
+      ID: 86
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -711,7 +673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 91 PointerType **table<string,[]string>
+          Type: 87 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -730,10 +692,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 118 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 115 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 114 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 109
+      ID: 105
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -746,7 +708,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 110 PointerType **table<string,string>
+          Type: 106 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -765,21 +727,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 128 GoSliceDataType []*table<string,string>.array
-      GroupType: 125 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,string>.array
+      GroupType: 121 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 107
+      ID: 103
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.153536e+06
       GoKind: 21
-      HeaderType: 109 GoSwissMapHeaderType map<string,string>
+      HeaderType: 105 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 98
+      ID: 94
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.049376e+06
@@ -792,7 +754,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 78
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.04784e+06
@@ -805,14 +767,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 88
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.154272e+06
       GoKind: 21
-      HeaderType: 90 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.047968e+06
@@ -825,7 +787,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.048224e+06
@@ -849,7 +811,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 86 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -861,19 +823,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 88 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 93 GoInterfaceType io.ReadCloser
+          Type: 89 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 94 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 90 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 95 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -882,16 +844,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 96 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 96 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 97 PointerType *mime/multipart.Form
+          Type: 93 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 88 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -900,30 +862,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 99 PointerType *crypto/tls.ConnectionState
+          Type: 95 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 101 GoChannelType <-chan struct {}
+          Type: 97 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 102 PointerType *net/http.Response
+          Type: 98 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 104 GoInterfaceType context.Context
+          Type: 100 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 105 PointerType *net/http.pattern
+          Type: 101 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 95 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 107 GoMapType map[string]string
+          Type: 103 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 103
+      ID: 99
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -940,48 +902,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 83
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 106
+      ID: 102
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 85
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 87
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 96
+      ID: 92
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.927712e+06
       GoKind: 21
-      HeaderType: 90 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 116
+      ID: 112
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 117 StructureType noalg.struct { key string; elem []string }
+      Element: 113 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 126
+      ID: 122
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 127 StructureType noalg.struct { key string; elem string }
+      Element: 123 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 115
+      ID: 111
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -992,9 +954,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 116 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 112 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 125
+      ID: 121
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -1005,9 +967,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 126 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 122 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 117
+      ID: 113
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -1018,9 +980,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 95 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 127
+      ID: 123
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -1041,17 +1003,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 44 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 43 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 43
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 52
+      ID: 48
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.990688e+06
@@ -1059,12 +1021,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 66
+      ID: 62
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.066816e+06
@@ -1072,15 +1034,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 48
+      ID: 44
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.990176e+06
@@ -1088,12 +1050,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 58
+      ID: 54
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.065664e+06
@@ -1101,15 +1063,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 72
+      ID: 68
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136544e+06
@@ -1117,18 +1079,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 60
+      ID: 56
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.065952e+06
@@ -1136,15 +1098,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 56
+      ID: 52
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.065376e+06
@@ -1152,15 +1114,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 68
+      ID: 64
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.135904e+06
@@ -1168,18 +1130,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 76
+      ID: 72
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.198528e+06
@@ -1187,21 +1149,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 70
+      ID: 66
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136224e+06
@@ -1209,18 +1171,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 54
+      ID: 50
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.990944e+06
@@ -1228,12 +1190,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 50
+      ID: 46
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.990432e+06
@@ -1241,12 +1203,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 62
+      ID: 58
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.06624e+06
@@ -1254,15 +1216,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 74
+      ID: 70
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136864e+06
@@ -1270,18 +1232,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 80 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 64
+      ID: 60
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.066528e+06
@@ -1289,15 +1251,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 77 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 81 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 112
+      ID: 108
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -1319,9 +1281,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 113 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 109 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 122
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -1343,7 +1305,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 123 GoSwissMapGroupsType groupReference<string,string>
+          Type: 119 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -1386,6 +1348,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595072
       GoKind: 26
-MaxTypeID: 131
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x139d860", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 123 EventRootType Probe[main.HandleHTTP]
+          Type: 118 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 124 EventRootType Probe[main.LookAtTheRequest]
+          Type: 119 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -72,45 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 39 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd28b8f..0xd28bb1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd28bb1..0xd28c90
-              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0xd28a68..0xd28a68
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xd28a68..0xd28aa8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd28aa8..0xd28aac
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 42 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0xd289e0..0xd28c90
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd28d60..0xd28e25]
@@ -129,10 +90,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 120
+      ID: 115
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []string.array
+      Pointee: 114 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -141,29 +102,22 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 92
+      ID: 87
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 93 GoHMapBucketType bucket<string,[]string>
+      Pointee: 88 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 113
+      ID: 108
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 114 GoHMapBucketType bucket<string,string>
+      Pointee: 109 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 39
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.114976e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 102
+      ID: 97
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 103 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 98 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -186,22 +140,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 46
+      ID: 41
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.361664e+06
       GoKind: 22
-      Pointee: 47 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 90
+      ID: 85
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 91 GoHMapHeaderType hash<string,[]string>
+      Pointee: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 111
+      ID: 106
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 112 GoHMapHeaderType hash<string,string>
+      Pointee: 107 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -238,12 +192,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 100
+      ID: 95
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 101 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 96 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -252,47 +206,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 105
+      ID: 100
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 106 UnresolvedPointeeType net/http.Response
+      Pointee: 101 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 83
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.832832e+06
       GoKind: 22
-      Pointee: 84 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 108
+      ID: 103
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 109 UnresolvedPointeeType net/http.pattern
+      Pointee: 104 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 85
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.059008e+06
       GoKind: 22
-      Pointee: 86 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 87
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 88 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 94
+      ID: 89
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 95 UnresolvedPointeeType runtime.mapextra
+      Pointee: 90 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -301,115 +255,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 45
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 44 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 52
+      ID: 47
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.495904e+06
       GoKind: 22
-      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 66
+      ID: 61
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.61568e+06
       GoKind: 22
-      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 48
+      ID: 43
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.49552e+06
       GoKind: 22
-      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 58
+      ID: 53
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.614912e+06
       GoKind: 22
-      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 72
+      ID: 67
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.684896e+06
       GoKind: 22
-      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 60
+      ID: 55
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615104e+06
       GoKind: 22
-      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 56
+      ID: 51
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.61472e+06
       GoKind: 22
-      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 68
+      ID: 63
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.684448e+06
       GoKind: 22
-      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 76
+      ID: 71
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.750176e+06
       GoKind: 22
-      Pointee: 77 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 70
+      ID: 65
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.684672e+06
       GoKind: 22
-      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 54
+      ID: 49
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.496096e+06
       GoKind: 22
-      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 50
+      ID: 45
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.495712e+06
       GoKind: 22
-      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 62
+      ID: 57
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.615296e+06
       GoKind: 22
-      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 74
+      ID: 69
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.68512e+06
       GoKind: 22
-      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 64
+      ID: 59
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615488e+06
       GoKind: 22
-      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -453,12 +407,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 104
+      ID: 99
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: EventRootType
-      ID: 123
+      ID: 118
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -482,7 +436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 124
+      ID: 119
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -497,7 +451,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 115
+      ID: 110
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -506,24 +460,24 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 113
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 93 GoHMapBucketType bucket<string,[]string>
+      Element: 88 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 122
+      ID: 117
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 114 GoHMapBucketType bucket<string,string>
+      Element: 109 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 116
+      ID: 111
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 93
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -538,21 +492,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 119 GoSliceDataType []string.array
+      Data: 114 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 114
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 117
+      ID: 112
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 98 GoSliceHeaderType []string
+      Element: 93 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 121
+      ID: 116
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -565,47 +519,43 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 93
+      ID: 88
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 115 ArrayType [8]uint8
+          Type: 110 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 116 ArrayType []key<string>
+          Type: 111 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 117 ArrayType []val<[]string>
+          Type: 112 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 92 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 98 GoSliceHeaderType []string
+      ValueType: 93 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 114
+      ID: 109
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 115 ArrayType [8]uint8
+          Type: 110 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 116 ArrayType []key<string>
+          Type: 111 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 121 ArrayType []val<string>
+          Type: 116 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 113 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -619,7 +569,7 @@ Types:
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 107
+      ID: 102
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187104e+06
@@ -631,23 +581,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 42
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.6672e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 43 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 43
-      Name: context.emptyCtx
-      GoRuntimeType: 1.399456e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 103
+      ID: 98
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -676,13 +611,13 @@ Types:
       GoRuntimeType: 534528
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 97
+      ID: 92
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 78
+      ID: 73
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.235648e+06
@@ -695,24 +630,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 47
+      ID: 42
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 41
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.295936e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 91
+      ID: 86
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -733,20 +655,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 92 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 92 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 94 PointerType *runtime.mapextra
-      BucketType: 93 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 118 GoSliceDataType []bucket<string,[]string>.array
+          Type: 89 PointerType *runtime.mapextra
+      BucketType: 88 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 113 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 112
+      ID: 107
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -767,18 +689,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 113 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 113 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 94 PointerType *runtime.mapextra
-      BucketType: 114 GoHMapBucketType bucket<string,string>
-      BucketsType: 122 GoSliceDataType []bucket<string,string>.array
+          Type: 89 PointerType *runtime.mapextra
+      BucketType: 109 GoHMapBucketType bucket<string,string>
+      BucketsType: 117 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -810,7 +732,7 @@ Types:
       GoRuntimeType: 533632
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 96
+      ID: 91
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067136e+06
@@ -823,18 +745,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 110
+      ID: 105
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 112 GoHMapHeaderType hash<string,string>
+      HeaderType: 107 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 101
+      ID: 96
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 983104
@@ -847,7 +769,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 981696
@@ -860,14 +782,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 89
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.91744e+06
       GoKind: 21
-      HeaderType: 91 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 82
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 981824
@@ -880,7 +802,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 982080
@@ -904,7 +826,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 87 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -916,19 +838,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 89 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 96 GoInterfaceType io.ReadCloser
+          Type: 91 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 97 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 92 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 98 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -937,16 +859,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 99 GoMapType net/url.Values
+          Type: 94 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 99 GoMapType net/url.Values
+          Type: 94 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 100 PointerType *mime/multipart.Form
+          Type: 95 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 89 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -955,30 +877,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 102 PointerType *crypto/tls.ConnectionState
+          Type: 97 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 104 GoChannelType <-chan struct {}
+          Type: 99 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 105 PointerType *net/http.Response
+          Type: 100 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 107 GoInterfaceType context.Context
+          Type: 102 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 108 PointerType *net/http.pattern
+          Type: 103 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 98 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 110 GoMapType map[string]string
+          Type: 105 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 106
+      ID: 101
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -995,30 +917,30 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 84
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 109
+      ID: 104
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 86
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 88
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 99
+      ID: 94
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.670784e+06
       GoKind: 21
-      HeaderType: 91 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 95
+      ID: 90
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -1030,17 +952,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 45 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 44 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 44
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 53
+      ID: 48
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.810144e+06
@@ -1048,12 +970,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 67
+      ID: 62
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885248e+06
@@ -1061,15 +983,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 49
+      ID: 44
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.809632e+06
@@ -1077,12 +999,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 59
+      ID: 54
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.884096e+06
@@ -1090,15 +1012,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 73
+      ID: 68
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.9472e+06
@@ -1106,18 +1028,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 61
+      ID: 56
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.884384e+06
@@ -1125,15 +1047,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 57
+      ID: 52
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.883808e+06
@@ -1141,15 +1063,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 69
+      ID: 64
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.94656e+06
@@ -1157,18 +1079,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 77
+      ID: 72
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.005088e+06
@@ -1176,21 +1098,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 71
+      ID: 66
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.94688e+06
@@ -1198,18 +1120,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 55
+      ID: 50
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.8104e+06
@@ -1217,12 +1139,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 51
+      ID: 46
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.809888e+06
@@ -1230,12 +1152,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 63
+      ID: 58
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.884672e+06
@@ -1243,15 +1165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 75
+      ID: 70
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.94752e+06
@@ -1259,18 +1181,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 65
+      ID: 60
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.88496e+06
@@ -1278,13 +1200,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -1327,6 +1249,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534656
       GoKind: 26
-MaxTypeID: 124
+MaxTypeID: 119
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 131 EventRootType Probe[main.HandleHTTP]
+          Type: 126 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 132 EventRootType Probe[main.LookAtTheRequest]
+          Type: 127 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -72,45 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 39 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xcfc7ee..0xcfc809
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcfc809..0xcfc8f0
-              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0xcfc6c8..0xcfc6c8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xcfc6c8..0xcfc708
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcfc708..0xcfc70c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 42 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0xcfc640..0xcfc8f0
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xcfc9c0..0xcfca85]
@@ -129,20 +90,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 92
+      ID: 87
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 93 PointerType *table<string,[]string>
+      Pointee: 88 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 111
+      ID: 106
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 112 PointerType *table<string,string>
+      Pointee: 107 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 122
+      ID: 117
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 121 GoSliceDataType []string.array
+      Pointee: 116 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -151,19 +112,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 39
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.245824e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 100
+      ID: 95
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 101 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 96 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -186,12 +140,12 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 46
+      ID: 41
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.539904e+06
       GoKind: 22
-      Pointee: 47 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -228,22 +182,22 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 90
+      ID: 85
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 91 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 109
+      ID: 104
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 110 GoSwissMapHeaderType map<string,string>
+      Pointee: 105 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 98
+      ID: 93
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 99 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 94 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -252,50 +206,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 103
+      ID: 98
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 104 UnresolvedPointeeType net/http.Response
+      Pointee: 99 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 83
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.99632e+06
       GoKind: 22
-      Pointee: 84 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 106
+      ID: 101
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 107 UnresolvedPointeeType net/http.pattern
+      Pointee: 102 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 85
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.189984e+06
       GoKind: 22
-      Pointee: 86 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 87
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 88 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 115
+      ID: 110
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 116 StructureType noalg.map.group[string][]string
+      Pointee: 111 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 125
+      ID: 120
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 126 StructureType noalg.map.group[string]string
+      Pointee: 121 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -304,125 +258,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 45
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 44 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 52
+      ID: 47
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.677056e+06
       GoKind: 22
-      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 66
+      ID: 61
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.729472e+06
       GoKind: 22
-      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 48
+      ID: 43
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.676672e+06
       GoKind: 22
-      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 58
+      ID: 53
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.728704e+06
       GoKind: 22
-      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 72
+      ID: 67
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.800096e+06
       GoKind: 22
-      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 60
+      ID: 55
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728896e+06
       GoKind: 22
-      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 56
+      ID: 51
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.728512e+06
       GoKind: 22
-      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 68
+      ID: 63
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.799648e+06
       GoKind: 22
-      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 76
+      ID: 71
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.869504e+06
       GoKind: 22
-      Pointee: 77 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 70
+      ID: 65
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799872e+06
       GoKind: 22
-      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 54
+      ID: 49
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.677248e+06
       GoKind: 22
-      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 50
+      ID: 45
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.676864e+06
       GoKind: 22
-      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 62
+      ID: 57
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.729088e+06
       GoKind: 22
-      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 74
+      ID: 69
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.80032e+06
       GoKind: 22
-      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 64
+      ID: 59
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.72928e+06
       GoKind: 22
-      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 93
+      ID: 88
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 113 StructureType table<string,[]string>
+      Pointee: 108 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 112
+      ID: 107
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 123 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -466,12 +420,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 102
+      ID: 97
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: EventRootType
-      ID: 131
+      ID: 126
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -495,7 +449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 132
+      ID: 127
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -510,27 +464,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 114
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 93 PointerType *table<string,[]string>
+      Element: 88 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 129
+      ID: 124
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 112 PointerType *table<string,string>
+      Element: 107 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 115
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 116 StructureType noalg.map.group[string][]string
+      Element: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 125
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 126 StructureType noalg.map.group[string]string
+      Element: 121 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 91
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -545,9 +499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 121 GoSliceDataType []string.array
+      Data: 116 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 121
+      ID: 116
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -557,10 +511,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 580672
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -574,7 +524,7 @@ Types:
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 105
+      ID: 100
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.267616e+06
@@ -586,23 +536,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 42
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.781952e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 43 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 43
-      Name: context.emptyCtx
-      GoRuntimeType: 1.580704e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 101
+      ID: 96
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -631,13 +566,13 @@ Types:
       GoRuntimeType: 580608
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 95
+      ID: 90
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 78
+      ID: 73
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.40832e+06
@@ -650,50 +585,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 47
+      ID: 42
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 41
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.469568e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 114
+      ID: 109
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 115 PointerType *noalg.map.group[string][]string
+          Type: 110 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 116 StructureType noalg.map.group[string][]string
-      GroupSliceType: 120 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
+      GroupSliceType: 115 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 124
+      ID: 119
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 125 PointerType *noalg.map.group[string]string
+          Type: 120 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 126 StructureType noalg.map.group[string]string
-      GroupSliceType: 130 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 121 StructureType noalg.map.group[string]string
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -725,7 +647,7 @@ Types:
       GoRuntimeType: 579712
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 94
+      ID: 89
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10128e+06
@@ -738,7 +660,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 91
+      ID: 86
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -751,7 +673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 92 PointerType **table<string,[]string>
+          Type: 87 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -767,10 +689,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 119 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 116 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 114 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 110
+      ID: 105
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -783,7 +705,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 111 PointerType **table<string,string>
+          Type: 106 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -799,21 +721,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 129 GoSliceDataType []*table<string,string>.array
-      GroupType: 126 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,string>.array
+      GroupType: 121 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 108
+      ID: 103
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119712e+06
       GoKind: 21
-      HeaderType: 110 GoSwissMapHeaderType map<string,string>
+      HeaderType: 105 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 99
+      ID: 94
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.019104e+06
@@ -826,7 +748,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.017696e+06
@@ -839,14 +761,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 89
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.088128e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 82
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.017824e+06
@@ -859,7 +781,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.01808e+06
@@ -883,7 +805,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 87 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -895,19 +817,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 89 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 94 GoInterfaceType io.ReadCloser
+          Type: 89 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 95 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 90 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 96 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -916,16 +838,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 97 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 97 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 98 PointerType *mime/multipart.Form
+          Type: 93 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 89 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -934,30 +856,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 100 PointerType *crypto/tls.ConnectionState
+          Type: 95 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 102 GoChannelType <-chan struct {}
+          Type: 97 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 103 PointerType *net/http.Response
+          Type: 98 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 105 GoInterfaceType context.Context
+          Type: 100 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 106 PointerType *net/http.pattern
+          Type: 101 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 96 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 108 GoMapType map[string]string
+          Type: 103 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 104
+      ID: 99
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -974,48 +896,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 84
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 107
+      ID: 102
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 86
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 88
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 97
+      ID: 92
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.871296e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 117
+      ID: 112
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 118 StructureType noalg.struct { key string; elem []string }
+      Element: 113 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 127
+      ID: 122
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 128 StructureType noalg.struct { key string; elem string }
+      Element: 123 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 116
+      ID: 111
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -1026,9 +948,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 117 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 112 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 126
+      ID: 121
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -1039,9 +961,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 127 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 122 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 118
+      ID: 113
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -1052,9 +974,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 96 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 128
+      ID: 123
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -1075,17 +997,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 45 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 44 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 44
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 53
+      ID: 48
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.9328e+06
@@ -1093,12 +1015,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 67
+      ID: 62
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.010432e+06
@@ -1106,15 +1028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 49
+      ID: 44
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.932288e+06
@@ -1122,12 +1044,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 59
+      ID: 54
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.00928e+06
@@ -1135,15 +1057,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 73
+      ID: 68
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071712e+06
@@ -1151,18 +1073,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 61
+      ID: 56
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009568e+06
@@ -1170,15 +1092,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 57
+      ID: 52
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.008992e+06
@@ -1186,15 +1108,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 69
+      ID: 64
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.071072e+06
@@ -1202,18 +1124,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 77
+      ID: 72
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.131456e+06
@@ -1221,21 +1143,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 71
+      ID: 66
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071392e+06
@@ -1243,18 +1165,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 55
+      ID: 50
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.933056e+06
@@ -1262,12 +1184,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 51
+      ID: 46
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.932544e+06
@@ -1275,12 +1197,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 63
+      ID: 58
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.009856e+06
@@ -1288,15 +1210,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 75
+      ID: 70
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.072032e+06
@@ -1304,18 +1226,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 65
+      ID: 60
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.010144e+06
@@ -1323,15 +1245,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 113
+      ID: 108
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -1353,9 +1275,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 114 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 109 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 123
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -1377,7 +1299,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 124 GoSwissMapGroupsType groupReference<string,string>
+          Type: 119 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -1420,6 +1342,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580736
       GoKind: 26
-MaxTypeID: 132
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 129 EventRootType Probe[main.HandleHTTP]
+          Type: 126 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 130 EventRootType Probe[main.LookAtTheRequest]
+          Type: 127 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -72,38 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 39 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0xd0500e..0xd05029
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd05029..0xd05110
-              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0xd04ee8..0xd04ee8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xd04ee8..0xd04f28
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04f28..0xd04f2c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd051e0..0xd052a5]
@@ -122,20 +90,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 90
+      ID: 87
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 91 PointerType *table<string,[]string>
+      Pointee: 88 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 109
+      ID: 106
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 110 PointerType *table<string,string>
+      Pointee: 107 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 120
+      ID: 117
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []string.array
+      Pointee: 116 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -144,19 +112,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 39
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.260704e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 98
+      ID: 95
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 99 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 96 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -179,12 +140,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 44
+      ID: 41
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.550528e+06
       GoKind: 22
-      Pointee: 45 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -221,22 +182,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 88
+      ID: 85
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 89 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 107
+      ID: 104
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<string,string>
+      Pointee: 105 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 96
+      ID: 93
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 97 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 94 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -245,50 +206,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 101
+      ID: 98
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718816e+06
       GoKind: 22
-      Pointee: 102 UnresolvedPointeeType net/http.Response
+      Pointee: 99 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 81
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.010368e+06
       GoKind: 22
-      Pointee: 82 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 104
+      ID: 101
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608608e+06
       GoKind: 22
-      Pointee: 105 UnresolvedPointeeType net/http.pattern
+      Pointee: 102 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 83
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.218272e+06
       GoKind: 22
-      Pointee: 84 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 85
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 86 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 113
+      ID: 110
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[string][]string
+      Pointee: 111 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 123
+      ID: 120
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 124 StructureType noalg.map.group[string]string
+      Pointee: 121 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -297,125 +258,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 43
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 42 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 50
+      ID: 47
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.68848e+06
       GoKind: 22
-      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 64
+      ID: 61
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.74224e+06
       GoKind: 22
-      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 46
+      ID: 43
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.688096e+06
       GoKind: 22
-      Pointee: 47 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 56
+      ID: 53
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741472e+06
       GoKind: 22
-      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 70
+      ID: 67
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.814048e+06
       GoKind: 22
-      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 58
+      ID: 55
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741664e+06
       GoKind: 22
-      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 54
+      ID: 51
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.74128e+06
       GoKind: 22
-      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 66
+      ID: 63
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.8136e+06
       GoKind: 22
-      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 74
+      ID: 71
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.882912e+06
       GoKind: 22
-      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 68
+      ID: 65
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813824e+06
       GoKind: 22
-      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 52
+      ID: 49
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.688672e+06
       GoKind: 22
-      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 48
+      ID: 45
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.688288e+06
       GoKind: 22
-      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 60
+      ID: 57
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741856e+06
       GoKind: 22
-      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 72
+      ID: 69
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.814272e+06
       GoKind: 22
-      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 62
+      ID: 59
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.742048e+06
       GoKind: 22
-      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 91
+      ID: 88
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 111 StructureType table<string,[]string>
+      Pointee: 108 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 110
+      ID: 107
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 121 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -459,12 +420,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 100
+      ID: 97
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
     - __kind: EventRootType
-      ID: 129
+      ID: 126
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -488,7 +449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 130
+      ID: 127
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -503,27 +464,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 117
+      ID: 114
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 91 PointerType *table<string,[]string>
+      Element: 88 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 127
+      ID: 124
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 110 PointerType *table<string,string>
+      Element: 107 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 115
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[string][]string
+      Element: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 125
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 124 StructureType noalg.map.group[string]string
+      Element: 121 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 91
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -538,9 +499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []string.array
+      Data: 116 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 116
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -550,10 +511,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 585472
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -567,7 +524,7 @@ Types:
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 103
+      ID: 100
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276992e+06
@@ -580,7 +537,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 99
+      ID: 96
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -609,13 +566,13 @@ Types:
       GoRuntimeType: 585408
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 93
+      ID: 90
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693344
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 76
+      ID: 73
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.417952e+06
@@ -628,50 +585,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 45
+      ID: 42
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 41
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.479712e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 112
+      ID: 109
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 113 PointerType *noalg.map.group[string][]string
+          Type: 110 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[string][]string
-      GroupSliceType: 118 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
+      GroupSliceType: 115 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 122
+      ID: 119
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 123 PointerType *noalg.map.group[string]string
+          Type: 120 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 124 StructureType noalg.map.group[string]string
-      GroupSliceType: 128 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 121 StructureType noalg.map.group[string]string
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -703,7 +647,7 @@ Types:
       GoRuntimeType: 584512
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 92
+      ID: 89
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -716,7 +660,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 89
+      ID: 86
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -729,7 +673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 90 PointerType **table<string,[]string>
+          Type: 87 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -748,10 +692,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 117 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 114 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 114 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 108
+      ID: 105
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -764,7 +708,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 109 PointerType **table<string,string>
+          Type: 106 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -783,21 +727,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 127 GoSliceDataType []*table<string,string>.array
-      GroupType: 124 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,string>.array
+      GroupType: 121 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 106
+      ID: 103
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.129024e+06
       GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<string,string>
+      HeaderType: 105 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 97
+      ID: 94
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.027552e+06
@@ -810,7 +754,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 77
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.026016e+06
@@ -823,14 +767,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 87
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.101632e+06
       GoKind: 21
-      HeaderType: 89 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.026144e+06
@@ -843,7 +787,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 78
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.0264e+06
@@ -867,7 +811,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 85 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -879,19 +823,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 87 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 92 GoInterfaceType io.ReadCloser
+          Type: 89 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 93 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 90 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 94 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -900,16 +844,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 95 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 95 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 96 PointerType *mime/multipart.Form
+          Type: 93 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 87 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -918,30 +862,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 98 PointerType *crypto/tls.ConnectionState
+          Type: 95 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 100 GoChannelType <-chan struct {}
+          Type: 97 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 101 PointerType *net/http.Response
+          Type: 98 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 103 GoInterfaceType context.Context
+          Type: 100 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 104 PointerType *net/http.pattern
+          Type: 101 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 94 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 106 GoMapType map[string]string
+          Type: 103 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 102
+      ID: 99
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -958,48 +902,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 82
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 105
+      ID: 102
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 84
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 86
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 95
+      ID: 92
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.885152e+06
       GoKind: 21
-      HeaderType: 89 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 115
+      ID: 112
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 116 StructureType noalg.struct { key string; elem []string }
+      Element: 113 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 125
+      ID: 122
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 126 StructureType noalg.struct { key string; elem string }
+      Element: 123 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 114
+      ID: 111
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -1010,9 +954,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 112 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 124
+      ID: 121
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -1023,9 +967,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 125 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 122 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 116
+      ID: 113
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -1036,9 +980,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 94 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 126
+      ID: 123
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -1059,17 +1003,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 43 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 42 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 42
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 51
+      ID: 48
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.947456e+06
@@ -1077,12 +1021,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 65
+      ID: 62
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.023616e+06
@@ -1090,15 +1034,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 47
+      ID: 44
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.946944e+06
@@ -1106,12 +1050,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 57
+      ID: 54
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.022464e+06
@@ -1119,15 +1063,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 71
+      ID: 68
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085568e+06
@@ -1135,18 +1079,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 59
+      ID: 56
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.022752e+06
@@ -1154,15 +1098,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 55
+      ID: 52
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.022176e+06
@@ -1170,15 +1114,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 67
+      ID: 64
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.084928e+06
@@ -1186,18 +1130,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 75
+      ID: 72
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.1464e+06
@@ -1205,21 +1149,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 69
+      ID: 66
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085248e+06
@@ -1227,18 +1171,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 53
+      ID: 50
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.947712e+06
@@ -1246,12 +1190,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 49
+      ID: 46
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.9472e+06
@@ -1259,12 +1203,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 61
+      ID: 58
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.02304e+06
@@ -1272,15 +1216,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 73
+      ID: 70
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085888e+06
@@ -1288,18 +1232,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 63
+      ID: 60
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.023328e+06
@@ -1307,15 +1251,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 111
+      ID: 108
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -1337,9 +1281,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 109 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 121
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -1361,7 +1305,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 122 GoSwissMapGroupsType groupReference<string,string>
+          Type: 119 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -1404,6 +1348,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585536
       GoKind: 26
-MaxTypeID: 130
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x182c9a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 123 EventRootType Probe[main.HandleHTTP]
+          Type: 118 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 124 EventRootType Probe[main.LookAtTheRequest]
+          Type: 119 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -72,45 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 39 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x8ad9b4..0x8ad9d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8ad9d0..0x8adab0
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0x8ad8d8..0x8ad8d8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x8ad8d8..0x8ad910
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8ad910..0x8ad914
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 42 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0x8ad860..0x8adab0
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8adb90..0x8adc50]
@@ -129,10 +90,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 120
+      ID: 115
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []string.array
+      Pointee: 114 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -141,29 +102,22 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 92
+      ID: 87
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 93 GoHMapBucketType bucket<string,[]string>
+      Pointee: 88 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 113
+      ID: 108
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 114 GoHMapBucketType bucket<string,string>
+      Pointee: 109 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 39
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.11552e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 102
+      ID: 97
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 103 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 98 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -186,22 +140,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 46
+      ID: 41
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.362016e+06
       GoKind: 22
-      Pointee: 47 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 90
+      ID: 85
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 91 GoHMapHeaderType hash<string,[]string>
+      Pointee: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 111
+      ID: 106
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 112 GoHMapHeaderType hash<string,string>
+      Pointee: 107 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -238,12 +192,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 100
+      ID: 95
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 101 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 96 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -252,47 +206,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 105
+      ID: 100
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 106 UnresolvedPointeeType net/http.Response
+      Pointee: 101 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 83
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.833376e+06
       GoKind: 22
-      Pointee: 84 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 108
+      ID: 103
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 109 UnresolvedPointeeType net/http.pattern
+      Pointee: 104 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 85
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.059552e+06
       GoKind: 22
-      Pointee: 86 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 87
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 88 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 94
+      ID: 89
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 95 UnresolvedPointeeType runtime.mapextra
+      Pointee: 90 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -301,115 +255,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 45
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 44 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 52
+      ID: 47
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.496256e+06
       GoKind: 22
-      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 66
+      ID: 61
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.616224e+06
       GoKind: 22
-      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 48
+      ID: 43
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.495872e+06
       GoKind: 22
-      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 58
+      ID: 53
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.615456e+06
       GoKind: 22
-      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 72
+      ID: 67
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.68544e+06
       GoKind: 22
-      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 60
+      ID: 55
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615648e+06
       GoKind: 22
-      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 56
+      ID: 51
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.615264e+06
       GoKind: 22
-      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 68
+      ID: 63
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.684992e+06
       GoKind: 22
-      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 76
+      ID: 71
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.75072e+06
       GoKind: 22
-      Pointee: 77 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 70
+      ID: 65
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.685216e+06
       GoKind: 22
-      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 54
+      ID: 49
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.496448e+06
       GoKind: 22
-      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 50
+      ID: 45
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.496064e+06
       GoKind: 22
-      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 62
+      ID: 57
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.61584e+06
       GoKind: 22
-      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 74
+      ID: 69
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.685664e+06
       GoKind: 22
-      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 64
+      ID: 59
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.616032e+06
       GoKind: 22
-      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -453,12 +407,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 104
+      ID: 99
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: EventRootType
-      ID: 123
+      ID: 118
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -482,7 +436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 124
+      ID: 119
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -497,7 +451,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 115
+      ID: 110
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -506,24 +460,24 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 113
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 93 GoHMapBucketType bucket<string,[]string>
+      Element: 88 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 122
+      ID: 117
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 114 GoHMapBucketType bucket<string,string>
+      Element: 109 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 116
+      ID: 111
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 93
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -538,21 +492,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 119 GoSliceDataType []string.array
+      Data: 114 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 114
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 117
+      ID: 112
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 98 GoSliceHeaderType []string
+      Element: 93 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 121
+      ID: 116
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -565,47 +519,43 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 93
+      ID: 88
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 115 ArrayType [8]uint8
+          Type: 110 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 116 ArrayType []key<string>
+          Type: 111 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 117 ArrayType []val<[]string>
+          Type: 112 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 92 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 98 GoSliceHeaderType []string
+      ValueType: 93 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 114
+      ID: 109
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 115 ArrayType [8]uint8
+          Type: 110 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 116 ArrayType []key<string>
+          Type: 111 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 121 ArrayType []val<string>
+          Type: 116 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 113 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -619,7 +569,7 @@ Types:
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 107
+      ID: 102
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187296e+06
@@ -631,23 +581,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 42
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.667744e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 43 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 43
-      Name: context.emptyCtx
-      GoRuntimeType: 1.399808e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 103
+      ID: 98
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -676,13 +611,13 @@ Types:
       GoRuntimeType: 534720
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 97
+      ID: 92
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 78
+      ID: 73
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.23584e+06
@@ -695,24 +630,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 47
+      ID: 42
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 41
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.296128e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 91
+      ID: 86
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -733,20 +655,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 92 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 92 PointerType *bucket<string,[]string>
+          Type: 87 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 94 PointerType *runtime.mapextra
-      BucketType: 93 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 118 GoSliceDataType []bucket<string,[]string>.array
+          Type: 89 PointerType *runtime.mapextra
+      BucketType: 88 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 113 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 112
+      ID: 107
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -767,18 +689,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 113 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 113 PointerType *bucket<string,string>
+          Type: 108 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 94 PointerType *runtime.mapextra
-      BucketType: 114 GoHMapBucketType bucket<string,string>
-      BucketsType: 122 GoSliceDataType []bucket<string,string>.array
+          Type: 89 PointerType *runtime.mapextra
+      BucketType: 109 GoHMapBucketType bucket<string,string>
+      BucketsType: 117 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -810,7 +732,7 @@ Types:
       GoRuntimeType: 533824
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 96
+      ID: 91
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067328e+06
@@ -823,18 +745,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 110
+      ID: 105
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 112 GoHMapHeaderType hash<string,string>
+      HeaderType: 107 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 101
+      ID: 96
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 983296
@@ -847,7 +769,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 981888
@@ -860,14 +782,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 89
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.917984e+06
       GoKind: 21
-      HeaderType: 91 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 82
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 982016
@@ -880,7 +802,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 982272
@@ -904,7 +826,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 87 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -916,19 +838,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 89 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 96 GoInterfaceType io.ReadCloser
+          Type: 91 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 97 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 92 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 98 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -937,16 +859,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 99 GoMapType net/url.Values
+          Type: 94 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 99 GoMapType net/url.Values
+          Type: 94 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 100 PointerType *mime/multipart.Form
+          Type: 95 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 89 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -955,30 +877,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 102 PointerType *crypto/tls.ConnectionState
+          Type: 97 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 104 GoChannelType <-chan struct {}
+          Type: 99 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 105 PointerType *net/http.Response
+          Type: 100 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 107 GoInterfaceType context.Context
+          Type: 102 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 108 PointerType *net/http.pattern
+          Type: 103 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 98 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 110 GoMapType map[string]string
+          Type: 105 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 106
+      ID: 101
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -995,30 +917,30 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 84
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 109
+      ID: 104
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 86
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 88
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 99
+      ID: 94
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.671328e+06
       GoKind: 21
-      HeaderType: 91 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 95
+      ID: 90
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -1030,17 +952,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 45 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 44 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 44
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 53
+      ID: 48
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.810688e+06
@@ -1048,12 +970,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 67
+      ID: 62
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885792e+06
@@ -1061,15 +983,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 49
+      ID: 44
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.810176e+06
@@ -1077,12 +999,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 59
+      ID: 54
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.88464e+06
@@ -1090,15 +1012,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 73
+      ID: 68
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.947744e+06
@@ -1106,18 +1028,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 61
+      ID: 56
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.884928e+06
@@ -1125,15 +1047,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 57
+      ID: 52
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.884352e+06
@@ -1141,15 +1063,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 69
+      ID: 64
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.947104e+06
@@ -1157,18 +1079,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 77
+      ID: 72
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.005632e+06
@@ -1176,21 +1098,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 71
+      ID: 66
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.947424e+06
@@ -1198,18 +1120,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 55
+      ID: 50
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.810944e+06
@@ -1217,12 +1139,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 51
+      ID: 46
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.810432e+06
@@ -1230,12 +1152,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 63
+      ID: 58
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.885216e+06
@@ -1243,15 +1165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 75
+      ID: 70
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.948064e+06
@@ -1259,18 +1181,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 65
+      ID: 60
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885504e+06
@@ -1278,13 +1200,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -1327,6 +1249,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534848
       GoKind: 26
-MaxTypeID: 124
+MaxTypeID: 119
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 131 EventRootType Probe[main.HandleHTTP]
+          Type: 126 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 132 EventRootType Probe[main.LookAtTheRequest]
+          Type: 127 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -72,45 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 39 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x86c254..0x86c268
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x86c268..0x86c340
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0x86c178..0x86c178
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x86c178..0x86c1b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x86c1b0..0x86c1b4
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
-        - Name: .autotmp_14
-          Type: 42 StructureType context.backgroundCtx
-          Locations:
-            - Range: 0x86c100..0x86c340
-              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x86c410..0x86c4c0]
@@ -129,20 +90,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 92
+      ID: 87
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 93 PointerType *table<string,[]string>
+      Pointee: 88 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 111
+      ID: 106
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 112 PointerType *table<string,string>
+      Pointee: 107 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 122
+      ID: 117
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 121 GoSliceDataType []string.array
+      Pointee: 116 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -151,19 +112,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 39
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.245056e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 100
+      ID: 95
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 101 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 96 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -186,12 +140,12 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 46
+      ID: 41
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.53936e+06
       GoKind: 22
-      Pointee: 47 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -228,22 +182,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 90
+      ID: 85
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 91 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 109
+      ID: 104
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 110 GoSwissMapHeaderType map<string,string>
+      Pointee: 105 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 98
+      ID: 93
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 99 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 94 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -252,50 +206,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 103
+      ID: 98
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 104 UnresolvedPointeeType net/http.Response
+      Pointee: 99 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 83
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.995552e+06
       GoKind: 22
-      Pointee: 84 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 106
+      ID: 101
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 107 UnresolvedPointeeType net/http.pattern
+      Pointee: 102 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 85
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.189216e+06
       GoKind: 22
-      Pointee: 86 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 87
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 88 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 115
+      ID: 110
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 116 StructureType noalg.map.group[string][]string
+      Pointee: 111 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 125
+      ID: 120
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 126 StructureType noalg.map.group[string]string
+      Pointee: 121 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -304,125 +258,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 45
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 44 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 52
+      ID: 47
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.676512e+06
       GoKind: 22
-      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 66
+      ID: 61
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728928e+06
       GoKind: 22
-      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 48
+      ID: 43
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.676128e+06
       GoKind: 22
-      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 58
+      ID: 53
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.72816e+06
       GoKind: 22
-      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 72
+      ID: 67
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799552e+06
       GoKind: 22
-      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 60
+      ID: 55
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728352e+06
       GoKind: 22
-      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 56
+      ID: 51
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.727968e+06
       GoKind: 22
-      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 68
+      ID: 63
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.799104e+06
       GoKind: 22
-      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 76
+      ID: 71
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.868736e+06
       GoKind: 22
-      Pointee: 77 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 70
+      ID: 65
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799328e+06
       GoKind: 22
-      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 54
+      ID: 49
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.676704e+06
       GoKind: 22
-      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 50
+      ID: 45
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.67632e+06
       GoKind: 22
-      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 62
+      ID: 57
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.728544e+06
       GoKind: 22
-      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 74
+      ID: 69
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799776e+06
       GoKind: 22
-      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 64
+      ID: 59
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728736e+06
       GoKind: 22
-      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 93
+      ID: 88
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 113 StructureType table<string,[]string>
+      Pointee: 108 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 112
+      ID: 107
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 123 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -466,12 +420,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 102
+      ID: 97
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: EventRootType
-      ID: 131
+      ID: 126
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -495,7 +449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 132
+      ID: 127
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -510,27 +464,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 114
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 93 PointerType *table<string,[]string>
+      Element: 88 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 129
+      ID: 124
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 112 PointerType *table<string,string>
+      Element: 107 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 120
+      ID: 115
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 116 StructureType noalg.map.group[string][]string
+      Element: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 125
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 126 StructureType noalg.map.group[string]string
+      Element: 121 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 91
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -545,9 +499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 121 GoSliceDataType []string.array
+      Data: 116 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 121
+      ID: 116
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -557,10 +511,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 580448
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -574,7 +524,7 @@ Types:
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 105
+      ID: 100
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.266912e+06
@@ -586,23 +536,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 42
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.781408e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 43 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 43
-      Name: context.emptyCtx
-      GoRuntimeType: 1.58016e+06
-      GoKind: 25
-      RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 101
+      ID: 96
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -631,13 +566,13 @@ Types:
       GoRuntimeType: 580384
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 95
+      ID: 90
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 78
+      ID: 73
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.407616e+06
@@ -650,50 +585,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 47
+      ID: 42
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 41
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.468864e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 114
+      ID: 109
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 115 PointerType *noalg.map.group[string][]string
+          Type: 110 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 116 StructureType noalg.map.group[string][]string
-      GroupSliceType: 120 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
+      GroupSliceType: 115 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 124
+      ID: 119
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 125 PointerType *noalg.map.group[string]string
+          Type: 120 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 126 StructureType noalg.map.group[string]string
-      GroupSliceType: 130 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 121 StructureType noalg.map.group[string]string
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -725,7 +647,7 @@ Types:
       GoRuntimeType: 579488
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 94
+      ID: 89
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.100576e+06
@@ -738,7 +660,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 91
+      ID: 86
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -751,7 +673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 92 PointerType **table<string,[]string>
+          Type: 87 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -767,10 +689,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 119 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 116 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 114 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 110
+      ID: 105
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -783,7 +705,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 111 PointerType **table<string,string>
+          Type: 106 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -799,21 +721,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 129 GoSliceDataType []*table<string,string>.array
-      GroupType: 126 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,string>.array
+      GroupType: 121 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 108
+      ID: 103
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119008e+06
       GoKind: 21
-      HeaderType: 110 GoSwissMapHeaderType map<string,string>
+      HeaderType: 105 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 99
+      ID: 94
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 81
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.0184e+06
@@ -826,7 +748,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.016992e+06
@@ -839,14 +761,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 89
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.08736e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 82
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.01712e+06
@@ -859,7 +781,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.017376e+06
@@ -883,7 +805,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 87 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -895,19 +817,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 89 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 94 GoInterfaceType io.ReadCloser
+          Type: 89 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 95 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 90 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 96 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -916,16 +838,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 97 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 97 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 98 PointerType *mime/multipart.Form
+          Type: 93 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 89 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -934,30 +856,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 100 PointerType *crypto/tls.ConnectionState
+          Type: 95 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 102 GoChannelType <-chan struct {}
+          Type: 97 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 103 PointerType *net/http.Response
+          Type: 98 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 105 GoInterfaceType context.Context
+          Type: 100 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 106 PointerType *net/http.pattern
+          Type: 101 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 96 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 108 GoMapType map[string]string
+          Type: 103 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 104
+      ID: 99
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -974,48 +896,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 84
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 107
+      ID: 102
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 86
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 88
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 97
+      ID: 92
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.870528e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 117
+      ID: 112
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 118 StructureType noalg.struct { key string; elem []string }
+      Element: 113 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 127
+      ID: 122
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 128 StructureType noalg.struct { key string; elem string }
+      Element: 123 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 116
+      ID: 111
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -1026,9 +948,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 117 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 112 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 126
+      ID: 121
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -1039,9 +961,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 127 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 122 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 118
+      ID: 113
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -1052,9 +974,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 96 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 128
+      ID: 123
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -1075,17 +997,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 45 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 44 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 44
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 53
+      ID: 48
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.932032e+06
@@ -1093,12 +1015,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 67
+      ID: 62
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009664e+06
@@ -1106,15 +1028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 49
+      ID: 44
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.93152e+06
@@ -1122,12 +1044,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 59
+      ID: 54
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.008512e+06
@@ -1135,15 +1057,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 73
+      ID: 68
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.070944e+06
@@ -1151,18 +1073,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 61
+      ID: 56
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.0088e+06
@@ -1170,15 +1092,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 57
+      ID: 52
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.008224e+06
@@ -1186,15 +1108,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 69
+      ID: 64
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.070304e+06
@@ -1202,18 +1124,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 77
+      ID: 72
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.130688e+06
@@ -1221,21 +1143,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 71
+      ID: 66
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.070624e+06
@@ -1243,18 +1165,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 79 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 55
+      ID: 50
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.932288e+06
@@ -1262,12 +1184,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 51
+      ID: 46
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.931776e+06
@@ -1275,12 +1197,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 63
+      ID: 58
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.009088e+06
@@ -1288,15 +1210,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 75
+      ID: 70
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071264e+06
@@ -1304,18 +1226,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 81 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 65
+      ID: 60
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009376e+06
@@ -1323,15 +1245,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 78 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 82 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 113
+      ID: 108
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -1353,9 +1275,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 114 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 109 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 123
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -1377,7 +1299,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 124 GoSwissMapGroupsType groupReference<string,string>
+          Type: 119 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -1420,6 +1342,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580512
       GoKind: 26
-MaxTypeID: 132
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 129 EventRootType Probe[main.HandleHTTP]
+          Type: 126 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b100", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 130 EventRootType Probe[main.LookAtTheRequest]
+          Type: 127 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b3fc", Frameless: true}]
           Condition: null
 Subprograms:
@@ -72,32 +72,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
-        - Name: '&buf'
-          Type: 39 PointerType *bytes.Buffer
-          Locations:
-            - Range: 0x82b23c..0x82b258
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x82b258..0x82b320
-              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: span
-          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-          Locations:
-            - Range: 0x82b164..0x82b164
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x82b164..0x82b1a4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x82b3f0..0x82b490]
@@ -116,20 +90,20 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 90
+      ID: 87
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 91 PointerType *table<string,[]string>
+      Pointee: 88 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 109
+      ID: 106
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 110 PointerType *table<string,string>
+      Pointee: 107 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 120
+      ID: 117
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []string.array
+      Pointee: 116 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -138,19 +112,12 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 39
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.259936e+06
-      GoKind: 22
-      Pointee: 40 UnresolvedPointeeType bytes.Buffer
-    - __kind: PointerType
-      ID: 98
+      ID: 95
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 99 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 96 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -173,12 +140,12 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 44
+      ID: 41
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.549984e+06
       GoKind: 22
-      Pointee: 45 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 42 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -215,22 +182,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 88
+      ID: 85
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 89 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 107
+      ID: 104
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<string,string>
+      Pointee: 105 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 96
+      ID: 93
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 97 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 94 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -239,50 +206,50 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 101
+      ID: 98
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718272e+06
       GoKind: 22
-      Pointee: 102 UnresolvedPointeeType net/http.Response
+      Pointee: 99 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 81
+      ID: 78
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.0096e+06
       GoKind: 22
-      Pointee: 82 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 79 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 104
+      ID: 101
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608064e+06
       GoKind: 22
-      Pointee: 105 UnresolvedPointeeType net/http.pattern
+      Pointee: 102 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 83
+      ID: 80
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.217504e+06
       GoKind: 22
-      Pointee: 84 UnresolvedPointeeType net/http.response
+      Pointee: 81 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 85
+      ID: 82
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 86 UnresolvedPointeeType net/url.URL
+      Pointee: 83 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 113
+      ID: 110
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[string][]string
+      Pointee: 111 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 123
+      ID: 120
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 124 StructureType noalg.map.group[string]string
+      Pointee: 121 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -291,125 +258,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 43
+      ID: 40
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 42 GoStringDataType string.str
+      Pointee: 39 GoStringDataType string.str
     - __kind: PointerType
-      ID: 50
+      ID: 47
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.687936e+06
       GoKind: 22
-      Pointee: 51 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 48 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 64
+      ID: 61
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741696e+06
       GoKind: 22
-      Pointee: 65 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 62 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 46
+      ID: 43
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.687552e+06
       GoKind: 22
-      Pointee: 47 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 44 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 56
+      ID: 53
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.740928e+06
       GoKind: 22
-      Pointee: 57 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 54 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 70
+      ID: 67
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813504e+06
       GoKind: 22
-      Pointee: 71 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 68 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 58
+      ID: 55
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.74112e+06
       GoKind: 22
-      Pointee: 59 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 56 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 54
+      ID: 51
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.740736e+06
       GoKind: 22
-      Pointee: 55 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 52 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 66
+      ID: 63
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.813056e+06
       GoKind: 22
-      Pointee: 67 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 64 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 74
+      ID: 71
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.882144e+06
       GoKind: 22
-      Pointee: 75 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 72 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 68
+      ID: 65
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.81328e+06
       GoKind: 22
-      Pointee: 69 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 66 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 52
+      ID: 49
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.688128e+06
       GoKind: 22
-      Pointee: 53 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 50 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 48
+      ID: 45
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.687744e+06
       GoKind: 22
-      Pointee: 49 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 46 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 60
+      ID: 57
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741312e+06
       GoKind: 22
-      Pointee: 61 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 58 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 72
+      ID: 69
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813728e+06
       GoKind: 22
-      Pointee: 73 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 70 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 62
+      ID: 59
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741504e+06
       GoKind: 22
-      Pointee: 63 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 60 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 91
+      ID: 88
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 111 StructureType table<string,[]string>
+      Pointee: 108 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 110
+      ID: 107
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 121 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -453,12 +420,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 100
+      ID: 97
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
     - __kind: EventRootType
-      ID: 129
+      ID: 126
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -482,7 +449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 130
+      ID: 127
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -497,27 +464,27 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceDataType
-      ID: 117
+      ID: 114
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 91 PointerType *table<string,[]string>
+      Element: 88 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 127
+      ID: 124
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 110 PointerType *table<string,string>
+      Element: 107 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 115
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[string][]string
+      Element: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 125
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 124 StructureType noalg.map.group[string]string
+      Element: 121 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 91
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -532,9 +499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []string.array
+      Data: 116 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 116
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -544,10 +511,6 @@ Types:
       ByteSize: 1
       GoRuntimeType: 585248
       GoKind: 1
-    - __kind: UnresolvedPointeeType
-      ID: 40
-      Name: bytes.Buffer
-      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -561,7 +524,7 @@ Types:
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 103
+      ID: 100
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276288e+06
@@ -574,7 +537,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 99
+      ID: 96
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -603,13 +566,13 @@ Types:
       GoRuntimeType: 585184
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 93
+      ID: 90
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693216
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 76
+      ID: 73
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.417248e+06
@@ -622,50 +585,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 45
+      ID: 42
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
-    - __kind: GoInterfaceType
-      ID: 41
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.479008e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 112
+      ID: 109
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 113 PointerType *noalg.map.group[string][]string
+          Type: 110 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[string][]string
-      GroupSliceType: 118 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
+      GroupSliceType: 115 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 122
+      ID: 119
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 123 PointerType *noalg.map.group[string]string
+          Type: 120 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 124 StructureType noalg.map.group[string]string
-      GroupSliceType: 128 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 121 StructureType noalg.map.group[string]string
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -697,7 +647,7 @@ Types:
       GoRuntimeType: 584288
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 92
+      ID: 89
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -710,7 +660,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 89
+      ID: 86
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -723,7 +673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 90 PointerType **table<string,[]string>
+          Type: 87 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -742,10 +692,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 117 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 114 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 114 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 111 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 108
+      ID: 105
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -758,7 +708,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 109 PointerType **table<string,string>
+          Type: 106 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -777,21 +727,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 127 GoSliceDataType []*table<string,string>.array
-      GroupType: 124 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,string>.array
+      GroupType: 121 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 106
+      ID: 103
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.12832e+06
       GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<string,string>
+      HeaderType: 105 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 97
+      ID: 94
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 79
+      ID: 76
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.026848e+06
@@ -804,7 +754,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 77
+      ID: 74
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.025312e+06
@@ -817,14 +767,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 87
+      ID: 84
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.100864e+06
       GoKind: 21
-      HeaderType: 89 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 80
+      ID: 77
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.02544e+06
@@ -837,7 +787,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 78
+      ID: 75
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.025696e+06
@@ -861,7 +811,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 85 PointerType *net/url.URL
+          Type: 82 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -873,19 +823,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 87 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 92 GoInterfaceType io.ReadCloser
+          Type: 89 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 93 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 90 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 94 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -894,16 +844,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 95 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 95 GoMapType net/url.Values
+          Type: 92 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 96 PointerType *mime/multipart.Form
+          Type: 93 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 87 GoMapType net/http.Header
+          Type: 84 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -912,30 +862,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 98 PointerType *crypto/tls.ConnectionState
+          Type: 95 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 100 GoChannelType <-chan struct {}
+          Type: 97 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 101 PointerType *net/http.Response
+          Type: 98 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 103 GoInterfaceType context.Context
+          Type: 100 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 104 PointerType *net/http.pattern
+          Type: 101 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 94 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 106 GoMapType map[string]string
+          Type: 103 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 102
+      ID: 99
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -952,48 +902,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 82
+      ID: 79
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 105
+      ID: 102
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 84
+      ID: 81
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 86
+      ID: 83
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 95
+      ID: 92
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.884384e+06
       GoKind: 21
-      HeaderType: 89 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 115
+      ID: 112
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 116 StructureType noalg.struct { key string; elem []string }
+      Element: 113 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 125
+      ID: 122
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 126 StructureType noalg.struct { key string; elem string }
+      Element: 123 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 114
+      ID: 111
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -1004,9 +954,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 112 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 124
+      ID: 121
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -1017,9 +967,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 125 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 122 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 116
+      ID: 113
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -1030,9 +980,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 94 GoSliceHeaderType []string
+          Type: 91 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 126
+      ID: 123
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -1053,17 +1003,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 43 PointerType *string.str
+          Type: 40 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 42 GoStringDataType string.str
+      Data: 39 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 42
+      ID: 39
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 51
+      ID: 48
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.946688e+06
@@ -1071,12 +1021,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 65
+      ID: 62
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.022848e+06
@@ -1084,15 +1034,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 47
+      ID: 44
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.946176e+06
@@ -1100,12 +1050,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 57
+      ID: 54
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.021696e+06
@@ -1113,15 +1063,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 71
+      ID: 68
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.0848e+06
@@ -1129,18 +1079,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 59
+      ID: 56
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.021984e+06
@@ -1148,15 +1098,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 55
+      ID: 52
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.021408e+06
@@ -1164,15 +1114,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 67
+      ID: 64
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.08416e+06
@@ -1180,18 +1130,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 75
+      ID: 72
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.145632e+06
@@ -1199,21 +1149,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 69
+      ID: 66
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.08448e+06
@@ -1221,18 +1171,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 77 GoInterfaceType net/http.Flusher
+          Type: 74 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 53
+      ID: 50
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.946944e+06
@@ -1240,12 +1190,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 49
+      ID: 46
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.946432e+06
@@ -1253,12 +1203,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 61
+      ID: 58
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.022272e+06
@@ -1266,15 +1216,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 73
+      ID: 70
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.08512e+06
@@ -1282,18 +1232,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 79 GoInterfaceType net/http.CloseNotifier
+          Type: 76 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 63
+      ID: 60
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.02256e+06
@@ -1301,15 +1251,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 76 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 73 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 78 GoInterfaceType net/http.Pusher
+          Type: 75 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 80 GoInterfaceType net/http.Hijacker
+          Type: 77 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 111
+      ID: 108
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -1331,9 +1281,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 109 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 121
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -1355,7 +1305,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 122 GoSwissMapGroupsType groupReference<string,string>
+          Type: 119 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -1398,6 +1348,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585312
       GoKind: 26
-MaxTypeID: 130
+MaxTypeID: 127
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x130d980", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -2326,15 +2326,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd045b6..0xd045c7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd045c7..0xd04665
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xd04680..0xd046e2]
@@ -2351,29 +2342,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xd04700..0xd0480e]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0475b..0xd04765
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd04765..0xd04780
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd04780..0xd04794
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd04756..0xd04760
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd04760..0xd04780
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd04780..0xd0478f
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xd04820..0xd04826]
@@ -3478,10 +3447,10 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 967
+      ID: 969
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 968 PointerType *main.deepSlice3
+      Pointee: 970 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 988
       Name: '**main.deepSlice8'
@@ -3499,7 +3468,7 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '**main.t'
       ByteSize: 8
       Pointee: 160 PointerType *main.t
@@ -3516,10 +3485,10 @@ Types:
       ByteSize: 8
       Pointee: 228 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 971
+      ID: 973
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 970 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 972 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 992
       Name: '*[]*main.deepSlice8.array'
@@ -3591,10 +3560,10 @@ Types:
       ByteSize: 8
       Pointee: 273 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 754
+      ID: 756
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 753 GoSliceDataType []float64.array
+      Pointee: 755 GoSliceDataType []float64.array
     - __kind: PointerType
       ID: 1001
       Name: '*[]interface {}.array'
@@ -3611,10 +3580,10 @@ Types:
       ByteSize: 8
       Pointee: 277 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 982
+      ID: 304
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 981 GoSliceDataType []main.structWithMap.array
+      Pointee: 303 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 270
       Name: '*[]main.structWithNoStrings.array'
@@ -3641,71 +3610,71 @@ Types:
       ByteSize: 8
       Pointee: 275 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 752
+      ID: 754
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 751 GoSliceDataType []uint8.array
+      Pointee: 753 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.848384e+06
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 882 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 528
+      ID: 530
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858336
       GoKind: 22
-      Pointee: 529 GoSliceHeaderType archive/tar.headerError
+      Pointee: 531 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 531
+      ID: 533
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 530 GoSliceDataType archive/tar.headerError.array
+      Pointee: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.252928e+06
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 822 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 767
+      ID: 769
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858528
       GoKind: 22
-      Pointee: 768 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 770 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 769
+      ID: 771
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858624
       GoKind: 22
-      Pointee: 770 StructureType archive/zip.dirWriter
+      Pointee: 772 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 866
+      ID: 868
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.772672e+06
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 869 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 795
+      ID: 797
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.016448e+06
       GoKind: 22
-      Pointee: 796 StructureType archive/zip.nopCloser
+      Pointee: 798 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 797
+      ID: 799
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.016704e+06
       GoKind: 22
-      Pointee: 798 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 800 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3739,10 +3708,10 @@ Types:
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 975
+      ID: 977
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 976 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 978 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1005
       Name: '*bucket<int,*main.deepMap8>'
@@ -3779,10 +3748,10 @@ Types:
       ByteSize: 8
       Pointee: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 720
+      ID: 722
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 723 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 106
       Name: '*bucket<string,int>'
@@ -3834,393 +3803,393 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 843
+      ID: 845
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.028864e+06
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType bufio.Reader
+      Pointee: 846 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 868
+      ID: 870
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.814112e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType bufio.Writer
+      Pointee: 871 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 915
+      ID: 917
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.121824e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType bytes.Buffer
+      Pointee: 918 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 441
+      ID: 443
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 840960
       GoKind: 22
-      Pointee: 336 BaseType compress/flate.CorruptInputError
+      Pointee: 338 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 442
+      ID: 444
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 337 GoStringHeaderType compress/flate.InternalError
+      Pointee: 339 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 339
+      ID: 341
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 338 GoStringDataType compress/flate.InternalError.str
+      Pointee: 340 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 817
+      ID: 819
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.243168e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 820 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 763
+      ID: 765
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 764 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 766 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 839
+      ID: 841
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.599296e+06
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 842 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 672
+      ID: 674
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.1176e+06
       GoKind: 22
-      Pointee: 673 StructureType context.deadlineExceededError
+      Pointee: 675 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 521
+      ID: 523
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853248
       GoKind: 22
-      Pointee: 350 BaseType crypto/aes.KeySizeError
+      Pointee: 352 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 522
+      ID: 524
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853440
       GoKind: 22
-      Pointee: 351 BaseType crypto/des.KeySizeError
+      Pointee: 353 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 829
+      ID: 831
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.37344e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 832 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 854
+      ID: 856
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.678304e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 857 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 523
+      ID: 525
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 352 BaseType crypto/rc4.KeySizeError
+      Pointee: 354 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 862
+      ID: 864
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.769856e+06
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 865 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 856
+      ID: 858
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.678752e+06
       GoKind: 22
-      Pointee: 857 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 859 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 858
+      ID: 860
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.6792e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 861 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 447
+      ID: 449
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842592
       GoKind: 22
-      Pointee: 340 BaseType crypto/tls.AlertError
+      Pointee: 342 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.004288e+06
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 615 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 941
+      ID: 943
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.230944e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 944 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 445
+      ID: 447
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842400
       GoKind: 22
-      Pointee: 446 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 448 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 443
+      ID: 445
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842304
       GoKind: 22
-      Pointee: 444 StructureType crypto/tls.RecordHeaderError
+      Pointee: 446 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 611
+      ID: 613
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.002624e+06
       GoKind: 22
-      Pointee: 568 BaseType crypto/tls.alert
+      Pointee: 570 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 827
+      ID: 829
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.37056e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 830 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 834
+      ID: 836
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.449632e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 837 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.243488e+06
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 710 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 722
+      ID: 724
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.905536e+06
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 725 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 517
+      ID: 519
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 518 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 520 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 511
+      ID: 513
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851712
       GoKind: 22
-      Pointee: 512 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 514 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 513
+      ID: 515
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 851808
       GoKind: 22
-      Pointee: 514 StructureType crypto/x509.HostnameError
+      Pointee: 516 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 510
+      ID: 512
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851616
       GoKind: 22
-      Pointee: 349 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 351 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 617
+      ID: 619
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010176e+06
       GoKind: 22
-      Pointee: 618 StructureType crypto/x509.SystemRootsError
+      Pointee: 620 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 519
+      ID: 521
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852288
       GoKind: 22
-      Pointee: 520 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 522 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 515
+      ID: 517
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852096
       GoKind: 22
-      Pointee: 516 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 518 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 532
+      ID: 534
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 858816
       GoKind: 22
-      Pointee: 533 StructureType encoding/asn1.StructuralError
+      Pointee: 535 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 536
+      ID: 538
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859008
       GoKind: 22
-      Pointee: 537 StructureType encoding/asn1.SyntaxError
+      Pointee: 539 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 534
+      ID: 536
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 858912
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 537 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 433
+      ID: 435
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839232
       GoKind: 22
-      Pointee: 334 BaseType encoding/base64.CorruptInputError
+      Pointee: 336 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 785
+      ID: 787
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 999424
       GoKind: 22
-      Pointee: 786 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 788 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 436
+      ID: 438
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840096
       GoKind: 22
-      Pointee: 335 BaseType encoding/hex.InvalidByteError
+      Pointee: 337 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 404
+      ID: 406
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 833952
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 407 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 603
+      ID: 605
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995072
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 606 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 396
+      ID: 398
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833568
       GoKind: 22
-      Pointee: 397 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 399 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 402
+      ID: 404
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 405 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 400
+      ID: 402
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 833760
       GoKind: 22
-      Pointee: 401 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 403 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 398
+      ID: 400
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833664
       GoKind: 22
-      Pointee: 399 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 401 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.147392e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 924 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 406
+      ID: 408
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834336
       GoKind: 22
-      Pointee: 407 StructureType encoding/json.jsonError
+      Pointee: 409 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 793
+      ID: 795
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.012992e+06
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 796 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 505
+      ID: 507
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 22
-      Pointee: 506 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 508 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 503
+      ID: 505
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850560
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 506 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 346 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 348 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 348
+      ID: 350
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 347 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 349 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 508
+      ID: 510
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 511 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.017344e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 902 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4229,19 +4198,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 374
+      ID: 376
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824256
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType errors.errorString
+      Pointee: 377 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 979712
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType errors.joinError
+      Pointee: 573 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4257,806 +4226,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 909
+      ID: 911
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.11312e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType fmt.pp
+      Pointee: 912 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 981504
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType fmt.wrapError
+      Pointee: 575 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 574
+      ID: 576
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 981632
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 577 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 434
+      ID: 436
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839616
       GoKind: 22
-      Pointee: 435 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 437 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 415
+      ID: 417
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 416 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 418 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 417
+      ID: 419
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 22
-      Pointee: 418 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 420 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 735
+      ID: 737
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836544
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 421
+      ID: 423
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 422 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 424 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 737
+      ID: 739
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 740 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 419
+      ID: 421
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 22
-      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 330 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 330
+      ID: 332
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 331 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 414
+      ID: 416
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836448
       GoKind: 22
-      Pointee: 325 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 327 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 327
+      ID: 329
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 328 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 420
+      ID: 422
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 22
-      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 333 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 333
+      ID: 335
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 334 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 807
+      ID: 809
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.12336e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 810 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 887
+      ID: 889
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.920544e+06
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 890 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 526
+      ID: 528
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857280
       GoKind: 22
-      Pointee: 527 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 529 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 681
+      ID: 683
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.126688e+06
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 684 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 917
+      ID: 919
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.12336e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 920 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 454
+      ID: 456
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846144
       GoKind: 22
-      Pointee: 455 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 457 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 461
+      ID: 463
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847200
       GoKind: 22
-      Pointee: 462 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 464 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 456
+      ID: 458
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 846912
       GoKind: 22
-      Pointee: 345 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 347 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 459
+      ID: 461
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 462 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 457
+      ID: 459
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 477
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849120
       GoKind: 22
-      Pointee: 478 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 481
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849312
       GoKind: 22
-      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 479
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849216
       GoKind: 22
-      Pointee: 480 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 475
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849024
       GoKind: 22
-      Pointee: 476 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 756
+      ID: 758
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 755 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 757 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 489
+      ID: 491
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 483
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849408
       GoKind: 22
-      Pointee: 484 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 487
+      ID: 489
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849600
       GoKind: 22
-      Pointee: 488 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 485
+      ID: 487
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 22
-      Pointee: 486 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 491
+      ID: 493
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 849792
       GoKind: 22
-      Pointee: 492 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 497
+      ID: 499
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850080
       GoKind: 22
-      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850176
       GoKind: 22
-      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 849984
       GoKind: 22
-      Pointee: 496 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 493
+      ID: 495
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 849888
       GoKind: 22
-      Pointee: 494 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 501
+      ID: 503
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850368
       GoKind: 22
-      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 504 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 423
+      ID: 425
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838272
       GoKind: 22
-      Pointee: 424 StructureType github.com/cihub/seelog.baseError
+      Pointee: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 846
+      ID: 848
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.675392e+06
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 849 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 425
+      ID: 427
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838368
       GoKind: 22
-      Pointee: 426 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 428 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 825
+      ID: 827
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.36944e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 828 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 781
+      ID: 783
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 998400
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 815
+      ID: 817
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.241248e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 818 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 429
+      ID: 431
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838560
       GoKind: 22
-      Pointee: 430 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 432 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 877
+      ID: 879
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.838592e+06
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 880 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 892
+      ID: 894
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.992e+06
       GoKind: 22
-      Pointee: 889 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 891 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 891
+      ID: 893
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.991616e+06
       GoKind: 22
-      Pointee: 890 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 892 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 783
+      ID: 785
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 998528
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 786 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 427
+      ID: 429
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838464
       GoKind: 22
-      Pointee: 428 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 430 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 431
+      ID: 433
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838656
       GoKind: 22
-      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 434 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 850
+      ID: 852
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.67696e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 853 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 883
+      ID: 885
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.874464e+06
       GoKind: 22
-      Pointee: 884 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 886 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 885
+      ID: 887
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.905216e+06
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 888 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 712
+      ID: 714
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.255328e+06
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 715 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 625
+      ID: 627
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.024384e+06
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 628 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 623
+      ID: 625
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024256e+06
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 626 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 627
+      ID: 629
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.028352e+06
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 630 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 629
+      ID: 631
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.02848e+06
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 632 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 836
+      ID: 838
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.47728e+06
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 839 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.010944e+06
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 622 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 437
+      ID: 439
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840288
       GoKind: 22
-      Pointee: 438 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 440 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 933
+      ID: 935
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.210048e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 936 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 683
+      ID: 685
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.13488e+06
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 686 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.11376e+06
       GoKind: 22
-      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 650
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.113376e+06
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 653 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 589
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 988928
       GoKind: 22
-      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 662
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114144e+06
       GoKind: 22
-      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 988800
       GoKind: 22
-      Pointee: 567 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 569 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.113632e+06
       GoKind: 22
-      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 652
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.113504e+06
       GoKind: 22
-      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 660
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114016e+06
       GoKind: 22
-      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 658
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.113888e+06
       GoKind: 22
-      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 937
+      ID: 939
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.221088e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 940 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 666
+      ID: 668
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.114528e+06
       GoKind: 22
-      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 669 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 593
+      ID: 595
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989184
       GoKind: 22
-      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 596 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 591
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989056
       GoKind: 22
-      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 664
+      ID: 666
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 548
+      ID: 550
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 870912
       GoKind: 22
-      Pointee: 357 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 359 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 359
+      ID: 361
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 358 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 360 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 725
+      ID: 727
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.475744e+06
       GoKind: 22
-      Pointee: 726 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 728 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 633
+      ID: 635
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.043328e+06
       GoKind: 22
-      Pointee: 634 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 636 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 813
+      ID: 815
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.173792e+06
       GoKind: 22
-      Pointee: 814 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 816 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.006976e+06
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 900 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.045632e+06
       GoKind: 22
-      Pointee: 800 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 802 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 549
+      ID: 551
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872160
       GoKind: 22
-      Pointee: 360 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 362 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 691
+      ID: 693
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.175456e+06
       GoKind: 22
-      Pointee: 692 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 694 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 552
+      ID: 554
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872448
       GoKind: 22
-      Pointee: 553 StructureType golang.org/x/net/http2.connError
+      Pointee: 555 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 551
+      ID: 553
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872352
       GoKind: 22
-      Pointee: 364 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 366 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 366
+      ID: 368
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 365 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 367 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 555
+      ID: 557
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872640
       GoKind: 22
-      Pointee: 370 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 372 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 372
+      ID: 374
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 371 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 373 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 554
+      ID: 556
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872544
       GoKind: 22
-      Pointee: 367 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 369 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 369
+      ID: 371
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 368 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 370 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 550
+      ID: 552
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872256
       GoKind: 22
-      Pointee: 361 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 363 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 363
+      ID: 365
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 362 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 364 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 895
+      ID: 897
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.005056e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 898 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872736
       GoKind: 22
-      Pointee: 557 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 559 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 558
+      ID: 560
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 872832
       GoKind: 22
-      Pointee: 373 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 375 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 544
+      ID: 546
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866304
       GoKind: 22
-      Pointee: 545 StructureType google.golang.org/grpc.dropError
+      Pointee: 547 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 689
+      ID: 691
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.172384e+06
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 692 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 714
+      ID: 716
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.262688e+06
       GoKind: 22
-      Pointee: 715 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 717 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 546
+      ID: 548
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869184
       GoKind: 22
-      Pointee: 547 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 549 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 860
+      ID: 862
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.68368e+06
       GoKind: 22
-      Pointee: 861 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 863 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.168928e+06
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 814 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 631
+      ID: 633
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.037568e+06
       GoKind: 22
-      Pointee: 632 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 634 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 771
+      ID: 773
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869280
       GoKind: 22
-      Pointee: 772 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 774 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855168
       GoKind: 22
-      Pointee: 525 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 527 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 621
+      ID: 623
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.0144e+06
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 624 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 687
+      ID: 689
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.14064e+06
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 690 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 685
+      ID: 687
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.140384e+06
       GoKind: 22
-      Pointee: 686 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 688 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 538
+      ID: 540
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 859872
       GoKind: 22
-      Pointee: 539 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 541 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 540
+      ID: 542
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 22
-      Pointee: 541 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 543 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 469
+      ID: 471
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 22
-      Pointee: 470 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 472 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 848
+      ID: 850
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.676064e+06
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 851 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 151
       Name: '*hash<[4]int,[4]int>'
@@ -5083,10 +5052,10 @@ Types:
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 973
+      ID: 975
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 974 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 976 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1003
       Name: '*hash<int,*main.deepMap8>'
@@ -5123,10 +5092,10 @@ Types:
       ByteSize: 8
       Pointee: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 718
+      ID: 720
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 719 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 721 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '*hash<string,int>'
@@ -5178,12 +5147,12 @@ Types:
       ByteSize: 8
       Pointee: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873600
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType html/template.Error
+      Pointee: 562 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -5227,82 +5196,82 @@ Types:
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 439
+      ID: 441
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840672
       GoKind: 22
-      Pointee: 440 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 442 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 828864
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 760 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 648
+      ID: 650
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.112608e+06
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 651 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 939
+      ID: 941
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.22576e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType internal/poll.FD
+      Pointee: 942 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.11248e+06
       GoKind: 22
-      Pointee: 647 StructureType internal/poll.errNetClosing
+      Pointee: 649 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 376
+      ID: 378
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828000
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 379 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 803
+      ID: 805
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.103648e+06
       GoKind: 22
-      Pointee: 804 UnresolvedPointeeType io.PipeWriter
+      Pointee: 806 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.103264e+06
       GoKind: 22
-      Pointee: 802 StructureType io.discard
+      Pointee: 804 StructureType io.discard
     - __kind: PointerType
-      ID: 775
+      ID: 777
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 979968
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType io.multiWriter
+      Pointee: 778 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112224e+06
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType io/fs.PathError
+      Pointee: 647 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 852
+      ID: 854
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.677184e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 855 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 233
       Name: '*main.deepMap2'
@@ -5311,12 +5280,12 @@ Types:
       GoKind: 22
       Pointee: 234 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 978
+      ID: 980
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356224
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType main.deepMap3
+      Pointee: 981 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -5346,12 +5315,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 943
+      ID: 945
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356800
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType main.deepPtr3
+      Pointee: 946 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5381,12 +5350,12 @@ Types:
       GoKind: 22
       Pointee: 227 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 968
+      ID: 970
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357376
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType main.deepSlice3
+      Pointee: 971 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5422,12 +5391,12 @@ Types:
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 959
+      ID: 961
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 823968
       GoKind: 22
-      Pointee: 960 StructureType main.firstBehavior
+      Pointee: 962 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 159
       Name: '*main.node'
@@ -5442,19 +5411,19 @@ Types:
       GoKind: 22
       Pointee: 174 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 961
+      ID: 963
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824064
       GoKind: 22
-      Pointee: 962 StructureType main.secondBehavior
+      Pointee: 964 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 948
+      ID: 950
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824160
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType main.somethingImpl
+      Pointee: 951 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
@@ -5462,16 +5431,16 @@ Types:
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 946
+      ID: 948
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 945 GoStringDataType main.stringType1.str
+      Pointee: 947 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType main.stringType2
+      Pointee: 949 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 177
       Name: '*main.structWithCyclicSlices'
@@ -5502,10 +5471,10 @@ Types:
       GoKind: 22
       Pointee: 161 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 965
+      ID: 967
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 964 GoSliceDataType main.t.array
+      Pointee: 966 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 172
       Name: '*main.threeStringStruct'
@@ -5519,580 +5488,580 @@ Types:
       GoKind: 22
       Pointee: 103 GoMapType map[string]int
     - __kind: PointerType
-      ID: 473
+      ID: 475
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848448
       GoKind: 22
-      Pointee: 474 StructureType math/big.ErrNaN
+      Pointee: 476 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 765
+      ID: 767
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843072
       GoKind: 22
-      Pointee: 766 StructureType mime/multipart.writerOnly·1
+      Pointee: 768 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.120928e+06
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType net.AddrError
+      Pointee: 678 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 701
+      ID: 703
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.239488e+06
       GoKind: 22
-      Pointee: 702 UnresolvedPointeeType net.DNSError
+      Pointee: 704 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.085792e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType net.IPConn
+      Pointee: 906 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 699
+      ID: 701
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.239168e+06
       GoKind: 22
-      Pointee: 700 UnresolvedPointeeType net.OpError
+      Pointee: 702 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 677
+      ID: 679
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121056e+06
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType net.ParseError
+      Pointee: 680 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 913
+      ID: 915
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.115168e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType net.TCPConn
+      Pointee: 916 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 923
+      ID: 925
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.160128e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net.UDPConn
+      Pointee: 926 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 911
+      ID: 913
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.114656e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType net.UnixConn
+      Pointee: 914 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 674
+      ID: 676
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.12016e+06
       GoKind: 22
-      Pointee: 637 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 639 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 639
+      ID: 641
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 638 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 640 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 605
+      ID: 607
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 995840
       GoKind: 22
-      Pointee: 606 StructureType net.canceledError
+      Pointee: 608 StructureType net.canceledError
     - __kind: PointerType
-      ID: 881
+      ID: 883
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.87216e+06
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType net.conn
+      Pointee: 884 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 744
+      ID: 746
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.716384e+06
       GoKind: 22
-      Pointee: 745 StructureType net.dialResult·1
+      Pointee: 747 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.164384e+06
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType net.netFD
+      Pointee: 928 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 408
+      ID: 410
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835296
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType net.notFoundError
+      Pointee: 411 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 410
+      ID: 412
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 835968
       GoKind: 22
-      Pointee: 411 StructureType net.result·2
+      Pointee: 413 StructureType net.result·2
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.09968e+06
       GoKind: 22
-      Pointee: 908 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 910 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.0992e+06
       GoKind: 22
-      Pointee: 906 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 908 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 679
+      ID: 681
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.121696e+06
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType net.temporaryError
+      Pointee: 682 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 703
+      ID: 705
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.239648e+06
       GoKind: 22
-      Pointee: 704 UnresolvedPointeeType net.timeoutError
+      Pointee: 706 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 595
+      ID: 597
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 991616
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 598 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 759
+      ID: 761
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831168
       GoKind: 22
-      Pointee: 760 StructureType net/http.bufioFlushWriter
+      Pointee: 762 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 385
+      ID: 387
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 831840
       GoKind: 22
-      Pointee: 306 BaseType net/http.http2ConnectionError
+      Pointee: 308 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 386
+      ID: 388
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 831936
       GoKind: 22
-      Pointee: 387 StructureType net/http.http2GoAwayError
+      Pointee: 389 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 695
+      ID: 697
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.235328e+06
       GoKind: 22
-      Pointee: 696 StructureType net/http.http2StreamError
+      Pointee: 698 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 390
+      ID: 392
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832416
       GoKind: 22
-      Pointee: 391 StructureType net/http.http2connError
+      Pointee: 393 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 821
+      ID: 823
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.36608e+06
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 824 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 389
+      ID: 391
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832320
       GoKind: 22
-      Pointee: 310 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 312 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 312
+      ID: 314
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 313 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 393
+      ID: 395
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832608
       GoKind: 22
-      Pointee: 316 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 318 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 318
+      ID: 320
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 319 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 392
+      ID: 394
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832512
       GoKind: 22
-      Pointee: 313 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 315 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 315
+      ID: 317
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 316 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 670
+      ID: 672
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.116704e+06
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 673 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 601
+      ID: 603
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992256
       GoKind: 22
-      Pointee: 602 StructureType net/http.http2noCachedConnError
+      Pointee: 604 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.81616e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 875 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 388
+      ID: 390
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832224
       GoKind: 22
-      Pointee: 307 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 309 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 309
+      ID: 311
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 310 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 761
+      ID: 763
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832704
       GoKind: 22
-      Pointee: 762 StructureType net/http.http2stickyErrWriter
+      Pointee: 764 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 597
+      ID: 599
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 991872
       GoKind: 22
-      Pointee: 598 StructureType net/http.nothingWrittenError
+      Pointee: 600 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 823
+      ID: 825
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.030112e+06
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType net/http.persistConn
+      Pointee: 826 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 779
+      ID: 781
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 991744
       GoKind: 22
-      Pointee: 780 StructureType net/http.persistConnWriter
+      Pointee: 782 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 805
+      ID: 807
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.11568e+06
       GoKind: 22
-      Pointee: 806 StructureType net/http.readWriteCloserBody
+      Pointee: 808 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 394
+      ID: 396
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 832800
       GoKind: 22
-      Pointee: 395 StructureType net/http.requestBodyReadError
+      Pointee: 397 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 697
+      ID: 699
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.236448e+06
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 700 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 668
+      ID: 670
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.116576e+06
       GoKind: 22
-      Pointee: 669 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 671 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 599
+      ID: 601
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992000
       GoKind: 22
-      Pointee: 600 StructureType net/http.transportReadFromServerError
+      Pointee: 602 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 383
+      ID: 385
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831072
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 386 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.817696e+06
       GoKind: 22
-      Pointee: 875 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 877 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 789
+      ID: 791
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.005312e+06
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 792 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 465
+      ID: 467
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847392
       GoKind: 22
-      Pointee: 466 StructureType net/netip.parseAddrError
+      Pointee: 468 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 463
+      ID: 465
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847296
       GoKind: 22
-      Pointee: 464 StructureType net/netip.parsePrefixError
+      Pointee: 466 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 831
+      ID: 833
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.979776e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType net/smtp.Client
+      Pointee: 834 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 791
+      ID: 793
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.010432e+06
       GoKind: 22
-      Pointee: 792 StructureType net/smtp.dataCloser
+      Pointee: 794 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 449
+      ID: 451
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843264
       GoKind: 22
-      Pointee: 450 UnresolvedPointeeType net/textproto.Error
+      Pointee: 452 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 448
+      ID: 450
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843168
       GoKind: 22
-      Pointee: 341 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 343 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 343
+      ID: 345
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 342 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 344 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 787
+      ID: 789
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.004672e+06
       GoKind: 22
-      Pointee: 788 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 790 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 705
+      ID: 707
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.239968e+06
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType net/url.Error
+      Pointee: 708 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 412
+      ID: 414
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836064
       GoKind: 22
-      Pointee: 319 GoStringHeaderType net/url.EscapeError
+      Pointee: 321 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 321
+      ID: 323
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType net/url.EscapeError.str
+      Pointee: 322 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 413
+      ID: 415
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836160
       GoKind: 22
-      Pointee: 322 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 324 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 324
+      ID: 326
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 325 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.201632e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType os.File
+      Pointee: 934 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 982784
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType os.LinkError
+      Pointee: 579 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105184e+06
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType os.SyscallError
+      Pointee: 643 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.198688e+06
       GoKind: 22
-      Pointee: 930 StructureType os.fileWithoutReadFrom
+      Pointee: 932 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 927
+      ID: 929
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.197952e+06
       GoKind: 22
-      Pointee: 928 StructureType os.fileWithoutWriteTo
+      Pointee: 930 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 607
+      ID: 609
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001344e+06
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType os/exec.Error
+      Pointee: 610 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.951744e+06
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 750 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 809
+      ID: 811
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.127712e+06
       GoKind: 22
-      Pointee: 810 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 812 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 609
+      ID: 611
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.001472e+06
       GoKind: 22
-      Pointee: 610 StructureType os/exec.wrappedError
+      Pointee: 612 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 543
+      ID: 545
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864384
       GoKind: 22
-      Pointee: 354 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 356 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 356
+      ID: 358
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 355 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 357 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 542
+      ID: 544
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864288
       GoKind: 22
-      Pointee: 353 BaseType os/user.UnknownUserIdError
+      Pointee: 355 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 378
+      ID: 380
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 828768
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType reflect.ValueError
+      Pointee: 381 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 471
+      ID: 473
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848064
       GoKind: 22
-      Pointee: 472 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 474 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 579
+      ID: 581
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984320
       GoKind: 22
-      Pointee: 580 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 582 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986240
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 587 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 581
+      ID: 583
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 984448
       GoKind: 22
-      Pointee: 582 StructureType runtime.boundsError
+      Pointee: 584 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 642
+      ID: 644
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.11056e+06
       GoKind: 22
-      Pointee: 643 StructureType runtime.errorAddressString
+      Pointee: 645 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984064
       GoKind: 22
-      Pointee: 561 GoStringHeaderType runtime.errorString
+      Pointee: 563 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 563
+      ID: 565
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 562 GoStringDataType runtime.errorString.str
+      Pointee: 564 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
@@ -6101,24 +6070,24 @@ Types:
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 583
+      ID: 585
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 985984
       GoKind: 22
-      Pointee: 564 GoStringHeaderType runtime.plainError
+      Pointee: 566 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 566
+      ID: 568
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 565 GoStringDataType runtime.plainError.str
+      Pointee: 567 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 986496
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType strconv.NumError
+      Pointee: 589 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6132,73 +6101,73 @@ Types:
       ByteSize: 8
       Pointee: 223 GoStringDataType string.str
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.81488e+06
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType strings.Builder
+      Pointee: 873 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 777
+      ID: 779
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 986624
       GoKind: 22
-      Pointee: 778 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 780 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 773
+      ID: 775
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 774 StructureType struct { io.Writer }
+      Pointee: 776 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.234688e+06
       GoKind: 22
-      Pointee: 693 BaseType syscall.Errno
+      Pointee: 695 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.017728e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 904 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 635
+      ID: 637
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.047168e+06
       GoKind: 22
-      Pointee: 636 StructureType text/template.ExecError
+      Pointee: 638 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 710
+      ID: 712
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.4312e+06
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType time.Location
+      Pointee: 713 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 381
+      ID: 383
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829632
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType time.ParseError
+      Pointee: 384 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 380
+      ID: 382
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829536
       GoKind: 22
-      Pointee: 303 GoStringHeaderType time.fileSizeError
+      Pointee: 305 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 305
+      ID: 307
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 304 GoStringDataType time.fileSizeError.str
+      Pointee: 306 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6242,54 +6211,54 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 864
+      ID: 866
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.771136e+06
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 867 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 467
+      ID: 469
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847488
       GoKind: 22
-      Pointee: 468 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 470 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 893
+      ID: 895
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.994304e+06
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 896 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 451
+      ID: 453
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843648
       GoKind: 22
-      Pointee: 452 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 454 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 453
+      ID: 455
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 843744
       GoKind: 22
-      Pointee: 344 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 346 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 614
+      ID: 616
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005056e+06
       GoKind: 22
-      Pointee: 615 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 617 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005184e+06
       GoKind: 22
-      Pointee: 569 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 571 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1124
       Name: Probe[main.stackC]
@@ -8280,7 +8249,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 739
+      ID: 741
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 624000
@@ -8320,7 +8289,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 966
+      ID: 968
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446848
@@ -8328,19 +8297,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 967 PointerType **main.deepSlice3
+          Type: 969 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 970 GoSliceDataType []*main.deepSlice3.array
+      Data: 972 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 970
+      ID: 972
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 968 PointerType *main.deepSlice3
+      Element: 970 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 987
       Name: '[]*main.deepSlice8'
@@ -8581,10 +8550,10 @@ Types:
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 980
+      ID: 982
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 976 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 978 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1010
       Name: '[]bucket<int,*main.deepMap8>.array'
@@ -8621,10 +8590,10 @@ Types:
       ByteSize: 2048
       Element: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 750
+      ID: 752
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 2048
-      Element: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 723 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 241
       Name: '[]bucket<string,int>.array'
@@ -8676,7 +8645,7 @@ Types:
       ByteSize: 2048
       Element: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 734
+      ID: 736
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454080
@@ -8691,9 +8660,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 753 GoSliceDataType []float64.array
+      Data: 755 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 753
+      ID: 755
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 17 BaseType float64
@@ -8804,9 +8773,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 981 GoSliceDataType []main.structWithMap.array
+      Data: 303 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 981
+      ID: 303
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 92 StructureType main.structWithMap
@@ -8898,7 +8867,7 @@ Types:
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 728
+      ID: 730
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 453056
@@ -8913,9 +8882,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 751 GoSliceDataType []uint8.array
+      Data: 753 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 751
+      ID: 753
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -8927,12 +8896,12 @@ Types:
       HasCount: true
       Element: 233 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 977
+      ID: 979
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 978 PointerType *main.deepMap3
+      Element: 980 PointerType *main.deepMap3
     - __kind: ArrayType
       ID: 1007
       Name: '[]val<*main.deepMap8>'
@@ -8976,12 +8945,12 @@ Types:
       HasCount: true
       Element: 168 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 749
+      ID: 751
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 743 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
       ID: 236
       Name: '[]val<int>'
@@ -9060,11 +9029,11 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 882
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 529
+      ID: 531
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858432
@@ -9079,32 +9048,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 530 GoSliceDataType archive/tar.headerError.array
+      Data: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 532
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 822
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 768
+      ID: 770
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 770
+      ID: 772
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.078272e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 869
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 796
+      ID: 798
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.37616e+06
@@ -9114,7 +9083,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 798
+      ID: 800
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9219,7 +9188,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 233 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 976
+      ID: 978
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
@@ -9231,12 +9200,12 @@ Types:
           Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 977 ArrayType []val<*main.deepMap3>
+          Type: 979 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 975 PointerType *bucket<int,*main.deepMap3>
+          Type: 977 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 978 PointerType *main.deepMap3
+      ValueType: 980 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
       ID: 1006
       Name: bucket<int,*main.deepMap8>
@@ -9371,7 +9340,7 @@ Types:
       KeyType: 11 GoStringHeaderType string
       ValueType: 168 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 721
+      ID: 723
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
@@ -9383,12 +9352,12 @@ Types:
           Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 749 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 751 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 722 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 743 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 107
       Name: bucket<string,int>
@@ -9580,15 +9549,15 @@ Types:
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 846
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 871
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 918
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9614,13 +9583,13 @@ Types:
       GoRuntimeType: 532064
       GoKind: 15
     - __kind: BaseType
-      ID: 336
+      ID: 338
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764544
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 337
+      ID: 339
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764640
@@ -9628,91 +9597,91 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 339 PointerType *compress/flate.InternalError.str
+          Type: 341 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 338 GoStringDataType compress/flate.InternalError.str
+      Data: 340 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 338
+      ID: 340
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 820
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 764
+      ID: 766
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 842
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 673
+      ID: 675
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296096e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 350
+      ID: 352
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767136
       GoKind: 2
     - __kind: BaseType
-      ID: 351
+      ID: 353
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767232
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 832
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 857
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 352
+      ID: 354
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767328
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 865
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 857
+      ID: 859
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 861
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 340
+      ID: 342
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765120
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 615
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 944
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 446
+      ID: 448
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 444
+      ID: 446
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.60448e+06
@@ -9723,34 +9692,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 739 ArrayType [5]uint8
+          Type: 741 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 740 GoInterfaceType net.Conn
+          Type: 742 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 568
+      ID: 570
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951296
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 830
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 837
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 710
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 725
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 518
+      ID: 520
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.607552e+06
@@ -9758,21 +9727,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 722 PointerType *crypto/x509.Certificate
+          Type: 724 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 742 BaseType crypto/x509.InvalidReason
+          Type: 744 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 512
+      ID: 514
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.075584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 514
+      ID: 516
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.408512e+06
@@ -9780,24 +9749,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 722 PointerType *crypto/x509.Certificate
+          Type: 724 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 349
+      ID: 351
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 766752
       GoKind: 2
     - __kind: BaseType
-      ID: 742
+      ID: 744
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537568
       GoKind: 2
     - __kind: StructureType
-      ID: 618
+      ID: 620
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.37248e+06
@@ -9807,13 +9776,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 520
+      ID: 522
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.07584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 516
+      ID: 518
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.60736e+06
@@ -9821,15 +9790,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 722 PointerType *crypto/x509.Certificate
+          Type: 724 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 722 PointerType *crypto/x509.Certificate
+          Type: 724 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 533
+      ID: 535
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.253568e+06
@@ -9839,7 +9808,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 537
+      ID: 539
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.253728e+06
@@ -9849,55 +9818,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 537
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 334
+      ID: 336
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764160
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 786
+      ID: 788
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 335
+      ID: 337
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764352
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 407
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 606
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 397
+      ID: 399
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 405
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 401
+      ID: 403
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 399
+      ID: 401
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 407
+      ID: 409
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.238208e+06
@@ -9907,19 +9876,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 796
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 506
+      ID: 508
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 506
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 346
+      ID: 348
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766656
@@ -9927,21 +9896,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 348 PointerType *encoding/xml.UnmarshalError.str
+          Type: 350 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 347 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 349 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 347
+      ID: 349
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 511
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 902
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9958,11 +9927,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 377
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 573
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9978,15 +9947,15 @@ Types:
       GoRuntimeType: 532256
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 912
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 575
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 577
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9996,11 +9965,11 @@ Types:
       GoRuntimeType: 445248
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 435
+      ID: 437
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 416
+      ID: 418
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.602752e+06
@@ -10008,7 +9977,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 732 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 734 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -10016,25 +9985,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 418
+      ID: 420
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 738
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 422
+      ID: 424
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 740
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 330
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763584
@@ -10042,17 +10011,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 332 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 331 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 331
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 732
+      ID: 734
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.073568e+06
@@ -10060,7 +10029,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 733 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 735 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -10075,7 +10044,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 734 GoSliceHeaderType []float64
+          Type: 736 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -10084,10 +10053,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 737 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 737 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 739 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 168 GoSliceHeaderType []string
@@ -10101,13 +10070,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 733
+      ID: 735
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534112
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 327
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763488
@@ -10115,17 +10084,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 329 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 326 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 328 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 328
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 333
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763680
@@ -10133,59 +10102,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 335 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 334 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 334
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 810
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 890
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 527
+      ID: 529
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 684
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 920
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 455
+      ID: 457
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 462
+      ID: 464
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.074816e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 345
+      ID: 347
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 765792
       GoKind: 2
     - __kind: StructureType
-      ID: 460
+      ID: 462
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.074688e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 458
+      ID: 460
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.406592e+06
@@ -10198,7 +10167,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 478
+      ID: 480
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.407392e+06
@@ -10211,7 +10180,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 482
+      ID: 484
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.606784e+06
@@ -10227,7 +10196,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 480
+      ID: 482
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.247968e+06
@@ -10237,7 +10206,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 476
+      ID: 478
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.247648e+06
@@ -10247,14 +10216,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 717
+      ID: 719
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135136e+06
       GoKind: 21
-      HeaderType: 719 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 721 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 741
+      ID: 743
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.008768e+06
@@ -10269,14 +10238,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 755 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 757 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 755
+      ID: 757
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 490
+      ID: 492
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.407712e+06
@@ -10284,12 +10253,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 717 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 719 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 717 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 719 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 484
+      ID: 486
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.248128e+06
@@ -10299,7 +10268,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 488
+      ID: 490
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.606976e+06
@@ -10310,12 +10279,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 743 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 743 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 486
+      ID: 488
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.407552e+06
@@ -10328,7 +10297,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 492
+      ID: 494
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.248288e+06
@@ -10336,9 +10305,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 709 StructureType time.Time
+          Type: 711 StructureType time.Time
     - __kind: StructureType
-      ID: 498
+      ID: 500
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.408032e+06
@@ -10351,7 +10320,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 500
+      ID: 502
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.248608e+06
@@ -10361,7 +10330,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 496
+      ID: 498
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.407872e+06
@@ -10374,7 +10343,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 494
+      ID: 496
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.248448e+06
@@ -10384,7 +10353,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 502
+      ID: 504
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.408192e+06
@@ -10397,7 +10366,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 424
+      ID: 426
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.240448e+06
@@ -10407,11 +10376,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 849
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 426
+      ID: 428
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.240608e+06
@@ -10419,21 +10388,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 424 StructureType github.com/cihub/seelog.baseError
+          Type: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 828
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 784
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 818
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 430
+      ID: 432
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.240928e+06
@@ -10441,13 +10410,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 424 StructureType github.com/cihub/seelog.baseError
+          Type: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 880
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 889
+      ID: 891
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.96784e+06
@@ -10455,12 +10424,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 877 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 879 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 890
+      ID: 892
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.991232e+06
@@ -10468,7 +10437,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 877 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 879 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -10476,11 +10445,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 786
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 428
+      ID: 430
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.240768e+06
@@ -10488,9 +10457,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 424 StructureType github.com/cihub/seelog.baseError
+          Type: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 432
+      ID: 434
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.241088e+06
@@ -10498,64 +10467,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 424 StructureType github.com/cihub/seelog.baseError
+          Type: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 853
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 884
+      ID: 886
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 888
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 715
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 628
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 626
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 630
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 632
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 839
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 622
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 438
+      ID: 440
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.242048e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 936
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 686
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 659
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.711456e+06
@@ -10571,11 +10540,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.509248e+06
@@ -10588,7 +10557,7 @@ Types:
           Offset: 1
           Type: 14 BaseType int8
     - __kind: StructureType
-      ID: 663
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.711904e+06
@@ -10604,13 +10573,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 567
+      ID: 569
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 948704
       GoKind: 8
     - __kind: StructureType
-      ID: 655
+      ID: 657
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.711232e+06
@@ -10626,13 +10595,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 743
+      ID: 745
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 761760
       GoKind: 8
     - __kind: StructureType
-      ID: 653
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.711008e+06
@@ -10640,15 +10609,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 743 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 745 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 743 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 745 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 661
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.6296e+06
@@ -10661,7 +10630,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 659
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.71168e+06
@@ -10677,11 +10646,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 940
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 669
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.43216e+06
@@ -10691,19 +10660,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 594
+      ID: 596
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.194976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 592
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.194848e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 665
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.629792e+06
@@ -10716,7 +10685,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 357
+      ID: 359
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769152
@@ -10724,21 +10693,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 359 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 361 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 358 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 360 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 358
+      ID: 360
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 726
+      ID: 728
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 634
+      ID: 636
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.265408e+06
@@ -10748,7 +10717,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 814
+      ID: 816
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.486112e+06
@@ -10756,13 +10725,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 838 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 840 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 900
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 838
+      ID: 840
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.085696e+06
@@ -10775,7 +10744,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 800
+      ID: 802
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.38096e+06
@@ -10785,19 +10754,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 360
+      ID: 362
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769728
       GoKind: 10
     - __kind: BaseType
-      ID: 724
+      ID: 726
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 961952
       GoKind: 10
     - __kind: StructureType
-      ID: 692
+      ID: 694
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.749984e+06
@@ -10808,12 +10777,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 724 BaseType golang.org/x/net/http2.ErrCode
+          Type: 726 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 553
+      ID: 555
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.415392e+06
@@ -10821,12 +10790,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 724 BaseType golang.org/x/net/http2.ErrCode
+          Type: 726 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 364
+      ID: 366
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769920
@@ -10834,17 +10803,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 366 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 368 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 365 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 367 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 365
+      ID: 367
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 370
+      ID: 372
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770112
@@ -10852,17 +10821,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 372 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 374 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 371 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 373 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 371
+      ID: 373
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 367
+      ID: 369
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770016
@@ -10870,17 +10839,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 369 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 371 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 368 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 370 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 368
+      ID: 370
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 361
+      ID: 363
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769824
@@ -10888,21 +10857,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 363 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 365 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 362 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 364 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 362
+      ID: 364
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 898
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 559
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.266048e+06
@@ -10912,13 +10881,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 373
+      ID: 375
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770208
       GoKind: 2
     - __kind: StructureType
-      ID: 545
+      ID: 547
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.261088e+06
@@ -10928,11 +10897,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 692
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 715
+      ID: 717
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.775744e+06
@@ -10948,7 +10917,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 547
+      ID: 549
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.414912e+06
@@ -10961,7 +10930,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 861
+      ID: 863
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.829216e+06
@@ -10969,16 +10938,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 740 GoInterfaceType net.Conn
+          Type: 742 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 876 GoInterfaceType io.Reader
+          Type: 878 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 814
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 632
+      ID: 634
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.37856e+06
@@ -10988,29 +10957,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 772
+      ID: 774
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 525
+      ID: 527
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 624
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 690
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 688
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.325696e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 539
+      ID: 541
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.254368e+06
@@ -11020,7 +10989,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 541
+      ID: 543
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.254528e+06
@@ -11030,11 +10999,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 470
+      ID: 472
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 851
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -11208,7 +11177,7 @@ Types:
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
       BucketsType: 235 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 974
+      ID: 976
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -11229,18 +11198,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 975 PointerType *bucket<int,*main.deepMap3>
+          Type: 977 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 975 PointerType *bucket<int,*main.deepMap3>
+          Type: 977 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 976 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 980 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 978 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 982 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
       ID: 1004
       Name: hash<int,*main.deepMap8>
@@ -11480,7 +11449,7 @@ Types:
       BucketType: 112 GoHMapBucketType bucket<string,[]string>
       BucketsType: 243 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 719
+      ID: 721
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -11501,18 +11470,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 722 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 722 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 750 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 723 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 752 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 105
       Name: hash<string,int>
@@ -11854,7 +11823,7 @@ Types:
       BucketType: 139 GoHMapBucketType bucket<uint8,uint8>
       BucketsType: 258 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 562
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11901,37 +11870,37 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 440
+      ID: 442
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 760
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 651
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 942
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 647
+      ID: 649
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293056e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 379
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 804
+      ID: 806
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 845
+      ID: 847
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.103392e+06
@@ -11944,7 +11913,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 876
+      ID: 878
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 980096
@@ -11957,7 +11926,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 833
+      ID: 835
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.068416e+06
@@ -11983,21 +11952,21 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 802
+      ID: 804
       Name: io.discard
       GoRuntimeType: 1.280416e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 778
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 647
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 855
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -12065,9 +12034,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 972 GoMapType map[int]*main.deepMap3
+          Type: 974 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 981
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -12119,9 +12088,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 943 PointerType *main.deepPtr3
+          Type: 945 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 946
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -12173,9 +12142,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 966 GoSliceHeaderType []*main.deepSlice3
+          Type: 968 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 971
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -12225,16 +12194,16 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 950 StructureType sync.Mutex
+          Type: 952 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 951 StructureType sync.Once
+          Type: 953 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 954 StructureType sync.WaitGroup
+          Type: 956 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 958 StructureType sync/atomic.Int32
+          Type: 960 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
@@ -12264,7 +12233,7 @@ Types:
           Offset: 56
           Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 960
+      ID: 962
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.231488e+06
@@ -12309,7 +12278,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 962
+      ID: 964
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.231648e+06
@@ -12329,7 +12298,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 951
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12340,17 +12309,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 946 PointerType *main.stringType1.str
+          Type: 948 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 945 GoStringDataType main.stringType1.str
+      Data: 947 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 945
+      ID: 947
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 949
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -12453,16 +12422,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 963 PointerType **main.t
+          Type: 965 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 964 GoSliceDataType main.t.array
+      Data: 966 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 964
+      ID: 966
       Name: main.t.array
       ByteSize: 2048
       Element: 160 PointerType *main.t
@@ -12522,12 +12491,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 972
+      ID: 974
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879744
       GoKind: 21
-      HeaderType: 974 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 976 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1002
       Name: map[int]*main.deepMap8
@@ -12642,7 +12611,7 @@ Types:
       GoKind: 21
       HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 474
+      ID: 476
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.247328e+06
@@ -12652,7 +12621,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 766
+      ID: 768
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.244128e+06
@@ -12662,11 +12631,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 678
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 740
+      ID: 742
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.405312e+06
@@ -12679,35 +12648,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 702
+      ID: 704
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 906
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 700
+      ID: 702
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 680
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 916
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 926
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 914
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 637
+      ID: 639
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.071616e+06
@@ -12715,27 +12684,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 639 PointerType *net.UnknownNetworkError.str
+          Type: 641 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 638 GoStringDataType net.UnknownNetworkError.str
+      Data: 640 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 638
+      ID: 640
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 606
+      ID: 608
       Name: net.canceledError
       GoRuntimeType: 1.195872e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 884
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 745
+      ID: 747
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.967136e+06
@@ -12743,7 +12712,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 740 GoInterfaceType net.Conn
+          Type: 742 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -12754,27 +12723,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 928
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 920
+      ID: 922
       Name: net.noReadFrom
       GoRuntimeType: 1.071872e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 919
+      ID: 921
       Name: net.noWriteTo
       GoRuntimeType: 1.071744e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 411
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 411
+      ID: 413
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.60256e+06
@@ -12782,7 +12751,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 727 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 729 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -12790,7 +12759,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 908
+      ID: 910
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.143456e+06
@@ -12798,12 +12767,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 920 StructureType net.noReadFrom
+          Type: 922 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 913 PointerType *net.TCPConn
+          Type: 915 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 906
+      ID: 908
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.142912e+06
@@ -12811,24 +12780,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 919 StructureType net.noWriteTo
+          Type: 921 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 913 PointerType *net.TCPConn
+          Type: 915 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 682
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 704
+      ID: 706
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 598
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 760
+      ID: 762
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.235648e+06
@@ -12838,19 +12807,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 306
+      ID: 308
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762240
       GoKind: 10
     - __kind: BaseType
-      ID: 716
+      ID: 718
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 948800
       GoKind: 10
     - __kind: StructureType
-      ID: 387
+      ID: 389
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.60064e+06
@@ -12861,12 +12830,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 716 BaseType net/http.http2ErrCode
+          Type: 718 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 696
+      ID: 698
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.766016e+06
@@ -12877,12 +12846,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 716 BaseType net/http.http2ErrCode
+          Type: 718 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 391
+      ID: 393
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.404832e+06
@@ -12890,16 +12859,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 716 BaseType net/http.http2ErrCode
+          Type: 718 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 824
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 312
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762432
@@ -12907,17 +12876,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 314 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 311 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 313 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 313
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 318
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762624
@@ -12925,17 +12894,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *net/http.http2headerFieldNameError.str
+          Type: 320 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 319 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 319
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 315
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762528
@@ -12943,31 +12912,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *net/http.http2headerFieldValueError.str
+          Type: 317 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 314 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 316 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 316
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 673
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 602
+      ID: 604
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.195232e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 875
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 309
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762336
@@ -12975,17 +12944,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 311 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 310 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 310
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 762
+      ID: 764
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.601408e+06
@@ -12993,22 +12962,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 740 GoInterfaceType net.Conn
+          Type: 742 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 841 BaseType time.Duration
+          Type: 843 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 33 PointerType *error
     - __kind: ArrayType
-      ID: 842
+      ID: 844
       Name: net/http.incomparable
       GoRuntimeType: 830880
       GoKind: 17
       HasCount: true
       Element: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 598
+      ID: 600
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.36672e+06
@@ -13018,11 +12987,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 826
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 780
+      ID: 782
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.36656e+06
@@ -13030,9 +12999,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 823 PointerType *net/http.persistConn
+          Type: 825 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 806
+      ID: 808
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.672704e+06
@@ -13040,15 +13009,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 842 ArrayType net/http.incomparable
+          Type: 844 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 843 PointerType *bufio.Reader
+          Type: 845 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 845 GoInterfaceType io.ReadWriteCloser
+          Type: 847 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 395
+      ID: 397
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.236608e+06
@@ -13058,17 +13027,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 700
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 671
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.295776e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 600
+      ID: 602
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.36688e+06
@@ -13078,11 +13047,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 386
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 877
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.904256e+06
@@ -13090,13 +13059,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 868 PointerType *bufio.Writer
+          Type: 870 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 792
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 466
+      ID: 468
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.6064e+06
@@ -13112,7 +13081,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 464
+      ID: 466
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.406752e+06
@@ -13125,11 +13094,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 834
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 792
+      ID: 794
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.408672e+06
@@ -13137,16 +13106,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 831 PointerType *net/smtp.Client
+          Type: 833 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 833 GoInterfaceType io.WriteCloser
+          Type: 835 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 450
+      ID: 452
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 341
+      ID: 343
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765216
@@ -13154,25 +13123,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 343 PointerType *net/textproto.ProtocolError.str
+          Type: 345 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 342 GoStringDataType net/textproto.ProtocolError.str
+      Data: 344 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 342
+      ID: 344
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 788
+      ID: 790
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 708
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 321
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763200
@@ -13180,17 +13149,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *net/url.EscapeError.str
+          Type: 323 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 320 GoStringDataType net/url.EscapeError.str
+      Data: 322 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 322
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 324
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763296
@@ -13198,29 +13167,29 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *net/url.InvalidHostError.str
+          Type: 326 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 323 GoStringDataType net/url.InvalidHostError.str
+      Data: 325 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 325
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 934
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 579
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 643
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 930
+      ID: 932
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.211648e+06
@@ -13228,12 +13197,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 936 StructureType os.noReadFrom
+          Type: 938 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 931 PointerType *os.File
+          Type: 933 PointerType *os.File
     - __kind: StructureType
-      ID: 928
+      ID: 930
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.210848e+06
@@ -13241,36 +13210,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 935 StructureType os.noWriteTo
+          Type: 937 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 931 PointerType *os.File
+          Type: 933 PointerType *os.File
     - __kind: StructureType
-      ID: 936
+      ID: 938
       Name: os.noReadFrom
       GoRuntimeType: 1.069312e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 935
+      ID: 937
       Name: os.noWriteTo
       GoRuntimeType: 1.069184e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 610
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 750
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 810
+      ID: 812
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 610
+      ID: 612
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.509824e+06
@@ -13283,7 +13252,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 354
+      ID: 356
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768384
@@ -13291,39 +13260,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 356 PointerType *os/user.UnknownGroupIdError.str
+          Type: 358 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 355 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 357 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 355
+      ID: 357
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 353
+      ID: 355
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768288
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 381
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 472
+      ID: 474
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 580
+      ID: 582
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 587
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 582
+      ID: 584
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.755584e+06
@@ -13340,15 +13309,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 746 BaseType runtime.boundsErrorCode
+          Type: 748 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 746
+      ID: 748
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532448
       GoKind: 8
     - __kind: StructureType
-      ID: 643
+      ID: 645
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.626528e+06
@@ -13361,7 +13330,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 561
+      ID: 563
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 947648
@@ -13369,13 +13338,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 563 PointerType *runtime.errorString.str
+          Type: 565 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 562 GoStringDataType runtime.errorString.str
+      Data: 564 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 562
+      ID: 564
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
@@ -13383,7 +13352,7 @@ Types:
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 564
+      ID: 566
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948224
@@ -13391,17 +13360,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 566 PointerType *runtime.plainError.str
+          Type: 568 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 565 GoStringDataType runtime.plainError.str
+      Data: 567 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 565
+      ID: 567
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 589
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -13423,15 +13392,15 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 873
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 778
+      ID: 780
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 774
+      ID: 776
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.272576e+06
@@ -13447,7 +13416,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 950
+      ID: 952
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281216e+06
@@ -13460,7 +13429,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 951
+      ID: 953
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282336e+06
@@ -13468,12 +13437,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 952 StructureType sync/atomic.Uint32
+          Type: 954 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 950 StructureType sync.Mutex
+          Type: 952 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 954
+      ID: 956
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421024e+06
@@ -13481,21 +13450,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 955 StructureType sync.noCopy
+          Type: 957 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 956 StructureType sync/atomic.Uint64
+          Type: 958 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 955
+      ID: 957
       Name: sync.noCopy
       GoRuntimeType: 946592
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 958
+      ID: 960
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282656e+06
@@ -13503,12 +13472,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 953 StructureType sync/atomic.noCopy
+          Type: 955 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 952
+      ID: 954
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.282816e+06
@@ -13516,12 +13485,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 953 StructureType sync/atomic.noCopy
+          Type: 955 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 956
+      ID: 958
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.421408e+06
@@ -13529,37 +13498,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 953 StructureType sync/atomic.noCopy
+          Type: 955 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 957 StructureType sync/atomic.align64
+          Type: 959 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 957
+      ID: 959
       Name: sync/atomic.align64
       GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 953
+      ID: 955
       Name: sync/atomic.noCopy
       GoRuntimeType: 946688
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 693
+      ID: 695
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.194464e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 636
+      ID: 638
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.51424e+06
@@ -13572,21 +13541,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 841
+      ID: 843
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.781856e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 713
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 384
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 709
+      ID: 711
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.223872e+06
@@ -13600,9 +13569,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 710 PointerType *time.Location
+          Type: 712 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 303
+      ID: 305
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761376
@@ -13610,13 +13579,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 305 PointerType *time.fileSizeError.str
+          Type: 307 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 304 GoStringDataType time.fileSizeError.str
+      Data: 306 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 304
+      ID: 306
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -13662,11 +13631,11 @@ Types:
       GoRuntimeType: 532384
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 867
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 727
+      ID: 729
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.925984e+06
@@ -13674,13 +13643,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 728 GoSliceHeaderType []uint8
+          Type: 730 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 729 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 731 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 730 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 732 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -13695,18 +13664,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 731 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 733 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 731
+      ID: 733
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 952928
       GoKind: 9
     - __kind: StructureType
-      ID: 729
+      ID: 731
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.792352e+06
@@ -13731,21 +13700,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 468
+      ID: 470
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 730
+      ID: 732
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536032
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 896
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 452
+      ID: 454
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.244448e+06
@@ -13755,13 +13724,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 344
+      ID: 346
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765312
       GoKind: 2
     - __kind: StructureType
-      ID: 615
+      ID: 617
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510016e+06
@@ -13774,7 +13743,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 569
+      ID: 571
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 951776

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -2326,15 +2326,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd58d6..0xcd58e7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd58e7..0xcd5985
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcd59a0..0xcd5a02]
@@ -2351,29 +2342,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcd5a20..0xcd5b2e]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5a7b..0xcd5a85
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5a85..0xcd5aa0
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5aa0..0xcd5ab4
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5a76..0xcd5a80
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5a80..0xcd5aa0
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5aa0..0xcd5aaf
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcd5b40..0xcd5b46]
@@ -3478,10 +3447,10 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1093
+      ID: 1095
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1094 PointerType *main.deepSlice3
+      Pointee: 1096 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1120
       Name: '**main.deepSlice8'
@@ -3499,7 +3468,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1089
+      ID: 1091
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3536,10 +3505,10 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1101
+      ID: 1103
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1102 PointerType *table<int,*main.deepMap3>
+      Pointee: 1104 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1137
       Name: '**table<int,*main.deepMap8>'
@@ -3576,10 +3545,10 @@ Types:
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 832
+      ID: 834
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 833 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 835 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3636,10 +3605,10 @@ Types:
       ByteSize: 8
       Pointee: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1097
+      ID: 1099
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1096 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1098 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1124
       Name: '*[]*main.deepSlice8.array'
@@ -3711,10 +3680,10 @@ Types:
       ByteSize: 8
       Pointee: 346 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 871 GoSliceDataType []float64.array
+      Pointee: 873 GoSliceDataType []float64.array
     - __kind: PointerType
       ID: 1133
       Name: '*[]interface {}.array'
@@ -3731,10 +3700,10 @@ Types:
       ByteSize: 8
       Pointee: 350 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1114
+      ID: 412
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1113 GoSliceDataType []main.structWithMap.array
+      Pointee: 411 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 343
       Name: '*[]main.structWithNoStrings.array'
@@ -3761,71 +3730,71 @@ Types:
       ByteSize: 8
       Pointee: 348 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 869 GoSliceDataType []uint8.array
+      Pointee: 871 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 1002
+      ID: 1004
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.976896e+06
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1005 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 926624
       GoKind: 22
-      Pointee: 641 GoSliceHeaderType archive/tar.headerError
+      Pointee: 643 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 643
+      ID: 645
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 642 GoSliceDataType archive/tar.headerError.array
+      Pointee: 644 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 937
+      ID: 939
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.43072e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 940 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 885
+      ID: 887
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 888 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 887
+      ID: 889
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 888 StructureType archive/zip.dirWriter
+      Pointee: 890 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 985
+      ID: 987
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.896576e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 988 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 913
+      ID: 915
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.053248e+06
       GoKind: 22
-      Pointee: 914 StructureType archive/zip.nopCloser
+      Pointee: 916 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 915
+      ID: 917
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.053504e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 918 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3834,421 +3803,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 960
+      ID: 962
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.165024e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType bufio.Reader
+      Pointee: 963 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 989
+      ID: 991
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.941088e+06
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType bufio.Writer
+      Pointee: 992 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1040
+      ID: 1042
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.262304e+06
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1043 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 552
+      ID: 554
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 909152
       GoKind: 22
-      Pointee: 444 BaseType compress/flate.CorruptInputError
+      Pointee: 446 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 553
+      ID: 555
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 909248
       GoKind: 22
-      Pointee: 445 GoStringHeaderType compress/flate.InternalError
+      Pointee: 447 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 447
+      ID: 449
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 446 GoStringDataType compress/flate.InternalError.str
+      Pointee: 448 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 935
+      ID: 937
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.42016e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 938 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 881
+      ID: 883
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 909344
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 884 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 957
+      ID: 959
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.718336e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 960 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 784
+      ID: 786
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.199456e+06
       GoKind: 22
-      Pointee: 785 StructureType context.deadlineExceededError
+      Pointee: 787 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 632
+      ID: 634
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921248
       GoKind: 22
-      Pointee: 458 BaseType crypto/aes.KeySizeError
+      Pointee: 460 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 633
+      ID: 635
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921440
       GoKind: 22
-      Pointee: 459 BaseType crypto/des.KeySizeError
+      Pointee: 461 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 634
+      ID: 636
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921728
       GoKind: 22
-      Pointee: 460 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 462 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 947
+      ID: 949
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.56064e+06
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 950 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 981
+      ID: 983
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.855008e+06
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 984 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1013
+      ID: 1015
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.112352e+06
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1016 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 987
+      ID: 989
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.897088e+06
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 990 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 983
+      ID: 985
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.85568e+06
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 986 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 979
+      ID: 981
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.84784e+06
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 982 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 635
+      ID: 637
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922016
       GoKind: 22
-      Pointee: 461 BaseType crypto/rc4.KeySizeError
+      Pointee: 463 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 997
+      ID: 999
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.946464e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1000 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 969
+      ID: 971
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.801824e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 972 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 558
+      ID: 560
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 910880
       GoKind: 22
-      Pointee: 448 BaseType crypto/tls.AlertError
+      Pointee: 450 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 724
+      ID: 726
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.041856e+06
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 727 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1066
+      ID: 1068
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.374176e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1069 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 559 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 554
+      ID: 556
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 910592
       GoKind: 22
-      Pointee: 555 StructureType crypto/tls.RecordHeaderError
+      Pointee: 557 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 723
+      ID: 725
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.040192e+06
       GoKind: 22
-      Pointee: 680 BaseType crypto/tls.alert
+      Pointee: 682 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 945
+      ID: 947
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.5536e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 948 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 952
+      ID: 954
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.636032e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 955 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.42048e+06
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 822 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 834
+      ID: 836
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.034944e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 837 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 628
+      ID: 630
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 629 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 631 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 622
+      ID: 624
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 919808
       GoKind: 22
-      Pointee: 623 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 625 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 624
+      ID: 626
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 625 StructureType crypto/x509.HostnameError
+      Pointee: 627 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 621
+      ID: 623
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 457 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 459 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 729
+      ID: 731
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.047616e+06
       GoKind: 22
-      Pointee: 730 StructureType crypto/x509.SystemRootsError
+      Pointee: 732 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 630
+      ID: 632
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 631 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 633 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 920192
       GoKind: 22
-      Pointee: 627 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 629 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 927104
       GoKind: 22
-      Pointee: 645 StructureType encoding/asn1.StructuralError
+      Pointee: 647 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 648
+      ID: 650
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927296
       GoKind: 22
-      Pointee: 649 StructureType encoding/asn1.SyntaxError
+      Pointee: 651 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 649 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 542
+      ID: 544
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 907232
       GoKind: 22
-      Pointee: 442 BaseType encoding/base64.CorruptInputError
+      Pointee: 444 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.037376e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 906 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 545
+      ID: 547
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 908096
       GoKind: 22
-      Pointee: 443 BaseType encoding/hex.InvalidByteError
+      Pointee: 445 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 513
+      ID: 515
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 901952
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 516 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 715
+      ID: 717
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.033664e+06
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 718 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 505
+      ID: 507
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 901568
       GoKind: 22
-      Pointee: 506 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 508 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 511
+      ID: 513
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 901856
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 514 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 509
+      ID: 511
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 901760
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 512 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 901664
       GoKind: 22
-      Pointee: 508 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 510 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1046
+      ID: 1048
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.287328e+06
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1049 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 515
+      ID: 517
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 902336
       GoKind: 22
-      Pointee: 516 StructureType encoding/json.jsonError
+      Pointee: 518 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 911
+      ID: 913
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.050176e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 914 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 918752
       GoKind: 22
-      Pointee: 617 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 619 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 614
+      ID: 616
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 918656
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 617 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 618
+      ID: 620
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 454 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 456 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 456
+      ID: 458
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 455 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 457 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918944
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 622 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.150784e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1027 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4257,19 +4226,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 483
+      ID: 485
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 892256
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType errors.errorString
+      Pointee: 486 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 682
+      ID: 684
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.01856e+06
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType errors.joinError
+      Pointee: 685 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4285,813 +4254,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1034
+      ID: 1036
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.254624e+06
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType fmt.pp
+      Pointee: 1037 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 684
+      ID: 686
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.020352e+06
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType fmt.wrapError
+      Pointee: 687 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 686
+      ID: 688
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.02048e+06
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 689 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 543
+      ID: 545
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 907616
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 546 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 904736
       GoKind: 22
-      Pointee: 525 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 527 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 526
+      ID: 528
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 904832
       GoKind: 22
-      Pointee: 527 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 529 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 847
+      ID: 849
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 904544
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 850 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 530
+      ID: 532
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 22
-      Pointee: 531 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 533 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 849
+      ID: 851
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 904640
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 852 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 528
+      ID: 530
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 904928
       GoKind: 22
-      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 438 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 438
+      ID: 440
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 439 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 523
+      ID: 525
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 904448
       GoKind: 22
-      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 435 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 435
+      ID: 437
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 436 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 529
+      ID: 531
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 905024
       GoKind: 22
-      Pointee: 439 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 441 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 441
+      ID: 443
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 442 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.20496e+06
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 928 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1010
+      ID: 1012
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.049952e+06
       GoKind: 22
-      Pointee: 1011 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1013 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 641 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 793
+      ID: 795
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.208544e+06
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 796 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1042
+      ID: 1044
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.264352e+06
       GoKind: 22
-      Pointee: 1043 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1045 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 565
+      ID: 567
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 914240
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 568 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 915296
       GoKind: 22
-      Pointee: 573 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 575 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 567
+      ID: 569
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 453 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 455 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 915200
       GoKind: 22
-      Pointee: 571 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 573 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 568
+      ID: 570
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 915104
       GoKind: 22
-      Pointee: 569 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 571 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 589 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 591 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 917408
       GoKind: 22
-      Pointee: 593 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 595 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 917312
       GoKind: 22
-      Pointee: 591 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 593 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 917120
       GoKind: 22
-      Pointee: 587 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 589 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 873 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 875 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 600
+      ID: 602
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 917792
       GoKind: 22
-      Pointee: 601 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 603 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 595 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 597 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 598
+      ID: 600
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 917696
       GoKind: 22
-      Pointee: 599 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 601 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 597 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 599 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 917888
       GoKind: 22
-      Pointee: 603 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 605 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 608
+      ID: 610
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 609 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 610
+      ID: 612
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 606
+      ID: 608
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 607 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 609 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 604
+      ID: 606
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 917984
       GoKind: 22
-      Pointee: 605 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 607 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 918464
       GoKind: 22
-      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 615 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 532
+      ID: 534
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 906272
       GoKind: 22
-      Pointee: 533 StructureType github.com/cihub/seelog.baseError
+      Pointee: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.794432e+06
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 966 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 534
+      ID: 536
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 906368
       GoKind: 22
-      Pointee: 535 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 537 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 943
+      ID: 945
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.55248e+06
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 946 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.036352e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 933
+      ID: 935
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.41824e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 936 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 538
+      ID: 540
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 906560
       GoKind: 22
-      Pointee: 539 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 541 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1000
+      ID: 1002
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.966816e+06
       GoKind: 22
-      Pointee: 1001 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1003 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1017
+      ID: 1019
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.123936e+06
       GoKind: 22
-      Pointee: 1012 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1014 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1016
+      ID: 1018
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.123552e+06
       GoKind: 22
-      Pointee: 1015 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1017 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.03648e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 904 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 536
+      ID: 538
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 906464
       GoKind: 22
-      Pointee: 537 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 539 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 540
+      ID: 542
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 906656
       GoKind: 22
-      Pointee: 541 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 543 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 965
+      ID: 967
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.796224e+06
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 968 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1006
+      ID: 1008
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.003552e+06
       GoKind: 22
-      Pointee: 1007 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1009 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1008
+      ID: 1010
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.034624e+06
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1011 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 824
+      ID: 826
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.43312e+06
       GoKind: 22
-      Pointee: 825 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 827 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 737
+      ID: 739
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.061696e+06
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 740 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 735
+      ID: 737
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.061568e+06
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 738 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 739
+      ID: 741
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.065664e+06
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 742 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 741
+      ID: 743
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.065792e+06
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 744 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 954
+      ID: 956
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.663104e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 957 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 731
+      ID: 733
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.048256e+06
       GoKind: 22
-      Pointee: 732 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 734 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 546
+      ID: 548
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 908288
       GoKind: 22
-      Pointee: 547 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 549 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1058
+      ID: 1060
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.3504e+06
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1061 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 795
+      ID: 797
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.216992e+06
       GoKind: 22
-      Pointee: 796 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 798 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 768
+      ID: 770
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.195744e+06
       GoKind: 22
-      Pointee: 769 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 771 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 762
+      ID: 764
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.19536e+06
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 765 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 701
+      ID: 703
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.027648e+06
       GoKind: 22
-      Pointee: 702 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 704 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 774
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.196128e+06
       GoKind: 22
-      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 700
+      ID: 702
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.02752e+06
       GoKind: 22
-      Pointee: 679 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 681 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 766
+      ID: 768
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.195616e+06
       GoKind: 22
-      Pointee: 767 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 769 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 764
+      ID: 766
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.195488e+06
       GoKind: 22
-      Pointee: 765 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 767 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 772
+      ID: 774
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.196e+06
       GoKind: 22
-      Pointee: 773 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 770
+      ID: 772
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195872e+06
       GoKind: 22
-      Pointee: 771 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 773 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1062
+      ID: 1064
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.362208e+06
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1065 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.196512e+06
       GoKind: 22
-      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 705
+      ID: 707
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.027904e+06
       GoKind: 22
-      Pointee: 706 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 708 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 703
+      ID: 705
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.027776e+06
       GoKind: 22
-      Pointee: 704 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 706 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 776
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.196384e+06
       GoKind: 22
-      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 660
+      ID: 662
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 940064
       GoKind: 22
-      Pointee: 466 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 468 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 468
+      ID: 470
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 467 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 469 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 837
+      ID: 839
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.661568e+06
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 840 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 745
+      ID: 747
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.080512e+06
       GoKind: 22
-      Pointee: 746 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 748 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.256544e+06
       GoKind: 22
-      Pointee: 932 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 934 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1022
+      ID: 1024
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.138912e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1025 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 917
+      ID: 919
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.082816e+06
       GoKind: 22
-      Pointee: 918 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 920 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 661
+      ID: 663
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 941312
       GoKind: 22
-      Pointee: 469 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 471 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 803
+      ID: 805
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.258208e+06
       GoKind: 22
-      Pointee: 804 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 806 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 664
+      ID: 666
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 941600
       GoKind: 22
-      Pointee: 665 StructureType golang.org/x/net/http2.connError
+      Pointee: 667 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 663
+      ID: 665
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941504
       GoKind: 22
-      Pointee: 473 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 475 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 475
+      ID: 477
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 474 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 476 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 667
+      ID: 669
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 941792
       GoKind: 22
-      Pointee: 479 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 481 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 481
+      ID: 483
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 480 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 482 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 666
+      ID: 668
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 941696
       GoKind: 22
-      Pointee: 476 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 478 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 478
+      ID: 480
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 477 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 479 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 662
+      ID: 664
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941408
       GoKind: 22
-      Pointee: 470 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 472 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 472
+      ID: 474
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 471 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 473 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1020
+      ID: 1022
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.136992e+06
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1023 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 668
+      ID: 670
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 941888
       GoKind: 22
-      Pointee: 669 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 671 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 670
+      ID: 672
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 482 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 484 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 935264
       GoKind: 22
-      Pointee: 657 StructureType google.golang.org/grpc.dropError
+      Pointee: 659 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.255264e+06
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 804 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 826
+      ID: 828
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.44048e+06
       GoKind: 22
-      Pointee: 827 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 829 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 658
+      ID: 660
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 659 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 661 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 971
+      ID: 973
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.802272e+06
       GoKind: 22
-      Pointee: 972 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 974 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.251808e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 932 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 743
+      ID: 745
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.074752e+06
       GoKind: 22
-      Pointee: 744 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 746 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 889
+      ID: 891
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 938432
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 892 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 636
+      ID: 638
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 639 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 733
+      ID: 735
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.051584e+06
       GoKind: 22
-      Pointee: 734 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 736 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.223264e+06
       GoKind: 22
-      Pointee: 800 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 802 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 797
+      ID: 799
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.223008e+06
       GoKind: 22
-      Pointee: 798 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 800 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 650
+      ID: 652
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 928160
       GoKind: 22
-      Pointee: 651 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 653 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 652
+      ID: 654
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 928256
       GoKind: 22
-      Pointee: 653 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 655 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 580
+      ID: 582
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 915680
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 583 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 977
+      ID: 979
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.842912e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 980 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 671
+      ID: 673
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 942752
       GoKind: 22
-      Pointee: 672 UnresolvedPointeeType html/template.Error
+      Pointee: 674 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -5135,89 +5104,89 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 550
+      ID: 552
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 553 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 548
+      ID: 550
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 908768
       GoKind: 22
-      Pointee: 549 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 551 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 875
+      ID: 877
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 896768
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 878 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 760
+      ID: 762
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.194592e+06
       GoKind: 22
-      Pointee: 761 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 763 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1064
+      ID: 1066
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.36784e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1067 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 758
+      ID: 760
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.194464e+06
       GoKind: 22
-      Pointee: 759 StructureType internal/poll.errNetClosing
+      Pointee: 761 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 485
+      ID: 487
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 896000
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 488 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.186016e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType io.PipeWriter
+      Pointee: 924 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 919
+      ID: 921
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.185632e+06
       GoKind: 22
-      Pointee: 920 StructureType io.discard
+      Pointee: 922 StructureType io.discard
     - __kind: PointerType
-      ID: 893
+      ID: 895
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.018816e+06
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType io.multiWriter
+      Pointee: 896 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 756
+      ID: 758
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.194208e+06
       GoKind: 22
-      Pointee: 757 UnresolvedPointeeType io/fs.PathError
+      Pointee: 759 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 967
+      ID: 969
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.796448e+06
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 970 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 234
       Name: '*main.deepMap2'
@@ -5226,12 +5195,12 @@ Types:
       GoKind: 22
       Pointee: 235 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1109
+      ID: 1111
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383168
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType main.deepMap3
+      Pointee: 1112 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -5261,12 +5230,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1068
+      ID: 1070
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 1069 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1071 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5296,12 +5265,12 @@ Types:
       GoKind: 22
       Pointee: 225 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1094
+      ID: 1096
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384320
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1097 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5337,12 +5306,12 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1085
+      ID: 1087
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 891968
       GoKind: 22
-      Pointee: 1086 StructureType main.firstBehavior
+      Pointee: 1088 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
@@ -5357,19 +5326,19 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1087
+      ID: 1089
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 892064
       GoKind: 22
-      Pointee: 1088 StructureType main.secondBehavior
+      Pointee: 1090 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1073
+      ID: 1075
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 892160
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1076 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -5377,16 +5346,16 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1071
+      ID: 1073
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1070 GoStringDataType main.stringType1.str
+      Pointee: 1072 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType main.stringType2
+      Pointee: 1074 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 175
       Name: '*main.structWithCyclicSlices'
@@ -5417,10 +5386,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1091
+      ID: 1093
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1090 GoSliceDataType main.t.array
+      Pointee: 1092 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -5453,10 +5422,10 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1099
+      ID: 1101
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1100 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1102 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1135
       Name: '*map<int,*main.deepMap8>'
@@ -5493,10 +5462,10 @@ Types:
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 830
+      ID: 832
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 831 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 833 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -5554,451 +5523,451 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 585 StructureType math/big.ErrNaN
+      Pointee: 587 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 883
+      ID: 885
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 911360
       GoKind: 22
-      Pointee: 884 StructureType mime/multipart.writerOnly·1
+      Pointee: 886 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 787
+      ID: 789
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.202784e+06
       GoKind: 22
-      Pointee: 788 UnresolvedPointeeType net.AddrError
+      Pointee: 790 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 813
+      ID: 815
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.41648e+06
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType net.DNSError
+      Pointee: 816 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1028
+      ID: 1030
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.22544e+06
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType net.IPConn
+      Pointee: 1031 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.41616e+06
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType net.OpError
+      Pointee: 814 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 789
+      ID: 791
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.202912e+06
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType net.ParseError
+      Pointee: 792 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1038
+      ID: 1040
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.255648e+06
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType net.TCPConn
+      Pointee: 1041 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1048
+      ID: 1050
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.30064e+06
       GoKind: 22
-      Pointee: 1049 UnresolvedPointeeType net.UDPConn
+      Pointee: 1051 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1036
+      ID: 1038
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.255136e+06
       GoKind: 22
-      Pointee: 1037 UnresolvedPointeeType net.UnixConn
+      Pointee: 1039 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.202016e+06
       GoKind: 22
-      Pointee: 749 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 751 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 751
+      ID: 753
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 752 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 717
+      ID: 719
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.03456e+06
       GoKind: 22
-      Pointee: 718 StructureType net.canceledError
+      Pointee: 720 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1004
+      ID: 1006
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.000672e+06
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType net.conn
+      Pointee: 1007 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 856
+      ID: 858
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.838208e+06
       GoKind: 22
-      Pointee: 857 StructureType net.dialResult·1
+      Pointee: 859 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1050
+      ID: 1052
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.304896e+06
       GoKind: 22
-      Pointee: 1051 UnresolvedPointeeType net.netFD
+      Pointee: 1053 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 517
+      ID: 519
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 903296
       GoKind: 22
-      Pointee: 518 UnresolvedPointeeType net.notFoundError
+      Pointee: 520 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 519
+      ID: 521
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 903968
       GoKind: 22
-      Pointee: 520 StructureType net.result·2
+      Pointee: 522 StructureType net.result·2
     - __kind: PointerType
-      ID: 1032
+      ID: 1034
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.241664e+06
       GoKind: 22
-      Pointee: 1033 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1035 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1030
+      ID: 1032
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.241184e+06
       GoKind: 22
-      Pointee: 1031 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1033 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 791
+      ID: 793
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.203552e+06
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType net.temporaryError
+      Pointee: 794 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 815
+      ID: 817
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.41664e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType net.timeoutError
+      Pointee: 818 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.030336e+06
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 710 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 877
+      ID: 879
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 899072
       GoKind: 22
-      Pointee: 878 StructureType net/http.bufioFlushWriter
+      Pointee: 880 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 494
+      ID: 496
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 899744
       GoKind: 22
-      Pointee: 414 BaseType net/http.http2ConnectionError
+      Pointee: 416 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 899840
       GoKind: 22
-      Pointee: 496 StructureType net/http.http2GoAwayError
+      Pointee: 498 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 807
+      ID: 809
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.41232e+06
       GoKind: 22
-      Pointee: 808 StructureType net/http.http2StreamError
+      Pointee: 810 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 900416
       GoKind: 22
-      Pointee: 500 StructureType net/http.http2connError
+      Pointee: 502 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 939
+      ID: 941
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.54896e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 942 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 498
+      ID: 500
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900320
       GoKind: 22
-      Pointee: 418 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 420 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 420
+      ID: 422
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 421 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 502
+      ID: 504
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 900608
       GoKind: 22
-      Pointee: 424 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 426 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 426
+      ID: 428
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 425 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 427 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 501
+      ID: 503
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 900512
       GoKind: 22
-      Pointee: 421 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 423 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 423
+      ID: 425
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 422 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 424 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.19856e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 785 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 713
+      ID: 715
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.030976e+06
       GoKind: 22
-      Pointee: 714 StructureType net/http.http2noCachedConnError
+      Pointee: 716 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 993
+      ID: 995
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.943136e+06
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 996 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 497
+      ID: 499
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900224
       GoKind: 22
-      Pointee: 415 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 417 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 417
+      ID: 419
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 416 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 418 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 900704
       GoKind: 22
-      Pointee: 880 StructureType net/http.http2stickyErrWriter
+      Pointee: 882 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 709
+      ID: 711
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.030592e+06
       GoKind: 22
-      Pointee: 710 StructureType net/http.nothingWrittenError
+      Pointee: 712 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 941
+      ID: 943
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.166272e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType net/http.persistConn
+      Pointee: 944 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.030464e+06
       GoKind: 22
-      Pointee: 898 StructureType net/http.persistConnWriter
+      Pointee: 900 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 923
+      ID: 925
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.197664e+06
       GoKind: 22
-      Pointee: 924 StructureType net/http.readWriteCloserBody
+      Pointee: 926 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 503
+      ID: 505
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 900800
       GoKind: 22
-      Pointee: 504 StructureType net/http.requestBodyReadError
+      Pointee: 506 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 809
+      ID: 811
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.41344e+06
       GoKind: 22
-      Pointee: 810 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 812 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.198432e+06
       GoKind: 22
-      Pointee: 781 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 783 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 711
+      ID: 713
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.03072e+06
       GoKind: 22
-      Pointee: 712 StructureType net/http.transportReadFromServerError
+      Pointee: 714 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 975
+      ID: 977
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.834848e+06
       GoKind: 22
-      Pointee: 976 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 978 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 492
+      ID: 494
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 898976
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 495 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 995
+      ID: 997
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.944672e+06
       GoKind: 22
-      Pointee: 996 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 998 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.043008e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 910 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915488
       GoKind: 22
-      Pointee: 577 StructureType net/netip.parseAddrError
+      Pointee: 579 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 574
+      ID: 576
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915392
       GoKind: 22
-      Pointee: 575 StructureType net/netip.parsePrefixError
+      Pointee: 577 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 949
+      ID: 951
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.110944e+06
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType net/smtp.Client
+      Pointee: 952 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 909
+      ID: 911
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.047872e+06
       GoKind: 22
-      Pointee: 910 StructureType net/smtp.dataCloser
+      Pointee: 912 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 560
+      ID: 562
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 911552
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType net/textproto.Error
+      Pointee: 563 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 911456
       GoKind: 22
-      Pointee: 449 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 451 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 451
+      ID: 453
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 450 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 452 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.04224e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 908 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 817
+      ID: 819
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.41696e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net/url.Error
+      Pointee: 820 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 521
+      ID: 523
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 904064
       GoKind: 22
-      Pointee: 427 GoStringHeaderType net/url.EscapeError
+      Pointee: 429 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 429
+      ID: 431
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 428 GoStringDataType net/url.EscapeError.str
+      Pointee: 430 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 522
+      ID: 524
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 22
-      Pointee: 430 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 432 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 432
+      ID: 434
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 431 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 433 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 332
       Name: '*noalg.map.group[[4]int][4]int'
@@ -6025,10 +5994,10 @@ Types:
       ByteSize: 8
       Pointee: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1105
+      ID: 1107
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1106 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1108 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1141
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -6065,10 +6034,10 @@ Types:
       ByteSize: 8
       Pointee: 265 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 863
+      ID: 865
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 866 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 256
       Name: '*noalg.map.group[string]int'
@@ -6120,160 +6089,160 @@ Types:
       ByteSize: 8
       Pointee: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1056
+      ID: 1058
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.343552e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType os.File
+      Pointee: 1059 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 688
+      ID: 690
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.021632e+06
       GoKind: 22
-      Pointee: 689 UnresolvedPointeeType os.LinkError
+      Pointee: 691 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 752
+      ID: 754
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.187552e+06
       GoKind: 22
-      Pointee: 753 UnresolvedPointeeType os.SyscallError
+      Pointee: 755 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1054
+      ID: 1056
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.339872e+06
       GoKind: 22
-      Pointee: 1055 StructureType os.fileWithoutReadFrom
+      Pointee: 1057 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1052
+      ID: 1054
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.339136e+06
       GoKind: 22
-      Pointee: 1053 StructureType os.fileWithoutWriteTo
+      Pointee: 1055 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 719
+      ID: 721
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.038912e+06
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType os/exec.Error
+      Pointee: 722 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 859
+      ID: 861
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.0808e+06
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 862 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 927
+      ID: 929
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.209824e+06
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 930 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 721
+      ID: 723
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.03904e+06
       GoKind: 22
-      Pointee: 722 StructureType os/exec.wrappedError
+      Pointee: 724 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 655
+      ID: 657
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 933344
       GoKind: 22
-      Pointee: 463 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 465 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 465
+      ID: 467
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 464 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 466 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 933248
       GoKind: 22
-      Pointee: 462 BaseType os/user.UnknownUserIdError
+      Pointee: 464 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 487
+      ID: 489
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 896672
       GoKind: 22
-      Pointee: 488 UnresolvedPointeeType reflect.ValueError
+      Pointee: 490 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 582
+      ID: 584
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 916160
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 585 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 692
+      ID: 694
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.023168e+06
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 695 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 696
+      ID: 698
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.02496e+06
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 699 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.023296e+06
       GoKind: 22
-      Pointee: 695 StructureType runtime.boundsError
+      Pointee: 697 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 754
+      ID: 756
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.192928e+06
       GoKind: 22
-      Pointee: 755 StructureType runtime.errorAddressString
+      Pointee: 757 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 690
+      ID: 692
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.022784e+06
       GoKind: 22
-      Pointee: 673 GoStringHeaderType runtime.errorString
+      Pointee: 675 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 674 GoStringDataType runtime.errorString.str
+      Pointee: 676 GoStringDataType runtime.errorString.str
     - __kind: PointerType
-      ID: 691
+      ID: 693
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.022912e+06
       GoKind: 22
-      Pointee: 676 GoStringHeaderType runtime.plainError
+      Pointee: 678 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 678
+      ID: 680
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 677 GoStringDataType runtime.plainError.str
+      Pointee: 679 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 698
+      ID: 700
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.025216e+06
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType strconv.NumError
+      Pointee: 701 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6287,33 +6256,33 @@ Types:
       ByteSize: 8
       Pointee: 221 GoStringDataType string.str
     - __kind: PointerType
-      ID: 991
+      ID: 993
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.941856e+06
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType strings.Builder
+      Pointee: 994 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 895
+      ID: 897
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.025344e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 898 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 891
+      ID: 893
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 966144
       GoKind: 22
-      Pointee: 892 StructureType struct { io.Writer }
+      Pointee: 894 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 806
+      ID: 808
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.41168e+06
       GoKind: 22
-      Pointee: 805 BaseType syscall.Errno
+      Pointee: 807 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
@@ -6340,10 +6309,10 @@ Types:
       ByteSize: 8
       Pointee: 228 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1102
+      ID: 1104
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1103 StructureType table<int,*main.deepMap3>
+      Pointee: 1105 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1138
       Name: '*table<int,*main.deepMap8>'
@@ -6380,10 +6349,10 @@ Types:
       ByteSize: 8
       Pointee: 262 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 833
+      ID: 835
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 861 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 863 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
@@ -6435,45 +6404,45 @@ Types:
       ByteSize: 8
       Pointee: 305 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1026
+      ID: 1028
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.151168e+06
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1029 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.084352e+06
       GoKind: 22
-      Pointee: 748 StructureType text/template.ExecError
+      Pointee: 750 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 822
+      ID: 824
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.617024e+06
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType time.Location
+      Pointee: 825 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 490
+      ID: 492
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 897536
       GoKind: 22
-      Pointee: 491 UnresolvedPointeeType time.ParseError
+      Pointee: 493 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 489
+      ID: 491
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 897440
       GoKind: 22
-      Pointee: 411 GoStringHeaderType time.fileSizeError
+      Pointee: 413 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 413
+      ID: 415
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 412 GoStringDataType time.fileSizeError.str
+      Pointee: 414 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6517,47 +6486,47 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 915584
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 581 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1018
+      ID: 1020
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.126624e+06
       GoKind: 22
-      Pointee: 1019 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1021 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 562
+      ID: 564
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 563 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 565 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 564
+      ID: 566
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 911840
       GoKind: 22
-      Pointee: 452 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 454 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 726
+      ID: 728
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.042752e+06
       GoKind: 22
-      Pointee: 727 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 729 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 728
+      ID: 730
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.04288e+06
       GoKind: 22
-      Pointee: 681 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 683 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1274
       Name: Probe[main.stackC]
@@ -8548,7 +8517,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 851
+      ID: 853
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 680672
@@ -8579,7 +8548,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1092
+      ID: 1094
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474944
@@ -8587,19 +8556,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1093 PointerType **main.deepSlice3
+          Type: 1095 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1096 GoSliceDataType []*main.deepSlice3.array
+      Data: 1098 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1096
+      ID: 1098
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 1094 PointerType *main.deepSlice3
+      Element: 1096 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1119
       Name: '[]*main.deepSlice8'
@@ -8692,10 +8661,10 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1111
+      ID: 1113
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 1102 PointerType *table<int,*main.deepMap3>
+      Element: 1104 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1147
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -8732,10 +8701,10 @@ Types:
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 867
+      ID: 869
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 8192
-      Element: 833 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 835 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]*table<string,int>.array'
@@ -8935,7 +8904,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 846
+      ID: 848
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 483776
@@ -8950,9 +8919,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 871 GoSliceDataType []float64.array
+      Data: 873 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 871
+      ID: 873
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 18 BaseType float64
@@ -9015,9 +8984,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1113 GoSliceDataType []main.structWithMap.array
+      Data: 411 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1113
+      ID: 411
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -9068,10 +9037,10 @@ Types:
       ByteSize: 2048
       Element: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1112
+      ID: 1114
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 1106 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1108 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1148
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -9108,10 +9077,10 @@ Types:
       ByteSize: 2048
       Element: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 868
+      ID: 870
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 2048
-      Element: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 866 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]noalg.map.group[string]int.array'
@@ -9229,7 +9198,7 @@ Types:
       ByteSize: 2048
       Element: 6 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 840
+      ID: 842
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 482752
@@ -9244,18 +9213,18 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 869 GoSliceDataType []uint8.array
+      Data: 871 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 869
+      ID: 871
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1005
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 641
+      ID: 643
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 926720
@@ -9270,32 +9239,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 642 GoSliceDataType archive/tar.headerError.array
+      Data: 644 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 642
+      ID: 644
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 940
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 888
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 890
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.115488e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 988
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 914
+      ID: 916
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.55952e+06
@@ -9305,7 +9274,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 918
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9315,15 +9284,15 @@ Types:
       GoRuntimeType: 581408
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 963
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 992
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1043
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9349,13 +9318,13 @@ Types:
       GoRuntimeType: 581152
       GoKind: 15
     - __kind: BaseType
-      ID: 444
+      ID: 446
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831136
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 445
+      ID: 447
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 831232
@@ -9363,109 +9332,109 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 447 PointerType *compress/flate.InternalError.str
+          Type: 449 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 446 GoStringDataType compress/flate.InternalError.str
+      Data: 448 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 446
+      ID: 448
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 938
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 884
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 960
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 785
+      ID: 787
       Name: context.deadlineExceededError
       GoRuntimeType: 1.47392e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 458
+      ID: 460
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833728
       GoKind: 2
     - __kind: BaseType
-      ID: 459
+      ID: 461
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833824
       GoKind: 2
     - __kind: BaseType
-      ID: 460
+      ID: 462
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833920
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 950
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 984
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1016
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 990
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 986
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 982
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 461
+      ID: 463
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834016
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1000
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 972
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 448
+      ID: 450
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 831712
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 727
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1069
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 559
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 555
+      ID: 557
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.722944e+06
@@ -9476,34 +9445,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 851 ArrayType [5]uint8
+          Type: 853 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 680
+      ID: 682
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 988960
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 948
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 955
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 822
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 837
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 629
+      ID: 631
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.725824e+06
@@ -9511,21 +9480,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 834 PointerType *crypto/x509.Certificate
+          Type: 836 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 854 BaseType crypto/x509.InvalidReason
+          Type: 856 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 623
+      ID: 625
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.113056e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 625
+      ID: 627
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.59424e+06
@@ -9533,24 +9502,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 834 PointerType *crypto/x509.Certificate
+          Type: 836 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 457
+      ID: 459
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 833344
       GoKind: 2
     - __kind: BaseType
-      ID: 854
+      ID: 856
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 586592
       GoKind: 2
     - __kind: StructureType
-      ID: 730
+      ID: 732
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.55552e+06
@@ -9560,13 +9529,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 631
+      ID: 633
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.113312e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 627
+      ID: 629
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.725632e+06
@@ -9574,15 +9543,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 834 PointerType *crypto/x509.Certificate
+          Type: 836 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 834 PointerType *crypto/x509.Certificate
+          Type: 836 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 645
+      ID: 647
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.43136e+06
@@ -9592,7 +9561,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 649
+      ID: 651
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.43152e+06
@@ -9602,55 +9571,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 649
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 442
+      ID: 444
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830752
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 906
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 443
+      ID: 445
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 830944
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 516
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 718
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 506
+      ID: 508
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 514
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 512
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 508
+      ID: 510
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1049
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 516
+      ID: 518
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.4152e+06
@@ -9660,19 +9629,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 914
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 617
+      ID: 619
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 617
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 454
+      ID: 456
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 833248
@@ -9680,21 +9649,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 456 PointerType *encoding/xml.UnmarshalError.str
+          Type: 458 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 455 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 457 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 455
+      ID: 457
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 622
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1027
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9711,11 +9680,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 486
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 685
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9731,15 +9700,15 @@ Types:
       GoRuntimeType: 581344
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1037
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 687
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 689
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9749,11 +9718,11 @@ Types:
       GoRuntimeType: 473216
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 546
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 525
+      ID: 527
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.721792e+06
@@ -9761,7 +9730,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 844 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 846 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -9769,25 +9738,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 527
+      ID: 529
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 850
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 531
+      ID: 533
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.109344e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 852
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 436
+      ID: 438
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 830176
@@ -9795,17 +9764,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 440 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 439 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 437
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 844
+      ID: 846
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.210976e+06
@@ -9813,7 +9782,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 845 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 847 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9828,7 +9797,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 846 GoSliceHeaderType []float64
+          Type: 848 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -9837,10 +9806,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 847 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 849 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 849 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 851 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 166 GoSliceHeaderType []string
@@ -9854,13 +9823,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 845
+      ID: 847
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 583200
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 433
+      ID: 435
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 830080
@@ -9868,17 +9837,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 437 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 436 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 434
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 439
+      ID: 441
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 830272
@@ -9886,59 +9855,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 441 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 443 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 442 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 440
+      ID: 442
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 928
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1011
+      ID: 1013
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 641
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 796
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1043
+      ID: 1045
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 568
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 573
+      ID: 575
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.112288e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 453
+      ID: 455
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 832384
       GoKind: 2
     - __kind: StructureType
-      ID: 571
+      ID: 573
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.11216e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 569
+      ID: 571
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.59232e+06
@@ -9951,7 +9920,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 589
+      ID: 591
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.59312e+06
@@ -9964,7 +9933,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 593
+      ID: 595
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.725056e+06
@@ -9980,7 +9949,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 591
+      ID: 593
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.42496e+06
@@ -9990,7 +9959,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 587
+      ID: 589
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.42464e+06
@@ -10000,14 +9969,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 829
+      ID: 831
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.49488e+06
       GoKind: 21
-      HeaderType: 831 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 833 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 853
+      ID: 855
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.046336e+06
@@ -10022,14 +9991,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 873 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 875 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 873
+      ID: 875
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 601
+      ID: 603
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.59344e+06
@@ -10037,12 +10006,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 829 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 831 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 829 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 831 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 595
+      ID: 597
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.42512e+06
@@ -10052,7 +10021,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 599
+      ID: 601
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.725248e+06
@@ -10063,12 +10032,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 855 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 855 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 597
+      ID: 599
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.59328e+06
@@ -10081,7 +10050,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 603
+      ID: 605
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.42528e+06
@@ -10089,9 +10058,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 821 StructureType time.Time
+          Type: 823 StructureType time.Time
     - __kind: StructureType
-      ID: 609
+      ID: 611
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.59376e+06
@@ -10104,7 +10073,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 611
+      ID: 613
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.4256e+06
@@ -10114,7 +10083,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 609
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.5936e+06
@@ -10127,7 +10096,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 605
+      ID: 607
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.42544e+06
@@ -10137,7 +10106,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 613
+      ID: 615
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.59392e+06
@@ -10150,7 +10119,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 533
+      ID: 535
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.41744e+06
@@ -10160,11 +10129,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 966
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 535
+      ID: 537
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.4176e+06
@@ -10172,21 +10141,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 533 StructureType github.com/cihub/seelog.baseError
+          Type: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 946
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 902
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 936
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 539
+      ID: 541
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.41792e+06
@@ -10194,13 +10163,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 533 StructureType github.com/cihub/seelog.baseError
+          Type: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1001
+      ID: 1003
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1012
+      ID: 1014
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.09936e+06
@@ -10208,12 +10177,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1000 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1002 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1015
+      ID: 1017
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.123168e+06
@@ -10221,7 +10190,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1000 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1002 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10229,11 +10198,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 537
+      ID: 539
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.41776e+06
@@ -10241,9 +10210,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 533 StructureType github.com/cihub/seelog.baseError
+          Type: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 541
+      ID: 543
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.41808e+06
@@ -10251,64 +10220,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 533 StructureType github.com/cihub/seelog.baseError
+          Type: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 968
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1007
+      ID: 1009
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1011
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 825
+      ID: 827
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 740
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 738
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 742
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 744
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 957
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 732
+      ID: 734
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 547
+      ID: 549
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.41904e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1061
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 796
+      ID: 798
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 769
+      ID: 771
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.833056e+06
@@ -10324,11 +10293,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 765
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 704
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.69584e+06
@@ -10341,7 +10310,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 775
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.833504e+06
@@ -10357,13 +10326,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 679
+      ID: 681
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 986272
       GoKind: 8
     - __kind: StructureType
-      ID: 767
+      ID: 769
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.832832e+06
@@ -10379,13 +10348,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 855
+      ID: 857
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 828352
       GoKind: 8
     - __kind: StructureType
-      ID: 765
+      ID: 767
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.832608e+06
@@ -10393,15 +10362,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 855 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 857 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 855 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 857 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 773
+      ID: 775
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.747296e+06
@@ -10414,7 +10383,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 771
+      ID: 773
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.83328e+06
@@ -10430,11 +10399,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1065
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 779
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.617984e+06
@@ -10444,19 +10413,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 706
+      ID: 708
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.278752e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 704
+      ID: 706
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.278624e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 777
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.747488e+06
@@ -10469,7 +10438,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 466
+      ID: 468
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835840
@@ -10477,21 +10446,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 468 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 470 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 467 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 469 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 467
+      ID: 469
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 840
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 746
+      ID: 748
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.4432e+06
@@ -10501,7 +10470,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 932
+      ID: 934
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.671936e+06
@@ -10509,13 +10478,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 956 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 958 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1025
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 956
+      ID: 958
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.12304e+06
@@ -10528,7 +10497,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 918
+      ID: 920
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.56448e+06
@@ -10538,19 +10507,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 469
+      ID: 471
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 836416
       GoKind: 10
     - __kind: BaseType
-      ID: 836
+      ID: 838
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 999424
       GoKind: 10
     - __kind: StructureType
-      ID: 804
+      ID: 806
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.872256e+06
@@ -10561,12 +10530,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 836 BaseType golang.org/x/net/http2.ErrCode
+          Type: 838 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 665
+      ID: 667
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.60096e+06
@@ -10574,12 +10543,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 836 BaseType golang.org/x/net/http2.ErrCode
+          Type: 838 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 473
+      ID: 475
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836608
@@ -10587,17 +10556,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 475 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 477 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 474 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 476 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 474
+      ID: 476
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 479
+      ID: 481
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836800
@@ -10605,17 +10574,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 481 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 483 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 480 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 482 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 480
+      ID: 482
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 476
+      ID: 478
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836704
@@ -10623,17 +10592,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 478 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 480 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 477 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 479 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 477
+      ID: 479
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 470
+      ID: 472
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836512
@@ -10641,21 +10610,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 472 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 474 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 471 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 473 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 471
+      ID: 473
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1023
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 671
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.44384e+06
@@ -10665,13 +10634,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 482
+      ID: 484
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 2
     - __kind: StructureType
-      ID: 657
+      ID: 659
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.43888e+06
@@ -10681,11 +10650,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 804
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 827
+      ID: 829
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.90016e+06
@@ -10701,7 +10670,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 659
+      ID: 661
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.60048e+06
@@ -10714,7 +10683,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 972
+      ID: 974
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.957728e+06
@@ -10722,16 +10691,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 999 GoInterfaceType io.Reader
+          Type: 1001 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 932
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 744
+      ID: 746
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.56208e+06
@@ -10741,29 +10710,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 892
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 639
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 734
+      ID: 736
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 800
+      ID: 802
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 798
+      ID: 800
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.50544e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 651
+      ID: 653
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.43216e+06
@@ -10773,7 +10742,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 653
+      ID: 655
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.43232e+06
@@ -10783,7 +10752,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 583
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -10857,19 +10826,19 @@ Types:
       GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 237 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1104
+      ID: 1106
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1105 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1107 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1106 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1112 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1108 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1114 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1140
       Name: groupReference<int,*main.deepMap8>
@@ -10969,19 +10938,19 @@ Types:
       GroupType: 265 StructureType noalg.map.group[string][]string
       GroupSliceType: 269 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 862
+      ID: 864
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 863 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 865 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 868 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 866 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 870 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 255
       Name: groupReference<string,int>
@@ -11123,11 +11092,11 @@ Types:
       GroupType: 308 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 312 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 980
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 672
+      ID: 674
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11174,37 +11143,37 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 553
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 549
+      ID: 551
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 878
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 761
+      ID: 763
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1067
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 759
+      ID: 761
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.47072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 488
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1077
+      ID: 1079
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.46816e+06
@@ -11217,11 +11186,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 962
+      ID: 964
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.18576e+06
@@ -11234,7 +11203,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 999
+      ID: 1001
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.018944e+06
@@ -11247,7 +11216,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 951
+      ID: 953
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.105632e+06
@@ -11273,21 +11242,21 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 920
+      ID: 922
       Name: io.discard
       GoRuntimeType: 1.45808e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 896
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 757
+      ID: 759
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 970
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -11355,9 +11324,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1098 GoMapType map[int]*main.deepMap3
+          Type: 1100 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1112
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11409,9 +11378,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1068 PointerType *main.deepPtr3
+          Type: 1070 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1069
+      ID: 1071
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11463,9 +11432,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1092 GoSliceHeaderType []*main.deepSlice3
+          Type: 1094 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1097
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11515,16 +11484,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1075 StructureType sync.Mutex
+          Type: 1077 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1078 StructureType sync.Once
+          Type: 1080 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1081 StructureType sync.WaitGroup
+          Type: 1083 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1084 StructureType sync/atomic.Int32
+          Type: 1086 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -11554,7 +11523,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1086
+      ID: 1088
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.40832e+06
@@ -11599,7 +11568,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1088
+      ID: 1090
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.40848e+06
@@ -11619,7 +11588,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1076
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11630,17 +11599,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1071 PointerType *main.stringType1.str
+          Type: 1073 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1070 GoStringDataType main.stringType1.str
+      Data: 1072 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1070
+      ID: 1072
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1074
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11743,16 +11712,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1089 PointerType **main.t
+          Type: 1091 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1090 GoSliceDataType main.t.array
+      Data: 1092 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1090
+      ID: 1092
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -11937,7 +11906,7 @@ Types:
       TablePtrSliceType: 236 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1100
+      ID: 1102
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -11950,7 +11919,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1101 PointerType **table<int,*main.deepMap3>
+          Type: 1103 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11966,8 +11935,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1111 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1106 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1113 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1108 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1136
       Name: map<int,*main.deepMap8>
@@ -12193,7 +12162,7 @@ Types:
       TablePtrSliceType: 268 GoSliceDataType []*table<string,[]string>.array
       GroupType: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 831
+      ID: 833
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -12206,7 +12175,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 832 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 834 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12222,8 +12191,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 867 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 869 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 866 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -12580,12 +12549,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1098
+      ID: 1100
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124704e+06
       GoKind: 21
-      HeaderType: 1100 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1102 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1134
       Name: map[int]*main.deepMap8
@@ -12700,7 +12669,7 @@ Types:
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 585
+      ID: 587
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.42432e+06
@@ -12710,7 +12679,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 884
+      ID: 886
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.42112e+06
@@ -12720,11 +12689,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 788
+      ID: 790
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 852
+      ID: 854
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.59104e+06
@@ -12737,35 +12706,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 816
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1031
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 814
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 792
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1041
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1049
+      ID: 1051
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1037
+      ID: 1039
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 751
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.10896e+06
@@ -12773,27 +12742,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *net.UnknownNetworkError.str
+          Type: 753 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 750 GoStringDataType net.UnknownNetworkError.str
+      Data: 752 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 752
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 718
+      ID: 720
       Name: net.canceledError
       GoRuntimeType: 1.279776e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1007
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 859
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.098656e+06
@@ -12801,7 +12770,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -12812,27 +12781,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1051
+      ID: 1053
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1045
+      ID: 1047
       Name: net.noReadFrom
       GoRuntimeType: 1.109216e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1044
+      ID: 1046
       Name: net.noWriteTo
       GoRuntimeType: 1.109088e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 518
+      ID: 520
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 520
+      ID: 522
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.7216e+06
@@ -12840,7 +12809,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 839 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 841 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -12848,7 +12817,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1033
+      ID: 1035
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.283392e+06
@@ -12856,12 +12825,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1045 StructureType net.noReadFrom
+          Type: 1047 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1038 PointerType *net.TCPConn
+          Type: 1040 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1031
+      ID: 1033
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.282848e+06
@@ -12869,24 +12838,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1044 StructureType net.noWriteTo
+          Type: 1046 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1038 PointerType *net.TCPConn
+          Type: 1040 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 794
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 818
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 710
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 878
+      ID: 880
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.41264e+06
@@ -12896,19 +12865,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 414
+      ID: 416
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 828832
       GoKind: 10
     - __kind: BaseType
-      ID: 828
+      ID: 830
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 986368
       GoKind: 10
     - __kind: StructureType
-      ID: 496
+      ID: 498
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.719872e+06
@@ -12919,12 +12888,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 828 BaseType net/http.http2ErrCode
+          Type: 830 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 808
+      ID: 810
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.891456e+06
@@ -12935,12 +12904,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 828 BaseType net/http.http2ErrCode
+          Type: 830 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 500
+      ID: 502
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.59056e+06
@@ -12948,16 +12917,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 828 BaseType net/http.http2ErrCode
+          Type: 830 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 942
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 418
+      ID: 420
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829024
@@ -12965,17 +12934,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 420 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 422 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 421 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 419
+      ID: 421
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 424
+      ID: 426
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 829216
@@ -12983,17 +12952,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 426 PointerType *net/http.http2headerFieldNameError.str
+          Type: 428 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 425 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 427 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 425
+      ID: 427
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 421
+      ID: 423
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 829120
@@ -13001,31 +12970,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 423 PointerType *net/http.http2headerFieldValueError.str
+          Type: 425 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 422 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 424 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 422
+      ID: 424
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 785
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 714
+      ID: 716
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.279008e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 996
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 415
+      ID: 417
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828928
@@ -13033,17 +13002,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 417 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 419 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 416 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 418 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 416
+      ID: 418
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 880
+      ID: 882
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.815744e+06
@@ -13051,18 +13020,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 973 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 975 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 974 BaseType time.Duration
+          Type: 976 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 33 PointerType *error
     - __kind: GoInterfaceType
-      ID: 973
+      ID: 975
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.412e+06
@@ -13075,14 +13044,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 959
+      ID: 961
       Name: net/http.incomparable
       GoRuntimeType: 898784
       GoKind: 17
       HasCount: true
       Element: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 710
+      ID: 712
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.5496e+06
@@ -13092,11 +13061,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 944
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 898
+      ID: 900
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.54944e+06
@@ -13104,9 +13073,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 941 PointerType *net/http.persistConn
+          Type: 943 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 924
+      ID: 926
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.791744e+06
@@ -13114,15 +13083,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 959 ArrayType net/http.incomparable
+          Type: 961 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 960 PointerType *bufio.Reader
+          Type: 962 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 962 GoInterfaceType io.ReadWriteCloser
+          Type: 964 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 504
+      ID: 506
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.4136e+06
@@ -13132,17 +13101,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 810
+      ID: 812
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 781
+      ID: 783
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.4736e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 712
+      ID: 714
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.54976e+06
@@ -13152,7 +13121,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 976
+      ID: 978
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.017632e+06
@@ -13160,16 +13129,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 495
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 996
+      ID: 998
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.033664e+06
@@ -13177,13 +13146,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 989 PointerType *bufio.Writer
+          Type: 991 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 910
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 577
+      ID: 579
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.724672e+06
@@ -13199,7 +13168,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 575
+      ID: 577
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.59248e+06
@@ -13212,11 +13181,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 952
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 910
+      ID: 912
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.5944e+06
@@ -13224,16 +13193,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 949 PointerType *net/smtp.Client
+          Type: 951 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 951 GoInterfaceType io.WriteCloser
+          Type: 953 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 563
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 449
+      ID: 451
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 831808
@@ -13241,25 +13210,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 451 PointerType *net/textproto.ProtocolError.str
+          Type: 453 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 450 GoStringDataType net/textproto.ProtocolError.str
+      Data: 452 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 450
+      ID: 452
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 908
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 820
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 427
+      ID: 429
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 829792
@@ -13267,17 +13236,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 429 PointerType *net/url.EscapeError.str
+          Type: 431 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 428 GoStringDataType net/url.EscapeError.str
+      Data: 430 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 428
+      ID: 430
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 430
+      ID: 432
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 829888
@@ -13285,13 +13254,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 432 PointerType *net/url.InvalidHostError.str
+          Type: 434 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 431 GoStringDataType net/url.InvalidHostError.str
+      Data: 433 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 431
+      ID: 433
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: ArrayType
@@ -13340,14 +13309,14 @@ Types:
       HasCount: true
       Element: 233 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1107
+      ID: 1109
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678464
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1108 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1110 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1143
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -13412,14 +13381,14 @@ Types:
       HasCount: true
       Element: 267 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 865
+      ID: 867
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 755104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 866 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 868 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 258
       Name: noalg.[8]struct { key string; elem int }
@@ -13570,7 +13539,7 @@ Types:
           Offset: 8
           Type: 232 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1106
+      ID: 1108
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.290272e+06
@@ -13581,7 +13550,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1107 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1109 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1142
       Name: noalg.map.group[int]*main.deepMap8
@@ -13674,7 +13643,7 @@ Types:
           Offset: 8
           Type: 266 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 864
+      ID: 866
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.353504e+06
@@ -13685,7 +13654,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 865 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 867 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 257
       Name: noalg.map.group[string]int
@@ -13876,7 +13845,7 @@ Types:
           Offset: 8
           Type: 234 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1108
+      ID: 1110
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.290144e+06
@@ -13887,7 +13856,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1109 PointerType *main.deepMap3
+          Type: 1111 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1144
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -13980,7 +13949,7 @@ Types:
           Offset: 16
           Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 866
+      ID: 868
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.353376e+06
@@ -13991,7 +13960,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 855 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 259
       Name: noalg.struct { key string; elem int }
@@ -14117,19 +14086,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1059
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 689
+      ID: 691
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 753
+      ID: 755
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1055
+      ID: 1057
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.352e+06
@@ -14137,12 +14106,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1061 StructureType os.noReadFrom
+          Type: 1063 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1056 PointerType *os.File
+          Type: 1058 PointerType *os.File
     - __kind: StructureType
-      ID: 1053
+      ID: 1055
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.3512e+06
@@ -14150,36 +14119,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1060 StructureType os.noWriteTo
+          Type: 1062 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1056 PointerType *os.File
+          Type: 1058 PointerType *os.File
     - __kind: StructureType
-      ID: 1061
+      ID: 1063
       Name: os.noReadFrom
       GoRuntimeType: 1.106528e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1060
+      ID: 1062
       Name: os.noWriteTo
       GoRuntimeType: 1.1064e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 722
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 862
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 930
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 724
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.696416e+06
@@ -14192,7 +14161,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 463
+      ID: 465
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 835072
@@ -14200,39 +14169,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 465 PointerType *os/user.UnknownGroupIdError.str
+          Type: 467 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 464 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 466 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 464
+      ID: 466
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 462
+      ID: 464
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 834976
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 488
+      ID: 490
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 585
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 695
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 699
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 695
+      ID: 697
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.879872e+06
@@ -14249,15 +14218,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 858 BaseType runtime.boundsErrorCode
+          Type: 860 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 858
+      ID: 860
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 581536
       GoKind: 8
     - __kind: StructureType
-      ID: 755
+      ID: 757
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.744224e+06
@@ -14270,7 +14239,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 673
+      ID: 675
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 985024
@@ -14278,17 +14247,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 675 PointerType *runtime.errorString.str
+          Type: 677 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 674 GoStringDataType runtime.errorString.str
+      Data: 676 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 674
+      ID: 676
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 676
+      ID: 678
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 985120
@@ -14296,17 +14265,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 678 PointerType *runtime.plainError.str
+          Type: 680 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 677 GoStringDataType runtime.plainError.str
+      Data: 679 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 677
+      ID: 679
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 701
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14328,15 +14297,15 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 994
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 898
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 892
+      ID: 894
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.4504e+06
@@ -14352,7 +14321,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1075
+      ID: 1077
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.45888e+06
@@ -14360,12 +14329,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1076 StructureType sync.noCopy
+          Type: 1078 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1077 StructureType internal/sync.Mutex
+          Type: 1079 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1078
+      ID: 1080
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.607232e+06
@@ -14373,15 +14342,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1076 StructureType sync.noCopy
+          Type: 1078 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1079 StructureType sync/atomic.Uint32
+          Type: 1081 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1075 StructureType sync.Mutex
+          Type: 1077 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1081
+      ID: 1083
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.607424e+06
@@ -14389,21 +14358,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1076 StructureType sync.noCopy
+          Type: 1078 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1082 StructureType sync/atomic.Uint64
+          Type: 1084 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1076
+      ID: 1078
       Name: sync.noCopy
       GoRuntimeType: 983968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1084
+      ID: 1086
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.46016e+06
@@ -14411,12 +14380,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1080 StructureType sync/atomic.noCopy
+          Type: 1082 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1079
+      ID: 1081
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.46032e+06
@@ -14424,12 +14393,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1080 StructureType sync/atomic.noCopy
+          Type: 1082 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1082
+      ID: 1084
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607808e+06
@@ -14437,27 +14406,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1080 StructureType sync/atomic.noCopy
+          Type: 1082 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1083 StructureType sync/atomic.align64
+          Type: 1085 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1083
+      ID: 1085
       Name: sync/atomic.align64
       GoRuntimeType: 984160
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1080
+      ID: 1082
       Name: sync/atomic.noCopy
       GoRuntimeType: 984064
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 805
+      ID: 807
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.278368e+06
@@ -14583,7 +14552,7 @@ Types:
           Offset: 16
           Type: 229 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1103
+      ID: 1105
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -14605,7 +14574,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1104 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1106 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1139
       Name: table<int,*main.deepMap8>
@@ -14775,7 +14744,7 @@ Types:
           Offset: 16
           Type: 263 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 861
+      ID: 863
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -14797,7 +14766,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 862 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 864 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 254
       Name: table<string,int>
@@ -15039,11 +15008,11 @@ Types:
           Offset: 16
           Type: 306 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1029
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 748
+      ID: 750
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.700832e+06
@@ -15056,21 +15025,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 974
+      ID: 976
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.906016e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 825
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 491
+      ID: 493
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 821
+      ID: 823
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.36688e+06
@@ -15084,9 +15053,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 822 PointerType *time.Location
+          Type: 824 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 411
+      ID: 413
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 827968
@@ -15094,13 +15063,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 413 PointerType *time.fileSizeError.str
+          Type: 415 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 412 GoStringDataType time.fileSizeError.str
+      Data: 414 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 412
+      ID: 414
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -15146,7 +15115,7 @@ Types:
       GoRuntimeType: 581472
       GoKind: 26
     - __kind: StructureType
-      ID: 839
+      ID: 841
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.055072e+06
@@ -15154,13 +15123,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 840 GoSliceHeaderType []uint8
+          Type: 842 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 841 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 843 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 842 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 844 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -15175,18 +15144,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 843 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 845 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 843
+      ID: 845
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 990592
       GoKind: 9
     - __kind: StructureType
-      ID: 841
+      ID: 843
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.916768e+06
@@ -15211,21 +15180,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 581
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 842
+      ID: 844
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 585120
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1019
+      ID: 1021
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 563
+      ID: 565
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.42144e+06
@@ -15235,13 +15204,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 452
+      ID: 454
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 831904
       GoKind: 2
     - __kind: StructureType
-      ID: 727
+      ID: 729
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.696608e+06
@@ -15254,7 +15223,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 681
+      ID: 683
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 989440

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -2326,15 +2326,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda1b6..0xcda1c7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda1c7..0xcda265
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcda280..0xcda2e2]
@@ -2351,29 +2342,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcda300..0xcda405]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda35b..0xcda365
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcda365..0xcda375
-              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcda375..0xcda389
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda356..0xcda360
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcda360..0xcda375
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcda375..0xcda384
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcda420..0xcda426]
@@ -3478,10 +3447,10 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1109
+      ID: 1111
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1110 PointerType *main.deepSlice3
+      Pointee: 1112 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1136
       Name: '**main.deepSlice8'
@@ -3499,7 +3468,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1105
+      ID: 1107
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3536,10 +3505,10 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1117
+      ID: 1119
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1118 PointerType *table<int,*main.deepMap3>
+      Pointee: 1120 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1153
       Name: '**table<int,*main.deepMap8>'
@@ -3576,10 +3545,10 @@ Types:
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 848
+      ID: 850
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 849 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 851 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3636,10 +3605,10 @@ Types:
       ByteSize: 8
       Pointee: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1113
+      ID: 1115
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1112 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1114 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1140
       Name: '*[]*main.deepSlice8.array'
@@ -3711,10 +3680,10 @@ Types:
       ByteSize: 8
       Pointee: 346 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 888
+      ID: 890
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 887 GoSliceDataType []float64.array
+      Pointee: 889 GoSliceDataType []float64.array
     - __kind: PointerType
       ID: 1149
       Name: '*[]interface {}.array'
@@ -3731,10 +3700,10 @@ Types:
       ByteSize: 8
       Pointee: 350 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1130
+      ID: 412
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1129 GoSliceDataType []main.structWithMap.array
+      Pointee: 411 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 343
       Name: '*[]main.structWithNoStrings.array'
@@ -3761,71 +3730,71 @@ Types:
       ByteSize: 8
       Pointee: 348 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 886
+      ID: 888
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 885 GoSliceDataType []uint8.array
+      Pointee: 887 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 1018
+      ID: 1020
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.985952e+06
       GoKind: 22
-      Pointee: 1019 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1021 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 648
+      ID: 650
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 931392
       GoKind: 22
-      Pointee: 649 GoSliceHeaderType archive/tar.headerError
+      Pointee: 651 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 651
+      ID: 653
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 650 GoSliceDataType archive/tar.headerError.array
+      Pointee: 652 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 953
+      ID: 955
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.435072e+06
       GoKind: 22
-      Pointee: 954 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 956 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 931584
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 904 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 904 StructureType archive/zip.dirWriter
+      Pointee: 906 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 997
+      ID: 999
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.904096e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1000 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.057792e+06
       GoKind: 22
-      Pointee: 930 StructureType archive/zip.nopCloser
+      Pointee: 932 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.058048e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 934 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3834,435 +3803,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 976
+      ID: 978
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.174048e+06
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType bufio.Reader
+      Pointee: 979 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1005
+      ID: 1007
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.948832e+06
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType bufio.Writer
+      Pointee: 1008 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1056
+      ID: 1058
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.266912e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1059 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 558
+      ID: 560
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 913824
       GoKind: 22
-      Pointee: 447 BaseType compress/flate.CorruptInputError
+      Pointee: 449 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 913920
       GoKind: 22
-      Pointee: 448 GoStringHeaderType compress/flate.InternalError
+      Pointee: 450 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 450
+      ID: 452
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 449 GoStringDataType compress/flate.InternalError.str
+      Pointee: 451 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 951
+      ID: 953
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.424672e+06
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 954 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 914016
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 900 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 973
+      ID: 975
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.725376e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 976 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 796
+      ID: 798
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.203328e+06
       GoKind: 22
-      Pointee: 797 StructureType context.deadlineExceededError
+      Pointee: 799 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926016
       GoKind: 22
-      Pointee: 461 BaseType crypto/aes.KeySizeError
+      Pointee: 463 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 641
+      ID: 643
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 462 BaseType crypto/des.KeySizeError
+      Pointee: 464 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 642
+      ID: 644
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 463 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 465 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 968
+      ID: 970
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.666112e+06
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 971 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 745
+      ID: 747
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.0656e+06
       GoKind: 22
-      Pointee: 746 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 748 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 999
+      ID: 1001
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904608e+06
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1002 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1029
+      ID: 1031
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.1192e+06
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1032 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1003
+      ID: 1005
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.90512e+06
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1006 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1001
+      ID: 1003
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904864e+06
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1004 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 995
+      ID: 997
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.902304e+06
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 998 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 643
+      ID: 645
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926784
       GoKind: 22
-      Pointee: 464 BaseType crypto/rc4.KeySizeError
+      Pointee: 466 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1016
+      ID: 1018
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.983072e+06
       GoKind: 22
-      Pointee: 1017 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1019 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 991
+      ID: 993
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.87168e+06
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 994 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 566
+      ID: 568
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 915648
       GoKind: 22
-      Pointee: 451 BaseType crypto/tls.AlertError
+      Pointee: 453 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 734
+      ID: 736
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.0464e+06
       GoKind: 22
-      Pointee: 735 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 737 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1082
+      ID: 1084
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.378432e+06
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1085 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 562
+      ID: 564
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 915360
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 565 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 560
+      ID: 562
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 915264
       GoKind: 22
-      Pointee: 561 StructureType crypto/tls.RecordHeaderError
+      Pointee: 563 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 733
+      ID: 735
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.044736e+06
       GoKind: 22
-      Pointee: 688 BaseType crypto/tls.alert
+      Pointee: 690 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 961
+      ID: 963
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.558976e+06
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 964 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 564
+      ID: 566
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 565 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 567 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 966
+      ID: 968
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.641152e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 969 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 831
+      ID: 833
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.425152e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 834 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 850
+      ID: 852
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.04224e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 853 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 636
+      ID: 638
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 637 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 639 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 630
+      ID: 632
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 924576
       GoKind: 22
-      Pointee: 631 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 633 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 632
+      ID: 634
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 924672
       GoKind: 22
-      Pointee: 633 StructureType crypto/x509.HostnameError
+      Pointee: 635 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 629
+      ID: 631
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 460 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 462 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 739
+      ID: 741
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.05216e+06
       GoKind: 22
-      Pointee: 740 StructureType crypto/x509.SystemRootsError
+      Pointee: 742 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 925152
       GoKind: 22
-      Pointee: 639 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 641 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 634
+      ID: 636
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 635 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 637 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 652
+      ID: 654
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 653 StructureType encoding/asn1.StructuralError
+      Pointee: 655 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932064
       GoKind: 22
-      Pointee: 657 StructureType encoding/asn1.SyntaxError
+      Pointee: 659 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 931968
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 657 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 547
+      ID: 549
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 442 BaseType encoding/base64.CorruptInputError
+      Pointee: 444 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 919
+      ID: 921
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.041792e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 922 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 550
+      ID: 552
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 443 BaseType encoding/hex.InvalidByteError
+      Pointee: 445 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 518
+      ID: 520
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 519 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 521 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 723
+      ID: 725
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.037952e+06
       GoKind: 22
-      Pointee: 724 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 726 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 510
+      ID: 512
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 906240
       GoKind: 22
-      Pointee: 511 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 513 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 516
+      ID: 518
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 906528
       GoKind: 22
-      Pointee: 517 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 519 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 514
+      ID: 516
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 906432
       GoKind: 22
-      Pointee: 515 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 517 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 512
+      ID: 514
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 906336
       GoKind: 22
-      Pointee: 513 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 515 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1062
+      ID: 1064
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.292448e+06
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1065 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 520
+      ID: 522
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 521 StructureType encoding/json.jsonError
+      Pointee: 523 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 927
+      ID: 929
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.05472e+06
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 930 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 624
+      ID: 626
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 627 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 622
+      ID: 624
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 625 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923616
       GoKind: 22
-      Pointee: 457 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 459 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 459
+      ID: 461
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 458 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 460 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 627
+      ID: 629
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 630 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1040
+      ID: 1042
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.15904e+06
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1043 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4271,19 +4240,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 486
+      ID: 488
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896640
       GoKind: 22
-      Pointee: 487 UnresolvedPointeeType errors.errorString
+      Pointee: 489 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 690
+      ID: 692
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.022848e+06
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType errors.joinError
+      Pointee: 693 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4299,813 +4268,813 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 1050
+      ID: 1052
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.259232e+06
       GoKind: 22
-      Pointee: 1051 UnresolvedPointeeType fmt.pp
+      Pointee: 1053 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 692
+      ID: 694
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.02464e+06
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType fmt.wrapError
+      Pointee: 695 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.024768e+06
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 697 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 548
+      ID: 550
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 912192
       GoKind: 22
-      Pointee: 549 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 551 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 529
+      ID: 531
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 530 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 532 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 531
+      ID: 533
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 534 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 863
+      ID: 865
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 909216
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 866 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 535
+      ID: 537
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 909792
       GoKind: 22
-      Pointee: 536 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 538 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 865
+      ID: 867
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 909312
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 868 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 533
+      ID: 535
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 438 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 438
+      ID: 440
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 439 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 528
+      ID: 530
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 909120
       GoKind: 22
-      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 435 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 435
+      ID: 437
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 436 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 534
+      ID: 536
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 439 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 441 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 441
+      ID: 443
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 442 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 939
+      ID: 941
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.208832e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 942 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1026
+      ID: 1028
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.057248e+06
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1029 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 930336
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 649 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 805
+      ID: 807
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.212416e+06
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 808 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1058
+      ID: 1060
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.26896e+06
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1061 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 573
+      ID: 575
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 576 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 580
+      ID: 582
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 920064
       GoKind: 22
-      Pointee: 581 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 583 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 575
+      ID: 577
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 456 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 458 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 919968
       GoKind: 22
-      Pointee: 579 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 581 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 919872
       GoKind: 22
-      Pointee: 577 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 579 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 921984
       GoKind: 22
-      Pointee: 597 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 599 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 600
+      ID: 602
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 922176
       GoKind: 22
-      Pointee: 601 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 603 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 598
+      ID: 600
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 599 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 601 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 921888
       GoKind: 22
-      Pointee: 595 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 597 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 890
+      ID: 892
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 889 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 891 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 608
+      ID: 610
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 609 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 611 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 603 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 605 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 606
+      ID: 608
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 607 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 609 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 604
+      ID: 606
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 605 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 607 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 610
+      ID: 612
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 922656
       GoKind: 22
-      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 922944
       GoKind: 22
-      Pointee: 617 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 619 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 618
+      ID: 620
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 923040
       GoKind: 22
-      Pointee: 619 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 621 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 614
+      ID: 616
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 922848
       GoKind: 22
-      Pointee: 615 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 617 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 615 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 620
+      ID: 622
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 923232
       GoKind: 22
-      Pointee: 621 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 623 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 537
+      ID: 539
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 910944
       GoKind: 22
-      Pointee: 538 StructureType github.com/cihub/seelog.baseError
+      Pointee: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 979
+      ID: 981
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.80224e+06
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 982 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 539
+      ID: 541
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 911040
       GoKind: 22
-      Pointee: 540 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 542 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 959
+      ID: 961
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.557696e+06
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 962 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 915
+      ID: 917
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.04064e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 949
+      ID: 951
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.422752e+06
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 952 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 543
+      ID: 545
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 911232
       GoKind: 22
-      Pointee: 544 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 546 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1014
+      ID: 1016
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.975296e+06
       GoKind: 22
-      Pointee: 1015 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1017 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1033
+      ID: 1035
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.13184e+06
       GoKind: 22
-      Pointee: 1028 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1030 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1032
+      ID: 1034
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.131456e+06
       GoKind: 22
-      Pointee: 1031 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1033 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 917
+      ID: 919
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.040768e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 920 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 541
+      ID: 543
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 542 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 544 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 545
+      ID: 547
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 546 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 548 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 981
+      ID: 983
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.804032e+06
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 984 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1022
+      ID: 1024
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.011424e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1025 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.04192e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1027 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 836
+      ID: 838
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.437472e+06
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 839 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 749
+      ID: 751
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.066368e+06
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 752 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.06624e+06
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 750 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 751
+      ID: 753
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.070336e+06
       GoKind: 22
-      Pointee: 752 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 754 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 753
+      ID: 755
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.070464e+06
       GoKind: 22
-      Pointee: 754 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 756 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 970
+      ID: 972
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.668416e+06
       GoKind: 22
-      Pointee: 971 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 973 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 741
+      ID: 743
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.0528e+06
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 744 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 551
+      ID: 553
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 912864
       GoKind: 22
-      Pointee: 552 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 554 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1074
+      ID: 1076
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.35488e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1077 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 807
+      ID: 809
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.220992e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 810 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.199872e+06
       GoKind: 22
-      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 783 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 774
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.199488e+06
       GoKind: 22
-      Pointee: 775 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 777 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 709
+      ID: 711
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.031936e+06
       GoKind: 22
-      Pointee: 710 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 712 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.200256e+06
       GoKind: 22
-      Pointee: 787 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 789 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 708
+      ID: 710
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.031808e+06
       GoKind: 22
-      Pointee: 687 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 689 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.199744e+06
       GoKind: 22
-      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 776
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.199616e+06
       GoKind: 22
-      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 784
+      ID: 786
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.200128e+06
       GoKind: 22
-      Pointee: 785 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 787 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.2e+06
       GoKind: 22
-      Pointee: 783 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 785 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1078
+      ID: 1080
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.367488e+06
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1081 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 790
+      ID: 792
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.20064e+06
       GoKind: 22
-      Pointee: 791 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 793 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 713
+      ID: 715
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.032192e+06
       GoKind: 22
-      Pointee: 714 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 716 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 711
+      ID: 713
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.032064e+06
       GoKind: 22
-      Pointee: 712 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 714 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 788
+      ID: 790
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.200512e+06
       GoKind: 22
-      Pointee: 789 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 791 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 668
+      ID: 670
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944832
       GoKind: 22
-      Pointee: 469 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 471 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 471
+      ID: 473
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 470 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 472 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 853
+      ID: 855
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.66688e+06
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 856 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.085184e+06
       GoKind: 22
-      Pointee: 758 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 760 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 945
+      ID: 947
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.2608e+06
       GoKind: 22
-      Pointee: 946 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 948 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1038
+      ID: 1040
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.1472e+06
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1041 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 933
+      ID: 935
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.087488e+06
       GoKind: 22
-      Pointee: 934 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 936 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 669
+      ID: 671
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 946080
       GoKind: 22
-      Pointee: 472 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 474 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 815
+      ID: 817
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.262464e+06
       GoKind: 22
-      Pointee: 816 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 818 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 672
+      ID: 674
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 946368
       GoKind: 22
-      Pointee: 673 StructureType golang.org/x/net/http2.connError
+      Pointee: 675 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 671
+      ID: 673
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946272
       GoKind: 22
-      Pointee: 476 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 478 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 478
+      ID: 480
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 477 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 479 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 946560
       GoKind: 22
-      Pointee: 482 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 484 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 484
+      ID: 486
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 483 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 485 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 674
+      ID: 676
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 946464
       GoKind: 22
-      Pointee: 479 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 481 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 481
+      ID: 483
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 480 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 482 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 670
+      ID: 672
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946176
       GoKind: 22
-      Pointee: 473 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 475 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 475
+      ID: 477
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 474 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 476 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1036
+      ID: 1038
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.14528e+06
       GoKind: 22
-      Pointee: 1037 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1039 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 676
+      ID: 678
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 946656
       GoKind: 22
-      Pointee: 677 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 679 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 678
+      ID: 680
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 946752
       GoKind: 22
-      Pointee: 485 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 487 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 664
+      ID: 666
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 665 StructureType google.golang.org/grpc.dropError
+      Pointee: 667 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 813
+      ID: 815
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.25952e+06
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 816 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 838
+      ID: 840
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.444832e+06
       GoKind: 22
-      Pointee: 839 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 841 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 666
+      ID: 668
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 943104
       GoKind: 22
-      Pointee: 667 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 669 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 985
+      ID: 987
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.809632e+06
       GoKind: 22
-      Pointee: 986 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 988 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 943
+      ID: 945
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.256064e+06
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 946 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 755
+      ID: 757
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.079424e+06
       GoKind: 22
-      Pointee: 756 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 758 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 943200
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 908 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 928224
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 647 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 743
+      ID: 745
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.056128e+06
       GoKind: 22
-      Pointee: 744 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 746 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.227392e+06
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 814 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 809
+      ID: 811
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.227136e+06
       GoKind: 22
-      Pointee: 810 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 812 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 658
+      ID: 660
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932928
       GoKind: 22
-      Pointee: 659 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 661 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 660
+      ID: 662
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 933024
       GoKind: 22
-      Pointee: 661 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 663 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 591 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 993
+      ID: 995
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.900256e+06
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 996 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 679
+      ID: 681
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 947520
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType html/template.Error
+      Pointee: 682 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -5149,115 +5118,115 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 840
+      ID: 842
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.211552e+06
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType internal/abi.Type
+      Pointee: 843 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 913536
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 559 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 554
+      ID: 556
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 913440
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 557 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 891
+      ID: 893
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 901440
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 894 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 772
+      ID: 774
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.19872e+06
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 775 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1080
+      ID: 1082
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.373152e+06
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1083 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 770
+      ID: 772
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.198592e+06
       GoKind: 22
-      Pointee: 771 StructureType internal/poll.errNetClosing
+      Pointee: 773 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 490
+      ID: 492
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900672
       GoKind: 22
-      Pointee: 491 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 493 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 553
+      ID: 555
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 913248
       GoKind: 22
-      Pointee: 444 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 446 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 446
+      ID: 448
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 445 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 447 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 727
+      ID: 729
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.043072e+06
       GoKind: 22
-      Pointee: 728 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 730 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 937
+      ID: 939
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.190016e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType io.PipeWriter
+      Pointee: 940 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 935
+      ID: 937
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.189632e+06
       GoKind: 22
-      Pointee: 936 StructureType io.discard
+      Pointee: 938 StructureType io.discard
     - __kind: PointerType
-      ID: 909
+      ID: 911
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.023104e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType io.multiWriter
+      Pointee: 912 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 768
+      ID: 770
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.19808e+06
       GoKind: 22
-      Pointee: 769 UnresolvedPointeeType io/fs.PathError
+      Pointee: 771 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 983
+      ID: 985
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.804256e+06
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 986 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 234
       Name: '*main.deepMap2'
@@ -5266,12 +5235,12 @@ Types:
       GoKind: 22
       Pointee: 235 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1125
+      ID: 1127
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385984
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType main.deepMap3
+      Pointee: 1128 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -5301,12 +5270,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1084
+      ID: 1086
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1087 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5336,12 +5305,12 @@ Types:
       GoKind: 22
       Pointee: 225 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1110
+      ID: 1112
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387136
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1113 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5377,12 +5346,12 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1101
+      ID: 1103
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 896352
       GoKind: 22
-      Pointee: 1102 StructureType main.firstBehavior
+      Pointee: 1104 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
@@ -5397,19 +5366,19 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1103
+      ID: 1105
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 896448
       GoKind: 22
-      Pointee: 1104 StructureType main.secondBehavior
+      Pointee: 1106 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1089
+      ID: 1091
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 896544
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1092 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -5417,16 +5386,16 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1087
+      ID: 1089
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1086 GoStringDataType main.stringType1.str
+      Pointee: 1088 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType main.stringType2
+      Pointee: 1090 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 175
       Name: '*main.structWithCyclicSlices'
@@ -5457,10 +5426,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1107
+      ID: 1109
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1106 GoSliceDataType main.t.array
+      Pointee: 1108 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -5493,10 +5462,10 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1115
+      ID: 1117
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1116 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1118 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1151
       Name: '*map<int,*main.deepMap8>'
@@ -5533,10 +5502,10 @@ Types:
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 846
+      ID: 848
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 847 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 849 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -5594,451 +5563,451 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 921312
       GoKind: 22
-      Pointee: 593 StructureType math/big.ErrNaN
+      Pointee: 595 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 916128
       GoKind: 22
-      Pointee: 900 StructureType mime/multipart.writerOnly·1
+      Pointee: 902 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.206656e+06
       GoKind: 22
-      Pointee: 800 UnresolvedPointeeType net.AddrError
+      Pointee: 802 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 825
+      ID: 827
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.420992e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType net.DNSError
+      Pointee: 828 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1044
+      ID: 1046
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.231904e+06
       GoKind: 22
-      Pointee: 1045 UnresolvedPointeeType net.IPConn
+      Pointee: 1047 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 823
+      ID: 825
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.420672e+06
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType net.OpError
+      Pointee: 826 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.206784e+06
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType net.ParseError
+      Pointee: 804 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1054
+      ID: 1056
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.260256e+06
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType net.TCPConn
+      Pointee: 1057 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1064
+      ID: 1066
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.30576e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType net.UDPConn
+      Pointee: 1067 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1052
+      ID: 1054
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.259744e+06
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType net.UnixConn
+      Pointee: 1055 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 798
+      ID: 800
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.205888e+06
       GoKind: 22
-      Pointee: 761 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 763 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 763
+      ID: 765
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 762 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 764 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 725
+      ID: 727
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.038848e+06
       GoKind: 22
-      Pointee: 726 StructureType net.canceledError
+      Pointee: 728 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1020
+      ID: 1022
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.008832e+06
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType net.conn
+      Pointee: 1023 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.84704e+06
       GoKind: 22
-      Pointee: 873 StructureType net.dialResult·1
+      Pointee: 875 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1066
+      ID: 1068
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.310016e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType net.netFD
+      Pointee: 1069 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 522
+      ID: 524
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907968
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType net.notFoundError
+      Pointee: 525 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 525 StructureType net.result·2
+      Pointee: 527 StructureType net.result·2
     - __kind: PointerType
-      ID: 1048
+      ID: 1050
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.246272e+06
       GoKind: 22
-      Pointee: 1049 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1051 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1046
+      ID: 1048
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.245792e+06
       GoKind: 22
-      Pointee: 1047 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1049 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 803
+      ID: 805
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.207424e+06
       GoKind: 22
-      Pointee: 804 UnresolvedPointeeType net.temporaryError
+      Pointee: 806 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 827
+      ID: 829
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.421152e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net.timeoutError
+      Pointee: 830 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 715
+      ID: 717
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.034624e+06
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 718 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 893
+      ID: 895
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 903744
       GoKind: 22
-      Pointee: 894 StructureType net/http.bufioFlushWriter
+      Pointee: 896 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 904416
       GoKind: 22
-      Pointee: 414 BaseType net/http.http2ConnectionError
+      Pointee: 416 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 500
+      ID: 502
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 501 StructureType net/http.http2GoAwayError
+      Pointee: 503 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.416672e+06
       GoKind: 22
-      Pointee: 820 StructureType net/http.http2StreamError
+      Pointee: 822 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 504
+      ID: 506
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 505 StructureType net/http.http2connError
+      Pointee: 507 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 955
+      ID: 957
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.554176e+06
       GoKind: 22
-      Pointee: 956 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 958 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 503
+      ID: 505
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 22
-      Pointee: 418 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 420 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 420
+      ID: 422
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 421 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 905280
       GoKind: 22
-      Pointee: 424 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 426 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 426
+      ID: 428
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 425 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 427 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 506
+      ID: 508
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 905184
       GoKind: 22
-      Pointee: 421 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 423 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 423
+      ID: 425
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 422 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 424 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 794
+      ID: 796
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.20256e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 797 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 721
+      ID: 723
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.035264e+06
       GoKind: 22
-      Pointee: 722 StructureType net/http.http2noCachedConnError
+      Pointee: 724 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1009
+      ID: 1011
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.951136e+06
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1012 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 502
+      ID: 504
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 415 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 417 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 417
+      ID: 419
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 416 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 418 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 895
+      ID: 897
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 905376
       GoKind: 22
-      Pointee: 896 StructureType net/http.http2stickyErrWriter
+      Pointee: 898 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 717
+      ID: 719
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.03488e+06
       GoKind: 22
-      Pointee: 718 StructureType net/http.nothingWrittenError
+      Pointee: 720 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 957
+      ID: 959
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.175296e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType net/http.persistConn
+      Pointee: 960 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 913
+      ID: 915
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.034752e+06
       GoKind: 22
-      Pointee: 914 StructureType net/http.persistConnWriter
+      Pointee: 916 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 947
+      ID: 949
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.416832e+06
       GoKind: 22
-      Pointee: 948 StructureType net/http.readWriteCloserBody
+      Pointee: 950 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 508
+      ID: 510
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 509 StructureType net/http.requestBodyReadError
+      Pointee: 511 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 821
+      ID: 823
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.417952e+06
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 824 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 792
+      ID: 794
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.202432e+06
       GoKind: 22
-      Pointee: 793 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 795 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 719
+      ID: 721
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.035008e+06
       GoKind: 22
-      Pointee: 720 StructureType net/http.transportReadFromServerError
+      Pointee: 722 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 989
+      ID: 991
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.84368e+06
       GoKind: 22
-      Pointee: 990 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 992 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 497
+      ID: 499
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 903648
       GoKind: 22
-      Pointee: 498 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 500 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1011
+      ID: 1013
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.952928e+06
       GoKind: 22
-      Pointee: 1012 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1014 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 923
+      ID: 925
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.047552e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 926 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 920256
       GoKind: 22
-      Pointee: 585 StructureType net/netip.parseAddrError
+      Pointee: 587 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 582
+      ID: 584
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 583 StructureType net/netip.parsePrefixError
+      Pointee: 585 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.117792e+06
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType net/smtp.Client
+      Pointee: 966 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.052416e+06
       GoKind: 22
-      Pointee: 926 StructureType net/smtp.dataCloser
+      Pointee: 928 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 568
+      ID: 570
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 916320
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType net/textproto.Error
+      Pointee: 571 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 567
+      ID: 569
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 916224
       GoKind: 22
-      Pointee: 452 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 454 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 454
+      ID: 456
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 453 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 455 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.046784e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 924 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 829
+      ID: 831
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.421472e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType net/url.Error
+      Pointee: 832 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 526
+      ID: 528
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 427 GoStringHeaderType net/url.EscapeError
+      Pointee: 429 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 429
+      ID: 431
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 428 GoStringDataType net/url.EscapeError.str
+      Pointee: 430 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 527
+      ID: 529
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 908832
       GoKind: 22
-      Pointee: 430 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 432 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 432
+      ID: 434
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 431 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 433 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 332
       Name: '*noalg.map.group[[4]int][4]int'
@@ -6065,10 +6034,10 @@ Types:
       ByteSize: 8
       Pointee: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1121
+      ID: 1123
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1122 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1124 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1157
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -6105,10 +6074,10 @@ Types:
       ByteSize: 8
       Pointee: 265 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 882 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 256
       Name: '*noalg.map.group[string]int'
@@ -6160,174 +6129,174 @@ Types:
       ByteSize: 8
       Pointee: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1072
+      ID: 1074
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.349504e+06
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType os.File
+      Pointee: 1075 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 696
+      ID: 698
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.02592e+06
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType os.LinkError
+      Pointee: 699 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 764
+      ID: 766
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.191424e+06
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType os.SyscallError
+      Pointee: 767 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1070
+      ID: 1072
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.348032e+06
       GoKind: 22
-      Pointee: 1071 StructureType os.fileWithoutReadFrom
+      Pointee: 1073 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1068
+      ID: 1070
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.347296e+06
       GoKind: 22
-      Pointee: 1069 StructureType os.fileWithoutWriteTo
+      Pointee: 1071 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 729
+      ID: 731
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.043456e+06
       GoKind: 22
-      Pointee: 730 UnresolvedPointeeType os/exec.Error
+      Pointee: 732 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 875
+      ID: 877
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.089056e+06
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 878 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 941
+      ID: 943
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.213696e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 944 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 731
+      ID: 733
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.043584e+06
       GoKind: 22
-      Pointee: 732 StructureType os/exec.wrappedError
+      Pointee: 734 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 663
+      ID: 665
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 938112
       GoKind: 22
-      Pointee: 466 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 468 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 468
+      ID: 470
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 467 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 469 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 662
+      ID: 664
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 938016
       GoKind: 22
-      Pointee: 465 BaseType os/user.UnknownUserIdError
+      Pointee: 467 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 492
+      ID: 494
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 901344
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType reflect.ValueError
+      Pointee: 495 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 920928
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 593 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 700
+      ID: 702
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.027456e+06
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 703 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 704
+      ID: 706
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.029248e+06
       GoKind: 22
-      Pointee: 705 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 707 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 702
+      ID: 704
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.027584e+06
       GoKind: 22
-      Pointee: 703 StructureType runtime.boundsError
+      Pointee: 705 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 766
+      ID: 768
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.196928e+06
       GoKind: 22
-      Pointee: 767 StructureType runtime.errorAddressString
+      Pointee: 769 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 698
+      ID: 700
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.027072e+06
       GoKind: 22
-      Pointee: 681 GoStringHeaderType runtime.errorString
+      Pointee: 683 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 683
+      ID: 685
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 682 GoStringDataType runtime.errorString.str
+      Pointee: 684 GoStringDataType runtime.errorString.str
     - __kind: PointerType
-      ID: 699
+      ID: 701
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.0272e+06
       GoKind: 22
-      Pointee: 684 GoStringHeaderType runtime.plainError
+      Pointee: 686 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 686
+      ID: 688
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 685 GoStringDataType runtime.plainError.str
+      Pointee: 687 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 842
+      ID: 844
       Name: '*runtime.synctestBubble'
       ByteSize: 8
       GoRuntimeType: 1.551936e+06
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType runtime.synctestBubble
+      Pointee: 845 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 488
+      ID: 490
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 900000
       GoKind: 22
-      Pointee: 489 StructureType runtime.synctestDeadlockError
+      Pointee: 491 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
-      ID: 706
+      ID: 708
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.029504e+06
       GoKind: 22
-      Pointee: 707 UnresolvedPointeeType strconv.NumError
+      Pointee: 709 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6341,33 +6310,33 @@ Types:
       ByteSize: 8
       Pointee: 221 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1007
+      ID: 1009
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.949856e+06
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType strings.Builder
+      Pointee: 1010 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 911
+      ID: 913
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.029632e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 914 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 971104
       GoKind: 22
-      Pointee: 908 StructureType struct { io.Writer }
+      Pointee: 910 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 818
+      ID: 820
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.416032e+06
       GoKind: 22
-      Pointee: 817 BaseType syscall.Errno
+      Pointee: 819 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
@@ -6394,10 +6363,10 @@ Types:
       ByteSize: 8
       Pointee: 228 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1118
+      ID: 1120
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1119 StructureType table<int,*main.deepMap3>
+      Pointee: 1121 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1154
       Name: '*table<int,*main.deepMap8>'
@@ -6434,10 +6403,10 @@ Types:
       ByteSize: 8
       Pointee: 262 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 849
+      ID: 851
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 877 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 879 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
@@ -6489,45 +6458,45 @@ Types:
       ByteSize: 8
       Pointee: 305 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1042
+      ID: 1044
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.159424e+06
       GoKind: 22
-      Pointee: 1043 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1045 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 759
+      ID: 761
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.089024e+06
       GoKind: 22
-      Pointee: 760 StructureType text/template.ExecError
+      Pointee: 762 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 834
+      ID: 836
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.622144e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType time.Location
+      Pointee: 837 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902208
       GoKind: 22
-      Pointee: 496 UnresolvedPointeeType time.ParseError
+      Pointee: 498 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 494
+      ID: 496
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902112
       GoKind: 22
-      Pointee: 411 GoStringHeaderType time.fileSizeError
+      Pointee: 413 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 413
+      ID: 415
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 412 GoStringDataType time.fileSizeError.str
+      Pointee: 414 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6571,47 +6540,47 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 920352
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 589 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1034
+      ID: 1036
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.134912e+06
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1037 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 916512
       GoKind: 22
-      Pointee: 571 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 573 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 455 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 457 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 736
+      ID: 738
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.047296e+06
       GoKind: 22
-      Pointee: 737 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 739 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 738
+      ID: 740
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.047424e+06
       GoKind: 22
-      Pointee: 689 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 691 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1290
       Name: Probe[main.stackC]
@@ -8602,7 +8571,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 867
+      ID: 869
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684416
@@ -8633,7 +8602,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1108
+      ID: 1110
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477824
@@ -8641,19 +8610,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1109 PointerType **main.deepSlice3
+          Type: 1111 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1112 GoSliceDataType []*main.deepSlice3.array
+      Data: 1114 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1112
+      ID: 1114
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 1110 PointerType *main.deepSlice3
+      Element: 1112 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1135
       Name: '[]*main.deepSlice8'
@@ -8746,10 +8715,10 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1127
+      ID: 1129
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 1118 PointerType *table<int,*main.deepMap3>
+      Element: 1120 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1163
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -8786,10 +8755,10 @@ Types:
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 883
+      ID: 885
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 8192
-      Element: 849 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 851 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]*table<string,int>.array'
@@ -8989,7 +8958,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 862
+      ID: 864
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487104
@@ -9004,9 +8973,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 887 GoSliceDataType []float64.array
+      Data: 889 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 887
+      ID: 889
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 15 BaseType float64
@@ -9069,9 +9038,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1129 GoSliceDataType []main.structWithMap.array
+      Data: 411 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1129
+      ID: 411
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -9122,10 +9091,10 @@ Types:
       ByteSize: 2048
       Element: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1128
+      ID: 1130
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 1122 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1124 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1164
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -9162,10 +9131,10 @@ Types:
       ByteSize: 2048
       Element: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 884
+      ID: 886
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 2048
-      Element: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 882 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]noalg.map.group[string]int.array'
@@ -9283,7 +9252,7 @@ Types:
       ByteSize: 2048
       Element: 6 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 856
+      ID: 858
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 486080
@@ -9298,18 +9267,18 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 885 GoSliceDataType []uint8.array
+      Data: 887 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 885
+      ID: 887
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1019
+      ID: 1021
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 649
+      ID: 651
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 931488
@@ -9324,32 +9293,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 650 GoSliceDataType archive/tar.headerError.array
+      Data: 652 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 650
+      ID: 652
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 954
+      ID: 956
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 904
+      ID: 906
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.12032e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1000
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 930
+      ID: 932
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.564896e+06
@@ -9359,7 +9328,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 934
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9369,15 +9338,15 @@ Types:
       GoRuntimeType: 585184
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 979
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1008
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1059
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9403,13 +9372,13 @@ Types:
       GoRuntimeType: 584928
       GoKind: 15
     - __kind: BaseType
-      ID: 447
+      ID: 449
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834656
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 448
+      ID: 450
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 834752
@@ -9417,115 +9386,115 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 450 PointerType *compress/flate.InternalError.str
+          Type: 452 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 449 GoStringDataType compress/flate.InternalError.str
+      Data: 451 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 449
+      ID: 451
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 954
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 900
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 976
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 797
+      ID: 799
       Name: context.deadlineExceededError
       GoRuntimeType: 1.479296e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 461
+      ID: 463
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 2
     - __kind: BaseType
-      ID: 462
+      ID: 464
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837344
       GoKind: 2
     - __kind: BaseType
-      ID: 463
+      ID: 465
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837440
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 971
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 746
+      ID: 748
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.28928e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1002
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1032
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1006
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1004
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 998
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 464
+      ID: 466
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837536
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1017
+      ID: 1019
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 994
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 451
+      ID: 453
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835232
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 735
+      ID: 737
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1085
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 565
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 561
+      ID: 563
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.729984e+06
@@ -9536,38 +9505,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 867 ArrayType [5]uint8
+          Type: 869 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 688
+      ID: 690
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 993472
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 964
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 565
+      ID: 567
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 969
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 834
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 853
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 637
+      ID: 639
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.732864e+06
@@ -9575,21 +9544,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 850 PointerType *crypto/x509.Certificate
+          Type: 852 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 870 BaseType crypto/x509.InvalidReason
+          Type: 872 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 631
+      ID: 633
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.117888e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 633
+      ID: 635
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.599008e+06
@@ -9597,24 +9566,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 850 PointerType *crypto/x509.Certificate
+          Type: 852 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 460
+      ID: 462
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836864
       GoKind: 2
     - __kind: BaseType
-      ID: 870
+      ID: 872
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 590368
       GoKind: 2
     - __kind: StructureType
-      ID: 740
+      ID: 742
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.560896e+06
@@ -9624,13 +9593,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 639
+      ID: 641
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.118144e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 635
+      ID: 637
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.732672e+06
@@ -9638,15 +9607,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 850 PointerType *crypto/x509.Certificate
+          Type: 852 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 850 PointerType *crypto/x509.Certificate
+          Type: 852 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 653
+      ID: 655
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.435712e+06
@@ -9656,7 +9625,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 657
+      ID: 659
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.435872e+06
@@ -9666,55 +9635,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 657
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 442
+      ID: 444
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834176
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 922
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 443
+      ID: 445
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 834368
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 519
+      ID: 521
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 724
+      ID: 726
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 511
+      ID: 513
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 517
+      ID: 519
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 515
+      ID: 517
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 513
+      ID: 515
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1065
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 521
+      ID: 523
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.419712e+06
@@ -9724,19 +9693,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 930
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 627
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 625
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 457
+      ID: 459
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -9744,21 +9713,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 459 PointerType *encoding/xml.UnmarshalError.str
+          Type: 461 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 458 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 460 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 458
+      ID: 460
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 630
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1043
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9775,11 +9744,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 487
+      ID: 489
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 693
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9795,15 +9764,15 @@ Types:
       GoRuntimeType: 585120
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1051
+      ID: 1053
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 695
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 697
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9813,11 +9782,11 @@ Types:
       GoRuntimeType: 476032
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 549
+      ID: 551
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 530
+      ID: 532
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.728832e+06
@@ -9825,7 +9794,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 860 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 862 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -9833,25 +9802,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 534
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 866
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 536
+      ID: 538
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.114176e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 868
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 436
+      ID: 438
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 833600
@@ -9859,17 +9828,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 440 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 439 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 437
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 860
+      ID: 862
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.21872e+06
@@ -9877,7 +9846,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 861 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 863 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9892,7 +9861,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 862 GoSliceHeaderType []float64
+          Type: 864 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -9901,10 +9870,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 863 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 865 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 865 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 867 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 166 GoSliceHeaderType []string
@@ -9918,13 +9887,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 861
+      ID: 863
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586976
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 433
+      ID: 435
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 833504
@@ -9932,17 +9901,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 437 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 436 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 434
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 439
+      ID: 441
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 833696
@@ -9950,59 +9919,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 441 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 443 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 442 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 440
+      ID: 442
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 942
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1029
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 649
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 808
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1061
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 576
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 581
+      ID: 583
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.11712e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 456
+      ID: 458
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 835904
       GoKind: 2
     - __kind: StructureType
-      ID: 579
+      ID: 581
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.116992e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 577
+      ID: 579
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.597088e+06
@@ -10015,7 +9984,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 597
+      ID: 599
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.597888e+06
@@ -10028,7 +9997,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 601
+      ID: 603
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.732096e+06
@@ -10044,7 +10013,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 599
+      ID: 601
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.429632e+06
@@ -10054,7 +10023,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 595
+      ID: 597
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.429312e+06
@@ -10064,14 +10033,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 845
+      ID: 847
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.500096e+06
       GoKind: 21
-      HeaderType: 847 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 849 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 869
+      ID: 871
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.05088e+06
@@ -10086,14 +10055,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 889 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 891 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 889
+      ID: 891
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 609
+      ID: 611
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.598208e+06
@@ -10101,12 +10070,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 845 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 847 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 845 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 847 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 603
+      ID: 605
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.429792e+06
@@ -10116,7 +10085,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 609
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.732288e+06
@@ -10127,12 +10096,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 871 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 871 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 605
+      ID: 607
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.598048e+06
@@ -10145,7 +10114,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 611
+      ID: 613
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.429952e+06
@@ -10153,9 +10122,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 833 StructureType time.Time
+          Type: 835 StructureType time.Time
     - __kind: StructureType
-      ID: 617
+      ID: 619
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.598528e+06
@@ -10168,7 +10137,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 619
+      ID: 621
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.430272e+06
@@ -10178,7 +10147,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 615
+      ID: 617
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.598368e+06
@@ -10191,7 +10160,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 613
+      ID: 615
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.430112e+06
@@ -10201,7 +10170,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 621
+      ID: 623
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.598688e+06
@@ -10214,7 +10183,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 538
+      ID: 540
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.421952e+06
@@ -10224,11 +10193,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 982
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 540
+      ID: 542
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.422112e+06
@@ -10236,21 +10205,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 538 StructureType github.com/cihub/seelog.baseError
+          Type: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 962
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 918
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 952
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 544
+      ID: 546
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.422432e+06
@@ -10258,13 +10227,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 538 StructureType github.com/cihub/seelog.baseError
+          Type: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1015
+      ID: 1017
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1028
+      ID: 1030
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.106208e+06
@@ -10272,12 +10241,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1014 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1016 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1031
+      ID: 1033
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.131072e+06
@@ -10285,7 +10254,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1014 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1016 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10293,11 +10262,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 920
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 542
+      ID: 544
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.422272e+06
@@ -10305,9 +10274,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 538 StructureType github.com/cihub/seelog.baseError
+          Type: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 546
+      ID: 548
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.422592e+06
@@ -10315,64 +10284,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 538 StructureType github.com/cihub/seelog.baseError
+          Type: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 984
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1025
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1027
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 839
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 752
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 750
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 752
+      ID: 754
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 754
+      ID: 756
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 971
+      ID: 973
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 744
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 552
+      ID: 554
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.423552e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1077
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 810
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 781
+      ID: 783
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.841888e+06
@@ -10388,11 +10357,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 775
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 710
+      ID: 712
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.701536e+06
@@ -10405,7 +10374,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 787
+      ID: 789
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.842336e+06
@@ -10421,13 +10390,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 687
+      ID: 689
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 990784
       GoKind: 8
     - __kind: StructureType
-      ID: 779
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.841664e+06
@@ -10443,13 +10412,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 871
+      ID: 873
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 831776
       GoKind: 8
     - __kind: StructureType
-      ID: 777
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.84144e+06
@@ -10457,15 +10426,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 871 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 873 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 871 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 873 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 785
+      ID: 787
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.755488e+06
@@ -10478,7 +10447,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 783
+      ID: 785
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.842112e+06
@@ -10494,11 +10463,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1081
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 791
+      ID: 793
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.623104e+06
@@ -10508,19 +10477,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 714
+      ID: 716
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.283264e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 712
+      ID: 714
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.283136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 789
+      ID: 791
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.75568e+06
@@ -10533,7 +10502,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 469
+      ID: 471
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839360
@@ -10541,21 +10510,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 471 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 473 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 470 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 472 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 470
+      ID: 472
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 856
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 758
+      ID: 760
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.447552e+06
@@ -10565,7 +10534,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 946
+      ID: 948
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.677248e+06
@@ -10573,13 +10542,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 972 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 974 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1041
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 972
+      ID: 974
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.127872e+06
@@ -10592,7 +10561,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 934
+      ID: 936
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.569696e+06
@@ -10602,19 +10571,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 472
+      ID: 474
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 839936
       GoKind: 10
     - __kind: BaseType
-      ID: 852
+      ID: 854
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.003936e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 816
+      ID: 818
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.880416e+06
@@ -10625,12 +10594,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 852 BaseType golang.org/x/net/http2.ErrCode
+          Type: 854 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 673
+      ID: 675
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.605728e+06
@@ -10638,12 +10607,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 852 BaseType golang.org/x/net/http2.ErrCode
+          Type: 854 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 476
+      ID: 478
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840128
@@ -10651,17 +10620,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 478 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 480 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 477 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 479 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 477
+      ID: 479
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 482
+      ID: 484
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840320
@@ -10669,17 +10638,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 484 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 486 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 483 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 485 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 483
+      ID: 485
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 479
+      ID: 481
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -10687,17 +10656,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 481 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 483 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 480 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 482 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 480
+      ID: 482
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 473
+      ID: 475
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840032
@@ -10705,21 +10674,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 475 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 477 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 474 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 476 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 474
+      ID: 476
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1037
+      ID: 1039
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 679
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.448192e+06
@@ -10729,13 +10698,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 485
+      ID: 487
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840416
       GoKind: 2
     - __kind: StructureType
-      ID: 665
+      ID: 667
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.443232e+06
@@ -10745,11 +10714,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 816
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 839
+      ID: 841
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.908192e+06
@@ -10765,7 +10734,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 667
+      ID: 669
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.605248e+06
@@ -10778,7 +10747,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 986
+      ID: 988
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.96624e+06
@@ -10786,16 +10755,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1013 GoInterfaceType io.Reader
+          Type: 1015 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 946
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 756
+      ID: 758
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.567296e+06
@@ -10805,29 +10774,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 908
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 647
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 744
+      ID: 746
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 814
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 812
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.510816e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 659
+      ID: 661
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.436512e+06
@@ -10837,7 +10806,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 661
+      ID: 663
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.436672e+06
@@ -10847,7 +10816,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 591
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -10921,19 +10890,19 @@ Types:
       GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 237 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1120
+      ID: 1122
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1121 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1123 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1122 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1128 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1124 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1130 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1156
       Name: groupReference<int,*main.deepMap8>
@@ -11033,19 +11002,19 @@ Types:
       GroupType: 265 StructureType noalg.map.group[string][]string
       GroupSliceType: 269 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 878
+      ID: 880
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 879 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 881 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 884 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 882 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 886 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 255
       Name: groupReference<string,int>
@@ -11187,11 +11156,11 @@ Types:
       GroupType: 308 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 312 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 996
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 682
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11238,41 +11207,41 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 843
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 559
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 557
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 894
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 775
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1083
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 771
+      ID: 773
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.476096e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 491
+      ID: 493
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 444
+      ID: 446
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 834560
@@ -11280,17 +11249,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 446 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 448 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 445 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 447 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 445
+      ID: 447
       Name: internal/runtime/cgroup.stringError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 728
+      ID: 730
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.558656e+06
@@ -11298,9 +11267,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 840 PointerType *internal/abi.Type
+          Type: 842 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 1093
+      ID: 1095
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.473536e+06
@@ -11313,11 +11282,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 940
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 978
+      ID: 980
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.18976e+06
@@ -11330,7 +11299,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1013
+      ID: 1015
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.023232e+06
@@ -11343,7 +11312,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 965
+      ID: 967
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -11369,21 +11338,21 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 936
+      ID: 938
       Name: io.discard
       GoRuntimeType: 1.462656e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 912
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 769
+      ID: 771
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 986
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -11451,9 +11420,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1114 GoMapType map[int]*main.deepMap3
+          Type: 1116 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1128
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11505,9 +11474,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1084 PointerType *main.deepPtr3
+          Type: 1086 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1087
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11559,9 +11528,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1108 GoSliceHeaderType []*main.deepSlice3
+          Type: 1110 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1113
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11611,16 +11580,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1091 StructureType sync.Mutex
+          Type: 1093 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1094 StructureType sync.Once
+          Type: 1096 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1097 StructureType sync.WaitGroup
+          Type: 1099 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1100 StructureType sync/atomic.Int32
+          Type: 1102 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -11650,7 +11619,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1102
+      ID: 1104
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.412192e+06
@@ -11695,7 +11664,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1104
+      ID: 1106
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.412352e+06
@@ -11715,7 +11684,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1092
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11726,17 +11695,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1087 PointerType *main.stringType1.str
+          Type: 1089 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1086 GoStringDataType main.stringType1.str
+      Data: 1088 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1086
+      ID: 1088
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1090
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11839,16 +11808,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1105 PointerType **main.t
+          Type: 1107 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1106 GoSliceDataType main.t.array
+      Data: 1108 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1106
+      ID: 1108
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -12048,7 +12017,7 @@ Types:
       TablePtrSliceType: 236 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1116
+      ID: 1118
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -12061,7 +12030,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1117 PointerType **table<int,*main.deepMap3>
+          Type: 1119 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12080,8 +12049,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1127 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1122 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1129 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1124 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1152
       Name: map<int,*main.deepMap8>
@@ -12328,7 +12297,7 @@ Types:
       TablePtrSliceType: 268 GoSliceDataType []*table<string,[]string>.array
       GroupType: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 847
+      ID: 849
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -12341,7 +12310,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 848 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 850 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12360,8 +12329,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 883 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 885 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 882 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -12748,12 +12717,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1114
+      ID: 1116
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.129536e+06
       GoKind: 21
-      HeaderType: 1116 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1118 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1150
       Name: map[int]*main.deepMap8
@@ -12868,7 +12837,7 @@ Types:
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 593
+      ID: 595
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.428832e+06
@@ -12878,7 +12847,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 902
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.425632e+06
@@ -12888,11 +12857,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 800
+      ID: 802
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 868
+      ID: 870
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.595808e+06
@@ -12905,35 +12874,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 828
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1045
+      ID: 1047
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 826
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 804
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1057
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1067
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1055
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 761
+      ID: 763
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.113792e+06
@@ -12941,27 +12910,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 763 PointerType *net.UnknownNetworkError.str
+          Type: 765 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 762 GoStringDataType net.UnknownNetworkError.str
+      Data: 764 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 762
+      ID: 764
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 726
+      ID: 728
       Name: net.canceledError
       GoRuntimeType: 1.284288e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1023
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 873
+      ID: 875
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.105504e+06
@@ -12969,7 +12938,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -12980,27 +12949,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1069
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1061
+      ID: 1063
       Name: net.noReadFrom
       GoRuntimeType: 1.114048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1060
+      ID: 1062
       Name: net.noWriteTo
       GoRuntimeType: 1.11392e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 525
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 525
+      ID: 527
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.72864e+06
@@ -13008,7 +12977,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 855 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 857 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -13016,7 +12985,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1049
+      ID: 1051
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.288512e+06
@@ -13024,12 +12993,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1061 StructureType net.noReadFrom
+          Type: 1063 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1054 PointerType *net.TCPConn
+          Type: 1056 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1047
+      ID: 1049
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.287968e+06
@@ -13037,24 +13006,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1060 StructureType net.noWriteTo
+          Type: 1062 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1054 PointerType *net.TCPConn
+          Type: 1056 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 804
+      ID: 806
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 830
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 718
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 894
+      ID: 896
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.417152e+06
@@ -13064,19 +13033,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 414
+      ID: 416
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832256
       GoKind: 10
     - __kind: BaseType
-      ID: 844
+      ID: 846
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 990880
       GoKind: 10
     - __kind: StructureType
-      ID: 501
+      ID: 503
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.726912e+06
@@ -13087,12 +13056,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 844 BaseType net/http.http2ErrCode
+          Type: 846 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 820
+      ID: 822
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.89872e+06
@@ -13103,12 +13072,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 844 BaseType net/http.http2ErrCode
+          Type: 846 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 505
+      ID: 507
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.595328e+06
@@ -13116,16 +13085,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 844 BaseType net/http.http2ErrCode
+          Type: 846 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 956
+      ID: 958
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 418
+      ID: 420
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832448
@@ -13133,17 +13102,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 420 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 422 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 421 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 419
+      ID: 421
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 424
+      ID: 426
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -13151,17 +13120,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 426 PointerType *net/http.http2headerFieldNameError.str
+          Type: 428 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 425 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 427 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 425
+      ID: 427
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 421
+      ID: 423
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832544
@@ -13169,31 +13138,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 423 PointerType *net/http.http2headerFieldValueError.str
+          Type: 425 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 422 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 424 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 422
+      ID: 424
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 797
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 724
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.28352e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1012
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 415
+      ID: 417
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832352
@@ -13201,17 +13170,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 417 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 419 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 416 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 418 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 416
+      ID: 418
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 896
+      ID: 898
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.824576e+06
@@ -13219,18 +13188,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 987 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 989 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 988 BaseType time.Duration
+          Type: 990 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 33 PointerType *error
     - __kind: GoInterfaceType
-      ID: 987
+      ID: 989
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.416352e+06
@@ -13243,14 +13212,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 975
+      ID: 977
       Name: net/http.incomparable
       GoRuntimeType: 903456
       GoKind: 17
       HasCount: true
       Element: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 718
+      ID: 720
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.554816e+06
@@ -13260,11 +13229,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 960
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 914
+      ID: 916
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.554656e+06
@@ -13272,9 +13241,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 957 PointerType *net/http.persistConn
+          Type: 959 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 948
+      ID: 950
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.799552e+06
@@ -13282,15 +13251,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 975 ArrayType net/http.incomparable
+          Type: 977 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 976 PointerType *bufio.Reader
+          Type: 978 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 978 GoInterfaceType io.ReadWriteCloser
+          Type: 980 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 509
+      ID: 511
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.418112e+06
@@ -13300,17 +13269,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 824
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 793
+      ID: 795
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.478976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 720
+      ID: 722
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.554976e+06
@@ -13320,7 +13289,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 990
+      ID: 992
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.025216e+06
@@ -13328,16 +13297,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 498
+      ID: 500
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1012
+      ID: 1014
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.04096e+06
@@ -13345,13 +13314,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1005 PointerType *bufio.Writer
+          Type: 1007 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 926
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 585
+      ID: 587
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.731712e+06
@@ -13367,7 +13336,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 585
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.597248e+06
@@ -13380,11 +13349,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 966
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 926
+      ID: 928
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.599168e+06
@@ -13392,16 +13361,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 963 PointerType *net/smtp.Client
+          Type: 965 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 965 GoInterfaceType io.WriteCloser
+          Type: 967 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 571
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 452
+      ID: 454
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835328
@@ -13409,25 +13378,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 454 PointerType *net/textproto.ProtocolError.str
+          Type: 456 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 453 GoStringDataType net/textproto.ProtocolError.str
+      Data: 455 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 453
+      ID: 455
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 832
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 427
+      ID: 429
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833216
@@ -13435,17 +13404,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 429 PointerType *net/url.EscapeError.str
+          Type: 431 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 428 GoStringDataType net/url.EscapeError.str
+      Data: 430 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 428
+      ID: 430
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 430
+      ID: 432
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833312
@@ -13453,13 +13422,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 432 PointerType *net/url.InvalidHostError.str
+          Type: 434 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 431 GoStringDataType net/url.InvalidHostError.str
+      Data: 433 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 431
+      ID: 433
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: ArrayType
@@ -13508,14 +13477,14 @@ Types:
       HasCount: true
       Element: 233 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1123
+      ID: 1125
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1124 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1126 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1159
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -13580,14 +13549,14 @@ Types:
       HasCount: true
       Element: 267 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 881
+      ID: 883
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 759488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 882 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 884 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 258
       Name: noalg.[8]struct { key string; elem int }
@@ -13738,7 +13707,7 @@ Types:
           Offset: 8
           Type: 232 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1122
+      ID: 1124
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.294784e+06
@@ -13749,7 +13718,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1123 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1125 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1158
       Name: noalg.map.group[int]*main.deepMap8
@@ -13842,7 +13811,7 @@ Types:
           Offset: 8
           Type: 266 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 880
+      ID: 882
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.35776e+06
@@ -13853,7 +13822,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 881 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 883 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 257
       Name: noalg.map.group[string]int
@@ -14044,7 +14013,7 @@ Types:
           Offset: 8
           Type: 234 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1124
+      ID: 1126
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.294656e+06
@@ -14055,7 +14024,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1125 PointerType *main.deepMap3
+          Type: 1127 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1160
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -14148,7 +14117,7 @@ Types:
           Offset: 16
           Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 882
+      ID: 884
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.357632e+06
@@ -14159,7 +14128,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 871 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 259
       Name: noalg.struct { key string; elem int }
@@ -14285,19 +14254,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1075
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 699
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 767
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1071
+      ID: 1073
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.35888e+06
@@ -14305,12 +14274,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1077 StructureType os.noReadFrom
+          Type: 1079 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1072 PointerType *os.File
+          Type: 1074 PointerType *os.File
     - __kind: StructureType
-      ID: 1069
+      ID: 1071
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.35808e+06
@@ -14318,36 +14287,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1076 StructureType os.noWriteTo
+          Type: 1078 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1072 PointerType *os.File
+          Type: 1074 PointerType *os.File
     - __kind: StructureType
-      ID: 1077
+      ID: 1079
       Name: os.noReadFrom
       GoRuntimeType: 1.11136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1076
+      ID: 1078
       Name: os.noWriteTo
       GoRuntimeType: 1.111232e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 730
+      ID: 732
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 878
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 944
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 732
+      ID: 734
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.702112e+06
@@ -14360,7 +14329,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 466
+      ID: 468
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 838592
@@ -14368,39 +14337,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 468 PointerType *os/user.UnknownGroupIdError.str
+          Type: 470 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 467 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 469 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 467
+      ID: 469
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 465
+      ID: 467
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 838496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 495
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 593
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 703
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 705
+      ID: 707
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 703
+      ID: 705
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.887584e+06
@@ -14417,15 +14386,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 874 BaseType runtime.boundsErrorCode
+          Type: 876 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 874
+      ID: 876
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585312
       GoKind: 8
     - __kind: StructureType
-      ID: 767
+      ID: 769
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.752416e+06
@@ -14438,7 +14407,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 681
+      ID: 683
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 989440
@@ -14446,17 +14415,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 683 PointerType *runtime.errorString.str
+          Type: 685 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 682 GoStringDataType runtime.errorString.str
+      Data: 684 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 682
+      ID: 684
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 684
+      ID: 686
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 989536
@@ -14464,21 +14433,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 686 PointerType *runtime.plainError.str
+          Type: 688 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 685 GoStringDataType runtime.plainError.str
+      Data: 687 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 685
+      ID: 687
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 845
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 489
+      ID: 491
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.595008e+06
@@ -14489,9 +14458,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: bubble
           Offset: 16
-          Type: 842 PointerType *runtime.synctestBubble
+          Type: 844 PointerType *runtime.synctestBubble
     - __kind: UnresolvedPointeeType
-      ID: 707
+      ID: 709
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14513,15 +14482,15 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1010
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 914
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 908
+      ID: 910
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.454912e+06
@@ -14537,7 +14506,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1091
+      ID: 1093
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.463456e+06
@@ -14545,12 +14514,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1092 StructureType sync.noCopy
+          Type: 1094 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1093 StructureType internal/sync.Mutex
+          Type: 1095 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1094
+      ID: 1096
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.612352e+06
@@ -14558,15 +14527,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1092 StructureType sync.noCopy
+          Type: 1094 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1095 StructureType sync/atomic.Bool
+          Type: 1097 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1091 StructureType sync.Mutex
+          Type: 1093 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1097
+      ID: 1099
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.61216e+06
@@ -14574,21 +14543,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1092 StructureType sync.noCopy
+          Type: 1094 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1098 StructureType sync/atomic.Uint64
+          Type: 1100 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1092
+      ID: 1094
       Name: sync.noCopy
       GoRuntimeType: 988384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1095
+      ID: 1097
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.464576e+06
@@ -14596,12 +14565,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1096 StructureType sync/atomic.noCopy
+          Type: 1098 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1100
+      ID: 1102
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464736e+06
@@ -14609,12 +14578,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1096 StructureType sync/atomic.noCopy
+          Type: 1098 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1098
+      ID: 1100
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612736e+06
@@ -14622,27 +14591,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1096 StructureType sync/atomic.noCopy
+          Type: 1098 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1099 StructureType sync/atomic.align64
+          Type: 1101 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1099
+      ID: 1101
       Name: sync/atomic.align64
       GoRuntimeType: 988576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1096
+      ID: 1098
       Name: sync/atomic.noCopy
       GoRuntimeType: 988480
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 817
+      ID: 819
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.28288e+06
@@ -14768,7 +14737,7 @@ Types:
           Offset: 16
           Type: 229 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1119
+      ID: 1121
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -14790,7 +14759,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1120 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1122 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1155
       Name: table<int,*main.deepMap8>
@@ -14960,7 +14929,7 @@ Types:
           Offset: 16
           Type: 263 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 877
+      ID: 879
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -14982,7 +14951,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 878 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 880 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 254
       Name: table<string,int>
@@ -15224,11 +15193,11 @@ Types:
           Offset: 16
           Type: 306 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1043
+      ID: 1045
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 760
+      ID: 762
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.706528e+06
@@ -15241,21 +15210,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 988
+      ID: 990
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.91504e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 837
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 496
+      ID: 498
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 833
+      ID: 835
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.372192e+06
@@ -15269,9 +15238,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 834 PointerType *time.Location
+          Type: 836 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 411
+      ID: 413
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 831392
@@ -15279,13 +15248,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 413 PointerType *time.fileSizeError.str
+          Type: 415 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 412 GoStringDataType time.fileSizeError.str
+      Data: 414 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 412
+      ID: 414
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -15331,7 +15300,7 @@ Types:
       GoRuntimeType: 585248
       GoKind: 26
     - __kind: StructureType
-      ID: 855
+      ID: 857
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.062688e+06
@@ -15339,13 +15308,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 856 GoSliceHeaderType []uint8
+          Type: 858 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 857 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 859 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 858 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 860 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -15360,18 +15329,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 859 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 861 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 859
+      ID: 861
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995104
       GoKind: 9
     - __kind: StructureType
-      ID: 857
+      ID: 859
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.926048e+06
@@ -15396,21 +15365,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 589
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 858
+      ID: 860
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1037
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 571
+      ID: 573
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.425952e+06
@@ -15420,13 +15389,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 455
+      ID: 457
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 2
     - __kind: StructureType
-      ID: 737
+      ID: 739
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.702304e+06
@@ -15439,7 +15408,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 689
+      ID: 691
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 993952

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -2326,15 +2326,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d60c..0x88d61c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d61c..0x88d6c0
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x88d6c0..0x88d740]
@@ -2351,29 +2342,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x88d740..0x88d860]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d7a8..0x88d7b0
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d7b0..0x88d7c8
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d7c8..0x88d7dc
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d7a4..0x88d7ac
-              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d7ac..0x88d7c8
-              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d7c8..0x88d7d8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x88d860..0x88d870]
@@ -3478,10 +3447,10 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 967
+      ID: 969
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 968 PointerType *main.deepSlice3
+      Pointee: 970 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 988
       Name: '**main.deepSlice8'
@@ -3499,7 +3468,7 @@ Types:
       GoKind: 22
       Pointee: 80 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '**main.t'
       ByteSize: 8
       Pointee: 160 PointerType *main.t
@@ -3516,10 +3485,10 @@ Types:
       ByteSize: 8
       Pointee: 228 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 971
+      ID: 973
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 970 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 972 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 992
       Name: '*[]*main.deepSlice8.array'
@@ -3591,10 +3560,10 @@ Types:
       ByteSize: 8
       Pointee: 273 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 754
+      ID: 756
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 753 GoSliceDataType []float64.array
+      Pointee: 755 GoSliceDataType []float64.array
     - __kind: PointerType
       ID: 1001
       Name: '*[]interface {}.array'
@@ -3611,10 +3580,10 @@ Types:
       ByteSize: 8
       Pointee: 277 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 982
+      ID: 304
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 981 GoSliceDataType []main.structWithMap.array
+      Pointee: 303 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 270
       Name: '*[]main.structWithNoStrings.array'
@@ -3641,71 +3610,71 @@ Types:
       ByteSize: 8
       Pointee: 275 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 752
+      ID: 754
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 751 GoSliceDataType []uint8.array
+      Pointee: 753 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.848928e+06
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 882 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 528
+      ID: 530
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858432
       GoKind: 22
-      Pointee: 529 GoSliceHeaderType archive/tar.headerError
+      Pointee: 531 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 531
+      ID: 533
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 530 GoSliceDataType archive/tar.headerError.array
+      Pointee: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.25312e+06
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 822 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 767
+      ID: 769
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858624
       GoKind: 22
-      Pointee: 768 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 770 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 769
+      ID: 771
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858720
       GoKind: 22
-      Pointee: 770 StructureType archive/zip.dirWriter
+      Pointee: 772 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 866
+      ID: 868
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.773216e+06
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 869 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 795
+      ID: 797
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.01664e+06
       GoKind: 22
-      Pointee: 796 StructureType archive/zip.nopCloser
+      Pointee: 798 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 797
+      ID: 799
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.016896e+06
       GoKind: 22
-      Pointee: 798 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 800 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3739,10 +3708,10 @@ Types:
       ByteSize: 8
       Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 975
+      ID: 977
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 976 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 978 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1005
       Name: '*bucket<int,*main.deepMap8>'
@@ -3779,10 +3748,10 @@ Types:
       ByteSize: 8
       Pointee: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 720
+      ID: 722
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 723 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 106
       Name: '*bucket<string,int>'
@@ -3834,393 +3803,393 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 843
+      ID: 845
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.029408e+06
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType bufio.Reader
+      Pointee: 846 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 868
+      ID: 870
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.814656e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType bufio.Writer
+      Pointee: 871 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 915
+      ID: 917
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.122368e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType bytes.Buffer
+      Pointee: 918 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 441
+      ID: 443
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 336 BaseType compress/flate.CorruptInputError
+      Pointee: 338 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 442
+      ID: 444
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 337 GoStringHeaderType compress/flate.InternalError
+      Pointee: 339 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 339
+      ID: 341
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 338 GoStringDataType compress/flate.InternalError.str
+      Pointee: 340 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 817
+      ID: 819
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.24336e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 820 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 763
+      ID: 765
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841248
       GoKind: 22
-      Pointee: 764 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 766 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 839
+      ID: 841
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.59984e+06
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 842 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 672
+      ID: 674
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.117792e+06
       GoKind: 22
-      Pointee: 673 StructureType context.deadlineExceededError
+      Pointee: 675 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 521
+      ID: 523
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853344
       GoKind: 22
-      Pointee: 350 BaseType crypto/aes.KeySizeError
+      Pointee: 352 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 522
+      ID: 524
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853536
       GoKind: 22
-      Pointee: 351 BaseType crypto/des.KeySizeError
+      Pointee: 353 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 829
+      ID: 831
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.373792e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 832 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 854
+      ID: 856
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.678848e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 857 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 523
+      ID: 525
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853824
       GoKind: 22
-      Pointee: 352 BaseType crypto/rc4.KeySizeError
+      Pointee: 354 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 862
+      ID: 864
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.7704e+06
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 865 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 856
+      ID: 858
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.679296e+06
       GoKind: 22
-      Pointee: 857 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 859 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 858
+      ID: 860
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.679744e+06
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 861 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 447
+      ID: 449
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842688
       GoKind: 22
-      Pointee: 340 BaseType crypto/tls.AlertError
+      Pointee: 342 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.00448e+06
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 615 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 941
+      ID: 943
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.231488e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 944 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 445
+      ID: 447
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842496
       GoKind: 22
-      Pointee: 446 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 448 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 443
+      ID: 445
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842400
       GoKind: 22
-      Pointee: 444 StructureType crypto/tls.RecordHeaderError
+      Pointee: 446 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 611
+      ID: 613
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.002816e+06
       GoKind: 22
-      Pointee: 568 BaseType crypto/tls.alert
+      Pointee: 570 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 827
+      ID: 829
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.370912e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 830 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 834
+      ID: 836
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.449984e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 837 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.24368e+06
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 710 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 722
+      ID: 724
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90608e+06
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 725 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 517
+      ID: 519
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852288
       GoKind: 22
-      Pointee: 518 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 520 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 511
+      ID: 513
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851808
       GoKind: 22
-      Pointee: 512 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 514 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 513
+      ID: 515
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 851904
       GoKind: 22
-      Pointee: 514 StructureType crypto/x509.HostnameError
+      Pointee: 516 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 510
+      ID: 512
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851712
       GoKind: 22
-      Pointee: 349 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 351 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 617
+      ID: 619
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010368e+06
       GoKind: 22
-      Pointee: 618 StructureType crypto/x509.SystemRootsError
+      Pointee: 620 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 519
+      ID: 521
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852384
       GoKind: 22
-      Pointee: 520 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 522 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 515
+      ID: 517
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 516 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 518 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 532
+      ID: 534
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 858912
       GoKind: 22
-      Pointee: 533 StructureType encoding/asn1.StructuralError
+      Pointee: 535 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 536
+      ID: 538
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859104
       GoKind: 22
-      Pointee: 537 StructureType encoding/asn1.SyntaxError
+      Pointee: 539 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 534
+      ID: 536
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 859008
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 537 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 433
+      ID: 435
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839328
       GoKind: 22
-      Pointee: 334 BaseType encoding/base64.CorruptInputError
+      Pointee: 336 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 785
+      ID: 787
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 999616
       GoKind: 22
-      Pointee: 786 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 788 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 436
+      ID: 438
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840192
       GoKind: 22
-      Pointee: 335 BaseType encoding/hex.InvalidByteError
+      Pointee: 337 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 404
+      ID: 406
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 834048
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 407 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 603
+      ID: 605
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995264
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 606 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 396
+      ID: 398
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833664
       GoKind: 22
-      Pointee: 397 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 399 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 402
+      ID: 404
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 833952
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 405 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 400
+      ID: 402
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 401 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 403 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 398
+      ID: 400
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833760
       GoKind: 22
-      Pointee: 399 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 401 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.147936e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 924 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 406
+      ID: 408
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834432
       GoKind: 22
-      Pointee: 407 StructureType encoding/json.jsonError
+      Pointee: 409 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 793
+      ID: 795
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.013184e+06
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 796 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 505
+      ID: 507
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 506 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 508 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 503
+      ID: 505
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 506 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 346 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 348 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 348
+      ID: 350
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 347 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 349 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 508
+      ID: 510
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 850944
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 511 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.017888e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 902 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4229,19 +4198,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 374
+      ID: 376
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824352
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType errors.errorString
+      Pointee: 377 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 979904
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType errors.joinError
+      Pointee: 573 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4257,806 +4226,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 909
+      ID: 911
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.113664e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType fmt.pp
+      Pointee: 912 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 981696
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType fmt.wrapError
+      Pointee: 575 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 574
+      ID: 576
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 981824
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 577 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 434
+      ID: 436
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839712
       GoKind: 22
-      Pointee: 435 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 437 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 415
+      ID: 417
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 22
-      Pointee: 416 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 418 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 417
+      ID: 419
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 22
-      Pointee: 418 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 420 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 735
+      ID: 737
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 421
+      ID: 423
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837216
       GoKind: 22
-      Pointee: 422 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 424 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 737
+      ID: 739
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 740 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 419
+      ID: 421
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 22
-      Pointee: 328 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 330 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 330
+      ID: 332
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 331 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 414
+      ID: 416
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836544
       GoKind: 22
-      Pointee: 325 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 327 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 327
+      ID: 329
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 328 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 420
+      ID: 422
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 331 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 333 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 333
+      ID: 335
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 334 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 807
+      ID: 809
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.123552e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 810 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 887
+      ID: 889
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.921088e+06
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 890 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 526
+      ID: 528
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857376
       GoKind: 22
-      Pointee: 527 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 529 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 681
+      ID: 683
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.12688e+06
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 684 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 917
+      ID: 919
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.123904e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 920 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 454
+      ID: 456
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 22
-      Pointee: 455 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 457 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 461
+      ID: 463
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847296
       GoKind: 22
-      Pointee: 462 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 464 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 456
+      ID: 458
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 22
-      Pointee: 345 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 347 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 459
+      ID: 461
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847200
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 462 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 457
+      ID: 459
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 477
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849216
       GoKind: 22
-      Pointee: 478 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 481
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849408
       GoKind: 22
-      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 479
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849312
       GoKind: 22
-      Pointee: 480 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 475
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849120
       GoKind: 22
-      Pointee: 476 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 756
+      ID: 758
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 755 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 757 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 489
+      ID: 491
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849792
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 483
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 22
-      Pointee: 484 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 487
+      ID: 489
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 22
-      Pointee: 488 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 485
+      ID: 487
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849600
       GoKind: 22
-      Pointee: 486 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 491
+      ID: 493
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 849888
       GoKind: 22
-      Pointee: 492 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 497
+      ID: 499
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850176
       GoKind: 22
-      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850272
       GoKind: 22
-      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 850080
       GoKind: 22
-      Pointee: 496 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 493
+      ID: 495
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 849984
       GoKind: 22
-      Pointee: 494 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 501
+      ID: 503
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850464
       GoKind: 22
-      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 504 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 423
+      ID: 425
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838368
       GoKind: 22
-      Pointee: 424 StructureType github.com/cihub/seelog.baseError
+      Pointee: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 846
+      ID: 848
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.675936e+06
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 849 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 425
+      ID: 427
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838464
       GoKind: 22
-      Pointee: 426 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 428 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 825
+      ID: 827
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.369792e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 828 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 781
+      ID: 783
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 998592
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 815
+      ID: 817
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.24144e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 818 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 429
+      ID: 431
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838656
       GoKind: 22
-      Pointee: 430 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 432 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 877
+      ID: 879
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.839136e+06
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 880 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 892
+      ID: 894
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.992544e+06
       GoKind: 22
-      Pointee: 889 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 891 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 891
+      ID: 893
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.99216e+06
       GoKind: 22
-      Pointee: 890 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 892 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 783
+      ID: 785
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 998720
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 786 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 427
+      ID: 429
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838560
       GoKind: 22
-      Pointee: 428 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 430 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 431
+      ID: 433
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838752
       GoKind: 22
-      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 434 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 850
+      ID: 852
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.677504e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 853 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 883
+      ID: 885
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.875008e+06
       GoKind: 22
-      Pointee: 884 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 886 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 885
+      ID: 887
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.90576e+06
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 888 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 712
+      ID: 714
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.25552e+06
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 715 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 625
+      ID: 627
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.024576e+06
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 628 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 623
+      ID: 625
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024448e+06
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 626 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 627
+      ID: 629
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.028544e+06
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 630 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 629
+      ID: 631
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.028672e+06
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 632 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 836
+      ID: 838
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.477632e+06
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 839 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.011136e+06
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 622 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 437
+      ID: 439
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840384
       GoKind: 22
-      Pointee: 438 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 440 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 933
+      ID: 935
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.210592e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 936 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 683
+      ID: 685
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.135072e+06
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 686 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.113952e+06
       GoKind: 22
-      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 650
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.113568e+06
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 653 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 589
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 989120
       GoKind: 22
-      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 662
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114336e+06
       GoKind: 22
-      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 988992
       GoKind: 22
-      Pointee: 567 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 569 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.113824e+06
       GoKind: 22
-      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 652
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.113696e+06
       GoKind: 22
-      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 660
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 658
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.11408e+06
       GoKind: 22
-      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 937
+      ID: 939
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.221632e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 940 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 666
+      ID: 668
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.11472e+06
       GoKind: 22
-      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 669 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 593
+      ID: 595
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989376
       GoKind: 22
-      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 596 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 591
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989248
       GoKind: 22
-      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 664
+      ID: 666
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.114592e+06
       GoKind: 22
-      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 548
+      ID: 550
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871008
       GoKind: 22
-      Pointee: 357 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 359 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 359
+      ID: 361
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 358 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 360 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 725
+      ID: 727
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.476096e+06
       GoKind: 22
-      Pointee: 726 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 728 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 633
+      ID: 635
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.04352e+06
       GoKind: 22
-      Pointee: 634 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 636 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 813
+      ID: 815
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.173984e+06
       GoKind: 22
-      Pointee: 814 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 816 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.00752e+06
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 900 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.045824e+06
       GoKind: 22
-      Pointee: 800 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 802 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 549
+      ID: 551
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872256
       GoKind: 22
-      Pointee: 360 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 362 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 691
+      ID: 693
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.175648e+06
       GoKind: 22
-      Pointee: 692 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 694 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 552
+      ID: 554
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872544
       GoKind: 22
-      Pointee: 553 StructureType golang.org/x/net/http2.connError
+      Pointee: 555 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 551
+      ID: 553
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872448
       GoKind: 22
-      Pointee: 364 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 366 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 366
+      ID: 368
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 365 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 367 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 555
+      ID: 557
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872736
       GoKind: 22
-      Pointee: 370 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 372 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 372
+      ID: 374
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 371 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 373 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 554
+      ID: 556
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872640
       GoKind: 22
-      Pointee: 367 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 369 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 369
+      ID: 371
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 368 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 370 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 550
+      ID: 552
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872352
       GoKind: 22
-      Pointee: 361 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 363 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 363
+      ID: 365
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 362 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 364 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 895
+      ID: 897
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.0056e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 898 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872832
       GoKind: 22
-      Pointee: 557 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 559 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 558
+      ID: 560
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 872928
       GoKind: 22
-      Pointee: 373 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 375 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 544
+      ID: 546
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866400
       GoKind: 22
-      Pointee: 545 StructureType google.golang.org/grpc.dropError
+      Pointee: 547 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 689
+      ID: 691
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.172576e+06
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 692 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 714
+      ID: 716
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.26288e+06
       GoKind: 22
-      Pointee: 715 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 717 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 546
+      ID: 548
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869280
       GoKind: 22
-      Pointee: 547 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 549 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 860
+      ID: 862
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.684224e+06
       GoKind: 22
-      Pointee: 861 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 863 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.16912e+06
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 814 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 631
+      ID: 633
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.03776e+06
       GoKind: 22
-      Pointee: 632 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 634 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 771
+      ID: 773
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869376
       GoKind: 22
-      Pointee: 772 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 774 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855264
       GoKind: 22
-      Pointee: 525 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 527 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 621
+      ID: 623
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.014592e+06
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 624 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 687
+      ID: 689
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.140832e+06
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 690 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 685
+      ID: 687
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.140576e+06
       GoKind: 22
-      Pointee: 686 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 688 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 538
+      ID: 540
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 22
-      Pointee: 539 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 541 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 540
+      ID: 542
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 860064
       GoKind: 22
-      Pointee: 541 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 543 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 469
+      ID: 471
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847680
       GoKind: 22
-      Pointee: 470 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 472 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 848
+      ID: 850
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.676608e+06
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 851 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 151
       Name: '*hash<[4]int,[4]int>'
@@ -5083,10 +5052,10 @@ Types:
       ByteSize: 8
       Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 973
+      ID: 975
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 974 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 976 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1003
       Name: '*hash<int,*main.deepMap8>'
@@ -5123,10 +5092,10 @@ Types:
       ByteSize: 8
       Pointee: 110 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 718
+      ID: 720
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 719 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 721 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '*hash<string,int>'
@@ -5178,12 +5147,12 @@ Types:
       ByteSize: 8
       Pointee: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873696
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType html/template.Error
+      Pointee: 562 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -5227,82 +5196,82 @@ Types:
       GoKind: 22
       Pointee: 83 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 439
+      ID: 441
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840768
       GoKind: 22
-      Pointee: 440 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 442 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 828960
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 760 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 648
+      ID: 650
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.1128e+06
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 651 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 939
+      ID: 941
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.226304e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType internal/poll.FD
+      Pointee: 942 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.112672e+06
       GoKind: 22
-      Pointee: 647 StructureType internal/poll.errNetClosing
+      Pointee: 649 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 376
+      ID: 378
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828096
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 379 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 803
+      ID: 805
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.10384e+06
       GoKind: 22
-      Pointee: 804 UnresolvedPointeeType io.PipeWriter
+      Pointee: 806 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.103456e+06
       GoKind: 22
-      Pointee: 802 StructureType io.discard
+      Pointee: 804 StructureType io.discard
     - __kind: PointerType
-      ID: 775
+      ID: 777
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 980160
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType io.multiWriter
+      Pointee: 778 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112416e+06
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType io/fs.PathError
+      Pointee: 647 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 852
+      ID: 854
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.677728e+06
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 855 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 233
       Name: '*main.deepMap2'
@@ -5311,12 +5280,12 @@ Types:
       GoKind: 22
       Pointee: 234 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 978
+      ID: 980
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356288
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType main.deepMap3
+      Pointee: 981 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 75
       Name: '*main.deepMap7'
@@ -5346,12 +5315,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 943
+      ID: 945
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356864
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType main.deepPtr3
+      Pointee: 946 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5381,12 +5350,12 @@ Types:
       GoKind: 22
       Pointee: 227 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 968
+      ID: 970
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357440
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType main.deepSlice3
+      Pointee: 971 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5422,12 +5391,12 @@ Types:
       GoKind: 22
       Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 959
+      ID: 961
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 824064
       GoKind: 22
-      Pointee: 960 StructureType main.firstBehavior
+      Pointee: 962 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 159
       Name: '*main.node'
@@ -5442,19 +5411,19 @@ Types:
       GoKind: 22
       Pointee: 174 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 961
+      ID: 963
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824160
       GoKind: 22
-      Pointee: 962 StructureType main.secondBehavior
+      Pointee: 964 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 948
+      ID: 950
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824256
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType main.somethingImpl
+      Pointee: 951 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 77
       Name: '*main.stringType1'
@@ -5462,16 +5431,16 @@ Types:
       GoKind: 22
       Pointee: 78 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 946
+      ID: 948
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 945 GoStringDataType main.stringType1.str
+      Pointee: 947 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 80
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType main.stringType2
+      Pointee: 949 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 177
       Name: '*main.structWithCyclicSlices'
@@ -5502,10 +5471,10 @@ Types:
       GoKind: 22
       Pointee: 161 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 965
+      ID: 967
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 964 GoSliceDataType main.t.array
+      Pointee: 966 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 172
       Name: '*main.threeStringStruct'
@@ -5519,580 +5488,580 @@ Types:
       GoKind: 22
       Pointee: 103 GoMapType map[string]int
     - __kind: PointerType
-      ID: 473
+      ID: 475
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848544
       GoKind: 22
-      Pointee: 474 StructureType math/big.ErrNaN
+      Pointee: 476 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 765
+      ID: 767
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843168
       GoKind: 22
-      Pointee: 766 StructureType mime/multipart.writerOnly·1
+      Pointee: 768 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.12112e+06
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType net.AddrError
+      Pointee: 678 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 701
+      ID: 703
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.23968e+06
       GoKind: 22
-      Pointee: 702 UnresolvedPointeeType net.DNSError
+      Pointee: 704 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.085856e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType net.IPConn
+      Pointee: 906 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 699
+      ID: 701
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.23936e+06
       GoKind: 22
-      Pointee: 700 UnresolvedPointeeType net.OpError
+      Pointee: 702 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 677
+      ID: 679
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121248e+06
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType net.ParseError
+      Pointee: 680 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 913
+      ID: 915
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.115712e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType net.TCPConn
+      Pointee: 916 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 923
+      ID: 925
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.160672e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net.UDPConn
+      Pointee: 926 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 911
+      ID: 913
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.1152e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType net.UnixConn
+      Pointee: 914 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 674
+      ID: 676
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.120352e+06
       GoKind: 22
-      Pointee: 637 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 639 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 639
+      ID: 641
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 638 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 640 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 605
+      ID: 607
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 996032
       GoKind: 22
-      Pointee: 606 StructureType net.canceledError
+      Pointee: 608 StructureType net.canceledError
     - __kind: PointerType
-      ID: 881
+      ID: 883
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.872704e+06
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType net.conn
+      Pointee: 884 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 744
+      ID: 746
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.716928e+06
       GoKind: 22
-      Pointee: 745 StructureType net.dialResult·1
+      Pointee: 747 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.164928e+06
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType net.netFD
+      Pointee: 928 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 408
+      ID: 410
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835392
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType net.notFoundError
+      Pointee: 411 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 410
+      ID: 412
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 836064
       GoKind: 22
-      Pointee: 411 StructureType net.result·2
+      Pointee: 413 StructureType net.result·2
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.099744e+06
       GoKind: 22
-      Pointee: 908 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 910 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.099264e+06
       GoKind: 22
-      Pointee: 906 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 908 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 679
+      ID: 681
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.121888e+06
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType net.temporaryError
+      Pointee: 682 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 703
+      ID: 705
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.23984e+06
       GoKind: 22
-      Pointee: 704 UnresolvedPointeeType net.timeoutError
+      Pointee: 706 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 595
+      ID: 597
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 991808
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 598 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 759
+      ID: 761
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831264
       GoKind: 22
-      Pointee: 760 StructureType net/http.bufioFlushWriter
+      Pointee: 762 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 385
+      ID: 387
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 831936
       GoKind: 22
-      Pointee: 306 BaseType net/http.http2ConnectionError
+      Pointee: 308 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 386
+      ID: 388
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 832032
       GoKind: 22
-      Pointee: 387 StructureType net/http.http2GoAwayError
+      Pointee: 389 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 695
+      ID: 697
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.23552e+06
       GoKind: 22
-      Pointee: 696 StructureType net/http.http2StreamError
+      Pointee: 698 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 390
+      ID: 392
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832512
       GoKind: 22
-      Pointee: 391 StructureType net/http.http2connError
+      Pointee: 393 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 821
+      ID: 823
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.366432e+06
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 824 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 389
+      ID: 391
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832416
       GoKind: 22
-      Pointee: 310 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 312 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 312
+      ID: 314
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 313 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 393
+      ID: 395
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832704
       GoKind: 22
-      Pointee: 316 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 318 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 318
+      ID: 320
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 319 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 392
+      ID: 394
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832608
       GoKind: 22
-      Pointee: 313 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 315 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 315
+      ID: 317
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 316 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 670
+      ID: 672
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.116896e+06
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 673 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 601
+      ID: 603
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992448
       GoKind: 22
-      Pointee: 602 StructureType net/http.http2noCachedConnError
+      Pointee: 604 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.816704e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 875 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 388
+      ID: 390
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832320
       GoKind: 22
-      Pointee: 307 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 309 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 309
+      ID: 311
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 310 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 761
+      ID: 763
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832800
       GoKind: 22
-      Pointee: 762 StructureType net/http.http2stickyErrWriter
+      Pointee: 764 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 597
+      ID: 599
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 992064
       GoKind: 22
-      Pointee: 598 StructureType net/http.nothingWrittenError
+      Pointee: 600 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 823
+      ID: 825
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.030656e+06
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType net/http.persistConn
+      Pointee: 826 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 779
+      ID: 781
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 991936
       GoKind: 22
-      Pointee: 780 StructureType net/http.persistConnWriter
+      Pointee: 782 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 805
+      ID: 807
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.115872e+06
       GoKind: 22
-      Pointee: 806 StructureType net/http.readWriteCloserBody
+      Pointee: 808 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 394
+      ID: 396
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 832896
       GoKind: 22
-      Pointee: 395 StructureType net/http.requestBodyReadError
+      Pointee: 397 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 697
+      ID: 699
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.23664e+06
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 700 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 668
+      ID: 670
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.116768e+06
       GoKind: 22
-      Pointee: 669 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 671 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 599
+      ID: 601
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992192
       GoKind: 22
-      Pointee: 600 StructureType net/http.transportReadFromServerError
+      Pointee: 602 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 383
+      ID: 385
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831168
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 386 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.81824e+06
       GoKind: 22
-      Pointee: 875 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 877 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 789
+      ID: 791
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.005504e+06
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 792 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 465
+      ID: 467
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847488
       GoKind: 22
-      Pointee: 466 StructureType net/netip.parseAddrError
+      Pointee: 468 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 463
+      ID: 465
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847392
       GoKind: 22
-      Pointee: 464 StructureType net/netip.parsePrefixError
+      Pointee: 466 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 831
+      ID: 833
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.98032e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType net/smtp.Client
+      Pointee: 834 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 791
+      ID: 793
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.010624e+06
       GoKind: 22
-      Pointee: 792 StructureType net/smtp.dataCloser
+      Pointee: 794 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 449
+      ID: 451
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843360
       GoKind: 22
-      Pointee: 450 UnresolvedPointeeType net/textproto.Error
+      Pointee: 452 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 448
+      ID: 450
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843264
       GoKind: 22
-      Pointee: 341 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 343 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 343
+      ID: 345
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 342 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 344 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 787
+      ID: 789
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.004864e+06
       GoKind: 22
-      Pointee: 788 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 790 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 705
+      ID: 707
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.24016e+06
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType net/url.Error
+      Pointee: 708 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 412
+      ID: 414
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836160
       GoKind: 22
-      Pointee: 319 GoStringHeaderType net/url.EscapeError
+      Pointee: 321 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 321
+      ID: 323
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType net/url.EscapeError.str
+      Pointee: 322 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 413
+      ID: 415
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836256
       GoKind: 22
-      Pointee: 322 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 324 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 324
+      ID: 326
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 325 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.202176e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType os.File
+      Pointee: 934 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 982976
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType os.LinkError
+      Pointee: 579 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105376e+06
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType os.SyscallError
+      Pointee: 643 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.199232e+06
       GoKind: 22
-      Pointee: 930 StructureType os.fileWithoutReadFrom
+      Pointee: 932 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 927
+      ID: 929
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.198496e+06
       GoKind: 22
-      Pointee: 928 StructureType os.fileWithoutWriteTo
+      Pointee: 930 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 607
+      ID: 609
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001536e+06
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType os/exec.Error
+      Pointee: 610 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.952288e+06
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 750 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 809
+      ID: 811
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.127904e+06
       GoKind: 22
-      Pointee: 810 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 812 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 609
+      ID: 611
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.001664e+06
       GoKind: 22
-      Pointee: 610 StructureType os/exec.wrappedError
+      Pointee: 612 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 543
+      ID: 545
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864480
       GoKind: 22
-      Pointee: 354 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 356 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 356
+      ID: 358
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 355 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 357 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 542
+      ID: 544
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864384
       GoKind: 22
-      Pointee: 353 BaseType os/user.UnknownUserIdError
+      Pointee: 355 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 378
+      ID: 380
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 828864
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType reflect.ValueError
+      Pointee: 381 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 471
+      ID: 473
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848160
       GoKind: 22
-      Pointee: 472 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 474 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 579
+      ID: 581
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984512
       GoKind: 22
-      Pointee: 580 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 582 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986432
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 587 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 581
+      ID: 583
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 984640
       GoKind: 22
-      Pointee: 582 StructureType runtime.boundsError
+      Pointee: 584 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 642
+      ID: 644
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.110752e+06
       GoKind: 22
-      Pointee: 643 StructureType runtime.errorAddressString
+      Pointee: 645 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984256
       GoKind: 22
-      Pointee: 561 GoStringHeaderType runtime.errorString
+      Pointee: 563 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 563
+      ID: 565
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 562 GoStringDataType runtime.errorString.str
+      Pointee: 564 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 73
       Name: '*runtime.mapextra'
@@ -6101,24 +6070,24 @@ Types:
       GoKind: 22
       Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 583
+      ID: 585
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 986176
       GoKind: 22
-      Pointee: 564 GoStringHeaderType runtime.plainError
+      Pointee: 566 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 566
+      ID: 568
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 565 GoStringDataType runtime.plainError.str
+      Pointee: 567 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 986688
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType strconv.NumError
+      Pointee: 589 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6132,73 +6101,73 @@ Types:
       ByteSize: 8
       Pointee: 223 GoStringDataType string.str
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.815424e+06
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType strings.Builder
+      Pointee: 873 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 777
+      ID: 779
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 986816
       GoKind: 22
-      Pointee: 778 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 780 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 773
+      ID: 775
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 774 StructureType struct { io.Writer }
+      Pointee: 776 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.23488e+06
       GoKind: 22
-      Pointee: 693 BaseType syscall.Errno
+      Pointee: 695 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.018272e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 904 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 635
+      ID: 637
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.04736e+06
       GoKind: 22
-      Pointee: 636 StructureType text/template.ExecError
+      Pointee: 638 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 710
+      ID: 712
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.431552e+06
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType time.Location
+      Pointee: 713 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 381
+      ID: 383
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829728
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType time.ParseError
+      Pointee: 384 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 380
+      ID: 382
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829632
       GoKind: 22
-      Pointee: 303 GoStringHeaderType time.fileSizeError
+      Pointee: 305 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 305
+      ID: 307
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 304 GoStringDataType time.fileSizeError.str
+      Pointee: 306 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6242,54 +6211,54 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 864
+      ID: 866
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.77168e+06
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 867 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 467
+      ID: 469
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 22
-      Pointee: 468 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 470 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 893
+      ID: 895
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.994848e+06
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 896 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 451
+      ID: 453
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843744
       GoKind: 22
-      Pointee: 452 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 454 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 453
+      ID: 455
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 843840
       GoKind: 22
-      Pointee: 344 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 346 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 614
+      ID: 616
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005248e+06
       GoKind: 22
-      Pointee: 615 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 617 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005376e+06
       GoKind: 22
-      Pointee: 569 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 571 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1124
       Name: Probe[main.stackC]
@@ -8280,7 +8249,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 739
+      ID: 741
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 624192
@@ -8320,7 +8289,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 966
+      ID: 968
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 446976
@@ -8328,19 +8297,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 967 PointerType **main.deepSlice3
+          Type: 969 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 970 GoSliceDataType []*main.deepSlice3.array
+      Data: 972 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 970
+      ID: 972
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 968 PointerType *main.deepSlice3
+      Element: 970 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 987
       Name: '[]*main.deepSlice8'
@@ -8581,10 +8550,10 @@ Types:
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 980
+      ID: 982
       Name: '[]bucket<int,*main.deepMap3>.array'
       ByteSize: 2048
-      Element: 976 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 978 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1010
       Name: '[]bucket<int,*main.deepMap8>.array'
@@ -8621,10 +8590,10 @@ Types:
       ByteSize: 2048
       Element: 112 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 750
+      ID: 752
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 2048
-      Element: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 723 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 241
       Name: '[]bucket<string,int>.array'
@@ -8676,7 +8645,7 @@ Types:
       ByteSize: 2048
       Element: 139 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 734
+      ID: 736
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454208
@@ -8691,9 +8660,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 753 GoSliceDataType []float64.array
+      Data: 755 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 753
+      ID: 755
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 17 BaseType float64
@@ -8804,9 +8773,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 981 GoSliceDataType []main.structWithMap.array
+      Data: 303 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 981
+      ID: 303
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 92 StructureType main.structWithMap
@@ -8898,7 +8867,7 @@ Types:
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 728
+      ID: 730
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 453184
@@ -8913,9 +8882,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 751 GoSliceDataType []uint8.array
+      Data: 753 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 751
+      ID: 753
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -8927,12 +8896,12 @@ Types:
       HasCount: true
       Element: 233 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 977
+      ID: 979
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 978 PointerType *main.deepMap3
+      Element: 980 PointerType *main.deepMap3
     - __kind: ArrayType
       ID: 1007
       Name: '[]val<*main.deepMap8>'
@@ -8976,12 +8945,12 @@ Types:
       HasCount: true
       Element: 168 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 749
+      ID: 751
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 743 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
       ID: 236
       Name: '[]val<int>'
@@ -9060,11 +9029,11 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 882
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 529
+      ID: 531
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858528
@@ -9079,32 +9048,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 530 GoSliceDataType archive/tar.headerError.array
+      Data: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 532
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 822
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 768
+      ID: 770
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 770
+      ID: 772
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.078464e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 869
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 796
+      ID: 798
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.376512e+06
@@ -9114,7 +9083,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 798
+      ID: 800
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9219,7 +9188,7 @@ Types:
       KeyType: 9 BaseType int
       ValueType: 233 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 976
+      ID: 978
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
@@ -9231,12 +9200,12 @@ Types:
           Type: 231 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 977 ArrayType []val<*main.deepMap3>
+          Type: 979 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 975 PointerType *bucket<int,*main.deepMap3>
+          Type: 977 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 978 PointerType *main.deepMap3
+      ValueType: 980 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
       ID: 1006
       Name: bucket<int,*main.deepMap8>
@@ -9371,7 +9340,7 @@ Types:
       KeyType: 11 GoStringHeaderType string
       ValueType: 168 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 721
+      ID: 723
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
@@ -9383,12 +9352,12 @@ Types:
           Type: 238 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 749 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 751 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 722 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 743 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 107
       Name: bucket<string,int>
@@ -9580,15 +9549,15 @@ Types:
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 846
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 871
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 918
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9614,13 +9583,13 @@ Types:
       GoRuntimeType: 532256
       GoKind: 15
     - __kind: BaseType
-      ID: 336
+      ID: 338
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764640
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 337
+      ID: 339
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764736
@@ -9628,91 +9597,91 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 339 PointerType *compress/flate.InternalError.str
+          Type: 341 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 338 GoStringDataType compress/flate.InternalError.str
+      Data: 340 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 338
+      ID: 340
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 820
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 764
+      ID: 766
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 842
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 673
+      ID: 675
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296288e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 350
+      ID: 352
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767232
       GoKind: 2
     - __kind: BaseType
-      ID: 351
+      ID: 353
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767328
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 832
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 857
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 352
+      ID: 354
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767424
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 865
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 857
+      ID: 859
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 861
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 340
+      ID: 342
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765216
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 615
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 944
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 446
+      ID: 448
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 444
+      ID: 446
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.605024e+06
@@ -9723,34 +9692,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 739 ArrayType [5]uint8
+          Type: 741 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 740 GoInterfaceType net.Conn
+          Type: 742 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 568
+      ID: 570
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951488
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 830
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 837
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 710
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 725
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 518
+      ID: 520
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.608096e+06
@@ -9758,21 +9727,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 722 PointerType *crypto/x509.Certificate
+          Type: 724 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 742 BaseType crypto/x509.InvalidReason
+          Type: 744 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 512
+      ID: 514
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.075776e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 514
+      ID: 516
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.408864e+06
@@ -9780,24 +9749,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 722 PointerType *crypto/x509.Certificate
+          Type: 724 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 349
+      ID: 351
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 766848
       GoKind: 2
     - __kind: BaseType
-      ID: 742
+      ID: 744
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537760
       GoKind: 2
     - __kind: StructureType
-      ID: 618
+      ID: 620
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.372832e+06
@@ -9807,13 +9776,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 520
+      ID: 522
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.076032e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 516
+      ID: 518
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.607904e+06
@@ -9821,15 +9790,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 722 PointerType *crypto/x509.Certificate
+          Type: 724 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 722 PointerType *crypto/x509.Certificate
+          Type: 724 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 533
+      ID: 535
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.25376e+06
@@ -9839,7 +9808,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 537
+      ID: 539
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.25392e+06
@@ -9849,55 +9818,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 537
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 334
+      ID: 336
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764256
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 786
+      ID: 788
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 335
+      ID: 337
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764448
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 407
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 606
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 397
+      ID: 399
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 405
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 401
+      ID: 403
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 399
+      ID: 401
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 407
+      ID: 409
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.2384e+06
@@ -9907,19 +9876,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 796
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 506
+      ID: 508
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 506
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 346
+      ID: 348
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766752
@@ -9927,21 +9896,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 348 PointerType *encoding/xml.UnmarshalError.str
+          Type: 350 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 347 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 349 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 347
+      ID: 349
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 511
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 902
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9958,11 +9927,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 377
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 573
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9978,15 +9947,15 @@ Types:
       GoRuntimeType: 532448
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 912
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 575
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 577
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9996,11 +9965,11 @@ Types:
       GoRuntimeType: 445376
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 435
+      ID: 437
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 416
+      ID: 418
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.603296e+06
@@ -10008,7 +9977,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 732 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 734 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -10016,25 +9985,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 418
+      ID: 420
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 738
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 422
+      ID: 424
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.072192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 740
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 330
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763680
@@ -10042,17 +10011,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 332 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 329 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 331 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 331
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 732
+      ID: 734
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.074112e+06
@@ -10060,7 +10029,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 733 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 735 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -10075,7 +10044,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 734 GoSliceHeaderType []float64
+          Type: 736 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -10084,10 +10053,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 737 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 737 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 739 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 168 GoSliceHeaderType []string
@@ -10101,13 +10070,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 733
+      ID: 735
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534304
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 327
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763584
@@ -10115,17 +10084,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 329 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 326 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 328 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 328
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 333
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763776
@@ -10133,59 +10102,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 335 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 332 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 334 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 334
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 810
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 890
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 527
+      ID: 529
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 684
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 920
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 455
+      ID: 457
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 462
+      ID: 464
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.075008e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 345
+      ID: 347
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 765888
       GoKind: 2
     - __kind: StructureType
-      ID: 460
+      ID: 462
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.07488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 458
+      ID: 460
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.406944e+06
@@ -10198,7 +10167,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 478
+      ID: 480
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.407744e+06
@@ -10211,7 +10180,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 482
+      ID: 484
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.607328e+06
@@ -10227,7 +10196,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 480
+      ID: 482
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.24816e+06
@@ -10237,7 +10206,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 476
+      ID: 478
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.24784e+06
@@ -10247,14 +10216,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 717
+      ID: 719
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135328e+06
       GoKind: 21
-      HeaderType: 719 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 721 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 741
+      ID: 743
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.00896e+06
@@ -10269,14 +10238,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 755 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 757 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 755
+      ID: 757
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 490
+      ID: 492
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.408064e+06
@@ -10284,12 +10253,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 717 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 719 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 717 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 719 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 484
+      ID: 486
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.24832e+06
@@ -10299,7 +10268,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 488
+      ID: 490
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.60752e+06
@@ -10310,12 +10279,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 743 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 743 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 486
+      ID: 488
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.407904e+06
@@ -10328,7 +10297,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 492
+      ID: 494
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.24848e+06
@@ -10336,9 +10305,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 709 StructureType time.Time
+          Type: 711 StructureType time.Time
     - __kind: StructureType
-      ID: 498
+      ID: 500
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.408384e+06
@@ -10351,7 +10320,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 500
+      ID: 502
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.2488e+06
@@ -10361,7 +10330,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 496
+      ID: 498
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.408224e+06
@@ -10374,7 +10343,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 494
+      ID: 496
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.24864e+06
@@ -10384,7 +10353,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 502
+      ID: 504
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.408544e+06
@@ -10397,7 +10366,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 424
+      ID: 426
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.24064e+06
@@ -10407,11 +10376,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 849
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 426
+      ID: 428
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.2408e+06
@@ -10419,21 +10388,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 424 StructureType github.com/cihub/seelog.baseError
+          Type: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 828
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 784
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 818
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 430
+      ID: 432
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.24112e+06
@@ -10441,13 +10410,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 424 StructureType github.com/cihub/seelog.baseError
+          Type: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 880
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 889
+      ID: 891
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.968384e+06
@@ -10455,12 +10424,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 877 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 879 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 890
+      ID: 892
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.991776e+06
@@ -10468,7 +10437,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 877 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 879 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -10476,11 +10445,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 786
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 428
+      ID: 430
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.24096e+06
@@ -10488,9 +10457,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 424 StructureType github.com/cihub/seelog.baseError
+          Type: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 432
+      ID: 434
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.24128e+06
@@ -10498,64 +10467,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 424 StructureType github.com/cihub/seelog.baseError
+          Type: 426 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 853
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 884
+      ID: 886
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 888
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 715
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 628
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 626
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 630
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 632
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 839
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 622
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 438
+      ID: 440
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.24224e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 936
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 686
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 659
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.712e+06
@@ -10571,11 +10540,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.5096e+06
@@ -10588,7 +10557,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 663
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.712448e+06
@@ -10604,13 +10573,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 567
+      ID: 569
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 948896
       GoKind: 8
     - __kind: StructureType
-      ID: 655
+      ID: 657
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.711776e+06
@@ -10626,13 +10595,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 743
+      ID: 745
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 761856
       GoKind: 8
     - __kind: StructureType
-      ID: 653
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.711552e+06
@@ -10640,15 +10609,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 743 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 745 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 743 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 745 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 661
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.630144e+06
@@ -10661,7 +10630,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 659
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.712224e+06
@@ -10677,11 +10646,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 940
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 669
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.432512e+06
@@ -10691,19 +10660,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 594
+      ID: 596
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.195168e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 592
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.19504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 665
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.630336e+06
@@ -10716,7 +10685,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 357
+      ID: 359
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769248
@@ -10724,21 +10693,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 359 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 361 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 358 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 360 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 358
+      ID: 360
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 726
+      ID: 728
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 634
+      ID: 636
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.2656e+06
@@ -10748,7 +10717,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 814
+      ID: 816
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.486464e+06
@@ -10756,13 +10725,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 838 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 840 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 900
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 838
+      ID: 840
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.085888e+06
@@ -10775,7 +10744,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 800
+      ID: 802
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.381312e+06
@@ -10785,19 +10754,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 360
+      ID: 362
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769824
       GoKind: 10
     - __kind: BaseType
-      ID: 724
+      ID: 726
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 962144
       GoKind: 10
     - __kind: StructureType
-      ID: 692
+      ID: 694
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.750528e+06
@@ -10808,12 +10777,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 724 BaseType golang.org/x/net/http2.ErrCode
+          Type: 726 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 553
+      ID: 555
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.415744e+06
@@ -10821,12 +10790,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 724 BaseType golang.org/x/net/http2.ErrCode
+          Type: 726 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 364
+      ID: 366
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770016
@@ -10834,17 +10803,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 366 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 368 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 365 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 367 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 365
+      ID: 367
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 370
+      ID: 372
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770208
@@ -10852,17 +10821,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 372 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 374 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 371 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 373 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 371
+      ID: 373
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 367
+      ID: 369
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770112
@@ -10870,17 +10839,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 369 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 371 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 368 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 370 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 368
+      ID: 370
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 361
+      ID: 363
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769920
@@ -10888,21 +10857,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 363 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 365 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 362 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 364 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 362
+      ID: 364
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 898
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 559
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.26624e+06
@@ -10912,13 +10881,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 373
+      ID: 375
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770304
       GoKind: 2
     - __kind: StructureType
-      ID: 545
+      ID: 547
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.26128e+06
@@ -10928,11 +10897,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 692
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 715
+      ID: 717
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.776288e+06
@@ -10948,7 +10917,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 547
+      ID: 549
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.415264e+06
@@ -10961,7 +10930,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 861
+      ID: 863
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.82976e+06
@@ -10969,16 +10938,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 740 GoInterfaceType net.Conn
+          Type: 742 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 876 GoInterfaceType io.Reader
+          Type: 878 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 814
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 632
+      ID: 634
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.378912e+06
@@ -10988,29 +10957,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 772
+      ID: 774
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 525
+      ID: 527
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 624
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 690
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 688
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.326048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 539
+      ID: 541
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.25456e+06
@@ -11020,7 +10989,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 541
+      ID: 543
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.25472e+06
@@ -11030,11 +10999,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 470
+      ID: 472
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 851
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -11208,7 +11177,7 @@ Types:
       BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
       BucketsType: 235 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 974
+      ID: 976
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -11229,18 +11198,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 975 PointerType *bucket<int,*main.deepMap3>
+          Type: 977 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 975 PointerType *bucket<int,*main.deepMap3>
+          Type: 977 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 976 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 980 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 978 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 982 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
       ID: 1004
       Name: hash<int,*main.deepMap8>
@@ -11480,7 +11449,7 @@ Types:
       BucketType: 112 GoHMapBucketType bucket<string,[]string>
       BucketsType: 243 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 719
+      ID: 721
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -11501,18 +11470,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 722 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 720 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 722 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 73 PointerType *runtime.mapextra
-      BucketType: 721 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 750 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 723 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 752 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 105
       Name: hash<string,int>
@@ -11854,7 +11823,7 @@ Types:
       BucketType: 139 GoHMapBucketType bucket<uint8,uint8>
       BucketsType: 258 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 562
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11901,37 +11870,37 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 440
+      ID: 442
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 760
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 651
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 942
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 647
+      ID: 649
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293248e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 379
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 804
+      ID: 806
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 845
+      ID: 847
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.103584e+06
@@ -11944,7 +11913,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 876
+      ID: 878
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 980288
@@ -11957,7 +11926,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 833
+      ID: 835
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.068608e+06
@@ -11983,21 +11952,21 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 802
+      ID: 804
       Name: io.discard
       GoRuntimeType: 1.280608e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 778
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 647
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 855
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -12065,9 +12034,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 972 GoMapType map[int]*main.deepMap3
+          Type: 974 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 981
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -12119,9 +12088,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 943 PointerType *main.deepPtr3
+          Type: 945 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 946
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -12173,9 +12142,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 966 GoSliceHeaderType []*main.deepSlice3
+          Type: 968 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 971
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -12225,16 +12194,16 @@ Types:
           Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 950 StructureType sync.Mutex
+          Type: 952 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 951 StructureType sync.Once
+          Type: 953 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 954 StructureType sync.WaitGroup
+          Type: 956 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 958 StructureType sync/atomic.Int32
+          Type: 960 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 81
       Name: main.esotericStack
@@ -12264,7 +12233,7 @@ Types:
           Offset: 56
           Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 960
+      ID: 962
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.23168e+06
@@ -12309,7 +12278,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 962
+      ID: 964
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.23184e+06
@@ -12329,7 +12298,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 951
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -12340,17 +12309,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 946 PointerType *main.stringType1.str
+          Type: 948 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 945 GoStringDataType main.stringType1.str
+      Data: 947 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 945
+      ID: 947
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 949
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -12453,16 +12422,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 963 PointerType **main.t
+          Type: 965 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 964 GoSliceDataType main.t.array
+      Data: 966 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 964
+      ID: 966
       Name: main.t.array
       ByteSize: 2048
       Element: 160 PointerType *main.t
@@ -12522,12 +12491,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 972
+      ID: 974
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879840
       GoKind: 21
-      HeaderType: 974 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 976 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1002
       Name: map[int]*main.deepMap8
@@ -12642,7 +12611,7 @@ Types:
       GoKind: 21
       HeaderType: 137 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 474
+      ID: 476
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.24752e+06
@@ -12652,7 +12621,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 766
+      ID: 768
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.24432e+06
@@ -12662,11 +12631,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 678
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 740
+      ID: 742
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.405664e+06
@@ -12679,35 +12648,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 702
+      ID: 704
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 906
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 700
+      ID: 702
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 680
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 916
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 926
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 914
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 637
+      ID: 639
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.071808e+06
@@ -12715,27 +12684,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 639 PointerType *net.UnknownNetworkError.str
+          Type: 641 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 638 GoStringDataType net.UnknownNetworkError.str
+      Data: 640 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 638
+      ID: 640
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 606
+      ID: 608
       Name: net.canceledError
       GoRuntimeType: 1.196064e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 884
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 745
+      ID: 747
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.96768e+06
@@ -12743,7 +12712,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 740 GoInterfaceType net.Conn
+          Type: 742 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -12754,27 +12723,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 928
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 920
+      ID: 922
       Name: net.noReadFrom
       GoRuntimeType: 1.072064e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 919
+      ID: 921
       Name: net.noWriteTo
       GoRuntimeType: 1.071936e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 411
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 411
+      ID: 413
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.603104e+06
@@ -12782,7 +12751,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 727 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 729 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -12790,7 +12759,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 908
+      ID: 910
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.144e+06
@@ -12798,12 +12767,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 920 StructureType net.noReadFrom
+          Type: 922 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 913 PointerType *net.TCPConn
+          Type: 915 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 906
+      ID: 908
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.143456e+06
@@ -12811,24 +12780,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 919 StructureType net.noWriteTo
+          Type: 921 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 913 PointerType *net.TCPConn
+          Type: 915 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 682
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 704
+      ID: 706
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 598
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 760
+      ID: 762
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.23584e+06
@@ -12838,19 +12807,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 306
+      ID: 308
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762336
       GoKind: 10
     - __kind: BaseType
-      ID: 716
+      ID: 718
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 948992
       GoKind: 10
     - __kind: StructureType
-      ID: 387
+      ID: 389
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.601184e+06
@@ -12861,12 +12830,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 716 BaseType net/http.http2ErrCode
+          Type: 718 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 696
+      ID: 698
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.76656e+06
@@ -12877,12 +12846,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 716 BaseType net/http.http2ErrCode
+          Type: 718 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 391
+      ID: 393
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.405184e+06
@@ -12890,16 +12859,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 716 BaseType net/http.http2ErrCode
+          Type: 718 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 824
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 312
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762528
@@ -12907,17 +12876,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 314 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 311 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 313 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 313
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 318
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762720
@@ -12925,17 +12894,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *net/http.http2headerFieldNameError.str
+          Type: 320 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 319 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 319
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 315
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762624
@@ -12943,31 +12912,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *net/http.http2headerFieldValueError.str
+          Type: 317 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 314 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 316 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 316
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 673
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 602
+      ID: 604
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.195424e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 875
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 309
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762432
@@ -12975,17 +12944,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 311 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 310 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 310
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 762
+      ID: 764
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.601952e+06
@@ -12993,22 +12962,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 740 GoInterfaceType net.Conn
+          Type: 742 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 841 BaseType time.Duration
+          Type: 843 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 33 PointerType *error
     - __kind: ArrayType
-      ID: 842
+      ID: 844
       Name: net/http.incomparable
       GoRuntimeType: 830976
       GoKind: 17
       HasCount: true
       Element: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 598
+      ID: 600
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.367072e+06
@@ -13018,11 +12987,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 826
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 780
+      ID: 782
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.366912e+06
@@ -13030,9 +12999,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 823 PointerType *net/http.persistConn
+          Type: 825 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 806
+      ID: 808
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.673248e+06
@@ -13040,15 +13009,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 842 ArrayType net/http.incomparable
+          Type: 844 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 843 PointerType *bufio.Reader
+          Type: 845 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 845 GoInterfaceType io.ReadWriteCloser
+          Type: 847 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 395
+      ID: 397
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.2368e+06
@@ -13058,17 +13027,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 700
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 671
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.295968e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 600
+      ID: 602
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.367232e+06
@@ -13078,11 +13047,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 386
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 877
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.9048e+06
@@ -13090,13 +13059,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 868 PointerType *bufio.Writer
+          Type: 870 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 792
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 466
+      ID: 468
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.606944e+06
@@ -13112,7 +13081,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 464
+      ID: 466
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.407104e+06
@@ -13125,11 +13094,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 834
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 792
+      ID: 794
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.409024e+06
@@ -13137,16 +13106,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 831 PointerType *net/smtp.Client
+          Type: 833 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 833 GoInterfaceType io.WriteCloser
+          Type: 835 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 450
+      ID: 452
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 341
+      ID: 343
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765312
@@ -13154,25 +13123,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 343 PointerType *net/textproto.ProtocolError.str
+          Type: 345 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 342 GoStringDataType net/textproto.ProtocolError.str
+      Data: 344 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 342
+      ID: 344
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 788
+      ID: 790
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 708
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 321
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763296
@@ -13180,17 +13149,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *net/url.EscapeError.str
+          Type: 323 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 320 GoStringDataType net/url.EscapeError.str
+      Data: 322 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 322
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 324
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763392
@@ -13198,29 +13167,29 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *net/url.InvalidHostError.str
+          Type: 326 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 323 GoStringDataType net/url.InvalidHostError.str
+      Data: 325 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 325
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 934
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 579
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 643
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 930
+      ID: 932
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.212192e+06
@@ -13228,12 +13197,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 936 StructureType os.noReadFrom
+          Type: 938 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 931 PointerType *os.File
+          Type: 933 PointerType *os.File
     - __kind: StructureType
-      ID: 928
+      ID: 930
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.211392e+06
@@ -13241,36 +13210,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 935 StructureType os.noWriteTo
+          Type: 937 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 931 PointerType *os.File
+          Type: 933 PointerType *os.File
     - __kind: StructureType
-      ID: 936
+      ID: 938
       Name: os.noReadFrom
       GoRuntimeType: 1.069504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 935
+      ID: 937
       Name: os.noWriteTo
       GoRuntimeType: 1.069376e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 610
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 750
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 810
+      ID: 812
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 610
+      ID: 612
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.510176e+06
@@ -13283,7 +13252,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 354
+      ID: 356
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768480
@@ -13291,39 +13260,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 356 PointerType *os/user.UnknownGroupIdError.str
+          Type: 358 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 355 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 357 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 355
+      ID: 357
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 353
+      ID: 355
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768384
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 381
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 472
+      ID: 474
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 580
+      ID: 582
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 587
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 582
+      ID: 584
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.756128e+06
@@ -13340,15 +13309,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 746 BaseType runtime.boundsErrorCode
+          Type: 748 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 746
+      ID: 748
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532640
       GoKind: 8
     - __kind: StructureType
-      ID: 643
+      ID: 645
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.627072e+06
@@ -13361,7 +13330,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 561
+      ID: 563
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 947840
@@ -13369,13 +13338,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 563 PointerType *runtime.errorString.str
+          Type: 565 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 562 GoStringDataType runtime.errorString.str
+      Data: 564 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 562
+      ID: 564
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
@@ -13383,7 +13352,7 @@ Types:
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 564
+      ID: 566
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948416
@@ -13391,17 +13360,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 566 PointerType *runtime.plainError.str
+          Type: 568 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 565 GoStringDataType runtime.plainError.str
+      Data: 567 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 565
+      ID: 567
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 589
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -13423,15 +13392,15 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 873
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 778
+      ID: 780
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 774
+      ID: 776
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.272768e+06
@@ -13447,7 +13416,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 950
+      ID: 952
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281408e+06
@@ -13460,7 +13429,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 951
+      ID: 953
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282528e+06
@@ -13468,12 +13437,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 952 StructureType sync/atomic.Uint32
+          Type: 954 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 950 StructureType sync.Mutex
+          Type: 952 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 954
+      ID: 956
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421376e+06
@@ -13481,21 +13450,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 955 StructureType sync.noCopy
+          Type: 957 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 956 StructureType sync/atomic.Uint64
+          Type: 958 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 955
+      ID: 957
       Name: sync.noCopy
       GoRuntimeType: 946784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 958
+      ID: 960
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.282848e+06
@@ -13503,12 +13472,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 953 StructureType sync/atomic.noCopy
+          Type: 955 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 952
+      ID: 954
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.283008e+06
@@ -13516,12 +13485,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 953 StructureType sync/atomic.noCopy
+          Type: 955 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 956
+      ID: 958
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.42176e+06
@@ -13529,37 +13498,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 953 StructureType sync/atomic.noCopy
+          Type: 955 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 957 StructureType sync/atomic.align64
+          Type: 959 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 957
+      ID: 959
       Name: sync/atomic.align64
       GoRuntimeType: 946976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 953
+      ID: 955
       Name: sync/atomic.noCopy
       GoRuntimeType: 946880
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 693
+      ID: 695
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.194656e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 636
+      ID: 638
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.514592e+06
@@ -13572,21 +13541,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 841
+      ID: 843
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.7824e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 713
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 384
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 709
+      ID: 711
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.224416e+06
@@ -13600,9 +13569,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 710 PointerType *time.Location
+          Type: 712 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 303
+      ID: 305
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761472
@@ -13610,13 +13579,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 305 PointerType *time.fileSizeError.str
+          Type: 307 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 304 GoStringDataType time.fileSizeError.str
+      Data: 306 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 304
+      ID: 306
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -13662,11 +13631,11 @@ Types:
       GoRuntimeType: 532576
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 867
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 727
+      ID: 729
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.926528e+06
@@ -13674,13 +13643,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 728 GoSliceHeaderType []uint8
+          Type: 730 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 729 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 731 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 730 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 732 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -13695,18 +13664,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 731 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 733 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 731
+      ID: 733
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 953120
       GoKind: 9
     - __kind: StructureType
-      ID: 729
+      ID: 731
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.792896e+06
@@ -13731,21 +13700,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 468
+      ID: 470
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 730
+      ID: 732
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536224
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 896
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 452
+      ID: 454
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.24464e+06
@@ -13755,13 +13724,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 344
+      ID: 346
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765408
       GoKind: 2
     - __kind: StructureType
-      ID: 615
+      ID: 617
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510368e+06
@@ -13774,7 +13743,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 569
+      ID: 571
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 951968

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -2326,15 +2326,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84ad2c..0x84ad3c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ad3c..0x84add0
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x84add0..0x84ae50]
@@ -2351,29 +2342,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x84ae50..0x84af70]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84aeb8..0x84aec0
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84aec0..0x84aed8
-              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84aed8..0x84aeec
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84aeb4..0x84aebc
-              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84aebc..0x84aed8
-              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84aed8..0x84aee8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x84af70..0x84af80]
@@ -3478,10 +3447,10 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1093
+      ID: 1095
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1094 PointerType *main.deepSlice3
+      Pointee: 1096 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1120
       Name: '**main.deepSlice8'
@@ -3499,7 +3468,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1089
+      ID: 1091
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3536,10 +3505,10 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1101
+      ID: 1103
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1102 PointerType *table<int,*main.deepMap3>
+      Pointee: 1104 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1137
       Name: '**table<int,*main.deepMap8>'
@@ -3576,10 +3545,10 @@ Types:
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 832
+      ID: 834
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 833 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 835 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3636,10 +3605,10 @@ Types:
       ByteSize: 8
       Pointee: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1097
+      ID: 1099
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1096 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1098 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1124
       Name: '*[]*main.deepSlice8.array'
@@ -3711,10 +3680,10 @@ Types:
       ByteSize: 8
       Pointee: 346 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 871 GoSliceDataType []float64.array
+      Pointee: 873 GoSliceDataType []float64.array
     - __kind: PointerType
       ID: 1133
       Name: '*[]interface {}.array'
@@ -3731,10 +3700,10 @@ Types:
       ByteSize: 8
       Pointee: 350 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1114
+      ID: 412
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1113 GoSliceDataType []main.structWithMap.array
+      Pointee: 411 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 343
       Name: '*[]main.structWithNoStrings.array'
@@ -3761,71 +3730,71 @@ Types:
       ByteSize: 8
       Pointee: 348 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 870
+      ID: 872
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 869 GoSliceDataType []uint8.array
+      Pointee: 871 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 1002
+      ID: 1004
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.976128e+06
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1005 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 925920
       GoKind: 22
-      Pointee: 641 GoSliceHeaderType archive/tar.headerError
+      Pointee: 643 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 643
+      ID: 645
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 642 GoSliceDataType archive/tar.headerError.array
+      Pointee: 644 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 937
+      ID: 939
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.430016e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 940 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 885
+      ID: 887
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 888 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 887
+      ID: 889
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 888 StructureType archive/zip.dirWriter
+      Pointee: 890 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 985
+      ID: 987
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.895808e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 988 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 913
+      ID: 915
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.052544e+06
       GoKind: 22
-      Pointee: 914 StructureType archive/zip.nopCloser
+      Pointee: 916 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 915
+      ID: 917
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.0528e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 918 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3834,421 +3803,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 960
+      ID: 962
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.164256e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType bufio.Reader
+      Pointee: 963 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 989
+      ID: 991
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.94032e+06
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType bufio.Writer
+      Pointee: 992 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1040
+      ID: 1042
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.261536e+06
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1043 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 552
+      ID: 554
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 908544
       GoKind: 22
-      Pointee: 444 BaseType compress/flate.CorruptInputError
+      Pointee: 446 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 553
+      ID: 555
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 445 GoStringHeaderType compress/flate.InternalError
+      Pointee: 447 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 447
+      ID: 449
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 446 GoStringDataType compress/flate.InternalError.str
+      Pointee: 448 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 935
+      ID: 937
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.419456e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 938 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 881
+      ID: 883
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 884 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 957
+      ID: 959
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.717792e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 960 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 784
+      ID: 786
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.198752e+06
       GoKind: 22
-      Pointee: 785 StructureType context.deadlineExceededError
+      Pointee: 787 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 632
+      ID: 634
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 920544
       GoKind: 22
-      Pointee: 458 BaseType crypto/aes.KeySizeError
+      Pointee: 460 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 633
+      ID: 635
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 459 BaseType crypto/des.KeySizeError
+      Pointee: 461 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 634
+      ID: 636
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921024
       GoKind: 22
-      Pointee: 460 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 462 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 947
+      ID: 949
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.560096e+06
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 950 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 981
+      ID: 983
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.854464e+06
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 984 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1013
+      ID: 1015
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.111584e+06
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1016 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 987
+      ID: 989
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.89632e+06
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 990 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 983
+      ID: 985
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.854912e+06
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 986 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 979
+      ID: 981
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.847296e+06
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 982 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 635
+      ID: 637
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921312
       GoKind: 22
-      Pointee: 461 BaseType crypto/rc4.KeySizeError
+      Pointee: 463 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 997
+      ID: 999
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.945696e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1000 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 969
+      ID: 971
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.80128e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 972 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 558
+      ID: 560
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 448 BaseType crypto/tls.AlertError
+      Pointee: 450 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 724
+      ID: 726
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.041152e+06
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 727 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1066
+      ID: 1068
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.373408e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1069 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 559 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 554
+      ID: 556
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 555 StructureType crypto/tls.RecordHeaderError
+      Pointee: 557 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 723
+      ID: 725
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.039488e+06
       GoKind: 22
-      Pointee: 680 BaseType crypto/tls.alert
+      Pointee: 682 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 945
+      ID: 947
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.553056e+06
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 948 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 952
+      ID: 954
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.635488e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 955 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.419776e+06
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 822 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 834
+      ID: 836
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.034176e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 837 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 628
+      ID: 630
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 919584
       GoKind: 22
-      Pointee: 629 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 631 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 622
+      ID: 624
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 919104
       GoKind: 22
-      Pointee: 623 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 625 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 624
+      ID: 626
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 919200
       GoKind: 22
-      Pointee: 625 StructureType crypto/x509.HostnameError
+      Pointee: 627 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 621
+      ID: 623
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 457 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 459 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 729
+      ID: 731
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.046912e+06
       GoKind: 22
-      Pointee: 730 StructureType crypto/x509.SystemRootsError
+      Pointee: 732 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 630
+      ID: 632
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 919680
       GoKind: 22
-      Pointee: 631 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 633 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 919488
       GoKind: 22
-      Pointee: 627 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 629 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 926400
       GoKind: 22
-      Pointee: 645 StructureType encoding/asn1.StructuralError
+      Pointee: 647 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 648
+      ID: 650
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 926592
       GoKind: 22
-      Pointee: 649 StructureType encoding/asn1.SyntaxError
+      Pointee: 651 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 649 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 542
+      ID: 544
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 442 BaseType encoding/base64.CorruptInputError
+      Pointee: 444 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.036672e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 906 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 545
+      ID: 547
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 907488
       GoKind: 22
-      Pointee: 443 BaseType encoding/hex.InvalidByteError
+      Pointee: 445 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 513
+      ID: 515
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 901344
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 516 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 715
+      ID: 717
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.03296e+06
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 718 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 505
+      ID: 507
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 900960
       GoKind: 22
-      Pointee: 506 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 508 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 511
+      ID: 513
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 901248
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 514 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 509
+      ID: 511
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 901152
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 512 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 901056
       GoKind: 22
-      Pointee: 508 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 510 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1046
+      ID: 1048
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.28656e+06
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1049 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 515
+      ID: 517
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 516 StructureType encoding/json.jsonError
+      Pointee: 518 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 911
+      ID: 913
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.049472e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 914 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 918048
       GoKind: 22
-      Pointee: 617 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 619 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 614
+      ID: 616
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 917952
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 617 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 618
+      ID: 620
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918144
       GoKind: 22
-      Pointee: 454 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 456 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 456
+      ID: 458
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 455 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 457 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 619
+      ID: 621
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918240
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 622 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.150016e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1027 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4257,19 +4226,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 483
+      ID: 485
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 891648
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType errors.errorString
+      Pointee: 486 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 682
+      ID: 684
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.017856e+06
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType errors.joinError
+      Pointee: 685 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4285,813 +4254,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1034
+      ID: 1036
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.253856e+06
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType fmt.pp
+      Pointee: 1037 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 684
+      ID: 686
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.019648e+06
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType fmt.wrapError
+      Pointee: 687 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 686
+      ID: 688
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.019776e+06
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 689 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 543
+      ID: 545
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 546 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 904128
       GoKind: 22
-      Pointee: 525 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 527 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 526
+      ID: 528
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 904224
       GoKind: 22
-      Pointee: 527 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 529 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 847
+      ID: 849
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 850 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 530
+      ID: 532
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 531 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 533 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 849
+      ID: 851
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 852 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 528
+      ID: 530
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 904320
       GoKind: 22
-      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 438 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 438
+      ID: 440
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 439 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 523
+      ID: 525
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 903840
       GoKind: 22
-      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 435 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 435
+      ID: 437
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 436 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 529
+      ID: 531
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 904416
       GoKind: 22
-      Pointee: 439 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 441 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 441
+      ID: 443
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 442 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.204256e+06
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 928 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1010
+      ID: 1012
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.049184e+06
       GoKind: 22
-      Pointee: 1011 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1013 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 924864
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 641 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 793
+      ID: 795
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.20784e+06
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 796 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1042
+      ID: 1044
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.263584e+06
       GoKind: 22
-      Pointee: 1043 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1045 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 565
+      ID: 567
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 913536
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 568 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 914592
       GoKind: 22
-      Pointee: 573 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 575 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 567
+      ID: 569
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 453 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 455 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 914496
       GoKind: 22
-      Pointee: 571 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 573 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 568
+      ID: 570
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 569 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 571 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 916512
       GoKind: 22
-      Pointee: 589 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 591 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 916704
       GoKind: 22
-      Pointee: 593 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 595 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 591 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 593 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 916416
       GoKind: 22
-      Pointee: 587 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 589 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 874
+      ID: 876
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 873 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 875 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 600
+      ID: 602
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 917088
       GoKind: 22
-      Pointee: 601 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 603 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 595 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 597 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 598
+      ID: 600
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 599 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 601 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 916896
       GoKind: 22
-      Pointee: 597 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 599 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 917184
       GoKind: 22
-      Pointee: 603 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 605 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 608
+      ID: 610
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 609 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 610
+      ID: 612
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 606
+      ID: 608
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 917376
       GoKind: 22
-      Pointee: 607 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 609 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 604
+      ID: 606
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 917280
       GoKind: 22
-      Pointee: 605 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 607 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 917760
       GoKind: 22
-      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 615 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 532
+      ID: 534
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 905664
       GoKind: 22
-      Pointee: 533 StructureType github.com/cihub/seelog.baseError
+      Pointee: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.793888e+06
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 966 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 534
+      ID: 536
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 905760
       GoKind: 22
-      Pointee: 535 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 537 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 943
+      ID: 945
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.551936e+06
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 946 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.035648e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 933
+      ID: 935
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.417536e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 936 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 538
+      ID: 540
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 905952
       GoKind: 22
-      Pointee: 539 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 541 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1000
+      ID: 1002
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.966048e+06
       GoKind: 22
-      Pointee: 1001 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1003 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1017
+      ID: 1019
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.123168e+06
       GoKind: 22
-      Pointee: 1012 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1014 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1016
+      ID: 1018
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.122784e+06
       GoKind: 22
-      Pointee: 1015 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1017 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.035776e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 904 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 536
+      ID: 538
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 905856
       GoKind: 22
-      Pointee: 537 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 539 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 540
+      ID: 542
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 906048
       GoKind: 22
-      Pointee: 541 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 543 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 965
+      ID: 967
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.79568e+06
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 968 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1006
+      ID: 1008
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.002784e+06
       GoKind: 22
-      Pointee: 1007 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1009 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1008
+      ID: 1010
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.033856e+06
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1011 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 824
+      ID: 826
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.432416e+06
       GoKind: 22
-      Pointee: 825 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 827 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 737
+      ID: 739
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.060992e+06
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 740 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 735
+      ID: 737
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.060864e+06
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 738 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 739
+      ID: 741
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.06496e+06
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 742 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 741
+      ID: 743
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.065088e+06
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 744 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 954
+      ID: 956
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.66256e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 957 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 731
+      ID: 733
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.047552e+06
       GoKind: 22
-      Pointee: 732 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 734 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 546
+      ID: 548
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 907680
       GoKind: 22
-      Pointee: 547 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 549 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1058
+      ID: 1060
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.349632e+06
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1061 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 795
+      ID: 797
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.216288e+06
       GoKind: 22
-      Pointee: 796 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 798 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 768
+      ID: 770
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.19504e+06
       GoKind: 22
-      Pointee: 769 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 771 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 762
+      ID: 764
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.194656e+06
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 765 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 701
+      ID: 703
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.026944e+06
       GoKind: 22
-      Pointee: 702 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 704 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 774
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195424e+06
       GoKind: 22
-      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 700
+      ID: 702
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.026816e+06
       GoKind: 22
-      Pointee: 679 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 681 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 766
+      ID: 768
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.194912e+06
       GoKind: 22
-      Pointee: 767 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 769 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 764
+      ID: 766
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.194784e+06
       GoKind: 22
-      Pointee: 765 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 767 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 772
+      ID: 774
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.195296e+06
       GoKind: 22
-      Pointee: 773 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 775 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 770
+      ID: 772
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.195168e+06
       GoKind: 22
-      Pointee: 771 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 773 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1062
+      ID: 1064
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.36144e+06
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1065 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.195808e+06
       GoKind: 22
-      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 705
+      ID: 707
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.0272e+06
       GoKind: 22
-      Pointee: 706 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 708 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 703
+      ID: 705
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.027072e+06
       GoKind: 22
-      Pointee: 704 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 706 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 776
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.19568e+06
       GoKind: 22
-      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 660
+      ID: 662
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 939360
       GoKind: 22
-      Pointee: 466 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 468 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 468
+      ID: 470
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 467 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 469 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 837
+      ID: 839
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.661024e+06
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 840 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 745
+      ID: 747
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.079808e+06
       GoKind: 22
-      Pointee: 746 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 748 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.25584e+06
       GoKind: 22
-      Pointee: 932 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 934 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1022
+      ID: 1024
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.138144e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1025 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 917
+      ID: 919
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.082112e+06
       GoKind: 22
-      Pointee: 918 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 920 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 661
+      ID: 663
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 940608
       GoKind: 22
-      Pointee: 469 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 471 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 803
+      ID: 805
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.257504e+06
       GoKind: 22
-      Pointee: 804 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 806 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 664
+      ID: 666
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 940896
       GoKind: 22
-      Pointee: 665 StructureType golang.org/x/net/http2.connError
+      Pointee: 667 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 663
+      ID: 665
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940800
       GoKind: 22
-      Pointee: 473 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 475 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 475
+      ID: 477
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 474 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 476 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 667
+      ID: 669
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 941088
       GoKind: 22
-      Pointee: 479 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 481 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 481
+      ID: 483
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 480 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 482 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 666
+      ID: 668
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 940992
       GoKind: 22
-      Pointee: 476 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 478 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 478
+      ID: 480
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 477 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 479 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 662
+      ID: 664
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940704
       GoKind: 22
-      Pointee: 470 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 472 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 472
+      ID: 474
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 471 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 473 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1020
+      ID: 1022
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.136224e+06
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1023 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 668
+      ID: 670
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 941184
       GoKind: 22
-      Pointee: 669 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 671 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 670
+      ID: 672
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 941280
       GoKind: 22
-      Pointee: 482 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 484 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 934560
       GoKind: 22
-      Pointee: 657 StructureType google.golang.org/grpc.dropError
+      Pointee: 659 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.25456e+06
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 804 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 826
+      ID: 828
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.439776e+06
       GoKind: 22
-      Pointee: 827 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 829 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 658
+      ID: 660
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 659 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 661 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 971
+      ID: 973
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.801728e+06
       GoKind: 22
-      Pointee: 972 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 974 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.251104e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 932 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 743
+      ID: 745
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.074048e+06
       GoKind: 22
-      Pointee: 744 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 746 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 889
+      ID: 891
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 937728
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 892 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 636
+      ID: 638
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 639 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 733
+      ID: 735
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.05088e+06
       GoKind: 22
-      Pointee: 734 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 736 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.22256e+06
       GoKind: 22
-      Pointee: 800 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 802 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 797
+      ID: 799
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.222304e+06
       GoKind: 22
-      Pointee: 798 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 800 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 650
+      ID: 652
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 927456
       GoKind: 22
-      Pointee: 651 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 653 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 652
+      ID: 654
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 927552
       GoKind: 22
-      Pointee: 653 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 655 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 580
+      ID: 582
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 914976
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 583 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 977
+      ID: 979
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.842368e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 980 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 671
+      ID: 673
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 942048
       GoKind: 22
-      Pointee: 672 UnresolvedPointeeType html/template.Error
+      Pointee: 674 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -5135,89 +5104,89 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 550
+      ID: 552
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 553 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 548
+      ID: 550
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 549 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 551 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 875
+      ID: 877
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 896160
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 878 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 760
+      ID: 762
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.193888e+06
       GoKind: 22
-      Pointee: 761 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 763 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1064
+      ID: 1066
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.367072e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1067 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 758
+      ID: 760
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.19376e+06
       GoKind: 22
-      Pointee: 759 StructureType internal/poll.errNetClosing
+      Pointee: 761 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 485
+      ID: 487
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 895392
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 488 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.185312e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType io.PipeWriter
+      Pointee: 924 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 919
+      ID: 921
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.184928e+06
       GoKind: 22
-      Pointee: 920 StructureType io.discard
+      Pointee: 922 StructureType io.discard
     - __kind: PointerType
-      ID: 893
+      ID: 895
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.018112e+06
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType io.multiWriter
+      Pointee: 896 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 756
+      ID: 758
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.193504e+06
       GoKind: 22
-      Pointee: 757 UnresolvedPointeeType io/fs.PathError
+      Pointee: 759 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 967
+      ID: 969
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.795904e+06
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 970 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 234
       Name: '*main.deepMap2'
@@ -5226,12 +5195,12 @@ Types:
       GoKind: 22
       Pointee: 235 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1109
+      ID: 1111
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383072
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType main.deepMap3
+      Pointee: 1112 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -5261,12 +5230,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1068
+      ID: 1070
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 383648
       GoKind: 22
-      Pointee: 1069 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1071 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5296,12 +5265,12 @@ Types:
       GoKind: 22
       Pointee: 225 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1094
+      ID: 1096
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384224
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1097 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5337,12 +5306,12 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1085
+      ID: 1087
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 891360
       GoKind: 22
-      Pointee: 1086 StructureType main.firstBehavior
+      Pointee: 1088 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
@@ -5357,19 +5326,19 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1087
+      ID: 1089
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 891456
       GoKind: 22
-      Pointee: 1088 StructureType main.secondBehavior
+      Pointee: 1090 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1073
+      ID: 1075
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 891552
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1076 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -5377,16 +5346,16 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1071
+      ID: 1073
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1070 GoStringDataType main.stringType1.str
+      Pointee: 1072 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType main.stringType2
+      Pointee: 1074 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 175
       Name: '*main.structWithCyclicSlices'
@@ -5417,10 +5386,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1091
+      ID: 1093
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1090 GoSliceDataType main.t.array
+      Pointee: 1092 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -5453,10 +5422,10 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1099
+      ID: 1101
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1100 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1102 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1135
       Name: '*map<int,*main.deepMap8>'
@@ -5493,10 +5462,10 @@ Types:
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 830
+      ID: 832
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 831 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 833 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -5554,451 +5523,451 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 915840
       GoKind: 22
-      Pointee: 585 StructureType math/big.ErrNaN
+      Pointee: 587 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 883
+      ID: 885
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 910656
       GoKind: 22
-      Pointee: 884 StructureType mime/multipart.writerOnly·1
+      Pointee: 886 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 787
+      ID: 789
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.20208e+06
       GoKind: 22
-      Pointee: 788 UnresolvedPointeeType net.AddrError
+      Pointee: 790 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 813
+      ID: 815
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.415776e+06
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType net.DNSError
+      Pointee: 816 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1028
+      ID: 1030
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.224192e+06
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType net.IPConn
+      Pointee: 1031 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.415456e+06
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType net.OpError
+      Pointee: 814 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 789
+      ID: 791
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.202208e+06
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType net.ParseError
+      Pointee: 792 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1038
+      ID: 1040
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.25488e+06
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType net.TCPConn
+      Pointee: 1041 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1048
+      ID: 1050
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.299872e+06
       GoKind: 22
-      Pointee: 1049 UnresolvedPointeeType net.UDPConn
+      Pointee: 1051 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1036
+      ID: 1038
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.254368e+06
       GoKind: 22
-      Pointee: 1037 UnresolvedPointeeType net.UnixConn
+      Pointee: 1039 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.201312e+06
       GoKind: 22
-      Pointee: 749 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 751 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 751
+      ID: 753
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 752 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 717
+      ID: 719
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.033856e+06
       GoKind: 22
-      Pointee: 718 StructureType net.canceledError
+      Pointee: 720 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1004
+      ID: 1006
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.999904e+06
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType net.conn
+      Pointee: 1007 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 856
+      ID: 858
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.837664e+06
       GoKind: 22
-      Pointee: 857 StructureType net.dialResult·1
+      Pointee: 859 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1050
+      ID: 1052
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.304128e+06
       GoKind: 22
-      Pointee: 1051 UnresolvedPointeeType net.netFD
+      Pointee: 1053 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 517
+      ID: 519
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 518 UnresolvedPointeeType net.notFoundError
+      Pointee: 520 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 519
+      ID: 521
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 903360
       GoKind: 22
-      Pointee: 520 StructureType net.result·2
+      Pointee: 522 StructureType net.result·2
     - __kind: PointerType
-      ID: 1032
+      ID: 1034
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.240416e+06
       GoKind: 22
-      Pointee: 1033 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1035 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1030
+      ID: 1032
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.239936e+06
       GoKind: 22
-      Pointee: 1031 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1033 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 791
+      ID: 793
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.202848e+06
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType net.temporaryError
+      Pointee: 794 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 815
+      ID: 817
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.415936e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType net.timeoutError
+      Pointee: 818 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 707
+      ID: 709
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.029632e+06
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 710 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 877
+      ID: 879
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 898464
       GoKind: 22
-      Pointee: 878 StructureType net/http.bufioFlushWriter
+      Pointee: 880 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 494
+      ID: 496
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 899136
       GoKind: 22
-      Pointee: 414 BaseType net/http.http2ConnectionError
+      Pointee: 416 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 899232
       GoKind: 22
-      Pointee: 496 StructureType net/http.http2GoAwayError
+      Pointee: 498 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 807
+      ID: 809
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.411616e+06
       GoKind: 22
-      Pointee: 808 StructureType net/http.http2StreamError
+      Pointee: 810 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 899808
       GoKind: 22
-      Pointee: 500 StructureType net/http.http2connError
+      Pointee: 502 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 939
+      ID: 941
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.548416e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 942 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 498
+      ID: 500
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 899712
       GoKind: 22
-      Pointee: 418 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 420 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 420
+      ID: 422
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 421 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 502
+      ID: 504
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 900000
       GoKind: 22
-      Pointee: 424 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 426 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 426
+      ID: 428
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 425 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 427 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 501
+      ID: 503
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 899904
       GoKind: 22
-      Pointee: 421 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 423 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 423
+      ID: 425
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 422 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 424 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.197856e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 785 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 713
+      ID: 715
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.030272e+06
       GoKind: 22
-      Pointee: 714 StructureType net/http.http2noCachedConnError
+      Pointee: 716 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 993
+      ID: 995
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.942368e+06
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 996 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 497
+      ID: 499
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 899616
       GoKind: 22
-      Pointee: 415 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 417 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 417
+      ID: 419
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 416 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 418 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 900096
       GoKind: 22
-      Pointee: 880 StructureType net/http.http2stickyErrWriter
+      Pointee: 882 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 709
+      ID: 711
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.029888e+06
       GoKind: 22
-      Pointee: 710 StructureType net/http.nothingWrittenError
+      Pointee: 712 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 941
+      ID: 943
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.165504e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType net/http.persistConn
+      Pointee: 944 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.02976e+06
       GoKind: 22
-      Pointee: 898 StructureType net/http.persistConnWriter
+      Pointee: 900 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 923
+      ID: 925
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.19696e+06
       GoKind: 22
-      Pointee: 924 StructureType net/http.readWriteCloserBody
+      Pointee: 926 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 503
+      ID: 505
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 504 StructureType net/http.requestBodyReadError
+      Pointee: 506 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 809
+      ID: 811
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.412736e+06
       GoKind: 22
-      Pointee: 810 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 812 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.197728e+06
       GoKind: 22
-      Pointee: 781 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 783 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 711
+      ID: 713
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.030016e+06
       GoKind: 22
-      Pointee: 712 StructureType net/http.transportReadFromServerError
+      Pointee: 714 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 975
+      ID: 977
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.834304e+06
       GoKind: 22
-      Pointee: 976 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 978 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 492
+      ID: 494
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 898368
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 495 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 995
+      ID: 997
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.943904e+06
       GoKind: 22
-      Pointee: 996 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 998 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.042304e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 910 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 914784
       GoKind: 22
-      Pointee: 577 StructureType net/netip.parseAddrError
+      Pointee: 579 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 574
+      ID: 576
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 914688
       GoKind: 22
-      Pointee: 575 StructureType net/netip.parsePrefixError
+      Pointee: 577 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 949
+      ID: 951
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.110176e+06
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType net/smtp.Client
+      Pointee: 952 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 909
+      ID: 911
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.047168e+06
       GoKind: 22
-      Pointee: 910 StructureType net/smtp.dataCloser
+      Pointee: 912 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 560
+      ID: 562
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 910848
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType net/textproto.Error
+      Pointee: 563 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 910752
       GoKind: 22
-      Pointee: 449 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 451 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 451
+      ID: 453
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 450 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 452 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.041536e+06
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 908 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 817
+      ID: 819
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.416256e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net/url.Error
+      Pointee: 820 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 521
+      ID: 523
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 903456
       GoKind: 22
-      Pointee: 427 GoStringHeaderType net/url.EscapeError
+      Pointee: 429 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 429
+      ID: 431
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 428 GoStringDataType net/url.EscapeError.str
+      Pointee: 430 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 522
+      ID: 524
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 903552
       GoKind: 22
-      Pointee: 430 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 432 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 432
+      ID: 434
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 431 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 433 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 332
       Name: '*noalg.map.group[[4]int][4]int'
@@ -6025,10 +5994,10 @@ Types:
       ByteSize: 8
       Pointee: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1105
+      ID: 1107
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1106 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1108 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1141
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -6065,10 +6034,10 @@ Types:
       ByteSize: 8
       Pointee: 265 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 863
+      ID: 865
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 866 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 256
       Name: '*noalg.map.group[string]int'
@@ -6120,160 +6089,160 @@ Types:
       ByteSize: 8
       Pointee: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1056
+      ID: 1058
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.342784e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType os.File
+      Pointee: 1059 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 688
+      ID: 690
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.020928e+06
       GoKind: 22
-      Pointee: 689 UnresolvedPointeeType os.LinkError
+      Pointee: 691 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 752
+      ID: 754
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.186848e+06
       GoKind: 22
-      Pointee: 753 UnresolvedPointeeType os.SyscallError
+      Pointee: 755 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1054
+      ID: 1056
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.339104e+06
       GoKind: 22
-      Pointee: 1055 StructureType os.fileWithoutReadFrom
+      Pointee: 1057 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1052
+      ID: 1054
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.338368e+06
       GoKind: 22
-      Pointee: 1053 StructureType os.fileWithoutWriteTo
+      Pointee: 1055 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 719
+      ID: 721
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.038208e+06
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType os/exec.Error
+      Pointee: 722 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 859
+      ID: 861
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.080032e+06
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 862 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 927
+      ID: 929
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.20912e+06
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 930 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 721
+      ID: 723
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.038336e+06
       GoKind: 22
-      Pointee: 722 StructureType os/exec.wrappedError
+      Pointee: 724 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 655
+      ID: 657
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 932640
       GoKind: 22
-      Pointee: 463 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 465 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 465
+      ID: 467
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 464 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 466 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 932544
       GoKind: 22
-      Pointee: 462 BaseType os/user.UnknownUserIdError
+      Pointee: 464 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 487
+      ID: 489
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 896064
       GoKind: 22
-      Pointee: 488 UnresolvedPointeeType reflect.ValueError
+      Pointee: 490 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 582
+      ID: 584
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 585 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 692
+      ID: 694
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.022464e+06
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 695 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 696
+      ID: 698
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.024256e+06
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 699 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.022592e+06
       GoKind: 22
-      Pointee: 695 StructureType runtime.boundsError
+      Pointee: 697 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 754
+      ID: 756
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.192224e+06
       GoKind: 22
-      Pointee: 755 StructureType runtime.errorAddressString
+      Pointee: 757 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 690
+      ID: 692
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.02208e+06
       GoKind: 22
-      Pointee: 673 GoStringHeaderType runtime.errorString
+      Pointee: 675 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 674 GoStringDataType runtime.errorString.str
+      Pointee: 676 GoStringDataType runtime.errorString.str
     - __kind: PointerType
-      ID: 691
+      ID: 693
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.022208e+06
       GoKind: 22
-      Pointee: 676 GoStringHeaderType runtime.plainError
+      Pointee: 678 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 678
+      ID: 680
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 677 GoStringDataType runtime.plainError.str
+      Pointee: 679 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 698
+      ID: 700
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.024512e+06
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType strconv.NumError
+      Pointee: 701 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6287,33 +6256,33 @@ Types:
       ByteSize: 8
       Pointee: 221 GoStringDataType string.str
     - __kind: PointerType
-      ID: 991
+      ID: 993
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.941088e+06
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType strings.Builder
+      Pointee: 994 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 895
+      ID: 897
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.02464e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 898 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 891
+      ID: 893
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 965440
       GoKind: 22
-      Pointee: 892 StructureType struct { io.Writer }
+      Pointee: 894 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 806
+      ID: 808
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.410976e+06
       GoKind: 22
-      Pointee: 805 BaseType syscall.Errno
+      Pointee: 807 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
@@ -6340,10 +6309,10 @@ Types:
       ByteSize: 8
       Pointee: 228 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1102
+      ID: 1104
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1103 StructureType table<int,*main.deepMap3>
+      Pointee: 1105 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1138
       Name: '*table<int,*main.deepMap8>'
@@ -6380,10 +6349,10 @@ Types:
       ByteSize: 8
       Pointee: 262 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 833
+      ID: 835
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 861 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 863 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
@@ -6435,45 +6404,45 @@ Types:
       ByteSize: 8
       Pointee: 305 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1026
+      ID: 1028
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.1504e+06
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1029 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.083648e+06
       GoKind: 22
-      Pointee: 748 StructureType text/template.ExecError
+      Pointee: 750 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 822
+      ID: 824
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.61648e+06
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType time.Location
+      Pointee: 825 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 490
+      ID: 492
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 896928
       GoKind: 22
-      Pointee: 491 UnresolvedPointeeType time.ParseError
+      Pointee: 493 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 489
+      ID: 491
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 896832
       GoKind: 22
-      Pointee: 411 GoStringHeaderType time.fileSizeError
+      Pointee: 413 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 413
+      ID: 415
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 412 GoStringDataType time.fileSizeError.str
+      Pointee: 414 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6517,47 +6486,47 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 914880
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 581 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1018
+      ID: 1020
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.125856e+06
       GoKind: 22
-      Pointee: 1019 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1021 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 562
+      ID: 564
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 911040
       GoKind: 22
-      Pointee: 563 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 565 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 564
+      ID: 566
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 452 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 454 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 726
+      ID: 728
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.042048e+06
       GoKind: 22
-      Pointee: 727 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 729 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 728
+      ID: 730
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.042176e+06
       GoKind: 22
-      Pointee: 681 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 683 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1274
       Name: Probe[main.stackC]
@@ -8548,7 +8517,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 851
+      ID: 853
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 680448
@@ -8579,7 +8548,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1092
+      ID: 1094
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 474784
@@ -8587,19 +8556,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1093 PointerType **main.deepSlice3
+          Type: 1095 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1096 GoSliceDataType []*main.deepSlice3.array
+      Data: 1098 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1096
+      ID: 1098
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 1094 PointerType *main.deepSlice3
+      Element: 1096 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1119
       Name: '[]*main.deepSlice8'
@@ -8692,10 +8661,10 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1111
+      ID: 1113
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 1102 PointerType *table<int,*main.deepMap3>
+      Element: 1104 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1147
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -8732,10 +8701,10 @@ Types:
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 867
+      ID: 869
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 8192
-      Element: 833 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 835 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]*table<string,int>.array'
@@ -8935,7 +8904,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 846
+      ID: 848
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 483616
@@ -8950,9 +8919,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 871 GoSliceDataType []float64.array
+      Data: 873 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 871
+      ID: 873
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 18 BaseType float64
@@ -9015,9 +8984,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1113 GoSliceDataType []main.structWithMap.array
+      Data: 411 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1113
+      ID: 411
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -9068,10 +9037,10 @@ Types:
       ByteSize: 2048
       Element: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1112
+      ID: 1114
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 1106 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1108 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1148
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -9108,10 +9077,10 @@ Types:
       ByteSize: 2048
       Element: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 868
+      ID: 870
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 2048
-      Element: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 866 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]noalg.map.group[string]int.array'
@@ -9229,7 +9198,7 @@ Types:
       ByteSize: 2048
       Element: 6 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 840
+      ID: 842
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 482592
@@ -9244,18 +9213,18 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 869 GoSliceDataType []uint8.array
+      Data: 871 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 869
+      ID: 871
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1005
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 641
+      ID: 643
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 926016
@@ -9270,32 +9239,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 642 GoSliceDataType archive/tar.headerError.array
+      Data: 644 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 642
+      ID: 644
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 940
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 888
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 890
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.114784e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 988
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 914
+      ID: 916
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.558976e+06
@@ -9305,7 +9274,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 918
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9315,15 +9284,15 @@ Types:
       GoRuntimeType: 581184
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 963
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 992
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1043
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9349,13 +9318,13 @@ Types:
       GoRuntimeType: 580928
       GoKind: 15
     - __kind: BaseType
-      ID: 444
+      ID: 446
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830528
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 445
+      ID: 447
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 830624
@@ -9363,109 +9332,109 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 447 PointerType *compress/flate.InternalError.str
+          Type: 449 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 446 GoStringDataType compress/flate.InternalError.str
+      Data: 448 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 446
+      ID: 448
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 938
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 884
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 960
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 785
+      ID: 787
       Name: context.deadlineExceededError
       GoRuntimeType: 1.473216e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 458
+      ID: 460
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833120
       GoKind: 2
     - __kind: BaseType
-      ID: 459
+      ID: 461
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833216
       GoKind: 2
     - __kind: BaseType
-      ID: 460
+      ID: 462
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833312
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 950
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 984
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1016
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 990
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 986
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 982
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 461
+      ID: 463
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 833408
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1000
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 972
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 448
+      ID: 450
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 831104
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 727
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1069
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 559
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 555
+      ID: 557
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.7224e+06
@@ -9476,34 +9445,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 851 ArrayType [5]uint8
+          Type: 853 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 680
+      ID: 682
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 988256
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 948
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 955
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 822
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 837
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 629
+      ID: 631
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.72528e+06
@@ -9511,21 +9480,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 834 PointerType *crypto/x509.Certificate
+          Type: 836 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 854 BaseType crypto/x509.InvalidReason
+          Type: 856 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 623
+      ID: 625
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.112352e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 625
+      ID: 627
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.593696e+06
@@ -9533,24 +9502,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 834 PointerType *crypto/x509.Certificate
+          Type: 836 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 457
+      ID: 459
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 832736
       GoKind: 2
     - __kind: BaseType
-      ID: 854
+      ID: 856
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 586368
       GoKind: 2
     - __kind: StructureType
-      ID: 730
+      ID: 732
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.554976e+06
@@ -9560,13 +9529,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 631
+      ID: 633
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.112608e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 627
+      ID: 629
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.725088e+06
@@ -9574,15 +9543,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 834 PointerType *crypto/x509.Certificate
+          Type: 836 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 834 PointerType *crypto/x509.Certificate
+          Type: 836 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 645
+      ID: 647
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.430656e+06
@@ -9592,7 +9561,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 649
+      ID: 651
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.430816e+06
@@ -9602,55 +9571,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 649
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 442
+      ID: 444
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 830144
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 906
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 443
+      ID: 445
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 830336
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 516
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 718
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 506
+      ID: 508
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 514
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 512
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 508
+      ID: 510
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1049
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 516
+      ID: 518
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.414496e+06
@@ -9660,19 +9629,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 914
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 617
+      ID: 619
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 617
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 454
+      ID: 456
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -9680,21 +9649,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 456 PointerType *encoding/xml.UnmarshalError.str
+          Type: 458 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 455 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 457 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 455
+      ID: 457
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 622
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1027
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9711,11 +9680,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 486
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 685
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9731,15 +9700,15 @@ Types:
       GoRuntimeType: 581120
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1037
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 687
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 689
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9749,11 +9718,11 @@ Types:
       GoRuntimeType: 473056
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 546
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 525
+      ID: 527
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.721248e+06
@@ -9761,7 +9730,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 844 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 846 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -9769,25 +9738,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 527
+      ID: 529
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 850
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 531
+      ID: 533
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.10864e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 852
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 436
+      ID: 438
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 829568
@@ -9795,17 +9764,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 440 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 439 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 437
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 844
+      ID: 846
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.210208e+06
@@ -9813,7 +9782,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 845 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 847 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9828,7 +9797,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 846 GoSliceHeaderType []float64
+          Type: 848 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -9837,10 +9806,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 847 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 849 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 849 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 851 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 166 GoSliceHeaderType []string
@@ -9854,13 +9823,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 845
+      ID: 847
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 582976
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 433
+      ID: 435
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 829472
@@ -9868,17 +9837,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 437 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 436 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 434
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 439
+      ID: 441
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 829664
@@ -9886,59 +9855,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 441 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 443 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 442 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 440
+      ID: 442
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 928
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1011
+      ID: 1013
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 641
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 796
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1043
+      ID: 1045
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 568
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 573
+      ID: 575
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.111584e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 453
+      ID: 455
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 831776
       GoKind: 2
     - __kind: StructureType
-      ID: 571
+      ID: 573
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.111456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 569
+      ID: 571
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.591776e+06
@@ -9951,7 +9920,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 589
+      ID: 591
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.592576e+06
@@ -9964,7 +9933,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 593
+      ID: 595
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.724512e+06
@@ -9980,7 +9949,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 591
+      ID: 593
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.424256e+06
@@ -9990,7 +9959,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 587
+      ID: 589
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.423936e+06
@@ -10000,14 +9969,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 829
+      ID: 831
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.494336e+06
       GoKind: 21
-      HeaderType: 831 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 833 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 853
+      ID: 855
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.045632e+06
@@ -10022,14 +9991,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 873 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 875 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 873
+      ID: 875
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 601
+      ID: 603
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.592896e+06
@@ -10037,12 +10006,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 829 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 831 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 829 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 831 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 595
+      ID: 597
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.424416e+06
@@ -10052,7 +10021,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 599
+      ID: 601
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.724704e+06
@@ -10063,12 +10032,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 855 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 855 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 597
+      ID: 599
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.592736e+06
@@ -10081,7 +10050,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 603
+      ID: 605
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.424576e+06
@@ -10089,9 +10058,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 821 StructureType time.Time
+          Type: 823 StructureType time.Time
     - __kind: StructureType
-      ID: 609
+      ID: 611
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.593216e+06
@@ -10104,7 +10073,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 611
+      ID: 613
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.424896e+06
@@ -10114,7 +10083,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 609
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.593056e+06
@@ -10127,7 +10096,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 605
+      ID: 607
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.424736e+06
@@ -10137,7 +10106,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 613
+      ID: 615
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.593376e+06
@@ -10150,7 +10119,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 533
+      ID: 535
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.416736e+06
@@ -10160,11 +10129,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 966
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 535
+      ID: 537
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.416896e+06
@@ -10172,21 +10141,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 533 StructureType github.com/cihub/seelog.baseError
+          Type: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 946
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 902
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 936
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 539
+      ID: 541
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.417216e+06
@@ -10194,13 +10163,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 533 StructureType github.com/cihub/seelog.baseError
+          Type: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1001
+      ID: 1003
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1012
+      ID: 1014
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.098592e+06
@@ -10208,12 +10177,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1000 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1002 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1015
+      ID: 1017
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.1224e+06
@@ -10221,7 +10190,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1000 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1002 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10229,11 +10198,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 537
+      ID: 539
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.417056e+06
@@ -10241,9 +10210,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 533 StructureType github.com/cihub/seelog.baseError
+          Type: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 541
+      ID: 543
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.417376e+06
@@ -10251,64 +10220,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 533 StructureType github.com/cihub/seelog.baseError
+          Type: 535 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 968
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1007
+      ID: 1009
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1011
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 825
+      ID: 827
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 740
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 738
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 742
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 744
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 957
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 732
+      ID: 734
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 547
+      ID: 549
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.418336e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1061
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 796
+      ID: 798
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 769
+      ID: 771
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.832512e+06
@@ -10324,11 +10293,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 765
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 704
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.695296e+06
@@ -10341,7 +10310,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 775
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.83296e+06
@@ -10357,13 +10326,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 679
+      ID: 681
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 985568
       GoKind: 8
     - __kind: StructureType
-      ID: 767
+      ID: 769
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.832288e+06
@@ -10379,13 +10348,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 855
+      ID: 857
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 827744
       GoKind: 8
     - __kind: StructureType
-      ID: 765
+      ID: 767
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.832064e+06
@@ -10393,15 +10362,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 855 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 857 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 855 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 857 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 773
+      ID: 775
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.746752e+06
@@ -10414,7 +10383,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 771
+      ID: 773
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.832736e+06
@@ -10430,11 +10399,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1065
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 779
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.61744e+06
@@ -10444,19 +10413,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 706
+      ID: 708
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.278048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 704
+      ID: 706
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.27792e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 777
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.746944e+06
@@ -10469,7 +10438,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 466
+      ID: 468
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835232
@@ -10477,21 +10446,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 468 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 470 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 467 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 469 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 467
+      ID: 469
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 840
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 746
+      ID: 748
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.442496e+06
@@ -10501,7 +10470,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 932
+      ID: 934
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.671392e+06
@@ -10509,13 +10478,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 956 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 958 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1025
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 956
+      ID: 958
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.122336e+06
@@ -10528,7 +10497,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 918
+      ID: 920
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.563936e+06
@@ -10538,19 +10507,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 469
+      ID: 471
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 835808
       GoKind: 10
     - __kind: BaseType
-      ID: 836
+      ID: 838
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 998720
       GoKind: 10
     - __kind: StructureType
-      ID: 804
+      ID: 806
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.871488e+06
@@ -10561,12 +10530,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 836 BaseType golang.org/x/net/http2.ErrCode
+          Type: 838 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 665
+      ID: 667
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.600416e+06
@@ -10574,12 +10543,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 836 BaseType golang.org/x/net/http2.ErrCode
+          Type: 838 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 473
+      ID: 475
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836000
@@ -10587,17 +10556,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 475 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 477 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 474 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 476 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 474
+      ID: 476
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 479
+      ID: 481
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836192
@@ -10605,17 +10574,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 481 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 483 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 480 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 482 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 480
+      ID: 482
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 476
+      ID: 478
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836096
@@ -10623,17 +10592,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 478 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 480 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 477 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 479 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 477
+      ID: 479
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 470
+      ID: 472
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 835904
@@ -10641,21 +10610,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 472 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 474 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 471 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 473 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 471
+      ID: 473
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1023
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 671
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.443136e+06
@@ -10665,13 +10634,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 482
+      ID: 484
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836288
       GoKind: 2
     - __kind: StructureType
-      ID: 657
+      ID: 659
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.438176e+06
@@ -10681,11 +10650,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 804
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 827
+      ID: 829
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.899392e+06
@@ -10701,7 +10670,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 659
+      ID: 661
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.599936e+06
@@ -10714,7 +10683,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 972
+      ID: 974
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.95696e+06
@@ -10722,16 +10691,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 999 GoInterfaceType io.Reader
+          Type: 1001 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 932
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 744
+      ID: 746
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.561536e+06
@@ -10741,29 +10710,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 892
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 639
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 734
+      ID: 736
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 800
+      ID: 802
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 798
+      ID: 800
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.504896e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 651
+      ID: 653
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.431456e+06
@@ -10773,7 +10742,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 653
+      ID: 655
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.431616e+06
@@ -10783,7 +10752,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 583
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -10857,19 +10826,19 @@ Types:
       GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 237 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1104
+      ID: 1106
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1105 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1107 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1106 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1112 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1108 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1114 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1140
       Name: groupReference<int,*main.deepMap8>
@@ -10969,19 +10938,19 @@ Types:
       GroupType: 265 StructureType noalg.map.group[string][]string
       GroupSliceType: 269 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 862
+      ID: 864
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 863 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 865 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 868 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 866 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 870 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 255
       Name: groupReference<string,int>
@@ -11123,11 +11092,11 @@ Types:
       GroupType: 308 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 312 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 980
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 672
+      ID: 674
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11174,37 +11143,37 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 553
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 549
+      ID: 551
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 878
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 761
+      ID: 763
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1067
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 759
+      ID: 761
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.470016e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 488
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1077
+      ID: 1079
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.467456e+06
@@ -11217,11 +11186,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 962
+      ID: 964
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.185056e+06
@@ -11234,7 +11203,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 999
+      ID: 1001
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.01824e+06
@@ -11247,7 +11216,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 951
+      ID: 953
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.104928e+06
@@ -11273,21 +11242,21 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 920
+      ID: 922
       Name: io.discard
       GoRuntimeType: 1.457376e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 896
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 757
+      ID: 759
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 970
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -11355,9 +11324,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1098 GoMapType map[int]*main.deepMap3
+          Type: 1100 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1112
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11409,9 +11378,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1068 PointerType *main.deepPtr3
+          Type: 1070 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1069
+      ID: 1071
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11463,9 +11432,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1092 GoSliceHeaderType []*main.deepSlice3
+          Type: 1094 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1097
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11515,16 +11484,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1075 StructureType sync.Mutex
+          Type: 1077 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1078 StructureType sync.Once
+          Type: 1080 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1081 StructureType sync.WaitGroup
+          Type: 1083 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1084 StructureType sync/atomic.Int32
+          Type: 1086 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -11554,7 +11523,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1086
+      ID: 1088
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.407616e+06
@@ -11599,7 +11568,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1088
+      ID: 1090
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.407776e+06
@@ -11619,7 +11588,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1076
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11630,17 +11599,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1071 PointerType *main.stringType1.str
+          Type: 1073 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1070 GoStringDataType main.stringType1.str
+      Data: 1072 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1070
+      ID: 1072
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1074
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11743,16 +11712,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1089 PointerType **main.t
+          Type: 1091 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1090 GoSliceDataType main.t.array
+      Data: 1092 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1090
+      ID: 1092
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -11937,7 +11906,7 @@ Types:
       TablePtrSliceType: 236 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1100
+      ID: 1102
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -11950,7 +11919,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1101 PointerType **table<int,*main.deepMap3>
+          Type: 1103 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -11966,8 +11935,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1111 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1106 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1113 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1108 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1136
       Name: map<int,*main.deepMap8>
@@ -12193,7 +12162,7 @@ Types:
       TablePtrSliceType: 268 GoSliceDataType []*table<string,[]string>.array
       GroupType: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 831
+      ID: 833
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -12206,7 +12175,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 832 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 834 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12222,8 +12191,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 867 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 864 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 869 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 866 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -12580,12 +12549,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1098
+      ID: 1100
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.124e+06
       GoKind: 21
-      HeaderType: 1100 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1102 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1134
       Name: map[int]*main.deepMap8
@@ -12700,7 +12669,7 @@ Types:
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 585
+      ID: 587
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.423616e+06
@@ -12710,7 +12679,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 884
+      ID: 886
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.420416e+06
@@ -12720,11 +12689,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 788
+      ID: 790
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 852
+      ID: 854
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.590496e+06
@@ -12737,35 +12706,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 816
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1031
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 814
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 792
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1041
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1049
+      ID: 1051
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1037
+      ID: 1039
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 751
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.108256e+06
@@ -12773,27 +12742,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *net.UnknownNetworkError.str
+          Type: 753 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 750 GoStringDataType net.UnknownNetworkError.str
+      Data: 752 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 752
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 718
+      ID: 720
       Name: net.canceledError
       GoRuntimeType: 1.279072e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1007
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 859
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.097888e+06
@@ -12801,7 +12770,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -12812,27 +12781,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1051
+      ID: 1053
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1045
+      ID: 1047
       Name: net.noReadFrom
       GoRuntimeType: 1.108512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1044
+      ID: 1046
       Name: net.noWriteTo
       GoRuntimeType: 1.108384e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 518
+      ID: 520
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 520
+      ID: 522
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.721056e+06
@@ -12840,7 +12809,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 839 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 841 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -12848,7 +12817,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1033
+      ID: 1035
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.282624e+06
@@ -12856,12 +12825,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1045 StructureType net.noReadFrom
+          Type: 1047 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1038 PointerType *net.TCPConn
+          Type: 1040 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1031
+      ID: 1033
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.28208e+06
@@ -12869,24 +12838,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1044 StructureType net.noWriteTo
+          Type: 1046 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1038 PointerType *net.TCPConn
+          Type: 1040 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 794
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 818
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 710
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 878
+      ID: 880
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.411936e+06
@@ -12896,19 +12865,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 414
+      ID: 416
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 828224
       GoKind: 10
     - __kind: BaseType
-      ID: 828
+      ID: 830
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 985664
       GoKind: 10
     - __kind: StructureType
-      ID: 496
+      ID: 498
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.719328e+06
@@ -12919,12 +12888,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 828 BaseType net/http.http2ErrCode
+          Type: 830 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 808
+      ID: 810
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.890688e+06
@@ -12935,12 +12904,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 828 BaseType net/http.http2ErrCode
+          Type: 830 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 500
+      ID: 502
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.590016e+06
@@ -12948,16 +12917,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 828 BaseType net/http.http2ErrCode
+          Type: 830 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 942
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 418
+      ID: 420
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828416
@@ -12965,17 +12934,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 420 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 422 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 421 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 419
+      ID: 421
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 424
+      ID: 426
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 828608
@@ -12983,17 +12952,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 426 PointerType *net/http.http2headerFieldNameError.str
+          Type: 428 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 425 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 427 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 425
+      ID: 427
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 421
+      ID: 423
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 828512
@@ -13001,31 +12970,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 423 PointerType *net/http.http2headerFieldValueError.str
+          Type: 425 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 422 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 424 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 422
+      ID: 424
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 785
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 714
+      ID: 716
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.278304e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 996
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 415
+      ID: 417
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 828320
@@ -13033,17 +13002,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 417 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 419 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 416 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 418 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 416
+      ID: 418
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 880
+      ID: 882
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.8152e+06
@@ -13051,18 +13020,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 973 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 975 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 974 BaseType time.Duration
+          Type: 976 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 33 PointerType *error
     - __kind: GoInterfaceType
-      ID: 973
+      ID: 975
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.411296e+06
@@ -13075,14 +13044,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 959
+      ID: 961
       Name: net/http.incomparable
       GoRuntimeType: 898176
       GoKind: 17
       HasCount: true
       Element: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 710
+      ID: 712
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.549056e+06
@@ -13092,11 +13061,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 944
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 898
+      ID: 900
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.548896e+06
@@ -13104,9 +13073,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 941 PointerType *net/http.persistConn
+          Type: 943 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 924
+      ID: 926
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.7912e+06
@@ -13114,15 +13083,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 959 ArrayType net/http.incomparable
+          Type: 961 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 960 PointerType *bufio.Reader
+          Type: 962 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 962 GoInterfaceType io.ReadWriteCloser
+          Type: 964 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 504
+      ID: 506
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.412896e+06
@@ -13132,17 +13101,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 810
+      ID: 812
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 781
+      ID: 783
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.472896e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 712
+      ID: 714
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.549216e+06
@@ -13152,7 +13121,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 976
+      ID: 978
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.016864e+06
@@ -13160,16 +13129,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 852 GoInterfaceType net.Conn
+          Type: 854 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 495
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 996
+      ID: 998
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.032896e+06
@@ -13177,13 +13146,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 989 PointerType *bufio.Writer
+          Type: 991 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 910
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 577
+      ID: 579
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.724128e+06
@@ -13199,7 +13168,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 575
+      ID: 577
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.591936e+06
@@ -13212,11 +13181,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 952
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 910
+      ID: 912
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.593856e+06
@@ -13224,16 +13193,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 949 PointerType *net/smtp.Client
+          Type: 951 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 951 GoInterfaceType io.WriteCloser
+          Type: 953 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 563
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 449
+      ID: 451
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 831200
@@ -13241,25 +13210,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 451 PointerType *net/textproto.ProtocolError.str
+          Type: 453 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 450 GoStringDataType net/textproto.ProtocolError.str
+      Data: 452 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 450
+      ID: 452
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 908
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 820
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 427
+      ID: 429
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 829184
@@ -13267,17 +13236,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 429 PointerType *net/url.EscapeError.str
+          Type: 431 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 428 GoStringDataType net/url.EscapeError.str
+      Data: 430 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 428
+      ID: 430
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 430
+      ID: 432
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 829280
@@ -13285,13 +13254,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 432 PointerType *net/url.InvalidHostError.str
+          Type: 434 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 431 GoStringDataType net/url.InvalidHostError.str
+      Data: 433 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 431
+      ID: 433
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: ArrayType
@@ -13340,14 +13309,14 @@ Types:
       HasCount: true
       Element: 233 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1107
+      ID: 1109
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1108 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1110 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1143
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -13412,14 +13381,14 @@ Types:
       HasCount: true
       Element: 267 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 865
+      ID: 867
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 754592
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 866 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 868 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 258
       Name: noalg.[8]struct { key string; elem int }
@@ -13570,7 +13539,7 @@ Types:
           Offset: 8
           Type: 232 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1106
+      ID: 1108
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.289568e+06
@@ -13581,7 +13550,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1107 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1109 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1142
       Name: noalg.map.group[int]*main.deepMap8
@@ -13674,7 +13643,7 @@ Types:
           Offset: 8
           Type: 266 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 864
+      ID: 866
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.3528e+06
@@ -13685,7 +13654,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 865 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 867 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 257
       Name: noalg.map.group[string]int
@@ -13876,7 +13845,7 @@ Types:
           Offset: 8
           Type: 234 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1108
+      ID: 1110
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.28944e+06
@@ -13887,7 +13856,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1109 PointerType *main.deepMap3
+          Type: 1111 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1144
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -13980,7 +13949,7 @@ Types:
           Offset: 16
           Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 866
+      ID: 868
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.352672e+06
@@ -13991,7 +13960,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 853 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 855 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 259
       Name: noalg.struct { key string; elem int }
@@ -14117,19 +14086,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1059
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 689
+      ID: 691
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 753
+      ID: 755
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1055
+      ID: 1057
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.351232e+06
@@ -14137,12 +14106,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1061 StructureType os.noReadFrom
+          Type: 1063 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1056 PointerType *os.File
+          Type: 1058 PointerType *os.File
     - __kind: StructureType
-      ID: 1053
+      ID: 1055
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.350432e+06
@@ -14150,36 +14119,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1060 StructureType os.noWriteTo
+          Type: 1062 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1056 PointerType *os.File
+          Type: 1058 PointerType *os.File
     - __kind: StructureType
-      ID: 1061
+      ID: 1063
       Name: os.noReadFrom
       GoRuntimeType: 1.105824e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1060
+      ID: 1062
       Name: os.noWriteTo
       GoRuntimeType: 1.105696e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 722
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 862
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 930
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 724
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.695872e+06
@@ -14192,7 +14161,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 463
+      ID: 465
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 834464
@@ -14200,39 +14169,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 465 PointerType *os/user.UnknownGroupIdError.str
+          Type: 467 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 464 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 466 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 464
+      ID: 466
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 462
+      ID: 464
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 834368
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 488
+      ID: 490
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 585
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 695
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 699
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 695
+      ID: 697
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.879104e+06
@@ -14249,15 +14218,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 858 BaseType runtime.boundsErrorCode
+          Type: 860 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 858
+      ID: 860
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 581312
       GoKind: 8
     - __kind: StructureType
-      ID: 755
+      ID: 757
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.74368e+06
@@ -14270,7 +14239,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 673
+      ID: 675
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 984320
@@ -14278,17 +14247,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 675 PointerType *runtime.errorString.str
+          Type: 677 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 674 GoStringDataType runtime.errorString.str
+      Data: 676 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 674
+      ID: 676
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 676
+      ID: 678
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 984416
@@ -14296,17 +14265,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 678 PointerType *runtime.plainError.str
+          Type: 680 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 677 GoStringDataType runtime.plainError.str
+      Data: 679 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 677
+      ID: 679
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 701
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14328,15 +14297,15 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 994
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 898
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 892
+      ID: 894
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.449696e+06
@@ -14352,7 +14321,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1075
+      ID: 1077
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.458176e+06
@@ -14360,12 +14329,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1076 StructureType sync.noCopy
+          Type: 1078 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1077 StructureType internal/sync.Mutex
+          Type: 1079 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1078
+      ID: 1080
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.606688e+06
@@ -14373,15 +14342,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1076 StructureType sync.noCopy
+          Type: 1078 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1079 StructureType sync/atomic.Uint32
+          Type: 1081 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1075 StructureType sync.Mutex
+          Type: 1077 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1081
+      ID: 1083
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.60688e+06
@@ -14389,21 +14358,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1076 StructureType sync.noCopy
+          Type: 1078 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1082 StructureType sync/atomic.Uint64
+          Type: 1084 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1076
+      ID: 1078
       Name: sync.noCopy
       GoRuntimeType: 983264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1084
+      ID: 1086
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.459456e+06
@@ -14411,12 +14380,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1080 StructureType sync/atomic.noCopy
+          Type: 1082 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1079
+      ID: 1081
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.459616e+06
@@ -14424,12 +14393,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1080 StructureType sync/atomic.noCopy
+          Type: 1082 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1082
+      ID: 1084
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.607264e+06
@@ -14437,27 +14406,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1080 StructureType sync/atomic.noCopy
+          Type: 1082 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1083 StructureType sync/atomic.align64
+          Type: 1085 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1083
+      ID: 1085
       Name: sync/atomic.align64
       GoRuntimeType: 983456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1080
+      ID: 1082
       Name: sync/atomic.noCopy
       GoRuntimeType: 983360
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 805
+      ID: 807
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.277664e+06
@@ -14583,7 +14552,7 @@ Types:
           Offset: 16
           Type: 229 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1103
+      ID: 1105
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -14605,7 +14574,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1104 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1106 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1139
       Name: table<int,*main.deepMap8>
@@ -14775,7 +14744,7 @@ Types:
           Offset: 16
           Type: 263 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 861
+      ID: 863
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -14797,7 +14766,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 862 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 864 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 254
       Name: table<string,int>
@@ -15039,11 +15008,11 @@ Types:
           Offset: 16
           Type: 306 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1029
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 748
+      ID: 750
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.700288e+06
@@ -15056,21 +15025,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 974
+      ID: 976
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.905248e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 825
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 491
+      ID: 493
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 821
+      ID: 823
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.366112e+06
@@ -15084,9 +15053,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 822 PointerType *time.Location
+          Type: 824 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 411
+      ID: 413
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 827360
@@ -15094,13 +15063,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 413 PointerType *time.fileSizeError.str
+          Type: 415 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 412 GoStringDataType time.fileSizeError.str
+      Data: 414 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 412
+      ID: 414
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -15146,7 +15115,7 @@ Types:
       GoRuntimeType: 581248
       GoKind: 26
     - __kind: StructureType
-      ID: 839
+      ID: 841
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.054304e+06
@@ -15154,13 +15123,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 840 GoSliceHeaderType []uint8
+          Type: 842 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 841 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 843 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 842 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 844 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -15175,18 +15144,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 843 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 845 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 843
+      ID: 845
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 989888
       GoKind: 9
     - __kind: StructureType
-      ID: 841
+      ID: 843
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.916e+06
@@ -15211,21 +15180,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 581
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 842
+      ID: 844
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 584896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1019
+      ID: 1021
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 563
+      ID: 565
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.420736e+06
@@ -15235,13 +15204,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 452
+      ID: 454
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 831296
       GoKind: 2
     - __kind: StructureType
-      ID: 727
+      ID: 729
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.696064e+06
@@ -15254,7 +15223,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 681
+      ID: 683
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 988736

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -2326,15 +2326,6 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: z
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80755c..0x80756c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80756c..0x807600
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x807600..0x807670]
@@ -2351,25 +2342,7 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x807670..0x807780]
       InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80768c..0x8076f8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8076f8..0x807700
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80768c..0x8076f8
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8076f8..0x8076fc
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+      Variables: []
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x807780..0x807790]
@@ -3474,10 +3447,10 @@ Types:
       ByteSize: 8
       Pointee: 64 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1109
+      ID: 1111
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1110 PointerType *main.deepSlice3
+      Pointee: 1112 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1136
       Name: '**main.deepSlice8'
@@ -3495,7 +3468,7 @@ Types:
       GoKind: 22
       Pointee: 78 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1105
+      ID: 1107
       Name: '**main.t'
       ByteSize: 8
       Pointee: 158 PointerType *main.t
@@ -3532,10 +3505,10 @@ Types:
       ByteSize: 8
       Pointee: 72 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1117
+      ID: 1119
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1118 PointerType *table<int,*main.deepMap3>
+      Pointee: 1120 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1153
       Name: '**table<int,*main.deepMap8>'
@@ -3572,10 +3545,10 @@ Types:
       ByteSize: 8
       Pointee: 110 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 848
+      ID: 850
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 849 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 851 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 104
       Name: '**table<string,int>'
@@ -3632,10 +3605,10 @@ Types:
       ByteSize: 8
       Pointee: 226 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1113
+      ID: 1115
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1112 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1114 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1140
       Name: '*[]*main.deepSlice8.array'
@@ -3707,10 +3680,10 @@ Types:
       ByteSize: 8
       Pointee: 346 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 888
+      ID: 890
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 887 GoSliceDataType []float64.array
+      Pointee: 889 GoSliceDataType []float64.array
     - __kind: PointerType
       ID: 1149
       Name: '*[]interface {}.array'
@@ -3727,10 +3700,10 @@ Types:
       ByteSize: 8
       Pointee: 350 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 1130
+      ID: 412
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 1129 GoSliceDataType []main.structWithMap.array
+      Pointee: 411 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 343
       Name: '*[]main.structWithNoStrings.array'
@@ -3757,71 +3730,71 @@ Types:
       ByteSize: 8
       Pointee: 348 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 886
+      ID: 888
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 885 GoSliceDataType []uint8.array
+      Pointee: 887 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 1018
+      ID: 1020
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.985184e+06
       GoKind: 22
-      Pointee: 1019 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1021 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 648
+      ID: 650
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 930688
       GoKind: 22
-      Pointee: 649 GoSliceHeaderType archive/tar.headerError
+      Pointee: 651 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 651
+      ID: 653
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 650 GoSliceDataType archive/tar.headerError.array
+      Pointee: 652 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 953
+      ID: 955
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.434368e+06
       GoKind: 22
-      Pointee: 954 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 956 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 901
+      ID: 903
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 930880
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 904 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 903
+      ID: 905
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 930976
       GoKind: 22
-      Pointee: 904 StructureType archive/zip.dirWriter
+      Pointee: 906 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 997
+      ID: 999
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.903328e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1000 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 929
+      ID: 931
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.057088e+06
       GoKind: 22
-      Pointee: 930 StructureType archive/zip.nopCloser
+      Pointee: 932 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 931
+      ID: 933
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.057344e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 934 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3830,435 +3803,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 976
+      ID: 978
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.17328e+06
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType bufio.Reader
+      Pointee: 979 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1005
+      ID: 1007
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.948064e+06
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType bufio.Writer
+      Pointee: 1008 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1056
+      ID: 1058
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.266144e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1059 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 558
+      ID: 560
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 913216
       GoKind: 22
-      Pointee: 447 BaseType compress/flate.CorruptInputError
+      Pointee: 449 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 559
+      ID: 561
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 913312
       GoKind: 22
-      Pointee: 448 GoStringHeaderType compress/flate.InternalError
+      Pointee: 450 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 450
+      ID: 452
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 449 GoStringDataType compress/flate.InternalError.str
+      Pointee: 451 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 951
+      ID: 953
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.423968e+06
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 954 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 897
+      ID: 899
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 913408
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 900 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 973
+      ID: 975
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.724832e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 976 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 796
+      ID: 798
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.202624e+06
       GoKind: 22
-      Pointee: 797 StructureType context.deadlineExceededError
+      Pointee: 799 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 640
+      ID: 642
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925312
       GoKind: 22
-      Pointee: 461 BaseType crypto/aes.KeySizeError
+      Pointee: 463 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 641
+      ID: 643
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925504
       GoKind: 22
-      Pointee: 462 BaseType crypto/des.KeySizeError
+      Pointee: 464 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 642
+      ID: 644
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 463 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 465 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 968
+      ID: 970
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.665568e+06
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 971 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 745
+      ID: 747
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.064896e+06
       GoKind: 22
-      Pointee: 746 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 748 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 999
+      ID: 1001
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.90384e+06
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1002 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1029
+      ID: 1031
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.118432e+06
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1032 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1003
+      ID: 1005
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.904352e+06
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1006 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1001
+      ID: 1003
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.904096e+06
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1004 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 995
+      ID: 997
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.901536e+06
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 998 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 643
+      ID: 645
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926080
       GoKind: 22
-      Pointee: 464 BaseType crypto/rc4.KeySizeError
+      Pointee: 466 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1016
+      ID: 1018
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.982304e+06
       GoKind: 22
-      Pointee: 1017 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1019 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 991
+      ID: 993
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.870912e+06
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 994 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 566
+      ID: 568
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 914944
       GoKind: 22
-      Pointee: 451 BaseType crypto/tls.AlertError
+      Pointee: 453 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 734
+      ID: 736
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.045696e+06
       GoKind: 22
-      Pointee: 735 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 737 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1082
+      ID: 1084
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.377664e+06
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1085 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 562
+      ID: 564
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 914656
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 565 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 560
+      ID: 562
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 561 StructureType crypto/tls.RecordHeaderError
+      Pointee: 563 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 733
+      ID: 735
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.044032e+06
       GoKind: 22
-      Pointee: 688 BaseType crypto/tls.alert
+      Pointee: 690 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 961
+      ID: 963
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.558432e+06
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 964 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 564
+      ID: 566
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 914752
       GoKind: 22
-      Pointee: 565 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 567 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 966
+      ID: 968
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.640608e+06
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 969 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 831
+      ID: 833
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.424448e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 834 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 850
+      ID: 852
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.041472e+06
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 853 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 636
+      ID: 638
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 924352
       GoKind: 22
-      Pointee: 637 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 639 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 630
+      ID: 632
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 923872
       GoKind: 22
-      Pointee: 631 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 633 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 632
+      ID: 634
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 923968
       GoKind: 22
-      Pointee: 633 StructureType crypto/x509.HostnameError
+      Pointee: 635 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 629
+      ID: 631
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 460 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 462 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 739
+      ID: 741
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.051456e+06
       GoKind: 22
-      Pointee: 740 StructureType crypto/x509.SystemRootsError
+      Pointee: 742 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 638
+      ID: 640
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 639 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 641 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 634
+      ID: 636
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 924256
       GoKind: 22
-      Pointee: 635 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 637 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 652
+      ID: 654
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 931168
       GoKind: 22
-      Pointee: 653 StructureType encoding/asn1.StructuralError
+      Pointee: 655 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 656
+      ID: 658
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931360
       GoKind: 22
-      Pointee: 657 StructureType encoding/asn1.SyntaxError
+      Pointee: 659 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 654
+      ID: 656
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 931264
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 657 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 547
+      ID: 549
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 911200
       GoKind: 22
-      Pointee: 442 BaseType encoding/base64.CorruptInputError
+      Pointee: 444 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 919
+      ID: 921
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.041088e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 922 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 550
+      ID: 552
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 912064
       GoKind: 22
-      Pointee: 443 BaseType encoding/hex.InvalidByteError
+      Pointee: 445 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 518
+      ID: 520
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 906016
       GoKind: 22
-      Pointee: 519 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 521 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 723
+      ID: 725
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.037248e+06
       GoKind: 22
-      Pointee: 724 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 726 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 510
+      ID: 512
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 905632
       GoKind: 22
-      Pointee: 511 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 513 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 516
+      ID: 518
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 905920
       GoKind: 22
-      Pointee: 517 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 519 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 514
+      ID: 516
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 905824
       GoKind: 22
-      Pointee: 515 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 517 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 512
+      ID: 514
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 905728
       GoKind: 22
-      Pointee: 513 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 515 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1062
+      ID: 1064
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.29168e+06
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1065 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 520
+      ID: 522
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 906400
       GoKind: 22
-      Pointee: 521 StructureType encoding/json.jsonError
+      Pointee: 523 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 927
+      ID: 929
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.054016e+06
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 930 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 624
+      ID: 626
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 627 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 622
+      ID: 624
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 922720
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 625 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 626
+      ID: 628
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 457 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 459 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 459
+      ID: 461
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 458 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 460 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 627
+      ID: 629
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923008
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 630 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1040
+      ID: 1042
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.158272e+06
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1043 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -4267,19 +4240,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 486
+      ID: 488
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896032
       GoKind: 22
-      Pointee: 487 UnresolvedPointeeType errors.errorString
+      Pointee: 489 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 690
+      ID: 692
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.022144e+06
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType errors.joinError
+      Pointee: 693 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 35
       Name: '*float32'
@@ -4295,813 +4268,813 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 1050
+      ID: 1052
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.258464e+06
       GoKind: 22
-      Pointee: 1051 UnresolvedPointeeType fmt.pp
+      Pointee: 1053 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 692
+      ID: 694
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.023936e+06
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType fmt.wrapError
+      Pointee: 695 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 694
+      ID: 696
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.024064e+06
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 697 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 548
+      ID: 550
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 549 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 551 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 529
+      ID: 531
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 908800
       GoKind: 22
-      Pointee: 530 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 532 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 531
+      ID: 533
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 908896
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 534 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 863
+      ID: 865
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 866 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 535
+      ID: 537
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 909184
       GoKind: 22
-      Pointee: 536 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 538 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 865
+      ID: 867
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 868 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 533
+      ID: 535
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 908992
       GoKind: 22
-      Pointee: 436 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 438 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 438
+      ID: 440
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 439 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 528
+      ID: 530
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 435 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 435
+      ID: 437
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 436 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 534
+      ID: 536
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 909088
       GoKind: 22
-      Pointee: 439 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 441 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 441
+      ID: 443
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 442 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 939
+      ID: 941
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.208128e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 942 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1026
+      ID: 1028
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.05648e+06
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1029 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 646
+      ID: 648
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 929632
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 649 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 805
+      ID: 807
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.211712e+06
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 808 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1058
+      ID: 1060
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.268192e+06
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1061 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 573
+      ID: 575
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 576 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 580
+      ID: 582
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 919360
       GoKind: 22
-      Pointee: 581 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 583 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 575
+      ID: 577
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 919072
       GoKind: 22
-      Pointee: 456 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 458 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 578
+      ID: 580
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 579 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 581 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 576
+      ID: 578
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 919168
       GoKind: 22
-      Pointee: 577 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 579 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 596
+      ID: 598
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 597 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 599 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 600
+      ID: 602
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 921472
       GoKind: 22
-      Pointee: 601 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 603 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 598
+      ID: 600
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 599 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 601 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 594
+      ID: 596
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 595 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 597 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 890
+      ID: 892
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 889 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 891 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 608
+      ID: 610
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 921856
       GoKind: 22
-      Pointee: 609 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 611 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 602
+      ID: 604
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 921568
       GoKind: 22
-      Pointee: 603 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 605 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 606
+      ID: 608
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 607 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 609 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 604
+      ID: 606
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 921664
       GoKind: 22
-      Pointee: 605 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 607 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 610
+      ID: 612
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 921952
       GoKind: 22
-      Pointee: 611 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 616
+      ID: 618
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 922240
       GoKind: 22
-      Pointee: 617 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 619 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 618
+      ID: 620
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 922336
       GoKind: 22
-      Pointee: 619 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 621 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 614
+      ID: 616
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 922144
       GoKind: 22
-      Pointee: 615 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 617 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 612
+      ID: 614
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 922048
       GoKind: 22
-      Pointee: 613 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 615 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 620
+      ID: 622
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 922528
       GoKind: 22
-      Pointee: 621 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 623 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 537
+      ID: 539
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 910336
       GoKind: 22
-      Pointee: 538 StructureType github.com/cihub/seelog.baseError
+      Pointee: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 979
+      ID: 981
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.801696e+06
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 982 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 539
+      ID: 541
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 910432
       GoKind: 22
-      Pointee: 540 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 542 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 959
+      ID: 961
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.557152e+06
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 962 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 915
+      ID: 917
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.039936e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 949
+      ID: 951
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.422048e+06
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 952 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 543
+      ID: 545
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 910624
       GoKind: 22
-      Pointee: 544 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 546 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1014
+      ID: 1016
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.974528e+06
       GoKind: 22
-      Pointee: 1015 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1017 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1033
+      ID: 1035
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.131072e+06
       GoKind: 22
-      Pointee: 1028 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1030 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1032
+      ID: 1034
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.130688e+06
       GoKind: 22
-      Pointee: 1031 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1033 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 917
+      ID: 919
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.040064e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 920 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 541
+      ID: 543
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 910528
       GoKind: 22
-      Pointee: 542 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 544 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 545
+      ID: 547
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 910720
       GoKind: 22
-      Pointee: 546 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 548 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 981
+      ID: 983
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.803488e+06
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 984 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1022
+      ID: 1024
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.010656e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1025 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1024
+      ID: 1026
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.041152e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1027 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 836
+      ID: 838
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.436768e+06
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 839 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 749
+      ID: 751
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.065664e+06
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 752 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 747
+      ID: 749
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.065536e+06
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 750 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 751
+      ID: 753
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.069632e+06
       GoKind: 22
-      Pointee: 752 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 754 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 753
+      ID: 755
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.06976e+06
       GoKind: 22
-      Pointee: 754 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 756 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 970
+      ID: 972
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.667872e+06
       GoKind: 22
-      Pointee: 971 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 973 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 741
+      ID: 743
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.052096e+06
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 744 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 551
+      ID: 553
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 912256
       GoKind: 22
-      Pointee: 552 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 554 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1074
+      ID: 1076
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.354112e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1077 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 807
+      ID: 809
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.220288e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 810 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 780
+      ID: 782
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.199168e+06
       GoKind: 22
-      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 783 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 774
+      ID: 776
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.198784e+06
       GoKind: 22
-      Pointee: 775 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 777 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 709
+      ID: 711
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.031232e+06
       GoKind: 22
-      Pointee: 710 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 712 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 786
+      ID: 788
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.199552e+06
       GoKind: 22
-      Pointee: 787 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 789 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 708
+      ID: 710
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.031104e+06
       GoKind: 22
-      Pointee: 687 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 689 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 778
+      ID: 780
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.19904e+06
       GoKind: 22
-      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 781 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 776
+      ID: 778
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.198912e+06
       GoKind: 22
-      Pointee: 777 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 779 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 784
+      ID: 786
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.199424e+06
       GoKind: 22
-      Pointee: 785 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 787 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 782
+      ID: 784
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.199296e+06
       GoKind: 22
-      Pointee: 783 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 785 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1078
+      ID: 1080
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.36672e+06
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1081 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 790
+      ID: 792
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.199936e+06
       GoKind: 22
-      Pointee: 791 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 793 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 713
+      ID: 715
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.031488e+06
       GoKind: 22
-      Pointee: 714 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 716 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 711
+      ID: 713
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.03136e+06
       GoKind: 22
-      Pointee: 712 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 714 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 788
+      ID: 790
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.199808e+06
       GoKind: 22
-      Pointee: 789 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 791 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 668
+      ID: 670
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944128
       GoKind: 22
-      Pointee: 469 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 471 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 471
+      ID: 473
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 470 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 472 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 853
+      ID: 855
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.666336e+06
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 856 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 757
+      ID: 759
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.08448e+06
       GoKind: 22
-      Pointee: 758 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 760 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 945
+      ID: 947
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.260096e+06
       GoKind: 22
-      Pointee: 946 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 948 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1038
+      ID: 1040
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.146432e+06
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1041 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 933
+      ID: 935
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.086784e+06
       GoKind: 22
-      Pointee: 934 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 936 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 669
+      ID: 671
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 945376
       GoKind: 22
-      Pointee: 472 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 474 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 815
+      ID: 817
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.26176e+06
       GoKind: 22
-      Pointee: 816 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 818 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 672
+      ID: 674
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 945664
       GoKind: 22
-      Pointee: 673 StructureType golang.org/x/net/http2.connError
+      Pointee: 675 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 671
+      ID: 673
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945568
       GoKind: 22
-      Pointee: 476 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 478 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 478
+      ID: 480
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 477 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 479 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 675
+      ID: 677
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 945856
       GoKind: 22
-      Pointee: 482 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 484 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 484
+      ID: 486
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 483 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 485 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 674
+      ID: 676
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 945760
       GoKind: 22
-      Pointee: 479 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 481 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 481
+      ID: 483
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 480 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 482 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 670
+      ID: 672
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945472
       GoKind: 22
-      Pointee: 473 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 475 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 475
+      ID: 477
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 474 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 476 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1036
+      ID: 1038
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.144512e+06
       GoKind: 22
-      Pointee: 1037 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1039 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 676
+      ID: 678
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 945952
       GoKind: 22
-      Pointee: 677 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 679 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 678
+      ID: 680
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 946048
       GoKind: 22
-      Pointee: 485 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 487 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 664
+      ID: 666
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 665 StructureType google.golang.org/grpc.dropError
+      Pointee: 667 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 813
+      ID: 815
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.258816e+06
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 816 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 838
+      ID: 840
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.444128e+06
       GoKind: 22
-      Pointee: 839 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 841 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 666
+      ID: 668
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942400
       GoKind: 22
-      Pointee: 667 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 669 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 985
+      ID: 987
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.809088e+06
       GoKind: 22
-      Pointee: 986 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 988 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 943
+      ID: 945
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.25536e+06
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 946 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 755
+      ID: 757
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.07872e+06
       GoKind: 22
-      Pointee: 756 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 758 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 905
+      ID: 907
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 942496
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 908 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 644
+      ID: 646
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 927520
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 647 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 743
+      ID: 745
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.055424e+06
       GoKind: 22
-      Pointee: 744 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 746 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 811
+      ID: 813
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.226688e+06
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 814 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 809
+      ID: 811
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.226432e+06
       GoKind: 22
-      Pointee: 810 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 812 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 658
+      ID: 660
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932224
       GoKind: 22
-      Pointee: 659 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 661 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 660
+      ID: 662
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 932320
       GoKind: 22
-      Pointee: 661 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 663 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 588
+      ID: 590
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 919744
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 591 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 993
+      ID: 995
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.899488e+06
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 996 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 679
+      ID: 681
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 946816
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType html/template.Error
+      Pointee: 682 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -5145,115 +5118,115 @@ Types:
       GoKind: 22
       Pointee: 81 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 840
+      ID: 842
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.210784e+06
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType internal/abi.Type
+      Pointee: 843 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 556
+      ID: 558
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 912928
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 559 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 554
+      ID: 556
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 912832
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 557 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 891
+      ID: 893
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 900832
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 894 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 772
+      ID: 774
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.198016e+06
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 775 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1080
+      ID: 1082
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.372384e+06
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1083 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 770
+      ID: 772
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.197888e+06
       GoKind: 22
-      Pointee: 771 StructureType internal/poll.errNetClosing
+      Pointee: 773 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 490
+      ID: 492
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900064
       GoKind: 22
-      Pointee: 491 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 493 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 553
+      ID: 555
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 912640
       GoKind: 22
-      Pointee: 444 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 446 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 446
+      ID: 448
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 445 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 447 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 727
+      ID: 729
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.042368e+06
       GoKind: 22
-      Pointee: 728 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 730 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 937
+      ID: 939
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.189312e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType io.PipeWriter
+      Pointee: 940 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 935
+      ID: 937
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.188928e+06
       GoKind: 22
-      Pointee: 936 StructureType io.discard
+      Pointee: 938 StructureType io.discard
     - __kind: PointerType
-      ID: 909
+      ID: 911
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.0224e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType io.multiWriter
+      Pointee: 912 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 768
+      ID: 770
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.197376e+06
       GoKind: 22
-      Pointee: 769 UnresolvedPointeeType io/fs.PathError
+      Pointee: 771 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 983
+      ID: 985
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.803712e+06
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 986 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 234
       Name: '*main.deepMap2'
@@ -5262,12 +5235,12 @@ Types:
       GoKind: 22
       Pointee: 235 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1125
+      ID: 1127
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385888
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType main.deepMap3
+      Pointee: 1128 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 73
       Name: '*main.deepMap7'
@@ -5297,12 +5270,12 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1084
+      ID: 1086
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1087 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 59
       Name: '*main.deepPtr7'
@@ -5332,12 +5305,12 @@ Types:
       GoKind: 22
       Pointee: 225 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1110
+      ID: 1112
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387040
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1113 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 65
       Name: '*main.deepSlice7'
@@ -5373,12 +5346,12 @@ Types:
       GoKind: 22
       Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1101
+      ID: 1103
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 895744
       GoKind: 22
-      Pointee: 1102 StructureType main.firstBehavior
+      Pointee: 1104 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 157
       Name: '*main.node'
@@ -5393,19 +5366,19 @@ Types:
       GoKind: 22
       Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1103
+      ID: 1105
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 895840
       GoKind: 22
-      Pointee: 1104 StructureType main.secondBehavior
+      Pointee: 1106 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1089
+      ID: 1091
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 895936
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1092 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 75
       Name: '*main.stringType1'
@@ -5413,16 +5386,16 @@ Types:
       GoKind: 22
       Pointee: 76 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1087
+      ID: 1089
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1086 GoStringDataType main.stringType1.str
+      Pointee: 1088 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 78
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType main.stringType2
+      Pointee: 1090 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
       ID: 175
       Name: '*main.structWithCyclicSlices'
@@ -5453,10 +5426,10 @@ Types:
       GoKind: 22
       Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1107
+      ID: 1109
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1106 GoSliceDataType main.t.array
+      Pointee: 1108 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 170
       Name: '*main.threeStringStruct'
@@ -5489,10 +5462,10 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1115
+      ID: 1117
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1116 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1118 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1151
       Name: '*map<int,*main.deepMap8>'
@@ -5529,10 +5502,10 @@ Types:
       ByteSize: 8
       Pointee: 108 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 846
+      ID: 848
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 847 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 849 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 102
       Name: '*map<string,int>'
@@ -5590,451 +5563,451 @@ Types:
       GoKind: 22
       Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 592
+      ID: 594
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920608
       GoKind: 22
-      Pointee: 593 StructureType math/big.ErrNaN
+      Pointee: 595 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 899
+      ID: 901
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 915424
       GoKind: 22
-      Pointee: 900 StructureType mime/multipart.writerOnly·1
+      Pointee: 902 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 799
+      ID: 801
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.205952e+06
       GoKind: 22
-      Pointee: 800 UnresolvedPointeeType net.AddrError
+      Pointee: 802 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 825
+      ID: 827
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.420288e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType net.DNSError
+      Pointee: 828 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1044
+      ID: 1046
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.230656e+06
       GoKind: 22
-      Pointee: 1045 UnresolvedPointeeType net.IPConn
+      Pointee: 1047 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 823
+      ID: 825
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.419968e+06
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType net.OpError
+      Pointee: 826 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 801
+      ID: 803
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.20608e+06
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType net.ParseError
+      Pointee: 804 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1054
+      ID: 1056
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.259488e+06
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType net.TCPConn
+      Pointee: 1057 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1064
+      ID: 1066
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.304992e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType net.UDPConn
+      Pointee: 1067 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1052
+      ID: 1054
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.258976e+06
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType net.UnixConn
+      Pointee: 1055 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 798
+      ID: 800
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.205184e+06
       GoKind: 22
-      Pointee: 761 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 763 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 763
+      ID: 765
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 762 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 764 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 725
+      ID: 727
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.038144e+06
       GoKind: 22
-      Pointee: 726 StructureType net.canceledError
+      Pointee: 728 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1020
+      ID: 1022
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.008064e+06
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType net.conn
+      Pointee: 1023 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 872
+      ID: 874
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.846496e+06
       GoKind: 22
-      Pointee: 873 StructureType net.dialResult·1
+      Pointee: 875 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1066
+      ID: 1068
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.309248e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType net.netFD
+      Pointee: 1069 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 522
+      ID: 524
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907360
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType net.notFoundError
+      Pointee: 525 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 524
+      ID: 526
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908032
       GoKind: 22
-      Pointee: 525 StructureType net.result·2
+      Pointee: 527 StructureType net.result·2
     - __kind: PointerType
-      ID: 1048
+      ID: 1050
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.245024e+06
       GoKind: 22
-      Pointee: 1049 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1051 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1046
+      ID: 1048
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.244544e+06
       GoKind: 22
-      Pointee: 1047 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1049 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 803
+      ID: 805
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.20672e+06
       GoKind: 22
-      Pointee: 804 UnresolvedPointeeType net.temporaryError
+      Pointee: 806 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 827
+      ID: 829
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.420448e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net.timeoutError
+      Pointee: 830 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 715
+      ID: 717
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.03392e+06
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 718 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 893
+      ID: 895
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 903136
       GoKind: 22
-      Pointee: 894 StructureType net/http.bufioFlushWriter
+      Pointee: 896 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 499
+      ID: 501
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 903808
       GoKind: 22
-      Pointee: 414 BaseType net/http.http2ConnectionError
+      Pointee: 416 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 500
+      ID: 502
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 903904
       GoKind: 22
-      Pointee: 501 StructureType net/http.http2GoAwayError
+      Pointee: 503 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 819
+      ID: 821
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.415968e+06
       GoKind: 22
-      Pointee: 820 StructureType net/http.http2StreamError
+      Pointee: 822 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 504
+      ID: 506
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 904480
       GoKind: 22
-      Pointee: 505 StructureType net/http.http2connError
+      Pointee: 507 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 955
+      ID: 957
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.553632e+06
       GoKind: 22
-      Pointee: 956 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 958 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 503
+      ID: 505
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904384
       GoKind: 22
-      Pointee: 418 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 420 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 420
+      ID: 422
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 421 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 507
+      ID: 509
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 904672
       GoKind: 22
-      Pointee: 424 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 426 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 426
+      ID: 428
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 425 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 427 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 506
+      ID: 508
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 904576
       GoKind: 22
-      Pointee: 421 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 423 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 423
+      ID: 425
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 422 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 424 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 794
+      ID: 796
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.201856e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 797 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 721
+      ID: 723
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.03456e+06
       GoKind: 22
-      Pointee: 722 StructureType net/http.http2noCachedConnError
+      Pointee: 724 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1009
+      ID: 1011
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.950368e+06
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1012 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 502
+      ID: 504
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904288
       GoKind: 22
-      Pointee: 415 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 417 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 417
+      ID: 419
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 416 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 418 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 895
+      ID: 897
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 904768
       GoKind: 22
-      Pointee: 896 StructureType net/http.http2stickyErrWriter
+      Pointee: 898 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 717
+      ID: 719
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.034176e+06
       GoKind: 22
-      Pointee: 718 StructureType net/http.nothingWrittenError
+      Pointee: 720 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 957
+      ID: 959
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.174528e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType net/http.persistConn
+      Pointee: 960 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 913
+      ID: 915
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.034048e+06
       GoKind: 22
-      Pointee: 914 StructureType net/http.persistConnWriter
+      Pointee: 916 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 947
+      ID: 949
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.416128e+06
       GoKind: 22
-      Pointee: 948 StructureType net/http.readWriteCloserBody
+      Pointee: 950 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 508
+      ID: 510
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 904864
       GoKind: 22
-      Pointee: 509 StructureType net/http.requestBodyReadError
+      Pointee: 511 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 821
+      ID: 823
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.417248e+06
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 824 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 792
+      ID: 794
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.201728e+06
       GoKind: 22
-      Pointee: 793 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 795 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 719
+      ID: 721
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.034304e+06
       GoKind: 22
-      Pointee: 720 StructureType net/http.transportReadFromServerError
+      Pointee: 722 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 989
+      ID: 991
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.843136e+06
       GoKind: 22
-      Pointee: 990 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 992 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 497
+      ID: 499
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 903040
       GoKind: 22
-      Pointee: 498 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 500 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1011
+      ID: 1013
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.95216e+06
       GoKind: 22
-      Pointee: 1012 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1014 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 923
+      ID: 925
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.046848e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 926 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 584
+      ID: 586
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 919552
       GoKind: 22
-      Pointee: 585 StructureType net/netip.parseAddrError
+      Pointee: 587 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 582
+      ID: 584
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 919456
       GoKind: 22
-      Pointee: 583 StructureType net/netip.parsePrefixError
+      Pointee: 585 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 963
+      ID: 965
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.117024e+06
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType net/smtp.Client
+      Pointee: 966 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 925
+      ID: 927
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.051712e+06
       GoKind: 22
-      Pointee: 926 StructureType net/smtp.dataCloser
+      Pointee: 928 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 568
+      ID: 570
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 915616
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType net/textproto.Error
+      Pointee: 571 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 567
+      ID: 569
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 915520
       GoKind: 22
-      Pointee: 452 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 454 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 454
+      ID: 456
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 453 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 455 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 921
+      ID: 923
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.04608e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 924 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 829
+      ID: 831
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.420768e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType net/url.Error
+      Pointee: 832 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 526
+      ID: 528
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 908128
       GoKind: 22
-      Pointee: 427 GoStringHeaderType net/url.EscapeError
+      Pointee: 429 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 429
+      ID: 431
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 428 GoStringDataType net/url.EscapeError.str
+      Pointee: 430 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 527
+      ID: 529
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 430 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 432 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 432
+      ID: 434
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 431 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 433 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 332
       Name: '*noalg.map.group[[4]int][4]int'
@@ -6061,10 +6034,10 @@ Types:
       ByteSize: 8
       Pointee: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1121
+      ID: 1123
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1122 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1124 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1157
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -6101,10 +6074,10 @@ Types:
       ByteSize: 8
       Pointee: 265 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 879
+      ID: 881
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 882 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
       ID: 256
       Name: '*noalg.map.group[string]int'
@@ -6156,174 +6129,174 @@ Types:
       ByteSize: 8
       Pointee: 308 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1072
+      ID: 1074
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.348736e+06
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType os.File
+      Pointee: 1075 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 696
+      ID: 698
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.025216e+06
       GoKind: 22
-      Pointee: 697 UnresolvedPointeeType os.LinkError
+      Pointee: 699 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 764
+      ID: 766
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.19072e+06
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType os.SyscallError
+      Pointee: 767 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1070
+      ID: 1072
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.347264e+06
       GoKind: 22
-      Pointee: 1071 StructureType os.fileWithoutReadFrom
+      Pointee: 1073 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1068
+      ID: 1070
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.346528e+06
       GoKind: 22
-      Pointee: 1069 StructureType os.fileWithoutWriteTo
+      Pointee: 1071 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 729
+      ID: 731
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.042752e+06
       GoKind: 22
-      Pointee: 730 UnresolvedPointeeType os/exec.Error
+      Pointee: 732 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 875
+      ID: 877
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.088288e+06
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 878 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 941
+      ID: 943
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.212992e+06
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 944 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 731
+      ID: 733
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.04288e+06
       GoKind: 22
-      Pointee: 732 StructureType os/exec.wrappedError
+      Pointee: 734 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 663
+      ID: 665
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 466 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 468 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 468
+      ID: 470
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 467 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 469 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 662
+      ID: 664
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 937312
       GoKind: 22
-      Pointee: 465 BaseType os/user.UnknownUserIdError
+      Pointee: 467 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 492
+      ID: 494
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 900736
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType reflect.ValueError
+      Pointee: 495 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 590
+      ID: 592
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 593 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 700
+      ID: 702
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.026752e+06
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 703 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 704
+      ID: 706
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.028544e+06
       GoKind: 22
-      Pointee: 705 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 707 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
-      ID: 702
+      ID: 704
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.02688e+06
       GoKind: 22
-      Pointee: 703 StructureType runtime.boundsError
+      Pointee: 705 StructureType runtime.boundsError
     - __kind: PointerType
-      ID: 766
+      ID: 768
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.196224e+06
       GoKind: 22
-      Pointee: 767 StructureType runtime.errorAddressString
+      Pointee: 769 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 698
+      ID: 700
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.026368e+06
       GoKind: 22
-      Pointee: 681 GoStringHeaderType runtime.errorString
+      Pointee: 683 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 683
+      ID: 685
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 682 GoStringDataType runtime.errorString.str
+      Pointee: 684 GoStringDataType runtime.errorString.str
     - __kind: PointerType
-      ID: 699
+      ID: 701
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.026496e+06
       GoKind: 22
-      Pointee: 684 GoStringHeaderType runtime.plainError
+      Pointee: 686 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 686
+      ID: 688
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 685 GoStringDataType runtime.plainError.str
+      Pointee: 687 GoStringDataType runtime.plainError.str
     - __kind: PointerType
-      ID: 842
+      ID: 844
       Name: '*runtime.synctestBubble'
       ByteSize: 8
       GoRuntimeType: 1.551392e+06
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType runtime.synctestBubble
+      Pointee: 845 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 488
+      ID: 490
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 899392
       GoKind: 22
-      Pointee: 489 StructureType runtime.synctestDeadlockError
+      Pointee: 491 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
-      ID: 706
+      ID: 708
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.0288e+06
       GoKind: 22
-      Pointee: 707 UnresolvedPointeeType strconv.NumError
+      Pointee: 709 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -6337,33 +6310,33 @@ Types:
       ByteSize: 8
       Pointee: 221 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1007
+      ID: 1009
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.949088e+06
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType strings.Builder
+      Pointee: 1010 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 911
+      ID: 913
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.028928e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 914 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 907
+      ID: 909
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 970400
       GoKind: 22
-      Pointee: 908 StructureType struct { io.Writer }
+      Pointee: 910 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 818
+      ID: 820
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.415328e+06
       GoKind: 22
-      Pointee: 817 BaseType syscall.Errno
+      Pointee: 819 BaseType syscall.Errno
     - __kind: PointerType
       ID: 152
       Name: '*table<[4]int,[4]int>'
@@ -6390,10 +6363,10 @@ Types:
       ByteSize: 8
       Pointee: 228 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1118
+      ID: 1120
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1119 StructureType table<int,*main.deepMap3>
+      Pointee: 1121 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1154
       Name: '*table<int,*main.deepMap8>'
@@ -6430,10 +6403,10 @@ Types:
       ByteSize: 8
       Pointee: 262 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 849
+      ID: 851
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 877 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 879 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 105
       Name: '*table<string,int>'
@@ -6485,45 +6458,45 @@ Types:
       ByteSize: 8
       Pointee: 305 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1042
+      ID: 1044
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.158656e+06
       GoKind: 22
-      Pointee: 1043 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1045 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 759
+      ID: 761
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.08832e+06
       GoKind: 22
-      Pointee: 760 StructureType text/template.ExecError
+      Pointee: 762 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 834
+      ID: 836
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6216e+06
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType time.Location
+      Pointee: 837 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 495
+      ID: 497
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 901600
       GoKind: 22
-      Pointee: 496 UnresolvedPointeeType time.ParseError
+      Pointee: 498 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 494
+      ID: 496
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 901504
       GoKind: 22
-      Pointee: 411 GoStringHeaderType time.fileSizeError
+      Pointee: 413 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 413
+      ID: 415
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 412 GoStringDataType time.fileSizeError.str
+      Pointee: 414 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -6567,47 +6540,47 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 586
+      ID: 588
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 919648
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 589 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1034
+      ID: 1036
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.134144e+06
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1037 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 570
+      ID: 572
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 915808
       GoKind: 22
-      Pointee: 571 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 573 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 572
+      ID: 574
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 455 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 457 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 736
+      ID: 738
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.046592e+06
       GoKind: 22
-      Pointee: 737 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 739 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 738
+      ID: 740
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.04672e+06
       GoKind: 22
-      Pointee: 689 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 691 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
       ID: 1290
       Name: Probe[main.stackC]
@@ -8598,7 +8571,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 867
+      ID: 869
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684192
@@ -8629,7 +8602,7 @@ Types:
       ByteSize: 2048
       Element: 64 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1108
+      ID: 1110
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477664
@@ -8637,19 +8610,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1109 PointerType **main.deepSlice3
+          Type: 1111 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1112 GoSliceDataType []*main.deepSlice3.array
+      Data: 1114 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1112
+      ID: 1114
       Name: '[]*main.deepSlice3.array'
       ByteSize: 2048
-      Element: 1110 PointerType *main.deepSlice3
+      Element: 1112 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1135
       Name: '[]*main.deepSlice8'
@@ -8742,10 +8715,10 @@ Types:
       ByteSize: 8192
       Element: 72 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1127
+      ID: 1129
       Name: '[]*table<int,*main.deepMap3>.array'
       ByteSize: 8192
-      Element: 1118 PointerType *table<int,*main.deepMap3>
+      Element: 1120 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1163
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -8782,10 +8755,10 @@ Types:
       ByteSize: 8192
       Element: 110 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 883
+      ID: 885
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       ByteSize: 8192
-      Element: 849 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 851 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]*table<string,int>.array'
@@ -8985,7 +8958,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 862
+      ID: 864
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 486944
@@ -9000,9 +8973,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 887 GoSliceDataType []float64.array
+      Data: 889 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 887
+      ID: 889
       Name: '[]float64.array'
       ByteSize: 2048
       Element: 16 BaseType float64
@@ -9065,9 +9038,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1129 GoSliceDataType []main.structWithMap.array
+      Data: 411 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 1129
+      ID: 411
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 90 StructureType main.structWithMap
@@ -9118,10 +9091,10 @@ Types:
       ByteSize: 2048
       Element: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1128
+      ID: 1130
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       ByteSize: 2048
-      Element: 1122 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1124 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1164
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -9158,10 +9131,10 @@ Types:
       ByteSize: 2048
       Element: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 884
+      ID: 886
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 2048
-      Element: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 882 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]noalg.map.group[string]int.array'
@@ -9279,7 +9252,7 @@ Types:
       ByteSize: 2048
       Element: 6 BaseType uint16
     - __kind: GoSliceHeaderType
-      ID: 856
+      ID: 858
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 485920
@@ -9294,18 +9267,18 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 885 GoSliceDataType []uint8.array
+      Data: 887 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 885
+      ID: 887
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1019
+      ID: 1021
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 649
+      ID: 651
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 930784
@@ -9320,32 +9293,32 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 650 GoSliceDataType archive/tar.headerError.array
+      Data: 652 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 650
+      ID: 652
       Name: archive/tar.headerError.array
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 954
+      ID: 956
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 904
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 904
+      ID: 906
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.119616e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1000
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 930
+      ID: 932
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.564352e+06
@@ -9355,7 +9328,7 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 934
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -9365,15 +9338,15 @@ Types:
       GoRuntimeType: 584960
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 979
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1008
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1059
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -9399,13 +9372,13 @@ Types:
       GoRuntimeType: 584704
       GoKind: 15
     - __kind: BaseType
-      ID: 447
+      ID: 449
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834048
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 448
+      ID: 450
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 834144
@@ -9413,115 +9386,115 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 450 PointerType *compress/flate.InternalError.str
+          Type: 452 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 449 GoStringDataType compress/flate.InternalError.str
+      Data: 451 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 449
+      ID: 451
       Name: compress/flate.InternalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 954
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 900
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 976
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 797
+      ID: 799
       Name: context.deadlineExceededError
       GoRuntimeType: 1.478592e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 461
+      ID: 463
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 2
     - __kind: BaseType
-      ID: 462
+      ID: 464
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 2
     - __kind: BaseType
-      ID: 463
+      ID: 465
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836832
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 971
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 746
+      ID: 748
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.288576e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1002
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1032
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1006
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1004
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 998
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 464
+      ID: 466
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1017
+      ID: 1019
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 994
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 451
+      ID: 453
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 834624
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 735
+      ID: 737
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1085
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 565
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 561
+      ID: 563
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.72944e+06
@@ -9532,38 +9505,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 867 ArrayType [5]uint8
+          Type: 869 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 688
+      ID: 690
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 992768
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 964
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 565
+      ID: 567
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 969
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 834
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 853
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 637
+      ID: 639
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.73232e+06
@@ -9571,21 +9544,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 850 PointerType *crypto/x509.Certificate
+          Type: 852 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 870 BaseType crypto/x509.InvalidReason
+          Type: 872 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 631
+      ID: 633
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.117184e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 633
+      ID: 635
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.598464e+06
@@ -9593,24 +9566,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 850 PointerType *crypto/x509.Certificate
+          Type: 852 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 460
+      ID: 462
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836256
       GoKind: 2
     - __kind: BaseType
-      ID: 870
+      ID: 872
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 590144
       GoKind: 2
     - __kind: StructureType
-      ID: 740
+      ID: 742
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.560352e+06
@@ -9620,13 +9593,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 639
+      ID: 641
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.11744e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 635
+      ID: 637
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.732128e+06
@@ -9634,15 +9607,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 850 PointerType *crypto/x509.Certificate
+          Type: 852 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 850 PointerType *crypto/x509.Certificate
+          Type: 852 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 653
+      ID: 655
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.435008e+06
@@ -9652,7 +9625,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 657
+      ID: 659
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.435168e+06
@@ -9662,55 +9635,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 657
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 442
+      ID: 444
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 833568
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 922
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 443
+      ID: 445
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 833760
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 519
+      ID: 521
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 724
+      ID: 726
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 511
+      ID: 513
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 517
+      ID: 519
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 515
+      ID: 517
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 513
+      ID: 515
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1065
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 521
+      ID: 523
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.419008e+06
@@ -9720,19 +9693,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 930
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 627
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 625
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 457
+      ID: 459
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 836160
@@ -9740,21 +9713,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 459 PointerType *encoding/xml.UnmarshalError.str
+          Type: 461 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 458 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 460 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 458
+      ID: 460
       Name: encoding/xml.UnmarshalError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 630
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1043
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -9771,11 +9744,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 487
+      ID: 489
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 693
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -9791,15 +9764,15 @@ Types:
       GoRuntimeType: 584896
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1051
+      ID: 1053
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 695
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 697
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -9809,11 +9782,11 @@ Types:
       GoRuntimeType: 475872
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 549
+      ID: 551
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 530
+      ID: 532
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.728288e+06
@@ -9821,7 +9794,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 860 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 862 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -9829,25 +9802,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 534
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 866
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 536
+      ID: 538
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.113472e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 868
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 436
+      ID: 438
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 832992
@@ -9855,17 +9828,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 438 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 440 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 437 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 439 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 437
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 860
+      ID: 862
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.217952e+06
@@ -9873,7 +9846,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 861 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 863 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -9888,7 +9861,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 862 GoSliceHeaderType []float64
+          Type: 864 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -9897,10 +9870,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 863 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 865 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 865 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 867 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 166 GoSliceHeaderType []string
@@ -9914,13 +9887,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 861
+      ID: 863
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586752
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 433
+      ID: 435
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 832896
@@ -9928,17 +9901,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 437 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 436 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 434
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 439
+      ID: 441
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 833088
@@ -9946,59 +9919,59 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 441 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 443 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 440 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 442 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 440
+      ID: 442
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 942
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1029
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 649
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 808
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1061
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 576
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 581
+      ID: 583
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.116416e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 456
+      ID: 458
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 835296
       GoKind: 2
     - __kind: StructureType
-      ID: 579
+      ID: 581
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.116288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 577
+      ID: 579
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.596544e+06
@@ -10011,7 +9984,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 597
+      ID: 599
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.597344e+06
@@ -10024,7 +9997,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 601
+      ID: 603
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.731552e+06
@@ -10040,7 +10013,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 599
+      ID: 601
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.428928e+06
@@ -10050,7 +10023,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 595
+      ID: 597
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.428608e+06
@@ -10060,14 +10033,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 845
+      ID: 847
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.499552e+06
       GoKind: 21
-      HeaderType: 847 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 849 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 869
+      ID: 871
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.050176e+06
@@ -10082,14 +10055,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 889 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 891 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 889
+      ID: 891
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 609
+      ID: 611
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.597664e+06
@@ -10097,12 +10070,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 845 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 847 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 845 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 847 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 603
+      ID: 605
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.429088e+06
@@ -10112,7 +10085,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 609
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.731744e+06
@@ -10123,12 +10096,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 871 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 871 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 605
+      ID: 607
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.597504e+06
@@ -10141,7 +10114,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 611
+      ID: 613
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.429248e+06
@@ -10149,9 +10122,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 833 StructureType time.Time
+          Type: 835 StructureType time.Time
     - __kind: StructureType
-      ID: 617
+      ID: 619
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.597984e+06
@@ -10164,7 +10137,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 619
+      ID: 621
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.429568e+06
@@ -10174,7 +10147,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 615
+      ID: 617
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.597824e+06
@@ -10187,7 +10160,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 613
+      ID: 615
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.429408e+06
@@ -10197,7 +10170,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 621
+      ID: 623
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.598144e+06
@@ -10210,7 +10183,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 538
+      ID: 540
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.421248e+06
@@ -10220,11 +10193,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 982
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 540
+      ID: 542
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.421408e+06
@@ -10232,21 +10205,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 538 StructureType github.com/cihub/seelog.baseError
+          Type: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 962
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 918
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 952
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 544
+      ID: 546
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.421728e+06
@@ -10254,13 +10227,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 538 StructureType github.com/cihub/seelog.baseError
+          Type: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1015
+      ID: 1017
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1028
+      ID: 1030
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.10544e+06
@@ -10268,12 +10241,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1014 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1016 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1031
+      ID: 1033
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.130304e+06
@@ -10281,7 +10254,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1014 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1016 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -10289,11 +10262,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 920
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 542
+      ID: 544
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.421568e+06
@@ -10301,9 +10274,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 538 StructureType github.com/cihub/seelog.baseError
+          Type: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 546
+      ID: 548
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.421888e+06
@@ -10311,64 +10284,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 538 StructureType github.com/cihub/seelog.baseError
+          Type: 540 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 984
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1025
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1027
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 839
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 752
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 750
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 752
+      ID: 754
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 754
+      ID: 756
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 971
+      ID: 973
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 744
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 552
+      ID: 554
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.422848e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1077
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 810
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 781
+      ID: 783
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.841344e+06
@@ -10384,11 +10357,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 775
+      ID: 777
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 710
+      ID: 712
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.700992e+06
@@ -10401,7 +10374,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 787
+      ID: 789
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.841792e+06
@@ -10417,13 +10390,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 687
+      ID: 689
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 990080
       GoKind: 8
     - __kind: StructureType
-      ID: 779
+      ID: 781
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.84112e+06
@@ -10439,13 +10412,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 871
+      ID: 873
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 831168
       GoKind: 8
     - __kind: StructureType
-      ID: 777
+      ID: 779
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.840896e+06
@@ -10453,15 +10426,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 871 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 873 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 871 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 873 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 785
+      ID: 787
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.754944e+06
@@ -10474,7 +10447,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 783
+      ID: 785
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.841568e+06
@@ -10490,11 +10463,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1081
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 791
+      ID: 793
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.62256e+06
@@ -10504,19 +10477,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 714
+      ID: 716
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.28256e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 712
+      ID: 714
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.282432e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 789
+      ID: 791
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.755136e+06
@@ -10529,7 +10502,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 469
+      ID: 471
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 838752
@@ -10537,21 +10510,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 471 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 473 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 470 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 472 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 470
+      ID: 472
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 856
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 758
+      ID: 760
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.446848e+06
@@ -10561,7 +10534,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 946
+      ID: 948
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.676704e+06
@@ -10569,13 +10542,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 972 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 974 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1041
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 972
+      ID: 974
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.127168e+06
@@ -10588,7 +10561,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 934
+      ID: 936
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.569152e+06
@@ -10598,19 +10571,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 472
+      ID: 474
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 839328
       GoKind: 10
     - __kind: BaseType
-      ID: 852
+      ID: 854
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.003232e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 816
+      ID: 818
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.879648e+06
@@ -10621,12 +10594,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 852 BaseType golang.org/x/net/http2.ErrCode
+          Type: 854 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 673
+      ID: 675
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.605184e+06
@@ -10634,12 +10607,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 852 BaseType golang.org/x/net/http2.ErrCode
+          Type: 854 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 476
+      ID: 478
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839520
@@ -10647,17 +10620,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 478 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 480 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 477 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 479 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 477
+      ID: 479
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 482
+      ID: 484
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 839712
@@ -10665,17 +10638,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 484 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 486 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 483 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 485 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 483
+      ID: 485
       Name: golang.org/x/net/http2.headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 479
+      ID: 481
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 839616
@@ -10683,17 +10656,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 481 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 483 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 480 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 482 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 480
+      ID: 482
       Name: golang.org/x/net/http2.headerFieldValueError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 473
+      ID: 475
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839424
@@ -10701,21 +10674,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 475 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 477 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 474 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 476 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 474
+      ID: 476
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1037
+      ID: 1039
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 679
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.447488e+06
@@ -10725,13 +10698,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 485
+      ID: 487
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 839808
       GoKind: 2
     - __kind: StructureType
-      ID: 665
+      ID: 667
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.442528e+06
@@ -10741,11 +10714,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 816
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 839
+      ID: 841
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.907424e+06
@@ -10761,7 +10734,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 667
+      ID: 669
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.604704e+06
@@ -10774,7 +10747,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 986
+      ID: 988
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.965472e+06
@@ -10782,16 +10755,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1013 GoInterfaceType io.Reader
+          Type: 1015 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 946
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 756
+      ID: 758
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.566752e+06
@@ -10801,29 +10774,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 908
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 647
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 744
+      ID: 746
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 814
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 812
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.510272e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 659
+      ID: 661
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.435808e+06
@@ -10833,7 +10806,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 661
+      ID: 663
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.435968e+06
@@ -10843,7 +10816,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 591
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -10917,19 +10890,19 @@ Types:
       GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
       GroupSliceType: 237 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1120
+      ID: 1122
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1121 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1123 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1122 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1128 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1124 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1130 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1156
       Name: groupReference<int,*main.deepMap8>
@@ -11029,19 +11002,19 @@ Types:
       GroupType: 265 StructureType noalg.map.group[string][]string
       GroupSliceType: 269 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 878
+      ID: 880
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 879 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 881 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 884 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 882 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 886 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
       ID: 255
       Name: groupReference<string,int>
@@ -11183,11 +11156,11 @@ Types:
       GroupType: 308 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 312 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 996
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 682
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -11234,41 +11207,41 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 843
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 559
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 557
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 894
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 775
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1083
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 771
+      ID: 773
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.475392e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 491
+      ID: 493
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 444
+      ID: 446
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 833952
@@ -11276,17 +11249,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 446 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 448 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 445 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 447 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 445
+      ID: 447
       Name: internal/runtime/cgroup.stringError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 728
+      ID: 730
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.558112e+06
@@ -11294,9 +11267,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 840 PointerType *internal/abi.Type
+          Type: 842 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 1093
+      ID: 1095
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.472832e+06
@@ -11309,11 +11282,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 940
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 978
+      ID: 980
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.189056e+06
@@ -11326,7 +11299,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1013
+      ID: 1015
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.022528e+06
@@ -11339,7 +11312,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 965
+      ID: 967
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -11365,21 +11338,21 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 936
+      ID: 938
       Name: io.discard
       GoRuntimeType: 1.461952e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 912
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 769
+      ID: 771
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 986
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -11447,9 +11420,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1114 GoMapType map[int]*main.deepMap3
+          Type: 1116 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1128
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -11501,9 +11474,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1084 PointerType *main.deepPtr3
+          Type: 1086 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1087
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -11555,9 +11528,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1108 GoSliceHeaderType []*main.deepSlice3
+          Type: 1110 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1113
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -11607,16 +11580,16 @@ Types:
           Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1091 StructureType sync.Mutex
+          Type: 1093 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1094 StructureType sync.Once
+          Type: 1096 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1097 StructureType sync.WaitGroup
+          Type: 1099 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1100 StructureType sync/atomic.Int32
+          Type: 1102 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 79
       Name: main.esotericStack
@@ -11646,7 +11619,7 @@ Types:
           Offset: 56
           Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1102
+      ID: 1104
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.411488e+06
@@ -11691,7 +11664,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1104
+      ID: 1106
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.411648e+06
@@ -11711,7 +11684,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1092
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -11722,17 +11695,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1087 PointerType *main.stringType1.str
+          Type: 1089 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1086 GoStringDataType main.stringType1.str
+      Data: 1088 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1086
+      ID: 1088
       Name: main.stringType1.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1090
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -11835,16 +11808,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1105 PointerType **main.t
+          Type: 1107 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1106 GoSliceDataType main.t.array
+      Data: 1108 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1106
+      ID: 1108
       Name: main.t.array
       ByteSize: 2048
       Element: 158 PointerType *main.t
@@ -12044,7 +12017,7 @@ Types:
       TablePtrSliceType: 236 GoSliceDataType []*table<int,*main.deepMap2>.array
       GroupType: 231 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1116
+      ID: 1118
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -12057,7 +12030,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1117 PointerType **table<int,*main.deepMap3>
+          Type: 1119 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12076,8 +12049,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1127 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1122 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1129 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1124 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1152
       Name: map<int,*main.deepMap8>
@@ -12324,7 +12297,7 @@ Types:
       TablePtrSliceType: 268 GoSliceDataType []*table<string,[]string>.array
       GroupType: 265 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 847
+      ID: 849
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -12337,7 +12310,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 848 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 850 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -12356,8 +12329,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 883 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 880 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 885 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 882 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 103
       Name: map<string,int>
@@ -12744,12 +12717,12 @@ Types:
       GoKind: 21
       HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1114
+      ID: 1116
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.128832e+06
       GoKind: 21
-      HeaderType: 1116 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1118 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1150
       Name: map[int]*main.deepMap8
@@ -12864,7 +12837,7 @@ Types:
       GoKind: 21
       HeaderType: 135 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 593
+      ID: 595
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.428128e+06
@@ -12874,7 +12847,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 902
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.424928e+06
@@ -12884,11 +12857,11 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 800
+      ID: 802
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 868
+      ID: 870
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.595264e+06
@@ -12901,35 +12874,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 828
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1045
+      ID: 1047
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 826
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 804
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1057
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1067
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1055
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 761
+      ID: 763
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.113088e+06
@@ -12937,27 +12910,27 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 763 PointerType *net.UnknownNetworkError.str
+          Type: 765 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 762 GoStringDataType net.UnknownNetworkError.str
+      Data: 764 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 762
+      ID: 764
       Name: net.UnknownNetworkError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 726
+      ID: 728
       Name: net.canceledError
       GoRuntimeType: 1.283584e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1023
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 873
+      ID: 875
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.104736e+06
@@ -12965,7 +12938,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -12976,27 +12949,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1069
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1061
+      ID: 1063
       Name: net.noReadFrom
       GoRuntimeType: 1.113344e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1060
+      ID: 1062
       Name: net.noWriteTo
       GoRuntimeType: 1.113216e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 525
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 525
+      ID: 527
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.728096e+06
@@ -13004,7 +12977,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 855 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 857 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -13012,7 +12985,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1049
+      ID: 1051
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.287744e+06
@@ -13020,12 +12993,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1061 StructureType net.noReadFrom
+          Type: 1063 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1054 PointerType *net.TCPConn
+          Type: 1056 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1047
+      ID: 1049
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.2872e+06
@@ -13033,24 +13006,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1060 StructureType net.noWriteTo
+          Type: 1062 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1054 PointerType *net.TCPConn
+          Type: 1056 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 804
+      ID: 806
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 830
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 718
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 894
+      ID: 896
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.416448e+06
@@ -13060,19 +13033,19 @@ Types:
           Offset: 0
           Type: 55 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 414
+      ID: 416
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 831648
       GoKind: 10
     - __kind: BaseType
-      ID: 844
+      ID: 846
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 990176
       GoKind: 10
     - __kind: StructureType
-      ID: 501
+      ID: 503
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.726368e+06
@@ -13083,12 +13056,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 844 BaseType net/http.http2ErrCode
+          Type: 846 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 820
+      ID: 822
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.897952e+06
@@ -13099,12 +13072,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 844 BaseType net/http.http2ErrCode
+          Type: 846 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 505
+      ID: 507
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.594784e+06
@@ -13112,16 +13085,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 844 BaseType net/http.http2ErrCode
+          Type: 846 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 956
+      ID: 958
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 418
+      ID: 420
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 831840
@@ -13129,17 +13102,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 420 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 422 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 419 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 421 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 419
+      ID: 421
       Name: net/http.http2duplicatePseudoHeaderError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 424
+      ID: 426
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 832032
@@ -13147,17 +13120,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 426 PointerType *net/http.http2headerFieldNameError.str
+          Type: 428 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 425 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 427 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 425
+      ID: 427
       Name: net/http.http2headerFieldNameError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 421
+      ID: 423
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 831936
@@ -13165,31 +13138,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 423 PointerType *net/http.http2headerFieldValueError.str
+          Type: 425 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 422 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 424 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 422
+      ID: 424
       Name: net/http.http2headerFieldValueError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 797
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 724
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.282816e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1012
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 415
+      ID: 417
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 831744
@@ -13197,17 +13170,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 417 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 419 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 416 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 418 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 416
+      ID: 418
       Name: net/http.http2pseudoHeaderError.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 896
+      ID: 898
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.824032e+06
@@ -13215,18 +13188,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 987 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 989 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 988 BaseType time.Duration
+          Type: 990 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 33 PointerType *error
     - __kind: GoInterfaceType
-      ID: 987
+      ID: 989
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.415648e+06
@@ -13239,14 +13212,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 975
+      ID: 977
       Name: net/http.incomparable
       GoRuntimeType: 902848
       GoKind: 17
       HasCount: true
       Element: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 718
+      ID: 720
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.554272e+06
@@ -13256,11 +13229,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 960
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 914
+      ID: 916
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.554112e+06
@@ -13268,9 +13241,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 957 PointerType *net/http.persistConn
+          Type: 959 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 948
+      ID: 950
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.799008e+06
@@ -13278,15 +13251,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 975 ArrayType net/http.incomparable
+          Type: 977 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 976 PointerType *bufio.Reader
+          Type: 978 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 978 GoInterfaceType io.ReadWriteCloser
+          Type: 980 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 509
+      ID: 511
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.417408e+06
@@ -13296,17 +13269,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 824
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 793
+      ID: 795
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.478272e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 720
+      ID: 722
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.554432e+06
@@ -13316,7 +13289,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 990
+      ID: 992
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.024448e+06
@@ -13324,16 +13297,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 868 GoInterfaceType net.Conn
+          Type: 870 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 498
+      ID: 500
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1012
+      ID: 1014
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.040192e+06
@@ -13341,13 +13314,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1005 PointerType *bufio.Writer
+          Type: 1007 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 926
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 585
+      ID: 587
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.731168e+06
@@ -13363,7 +13336,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 585
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.596704e+06
@@ -13376,11 +13349,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 966
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 926
+      ID: 928
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.598624e+06
@@ -13388,16 +13361,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 963 PointerType *net/smtp.Client
+          Type: 965 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 965 GoInterfaceType io.WriteCloser
+          Type: 967 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 571
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 452
+      ID: 454
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 834720
@@ -13405,25 +13378,25 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 454 PointerType *net/textproto.ProtocolError.str
+          Type: 456 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 453 GoStringDataType net/textproto.ProtocolError.str
+      Data: 455 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 453
+      ID: 455
       Name: net/textproto.ProtocolError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 924
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 832
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 427
+      ID: 429
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 832608
@@ -13431,17 +13404,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 429 PointerType *net/url.EscapeError.str
+          Type: 431 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 428 GoStringDataType net/url.EscapeError.str
+      Data: 430 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 428
+      ID: 430
       Name: net/url.EscapeError.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 430
+      ID: 432
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 832704
@@ -13449,13 +13422,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 432 PointerType *net/url.InvalidHostError.str
+          Type: 434 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 431 GoStringDataType net/url.InvalidHostError.str
+      Data: 433 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 431
+      ID: 433
       Name: net/url.InvalidHostError.str
       ByteSize: 2048
     - __kind: ArrayType
@@ -13504,14 +13477,14 @@ Types:
       HasCount: true
       Element: 233 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1123
+      ID: 1125
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 681984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1124 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1126 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1159
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -13576,14 +13549,14 @@ Types:
       HasCount: true
       Element: 267 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 881
+      ID: 883
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 758976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 882 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 884 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
       ID: 258
       Name: noalg.[8]struct { key string; elem int }
@@ -13734,7 +13707,7 @@ Types:
           Offset: 8
           Type: 232 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1122
+      ID: 1124
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.29408e+06
@@ -13745,7 +13718,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1123 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1125 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1158
       Name: noalg.map.group[int]*main.deepMap8
@@ -13838,7 +13811,7 @@ Types:
           Offset: 8
           Type: 266 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 880
+      ID: 882
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.357056e+06
@@ -13849,7 +13822,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 881 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 883 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
       ID: 257
       Name: noalg.map.group[string]int
@@ -14040,7 +14013,7 @@ Types:
           Offset: 8
           Type: 234 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1124
+      ID: 1126
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.293952e+06
@@ -14051,7 +14024,7 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1125 PointerType *main.deepMap3
+          Type: 1127 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1160
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -14144,7 +14117,7 @@ Types:
           Offset: 16
           Type: 166 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 882
+      ID: 884
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.356928e+06
@@ -14155,7 +14128,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 869 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 871 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
       ID: 259
       Name: noalg.struct { key string; elem int }
@@ -14281,19 +14254,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1075
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 697
+      ID: 699
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 767
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1071
+      ID: 1073
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.358112e+06
@@ -14301,12 +14274,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1077 StructureType os.noReadFrom
+          Type: 1079 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1072 PointerType *os.File
+          Type: 1074 PointerType *os.File
     - __kind: StructureType
-      ID: 1069
+      ID: 1071
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.357312e+06
@@ -14314,36 +14287,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1076 StructureType os.noWriteTo
+          Type: 1078 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1072 PointerType *os.File
+          Type: 1074 PointerType *os.File
     - __kind: StructureType
-      ID: 1077
+      ID: 1079
       Name: os.noReadFrom
       GoRuntimeType: 1.110656e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1076
+      ID: 1078
       Name: os.noWriteTo
       GoRuntimeType: 1.110528e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 730
+      ID: 732
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 878
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 944
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 732
+      ID: 734
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.701568e+06
@@ -14356,7 +14329,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 466
+      ID: 468
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 837984
@@ -14364,39 +14337,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 468 PointerType *os/user.UnknownGroupIdError.str
+          Type: 470 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 467 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 469 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 467
+      ID: 469
       Name: os/user.UnknownGroupIdError.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 465
+      ID: 467
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 837888
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 495
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 593
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 703
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 705
+      ID: 707
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 703
+      ID: 705
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.886816e+06
@@ -14413,15 +14386,15 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 874 BaseType runtime.boundsErrorCode
+          Type: 876 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 874
+      ID: 876
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585088
       GoKind: 8
     - __kind: StructureType
-      ID: 767
+      ID: 769
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.751872e+06
@@ -14434,7 +14407,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 681
+      ID: 683
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 988736
@@ -14442,17 +14415,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 683 PointerType *runtime.errorString.str
+          Type: 685 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 682 GoStringDataType runtime.errorString.str
+      Data: 684 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 682
+      ID: 684
       Name: runtime.errorString.str
       ByteSize: 2048
     - __kind: GoStringHeaderType
-      ID: 684
+      ID: 686
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 988832
@@ -14460,21 +14433,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 686 PointerType *runtime.plainError.str
+          Type: 688 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 685 GoStringDataType runtime.plainError.str
+      Data: 687 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 685
+      ID: 687
       Name: runtime.plainError.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 845
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 489
+      ID: 491
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.594464e+06
@@ -14485,9 +14458,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: bubble
           Offset: 16
-          Type: 842 PointerType *runtime.synctestBubble
+          Type: 844 PointerType *runtime.synctestBubble
     - __kind: UnresolvedPointeeType
-      ID: 707
+      ID: 709
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14509,15 +14482,15 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1010
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 914
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 908
+      ID: 910
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.454208e+06
@@ -14533,7 +14506,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1091
+      ID: 1093
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.462752e+06
@@ -14541,12 +14514,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1092 StructureType sync.noCopy
+          Type: 1094 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1093 StructureType internal/sync.Mutex
+          Type: 1095 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1094
+      ID: 1096
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.611808e+06
@@ -14554,15 +14527,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1092 StructureType sync.noCopy
+          Type: 1094 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1095 StructureType sync/atomic.Bool
+          Type: 1097 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1091 StructureType sync.Mutex
+          Type: 1093 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1097
+      ID: 1099
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.611616e+06
@@ -14570,21 +14543,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1092 StructureType sync.noCopy
+          Type: 1094 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1098 StructureType sync/atomic.Uint64
+          Type: 1100 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1092
+      ID: 1094
       Name: sync.noCopy
       GoRuntimeType: 987680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1095
+      ID: 1097
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.463872e+06
@@ -14592,12 +14565,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1096 StructureType sync/atomic.noCopy
+          Type: 1098 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1100
+      ID: 1102
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.464032e+06
@@ -14605,12 +14578,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1096 StructureType sync/atomic.noCopy
+          Type: 1098 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1098
+      ID: 1100
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.612192e+06
@@ -14618,27 +14591,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1096 StructureType sync/atomic.noCopy
+          Type: 1098 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1099 StructureType sync/atomic.align64
+          Type: 1101 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1099
+      ID: 1101
       Name: sync/atomic.align64
       GoRuntimeType: 987872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1096
+      ID: 1098
       Name: sync/atomic.noCopy
       GoRuntimeType: 987776
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 817
+      ID: 819
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.282176e+06
@@ -14764,7 +14737,7 @@ Types:
           Offset: 16
           Type: 229 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1119
+      ID: 1121
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -14786,7 +14759,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1120 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1122 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1155
       Name: table<int,*main.deepMap8>
@@ -14956,7 +14929,7 @@ Types:
           Offset: 16
           Type: 263 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 877
+      ID: 879
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -14978,7 +14951,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 878 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 880 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
       ID: 254
       Name: table<string,int>
@@ -15220,11 +15193,11 @@ Types:
           Offset: 16
           Type: 306 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1043
+      ID: 1045
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 760
+      ID: 762
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.705984e+06
@@ -15237,21 +15210,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 988
+      ID: 990
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.914272e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 837
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 496
+      ID: 498
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 833
+      ID: 835
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.371424e+06
@@ -15265,9 +15238,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 834 PointerType *time.Location
+          Type: 836 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 411
+      ID: 413
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 830784
@@ -15275,13 +15248,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 413 PointerType *time.fileSizeError.str
+          Type: 415 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 412 GoStringDataType time.fileSizeError.str
+      Data: 414 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 412
+      ID: 414
       Name: time.fileSizeError.str
       ByteSize: 2048
     - __kind: BaseType
@@ -15327,7 +15300,7 @@ Types:
       GoRuntimeType: 585024
       GoKind: 26
     - __kind: StructureType
-      ID: 855
+      ID: 857
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.06192e+06
@@ -15335,13 +15308,13 @@ Types:
       RawFields:
         - Name: msg
           Offset: 0
-          Type: 856 GoSliceHeaderType []uint8
+          Type: 858 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 857 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 859 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 858 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 860 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -15356,18 +15329,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 859 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 861 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 859
+      ID: 861
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 994400
       GoKind: 9
     - __kind: StructureType
-      ID: 857
+      ID: 859
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.92528e+06
@@ -15392,21 +15365,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 589
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 858
+      ID: 860
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588672
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1037
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 571
+      ID: 573
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.425248e+06
@@ -15416,13 +15389,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 455
+      ID: 457
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 834816
       GoKind: 2
     - __kind: StructureType
-      ID: 737
+      ID: 739
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.70176e+06
@@ -15435,7 +15408,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 689
+      ID: 691
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 993248

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,11 +11,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 78 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0x4a6006", Frameless: false}]
+        - ID: 12
+          Type: 96 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0x4a6046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -28,11 +28,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 79 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0x4a6050", Frameless: false}]
+        - ID: 13
+          Type: 97 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0x4a6090", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -44,8 +44,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 76 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4a64f3", Frameless: false}]
+          Type: 93 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -55,14 +55,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 11}
       events:
-        - ID: 10
-          Type: 77 EventRootType Probe[main.inlined]
+        - ID: 11
+          Type: 95 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4a63ca"
+            - PC: "0x4a642a"
               Frameless: false
-            - PC: "0x4a5dce"
+            - PC: "0x4a5e0e"
               Frameless: false
           Condition: null
     - id: intArg
@@ -75,8 +75,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 68 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4a60aa", Frameless: false}]
+          Type: 85 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0x4a610a", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -88,8 +88,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 71 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4a622a", Frameless: false}]
+          Type: 88 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -101,8 +101,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 74 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4a63a0", Frameless: true}]
+          Type: 91 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0x4a6400", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -114,8 +114,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 70 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4a61aa", Frameless: false}]
+          Type: 87 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
     - id: mapArg
       version: 0
@@ -127,8 +127,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 75 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4a648a", Frameless: false}]
+          Type: 92 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -140,8 +140,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 69 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a612a", Frameless: false}]
+          Type: 86 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -153,8 +153,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 73 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4a632a", Frameless: false}]
+          Type: 90 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -166,31 +166,45 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 72 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a62aa", Frameless: false}]
+          Type: 89 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 10
+          Type: 94 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4a6616", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a60a0..0x4a6102]
+      OutOfLinePCRanges: [0x4a6100..0x4a6162]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a60a0..0x4a60b9
+            - Range: 0x4a6100..0x4a6119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4a6120..0x4a6191]
+      OutOfLinePCRanges: [0x4a6180..0x4a61f1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a6120..0x4a613e
+            - Range: 0x4a6180..0x4a619e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -200,13 +214,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a61a0..0x4a621a]
+      OutOfLinePCRanges: [0x4a6200..0x4a627a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 33 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a61a0..0x4a61be
+            - Range: 0x4a6200..0x4a621e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -218,25 +232,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a6220..0x4a6287]
+      OutOfLinePCRanges: [0x4a6280..0x4a62e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 34 ArrayType [3]int
           Locations:
-            - Range: 0x4a6220..0x4a6287
+            - Range: 0x4a6280..0x4a62e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a62a0..0x4a631a]
+      OutOfLinePCRanges: [0x4a6300..0x4a637a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 35 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4a62a0..0x4a62be
+            - Range: 0x4a6300..0x4a631e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -248,144 +262,159 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a6320..0x4a6387]
+      OutOfLinePCRanges: [0x4a6380..0x4a63e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 ArrayType [3]string
           Locations:
-            - Range: 0x4a6320..0x4a6387
+            - Range: 0x4a6380..0x4a63e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4a63a0..0x4a63a1]
+      OutOfLinePCRanges: [0x4a6400..0x4a6401]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 ArrayType [3]string
           Locations:
-            - Range: 0x4a63a0..0x4a63a1
+            - Range: 0x4a6400..0x4a6401
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4a6480..0x4a64d6]
+      OutOfLinePCRanges: [0x4a64e0..0x4a6536]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 37 GoMapType map[string]int
           Locations:
-            - Range: 0x4a6480..0x4a64ad
+            - Range: 0x4a64e0..0x4a650d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a64e0..0x4a659b]
+      OutOfLinePCRanges: [0x4a6540..0x4a65fb]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 44 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4a64e0..0x4a6513
+            - Range: 0x4a6540..0x4a6573
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a6513..0x4a659b
+            - Range: 0x4a6573..0x4a65fb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0x4a6600..0x4a67e5]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 49 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0x4a6600..0x4a67e5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 11
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a63c0..0x4a6422]
+      OutOfLinePCRanges: [0x4a6420..0x4a6482]
       InlinePCRanges:
-        - Ranges: [0x4a5dce..0x4a5e1f]
-          RootRanges: [0x4a5c40..0x4a609d]
+        - Ranges: [0x4a5e0e..0x4a5e5f]
+          RootRanges: [0x4a5c80..0x4a60e5]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a5dce..0x4a5e1f
+            - Range: 0x4a5e0e..0x4a5e5f
               Pieces: []
-            - Range: 0x4a63c0..0x4a63d9
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 11
-      Name: main.PointerChainArg
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x4a6006..0x4a6045]
-          RootRanges: [0x4a5c40..0x4a609d]
-      Variables:
-        - Name: ptr
-          Type: 49 PointerType *****int
-          Locations:
-            - Range: 0x4a5fdf..0x4a602b
+            - Range: 0x4a6420..0x4a6439
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x4a6046..0x4a6085]
+          RootRanges: [0x4a5c80..0x4a60e5]
+      Variables:
+        - Name: ptr
+          Type: 54 PointerType *****int
+          Locations:
+            - Range: 0x4a601f..0x4a606b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4a6050..0x4a608a]
-          RootRanges: [0x4a5c40..0x4a609d]
+        - Ranges: [0x4a6090..0x4a60ca]
+          RootRanges: [0x4a5c80..0x4a60e5]
       Variables:
         - Name: ptr
-          Type: 51 PointerType **int
+          Type: 56 PointerType **int
           Locations:
-            - Range: 0x4a6050..0x4a608a
+            - Range: 0x4a6090..0x4a60ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 49
+      ID: 54
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 32512
+      GoRuntimeType: 32992
       GoKind: 22
-      Pointee: 50 PointerType ****int
+      Pointee: 55 PointerType ****int
     - __kind: PointerType
-      ID: 50
+      ID: 55
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 32448
+      GoRuntimeType: 32928
       GoKind: 22
-      Pointee: 67 PointerType ***int
+      Pointee: 84 PointerType ***int
     - __kind: PointerType
-      ID: 67
+      ID: 84
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 32384
+      GoRuntimeType: 32864
       GoKind: 22
-      Pointee: 51 PointerType **int
+      Pointee: 56 PointerType **int
     - __kind: PointerType
-      ID: 51
+      ID: 56
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 32320
+      GoRuntimeType: 32800
       GoKind: 22
       Pointee: 27 PointerType *int
     - __kind: PointerType
-      ID: 55
+      ID: 60
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 54 GoSliceDataType []int.array
+      Pointee: 59 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 57
+      ID: 62
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 56 GoSliceDataType []string.array
+      Pointee: 61 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 26944
+      GoRuntimeType: 27424
       GoKind: 22
       Pointee: 4 BaseType bool
+    - __kind: PointerType
+      ID: 76
+      Name: '*bucket<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 77 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 40
       Name: '*bucket<string,int>'
@@ -397,26 +426,36 @@ Types:
       ByteSize: 8
       Pointee: 48 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
+      ID: 52
+      Name: '*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 53 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
       ID: 29
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 25856
+      GoRuntimeType: 26336
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 30
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 26816
+      GoRuntimeType: 27296
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 26880
+      GoRuntimeType: 27360
       GoKind: 22
       Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 74
+      Name: '*hash<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 75 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 38
       Name: '*hash<string,int>'
@@ -428,96 +467,101 @@ Types:
       ByteSize: 8
       Pointee: 46 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
+      ID: 50
+      Name: '*hash<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 51 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 26496
+      GoRuntimeType: 26976
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 26240
+      GoRuntimeType: 26720
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 26
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 26368
+      GoRuntimeType: 26848
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 63
+      ID: 68
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 24256
+      GoRuntimeType: 24736
       GoKind: 22
-      Pointee: 64 StructureType main.bigStruct
+      Pointee: 69 StructureType main.bigStruct
     - __kind: PointerType
       ID: 42
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 29760
+      GoRuntimeType: 30240
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 25920
+      GoRuntimeType: 26400
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 53
+      ID: 58
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 52 GoStringDataType string.str
+      Pointee: 57 GoStringDataType string.str
     - __kind: PointerType
       ID: 31
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 26560
+      GoRuntimeType: 27040
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 32
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 26176
+      GoRuntimeType: 26656
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 26304
+      GoRuntimeType: 26784
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 26432
+      GoRuntimeType: 26912
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26048
+      GoRuntimeType: 26528
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 26624
+      GoRuntimeType: 27104
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 78
+      ID: 96
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -525,14 +569,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 49 PointerType *****int
+            Type: 54 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 79
+      ID: 97
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -540,14 +584,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 51 PointerType **int
+            Type: 56 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 76
+      ID: 93
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -562,7 +606,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 77
+      ID: 95
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -573,11 +617,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 68
+      ID: 85
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -592,7 +636,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 71
+      ID: 88
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -607,7 +651,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 70
+      ID: 87
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -622,7 +666,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 75
+      ID: 92
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -637,7 +681,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 69
+      ID: 86
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -652,7 +696,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 74
+      ID: 91
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -667,7 +711,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 73
+      ID: 90
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -682,7 +726,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 72
+      ID: 89
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -696,11 +740,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 94
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
-      ID: 66
+      ID: 83
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 41888
+      GoRuntimeType: 42720
       GoKind: 17
       Count: 128
       HasCount: true
@@ -709,7 +756,7 @@ Types:
       ID: 34
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 41408
+      GoRuntimeType: 42144
       GoKind: 17
       Count: 3
       HasCount: true
@@ -718,35 +765,45 @@ Types:
       ID: 36
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 41504
+      GoRuntimeType: 42240
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 58
+      ID: 63
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 41600
+      GoRuntimeType: 42336
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 61
+      ID: 82
+      Name: '[]bucket<int,main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 2048
+      Element: 77 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 66
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 41 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 65
+      ID: 70
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
       Element: 48 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 78
+      Name: '[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 2048
+      Element: 53 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 33
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 33984
+      GoRuntimeType: 34592
       GoKind: 23
       RawFields:
         - Name: array
@@ -758,24 +815,38 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 54 GoSliceDataType []int.array
+      Data: 59 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 54
+      ID: 59
       Name: '[]int.array'
       ByteSize: 2048
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 59
+      ID: 79
+      Name: '[]key<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 9 BaseType int
+    - __kind: ArrayType
+      ID: 64
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 10 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 71
+      Name: '[]key<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 34304
+      GoRuntimeType: 34912
       GoKind: 23
       RawFields:
         - Name: array
@@ -787,32 +858,65 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 56 GoSliceDataType []string.array
+      Data: 61 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 56
+      ID: 61
       Name: '[]string.array'
       ByteSize: 2048
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 60
+      ID: 65
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 62
+      ID: 80
+      Name: '[]val<main.aStructNotUsedAsAnArgument>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 81 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: ArrayType
+      ID: 67
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 63 PointerType *main.bigStruct
+      Element: 68 PointerType *main.bigStruct
+    - __kind: ArrayType
+      ID: 72
+      Name: '[]val<map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 73 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 38464
+      GoRuntimeType: 39200
       GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 77
+      Name: bucket<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 80 ArrayType []val<main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 136
+          Type: 76 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+      KeyType: 9 BaseType int
+      ValueType: 81 StructureType main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 41
       Name: bucket<string,int>
@@ -820,13 +924,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 58 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 59 ArrayType []key<string>
+          Type: 64 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 60 ArrayType []val<int>
+          Type: 65 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 40 PointerType *bucket<string,int>
@@ -839,35 +943,54 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 58 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 59 ArrayType []key<string>
+          Type: 64 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 62 ArrayType []val<main.bigStruct>
+          Type: 67 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 47 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 63 PointerType *main.bigStruct
+      ValueType: 68 PointerType *main.bigStruct
+    - __kind: GoHMapBucketType
+      ID: 53
+      Name: bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 88
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 71 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 72 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 80
+          Type: 52 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      KeyType: 3 BaseType uint8
+      ValueType: 73 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 38272
+      GoRuntimeType: 39008
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 38208
+      GoRuntimeType: 38944
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 59008
+      GoRuntimeType: 60320
       GoKind: 20
       RawFields:
         - Name: tab
@@ -880,14 +1003,48 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 38336
+      GoRuntimeType: 39072
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 38400
+      GoRuntimeType: 39136
       GoKind: 14
+    - __kind: GoHMapHeaderType
+      ID: 75
+      Name: hash<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 76 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 76 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 42 PointerType *runtime.mapextra
+      BucketType: 77 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      BucketsType: 82 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 39
       Name: hash<string,int>
@@ -921,7 +1078,7 @@ Types:
           Offset: 40
           Type: 42 PointerType *runtime.mapextra
       BucketType: 41 GoHMapBucketType bucket<string,int>
-      BucketsType: 61 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 66 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 46
       Name: hash<string,main.bigStruct>
@@ -955,36 +1112,77 @@ Types:
           Offset: 40
           Type: 42 PointerType *runtime.mapextra
       BucketType: 48 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 65 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 70 GoSliceDataType []bucket<string,main.bigStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 51
+      Name: hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 52 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 52 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 42 PointerType *runtime.mapextra
+      BucketType: 53 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 78 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 38016
+      GoRuntimeType: 38752
       GoKind: 2
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 37760
+      GoRuntimeType: 38496
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 37888
+      GoRuntimeType: 38624
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 37504
+      GoRuntimeType: 38240
       GoKind: 3
     - __kind: StructureType
-      ID: 64
+      ID: 81
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 64640
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
+    - __kind: StructureType
+      ID: 69
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 110528
+      GoRuntimeType: 112544
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1010,21 +1208,35 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 66 ArrayType [128]uint8
+          Type: 83 ArrayType [128]uint8
+    - __kind: GoMapType
+      ID: 73
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 55680
+      GoKind: 21
+      HeaderType: 75 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 54656
+      GoRuntimeType: 55776
       GoKind: 21
       HeaderType: 39 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 44
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 54752
+      GoRuntimeType: 55872
       GoKind: 21
       HeaderType: 46 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 49
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 56064
+      GoKind: 21
+      HeaderType: 51 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: runtime.mapextra
@@ -1033,62 +1245,62 @@ Types:
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 37440
+      GoRuntimeType: 38176
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 53 PointerType *string.str
+          Type: 58 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 52 GoStringDataType string.str
+      Data: 57 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 52
+      ID: 57
       Name: string.str
       ByteSize: 2048
     - __kind: BaseType
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 38080
+      GoRuntimeType: 38816
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 37696
+      GoRuntimeType: 38432
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 37824
+      GoRuntimeType: 38560
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 37952
+      GoRuntimeType: 38688
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 37568
+      GoRuntimeType: 38304
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 38144
+      GoRuntimeType: 38880
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 38528
+      GoRuntimeType: 39264
       GoKind: 26
-MaxTypeID: 79
+MaxTypeID: 97
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x572240", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x573240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,11 +11,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 86 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0x4a8006", Frameless: false}]
+        - ID: 12
+          Type: 114 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0x4a8046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -28,11 +28,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 87 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0x4a8050", Frameless: false}]
+        - ID: 13
+          Type: 115 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0x4a8090", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -44,8 +44,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 84 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4a84f3", Frameless: false}]
+          Type: 111 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0x4a8553", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -55,14 +55,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 11}
       events:
-        - ID: 10
-          Type: 85 EventRootType Probe[main.inlined]
+        - ID: 11
+          Type: 113 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4a83ca"
+            - PC: "0x4a842a"
               Frameless: false
-            - PC: "0x4a7dce"
+            - PC: "0x4a7e0e"
               Frameless: false
           Condition: null
     - id: intArg
@@ -75,8 +75,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 76 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4a80aa", Frameless: false}]
+          Type: 103 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0x4a810a", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -88,8 +88,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 79 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4a822a", Frameless: false}]
+          Type: 106 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0x4a828a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -101,8 +101,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4a83a0", Frameless: true}]
+          Type: 109 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0x4a8400", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -114,8 +114,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 78 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4a81aa", Frameless: false}]
+          Type: 105 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0x4a820a", Frameless: false}]
           Condition: null
     - id: mapArg
       version: 0
@@ -127,8 +127,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 83 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4a848a", Frameless: false}]
+          Type: 110 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0x4a84ea", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -140,8 +140,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 77 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a812a", Frameless: false}]
+          Type: 104 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -153,8 +153,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 81 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4a832a", Frameless: false}]
+          Type: 108 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0x4a838a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -166,31 +166,45 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 80 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a82aa", Frameless: false}]
+          Type: 107 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 10
+          Type: 112 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4a8616", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a80a0..0x4a8102]
+      OutOfLinePCRanges: [0x4a8100..0x4a8162]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a80a0..0x4a80b9
+            - Range: 0x4a8100..0x4a8119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4a8120..0x4a8191]
+      OutOfLinePCRanges: [0x4a8180..0x4a81f1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8120..0x4a813e
+            - Range: 0x4a8180..0x4a819e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -200,13 +214,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a81a0..0x4a821a]
+      OutOfLinePCRanges: [0x4a8200..0x4a827a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 33 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a81a0..0x4a81be
+            - Range: 0x4a8200..0x4a821e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -218,25 +232,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a8220..0x4a8287]
+      OutOfLinePCRanges: [0x4a8280..0x4a82e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 34 ArrayType [3]int
           Locations:
-            - Range: 0x4a8220..0x4a8287
+            - Range: 0x4a8280..0x4a82e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a82a0..0x4a831a]
+      OutOfLinePCRanges: [0x4a8300..0x4a837a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 35 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4a82a0..0x4a82be
+            - Range: 0x4a8300..0x4a831e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -248,127 +262,142 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a8320..0x4a8387]
+      OutOfLinePCRanges: [0x4a8380..0x4a83e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 ArrayType [3]string
           Locations:
-            - Range: 0x4a8320..0x4a8387
+            - Range: 0x4a8380..0x4a83e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4a83a0..0x4a83a1]
+      OutOfLinePCRanges: [0x4a8400..0x4a8401]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 ArrayType [3]string
           Locations:
-            - Range: 0x4a83a0..0x4a83a1
+            - Range: 0x4a8400..0x4a8401
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4a8480..0x4a84d6]
+      OutOfLinePCRanges: [0x4a84e0..0x4a8536]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 37 GoMapType map[string]int
           Locations:
-            - Range: 0x4a8480..0x4a84ad
+            - Range: 0x4a84e0..0x4a850d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a84e0..0x4a859b]
+      OutOfLinePCRanges: [0x4a8540..0x4a85fb]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 42 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4a84e0..0x4a8513
+            - Range: 0x4a8540..0x4a8573
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a8513..0x4a859b
+            - Range: 0x4a8573..0x4a85fb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0x4a8600..0x4a87ef]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 47 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0x4a8600..0x4a87ef, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 11
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a83c0..0x4a8422]
+      OutOfLinePCRanges: [0x4a8420..0x4a8482]
       InlinePCRanges:
-        - Ranges: [0x4a7dce..0x4a7e1f]
-          RootRanges: [0x4a7c40..0x4a809d]
+        - Ranges: [0x4a7e0e..0x4a7e5f]
+          RootRanges: [0x4a7c80..0x4a80e5]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a7dce..0x4a7e1f
+            - Range: 0x4a7e0e..0x4a7e5f
               Pieces: []
-            - Range: 0x4a83c0..0x4a83d9
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 11
-      Name: main.PointerChainArg
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x4a8006..0x4a8045]
-          RootRanges: [0x4a7c40..0x4a809d]
-      Variables:
-        - Name: ptr
-          Type: 47 PointerType *****int
-          Locations:
-            - Range: 0x4a7fdf..0x4a802b
+            - Range: 0x4a8420..0x4a8439
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x4a8046..0x4a8085]
+          RootRanges: [0x4a7c80..0x4a80e5]
+      Variables:
+        - Name: ptr
+          Type: 52 PointerType *****int
+          Locations:
+            - Range: 0x4a801f..0x4a806b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4a8050..0x4a808a]
-          RootRanges: [0x4a7c40..0x4a809d]
+        - Ranges: [0x4a8090..0x4a80ca]
+          RootRanges: [0x4a7c80..0x4a80e5]
       Variables:
         - Name: ptr
-          Type: 49 PointerType **int
+          Type: 54 PointerType **int
           Locations:
-            - Range: 0x4a8050..0x4a808a
+            - Range: 0x4a8090..0x4a80ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 47
+      ID: 52
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 35264
+      GoRuntimeType: 35552
       GoKind: 22
-      Pointee: 48 PointerType ****int
+      Pointee: 53 PointerType ****int
     - __kind: PointerType
-      ID: 48
+      ID: 53
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 35200
+      GoRuntimeType: 35488
       GoKind: 22
-      Pointee: 75 PointerType ***int
+      Pointee: 102 PointerType ***int
     - __kind: PointerType
-      ID: 75
+      ID: 102
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 35136
+      GoRuntimeType: 35424
       GoKind: 22
-      Pointee: 49 PointerType **int
+      Pointee: 54 PointerType **int
     - __kind: PointerType
-      ID: 49
+      ID: 54
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 35072
+      GoRuntimeType: 35360
       GoKind: 22
       Pointee: 27 PointerType *int
+    - __kind: PointerType
+      ID: 88
+      Name: '**table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 89 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 40
       Name: '**table<string,int>'
@@ -380,71 +409,81 @@ Types:
       ByteSize: 8
       Pointee: 46 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 53
+      ID: 50
+      Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 51 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 58
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 52 GoSliceDataType []int.array
+      Pointee: 57 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 55
+      ID: 60
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 54 GoSliceDataType []string.array
+      Pointee: 59 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 29568
+      GoRuntimeType: 29856
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 29
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 28480
+      GoRuntimeType: 28768
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 30
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 29440
+      GoRuntimeType: 29728
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 29504
+      GoRuntimeType: 29792
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29120
+      GoRuntimeType: 29408
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 28864
+      GoRuntimeType: 29152
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 26
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 28992
+      GoRuntimeType: 29280
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 70
+      ID: 75
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 26944
+      GoRuntimeType: 27232
       GoKind: 22
-      Pointee: 71 StructureType main.bigStruct
+      Pointee: 76 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 86
+      Name: '*map<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 87 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 38
       Name: '*map<string,int>'
@@ -456,81 +495,106 @@ Types:
       ByteSize: 8
       Pointee: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 58
+      ID: 48
+      Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 49 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 94
+      Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 95 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: PointerType
+      ID: 63
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 59 StructureType noalg.map.group[string]int
+      Pointee: 64 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 66
+      ID: 71
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 67 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 72 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 81
+      Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 82 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28544
+      GoRuntimeType: 28832
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 51
+      ID: 56
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 50 GoStringDataType string.str
+      Pointee: 55 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 89
+      Name: '*table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 92 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 41
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 56 StructureType table<string,int>
+      Pointee: 61 StructureType table<string,int>
     - __kind: PointerType
       ID: 46
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 64 StructureType table<string,main.bigStruct>
+      Pointee: 69 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 51
+      Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 79 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 31
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 29184
+      GoRuntimeType: 29472
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 32
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 28800
+      GoRuntimeType: 29088
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 28928
+      GoRuntimeType: 29216
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29056
+      GoRuntimeType: 29344
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 28672
+      GoRuntimeType: 28960
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 29248
+      GoRuntimeType: 29536
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 86
+      ID: 114
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -538,14 +602,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 47 PointerType *****int
+            Type: 52 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 87
+      ID: 115
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -553,14 +617,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 49 PointerType **int
+            Type: 54 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 84
+      ID: 111
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -575,7 +639,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 85
+      ID: 113
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -586,11 +650,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 76
+      ID: 103
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -605,7 +669,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 79
+      ID: 106
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -620,7 +684,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 78
+      ID: 105
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -635,7 +699,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 83
+      ID: 110
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -650,7 +714,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 77
+      ID: 104
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -665,7 +729,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 82
+      ID: 109
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -680,7 +744,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 81
+      ID: 108
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -695,7 +759,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 80
+      ID: 107
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -709,11 +773,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 112
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
-      ID: 74
+      ID: 101
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 46240
+      GoRuntimeType: 47488
       GoKind: 17
       Count: 128
       HasCount: true
@@ -722,7 +789,7 @@ Types:
       ID: 34
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 45952
+      GoRuntimeType: 47104
       GoKind: 17
       Count: 3
       HasCount: true
@@ -731,26 +798,36 @@ Types:
       ID: 36
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 46048
+      GoRuntimeType: 47200
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 62
+      ID: 99
+      Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 8192
+      Element: 89 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 67
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 72
+      ID: 77
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 46 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 90
+      Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 8192
+      Element: 51 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 33
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 37696
+      GoRuntimeType: 38176
       GoKind: 23
       RawFields:
         - Name: array
@@ -762,27 +839,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 52 GoSliceDataType []int.array
+      Data: 57 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 52
+      ID: 57
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 63
+      ID: 100
+      Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
+      ByteSize: 2048
+      Element: 95 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoSliceDataType
+      ID: 68
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 59 StructureType noalg.map.group[string]int
+      Element: 64 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 78
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 67 StructureType noalg.map.group[string]main.bigStruct
+      Element: 72 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceDataType
+      ID: 91
+      Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
+      ByteSize: 2048
+      Element: 82 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 37952
+      GoRuntimeType: 38432
       GoKind: 23
       RawFields:
         - Name: array
@@ -794,9 +881,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 54 GoSliceDataType []string.array
+      Data: 59 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 54
+      ID: 59
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -804,25 +891,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 42400
+      GoRuntimeType: 43200
       GoKind: 1
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 42208
+      GoRuntimeType: 43008
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 42144
+      GoRuntimeType: 42944
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 63168
+      GoRuntimeType: 64672
       GoKind: 20
       RawFields:
         - Name: tab
@@ -835,71 +922,106 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 42272
+      GoRuntimeType: 43072
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 42336
+      GoRuntimeType: 43136
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 57
+      ID: 93
+      Name: groupReference<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 94 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 95 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 100 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+    - __kind: GoSwissMapGroupsType
+      ID: 62
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 58 PointerType *noalg.map.group[string]int
+          Type: 63 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 59 StructureType noalg.map.group[string]int
-      GroupSliceType: 63 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 64 StructureType noalg.map.group[string]int
+      GroupSliceType: 68 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 65
+      ID: 70
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 66 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 71 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 67 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 72 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 78 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 80
+      Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 81 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 82 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 91 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 41952
+      GoRuntimeType: 42752
       GoKind: 2
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 41696
+      GoRuntimeType: 42496
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 41824
+      GoRuntimeType: 42624
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 41440
+      GoRuntimeType: 42240
       GoKind: 3
     - __kind: StructureType
-      ID: 71
+      ID: 98
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 70912
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
+    - __kind: StructureType
+      ID: 76
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 119744
+      GoRuntimeType: 122528
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -925,7 +1047,39 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 74 ArrayType [128]uint8
+          Type: 101 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 87
+      Name: map<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 88 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 99 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 95 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 39
       Name: map<string,int>
@@ -956,8 +1110,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 62 GoSliceDataType []*table<string,int>.array
-      GroupType: 59 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 67 GoSliceDataType []*table<string,int>.array
+      GroupType: 64 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 44
       Name: map<string,main.bigStruct>
@@ -988,45 +1142,122 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 72 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 67 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 77 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 72 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 49
+      Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 50 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 90 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 82 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoMapType
+      ID: 85
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 68768
+      GoKind: 21
+      HeaderType: 87 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 67264
+      GoRuntimeType: 68896
       GoKind: 21
       HeaderType: 39 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 42
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 67392
+      GoRuntimeType: 69024
       GoKind: 21
       HeaderType: 44 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 47
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 69280
+      GoKind: 21
+      HeaderType: 49 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 68
+      ID: 96
+      Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 47296
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 97 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: ArrayType
+      ID: 73
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 46336
+      GoRuntimeType: 47584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 69 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 74 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 60
+      ID: 65
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 46144
+      GoRuntimeType: 47392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 61 StructureType noalg.struct { key string; elem int }
+      Element: 66 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 83
+      Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 47776
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 84 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 59
+      ID: 95
+      Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 76672
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 96 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 64
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 74656
+      GoRuntimeType: 76928
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1034,12 +1265,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 60 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 65 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 67
+      ID: 72
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 74912
+      GoRuntimeType: 77184
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1047,12 +1278,38 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 68 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 73 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 69
+      ID: 82
+      Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 77696
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 83 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 97
+      Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 76544
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 98 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: StructureType
+      ID: 74
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 74784
+      GoRuntimeType: 77056
       GoKind: 25
       RawFields:
         - Name: key
@@ -1060,12 +1317,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 70 PointerType *main.bigStruct
+          Type: 75 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 61
+      ID: 66
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 74528
+      GoRuntimeType: 76800
       GoKind: 25
       RawFields:
         - Name: key
@@ -1074,26 +1331,63 @@ Types:
         - Name: elem
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 84
+      Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 77568
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 85 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 41376
+      GoRuntimeType: 42176
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 51 PointerType *string.str
+          Type: 56 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 50 GoStringDataType string.str
+      Data: 55 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 50
+      ID: 55
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 56
+      ID: 92
+      Name: table<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 93 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+    - __kind: StructureType
+      ID: 61
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1115,9 +1409,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 57 GoSwissMapGroupsType groupReference<string,int>
+          Type: 62 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 64
+      ID: 69
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1139,49 +1433,73 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 65 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 70 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 79
+      Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 80 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 16
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 42016
+      GoRuntimeType: 42816
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 41632
+      GoRuntimeType: 42432
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 41760
+      GoRuntimeType: 42560
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 41888
+      GoRuntimeType: 42688
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 41504
+      GoRuntimeType: 42304
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 42080
+      GoRuntimeType: 42880
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 42464
+      GoRuntimeType: 43264
       GoKind: 26
-MaxTypeID: 87
+MaxTypeID: 115
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x57e340", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,11 +11,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 86 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0x4ae606", Frameless: false}]
+        - ID: 12
+          Type: 114 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0x4ae646", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -28,11 +28,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 87 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0x4ae650", Frameless: false}]
+        - ID: 13
+          Type: 115 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0x4ae690", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -44,8 +44,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 84 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4aeaf3", Frameless: false}]
+          Type: 111 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0x4aeb53", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -55,14 +55,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 11}
       events:
-        - ID: 10
-          Type: 85 EventRootType Probe[main.inlined]
+        - ID: 11
+          Type: 113 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4ae9ca"
+            - PC: "0x4aea2a"
               Frameless: false
-            - PC: "0x4ae3ce"
+            - PC: "0x4ae40e"
               Frameless: false
           Condition: null
     - id: intArg
@@ -75,8 +75,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 76 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4ae6aa", Frameless: false}]
+          Type: 103 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0x4ae70a", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -88,8 +88,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 79 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4ae82a", Frameless: false}]
+          Type: 106 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0x4ae88a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -101,8 +101,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4ae9a0", Frameless: true}]
+          Type: 109 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0x4aea00", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -114,8 +114,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 78 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4ae7aa", Frameless: false}]
+          Type: 105 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0x4ae80a", Frameless: false}]
           Condition: null
     - id: mapArg
       version: 0
@@ -127,8 +127,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 83 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4aea8a", Frameless: false}]
+          Type: 110 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0x4aeaea", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -140,8 +140,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 77 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4ae72a", Frameless: false}]
+          Type: 104 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -153,8 +153,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 81 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4ae92a", Frameless: false}]
+          Type: 108 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0x4ae98a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -166,31 +166,45 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 80 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4ae8aa", Frameless: false}]
+          Type: 107 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 10
+          Type: 112 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0x4aec16", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4ae6a0..0x4ae702]
+      OutOfLinePCRanges: [0x4ae700..0x4ae762]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4ae6a0..0x4ae6b9
+            - Range: 0x4ae700..0x4ae719
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4ae720..0x4ae791]
+      OutOfLinePCRanges: [0x4ae780..0x4ae7f1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4ae720..0x4ae73e
+            - Range: 0x4ae780..0x4ae79e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -200,13 +214,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4ae7a0..0x4ae81a]
+      OutOfLinePCRanges: [0x4ae800..0x4ae87a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 33 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4ae7a0..0x4ae7be
+            - Range: 0x4ae800..0x4ae81e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -218,25 +232,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4ae820..0x4ae887]
+      OutOfLinePCRanges: [0x4ae880..0x4ae8e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 34 ArrayType [3]int
           Locations:
-            - Range: 0x4ae820..0x4ae887
+            - Range: 0x4ae880..0x4ae8e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4ae8a0..0x4ae91a]
+      OutOfLinePCRanges: [0x4ae900..0x4ae97a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 35 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4ae8a0..0x4ae8be
+            - Range: 0x4ae900..0x4ae91e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -248,127 +262,142 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4ae920..0x4ae987]
+      OutOfLinePCRanges: [0x4ae980..0x4ae9e7]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 ArrayType [3]string
           Locations:
-            - Range: 0x4ae920..0x4ae987
+            - Range: 0x4ae980..0x4ae9e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4ae9a0..0x4ae9a1]
+      OutOfLinePCRanges: [0x4aea00..0x4aea01]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 ArrayType [3]string
           Locations:
-            - Range: 0x4ae9a0..0x4ae9a1
+            - Range: 0x4aea00..0x4aea01
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4aea80..0x4aead6]
+      OutOfLinePCRanges: [0x4aeae0..0x4aeb36]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 37 GoMapType map[string]int
           Locations:
-            - Range: 0x4aea80..0x4aeaad
+            - Range: 0x4aeae0..0x4aeb0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4aeae0..0x4aeb9b]
+      OutOfLinePCRanges: [0x4aeb40..0x4aebfb]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 42 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4aeae0..0x4aeb13
+            - Range: 0x4aeb40..0x4aeb73
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aeb13..0x4aeb9b
+            - Range: 0x4aeb73..0x4aebfb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0x4aec00..0x4aedf7]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 47 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0x4aec00..0x4aedf7, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 11
       Name: main.inlined
-      OutOfLinePCRanges: [0x4ae9c0..0x4aea22]
+      OutOfLinePCRanges: [0x4aea20..0x4aea82]
       InlinePCRanges:
-        - Ranges: [0x4ae3ce..0x4ae40f]
-          RootRanges: [0x4ae240..0x4ae69d]
+        - Ranges: [0x4ae40e..0x4ae44f]
+          RootRanges: [0x4ae280..0x4ae6e5]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4ae3ce..0x4ae40f
+            - Range: 0x4ae40e..0x4ae44f
               Pieces: []
-            - Range: 0x4ae9c0..0x4ae9d9
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 11
-      Name: main.PointerChainArg
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x4ae606..0x4ae645]
-          RootRanges: [0x4ae240..0x4ae69d]
-      Variables:
-        - Name: ptr
-          Type: 47 PointerType *****int
-          Locations:
-            - Range: 0x4ae5df..0x4ae62b
+            - Range: 0x4aea20..0x4aea39
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x4ae646..0x4ae685]
+          RootRanges: [0x4ae280..0x4ae6e5]
+      Variables:
+        - Name: ptr
+          Type: 52 PointerType *****int
+          Locations:
+            - Range: 0x4ae61f..0x4ae66b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x4ae650..0x4ae68a]
-          RootRanges: [0x4ae240..0x4ae69d]
+        - Ranges: [0x4ae690..0x4ae6ca]
+          RootRanges: [0x4ae280..0x4ae6e5]
       Variables:
         - Name: ptr
-          Type: 49 PointerType **int
+          Type: 54 PointerType **int
           Locations:
-            - Range: 0x4ae650..0x4ae68a
+            - Range: 0x4ae690..0x4ae6ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 47
+      ID: 52
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 36320
+      GoRuntimeType: 36640
       GoKind: 22
-      Pointee: 48 PointerType ****int
+      Pointee: 53 PointerType ****int
     - __kind: PointerType
-      ID: 48
+      ID: 53
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 36256
+      GoRuntimeType: 36576
       GoKind: 22
-      Pointee: 75 PointerType ***int
+      Pointee: 102 PointerType ***int
     - __kind: PointerType
-      ID: 75
+      ID: 102
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 36192
+      GoRuntimeType: 36512
       GoKind: 22
-      Pointee: 49 PointerType **int
+      Pointee: 54 PointerType **int
     - __kind: PointerType
-      ID: 49
+      ID: 54
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 36128
+      GoRuntimeType: 36448
       GoKind: 22
       Pointee: 26 PointerType *int
+    - __kind: PointerType
+      ID: 88
+      Name: '**table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 89 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 40
       Name: '**table<string,int>'
@@ -380,71 +409,81 @@ Types:
       ByteSize: 8
       Pointee: 46 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 53
+      ID: 50
+      Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 51 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 58
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 52 GoSliceDataType []int.array
+      Pointee: 57 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 55
+      ID: 60
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 54 GoSliceDataType []string.array
+      Pointee: 59 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30432
+      GoRuntimeType: 30752
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 29
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 29344
+      GoRuntimeType: 29664
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 30
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 30304
+      GoRuntimeType: 30624
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 30368
+      GoRuntimeType: 30688
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
       ID: 26
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29984
+      GoRuntimeType: 30304
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29728
+      GoRuntimeType: 30048
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 29856
+      GoRuntimeType: 30176
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 70
+      ID: 75
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 27808
+      GoRuntimeType: 28128
       GoKind: 22
-      Pointee: 71 StructureType main.bigStruct
+      Pointee: 76 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 86
+      Name: '*map<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 87 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 38
       Name: '*map<string,int>'
@@ -456,81 +495,106 @@ Types:
       ByteSize: 8
       Pointee: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 58
+      ID: 48
+      Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 49 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 94
+      Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 95 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: PointerType
+      ID: 63
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 59 StructureType noalg.map.group[string]int
+      Pointee: 64 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 66
+      ID: 71
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 67 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 72 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 81
+      Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 82 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 29408
+      GoRuntimeType: 29728
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 51
+      ID: 56
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 50 GoStringDataType string.str
+      Pointee: 55 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 89
+      Name: '*table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 92 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 41
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 56 StructureType table<string,int>
+      Pointee: 61 StructureType table<string,int>
     - __kind: PointerType
       ID: 46
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 64 StructureType table<string,main.bigStruct>
+      Pointee: 69 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 51
+      Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 79 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 31
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 30048
+      GoRuntimeType: 30368
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 32
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29664
+      GoRuntimeType: 29984
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 29792
+      GoRuntimeType: 30112
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29920
+      GoRuntimeType: 30240
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29536
+      GoRuntimeType: 29856
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 30112
+      GoRuntimeType: 30432
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 86
+      ID: 114
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -538,14 +602,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 47 PointerType *****int
+            Type: 52 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 87
+      ID: 115
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -553,14 +617,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 49 PointerType **int
+            Type: 54 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 84
+      ID: 111
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -575,7 +639,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 85
+      ID: 113
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -586,11 +650,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 76
+      ID: 103
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -605,7 +669,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 79
+      ID: 106
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -620,7 +684,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 78
+      ID: 105
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -635,7 +699,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 83
+      ID: 110
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -650,7 +714,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 77
+      ID: 104
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -665,7 +729,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 82
+      ID: 109
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -680,7 +744,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 81
+      ID: 108
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -695,7 +759,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 80
+      ID: 107
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -709,11 +773,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 112
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
-      ID: 74
+      ID: 101
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 47680
+      GoRuntimeType: 48960
       GoKind: 17
       Count: 128
       HasCount: true
@@ -722,7 +789,7 @@ Types:
       ID: 34
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 47392
+      GoRuntimeType: 48576
       GoKind: 17
       Count: 3
       HasCount: true
@@ -731,26 +798,36 @@ Types:
       ID: 36
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 47488
+      GoRuntimeType: 48672
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 62
+      ID: 99
+      Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 8192
+      Element: 89 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 67
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 72
+      ID: 77
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 46 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 90
+      Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 8192
+      Element: 51 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 33
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 38816
+      GoRuntimeType: 39328
       GoKind: 23
       RawFields:
         - Name: array
@@ -762,27 +839,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 52 GoSliceDataType []int.array
+      Data: 57 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 52
+      ID: 57
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 63
+      ID: 100
+      Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
+      ByteSize: 2048
+      Element: 95 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoSliceDataType
+      ID: 68
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 59 StructureType noalg.map.group[string]int
+      Element: 64 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 78
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 67 StructureType noalg.map.group[string]main.bigStruct
+      Element: 72 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceDataType
+      ID: 91
+      Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
+      ByteSize: 2048
+      Element: 82 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 39072
+      GoRuntimeType: 39584
       GoKind: 23
       RawFields:
         - Name: array
@@ -794,9 +881,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 54 GoSliceDataType []string.array
+      Data: 59 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 54
+      ID: 59
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -804,25 +891,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 43776
+      GoRuntimeType: 44608
       GoKind: 1
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 43584
+      GoRuntimeType: 44416
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 43520
+      GoRuntimeType: 44352
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 65856
+      GoRuntimeType: 67392
       GoKind: 20
       RawFields:
         - Name: tab
@@ -835,71 +922,106 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 43648
+      GoRuntimeType: 44480
       GoKind: 13
     - __kind: BaseType
       ID: 15
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 43712
+      GoRuntimeType: 44544
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 57
+      ID: 93
+      Name: groupReference<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 94 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 95 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 100 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+    - __kind: GoSwissMapGroupsType
+      ID: 62
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 58 PointerType *noalg.map.group[string]int
+          Type: 63 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 59 StructureType noalg.map.group[string]int
-      GroupSliceType: 63 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 64 StructureType noalg.map.group[string]int
+      GroupSliceType: 68 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 65
+      ID: 70
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 66 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 71 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 67 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 72 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 78 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 80
+      Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 81 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 82 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 91 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 43328
+      GoRuntimeType: 44160
       GoKind: 2
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 43072
+      GoRuntimeType: 43904
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 43200
+      GoRuntimeType: 44032
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 42816
+      GoRuntimeType: 43648
       GoKind: 3
     - __kind: StructureType
-      ID: 71
+      ID: 98
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 73536
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
+    - __kind: StructureType
+      ID: 76
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 124736
+      GoRuntimeType: 127552
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -925,7 +1047,42 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 74 ArrayType [128]uint8
+          Type: 101 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 87
+      Name: map<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 88 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 99 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 95 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 39
       Name: map<string,int>
@@ -959,8 +1116,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 62 GoSliceDataType []*table<string,int>.array
-      GroupType: 59 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 67 GoSliceDataType []*table<string,int>.array
+      GroupType: 64 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 44
       Name: map<string,main.bigStruct>
@@ -994,45 +1151,125 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 72 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 67 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 77 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 72 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 49
+      Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 50 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 90 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 82 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoMapType
+      ID: 85
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 71616
+      GoKind: 21
+      HeaderType: 87 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 70080
+      GoRuntimeType: 71744
       GoKind: 21
       HeaderType: 39 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 42
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 70208
+      GoRuntimeType: 71872
       GoKind: 21
       HeaderType: 44 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 47
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 72128
+      GoKind: 21
+      HeaderType: 49 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 68
+      ID: 96
+      Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 48768
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 97 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: ArrayType
+      ID: 73
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 47776
+      GoRuntimeType: 49056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 69 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 74 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 60
+      ID: 65
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 47584
+      GoRuntimeType: 48864
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 61 StructureType noalg.struct { key string; elem int }
+      Element: 66 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 83
+      Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 49248
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 84 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 59
+      ID: 95
+      Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 79296
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 96 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 64
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 77248
+      GoRuntimeType: 79552
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1040,12 +1277,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 60 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 65 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 67
+      ID: 72
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 77504
+      GoRuntimeType: 79808
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1053,12 +1290,38 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 68 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 73 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 69
+      ID: 82
+      Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 80320
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 83 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 97
+      Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 79168
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 98 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: StructureType
+      ID: 74
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 77376
+      GoRuntimeType: 79680
       GoKind: 25
       RawFields:
         - Name: key
@@ -1066,12 +1329,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 70 PointerType *main.bigStruct
+          Type: 75 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 61
+      ID: 66
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 77120
+      GoRuntimeType: 79424
       GoKind: 25
       RawFields:
         - Name: key
@@ -1080,26 +1343,63 @@ Types:
         - Name: elem
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 84
+      Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 80192
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 85 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 42752
+      GoRuntimeType: 43584
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 51 PointerType *string.str
+          Type: 56 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 50 GoStringDataType string.str
+      Data: 55 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 50
+      ID: 55
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 56
+      ID: 92
+      Name: table<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 93 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+    - __kind: StructureType
+      ID: 61
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1121,9 +1421,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 57 GoSwissMapGroupsType groupReference<string,int>
+          Type: 62 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 64
+      ID: 69
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1145,49 +1445,73 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 65 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 70 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 79
+      Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 80 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 17
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 43392
+      GoRuntimeType: 44224
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 43008
+      GoRuntimeType: 43840
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 43136
+      GoRuntimeType: 43968
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 43264
+      GoRuntimeType: 44096
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 42880
+      GoRuntimeType: 43712
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 43456
+      GoRuntimeType: 44288
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 43840
+      GoRuntimeType: 44672
       GoKind: 26
-MaxTypeID: 87
+MaxTypeID: 115
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x58c3a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x58d3a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,11 +11,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 79 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb5338", Frameless: false}]
+        - ID: 12
+          Type: 97 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0xb5388", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -28,11 +28,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 80 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb5370", Frameless: false}]
+        - ID: 13
+          Type: 98 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0xb53c0", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -44,8 +44,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 77 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb5820", Frameless: true}]
+          Type: 94 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0xb5870", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -55,14 +55,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 11}
       events:
-        - ID: 10
-          Type: 78 EventRootType Probe[main.inlined]
+        - ID: 11
+          Type: 96 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb56ec"
+            - PC: "0xb573c"
               Frameless: true
-            - PC: "0xb514c"
+            - PC: "0xb519c"
               Frameless: false
           Condition: null
     - id: intArg
@@ -75,8 +75,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 69 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb53cc", Frameless: true}]
+          Type: 86 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0xb541c", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -88,8 +88,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 72 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb554c", Frameless: true}]
+          Type: 89 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0xb559c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -101,8 +101,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 75 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb56d0", Frameless: true}]
+          Type: 92 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0xb5720", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -114,8 +114,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 71 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb54bc", Frameless: true}]
+          Type: 88 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0xb550c", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -127,8 +127,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 76 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb57ac", Frameless: true}]
+          Type: 93 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0xb57fc", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -140,8 +140,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 70 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb543c", Frameless: true}]
+          Type: 87 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb548c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -153,8 +153,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 74 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb565c", Frameless: true}]
+          Type: 91 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0xb56ac", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -166,31 +166,45 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 73 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb55cc", Frameless: true}]
+          Type: 90 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb561c", Frameless: true}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 10
+          Type: 95 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb5930", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb53c0..0xb5430]
+      OutOfLinePCRanges: [0xb5410..0xb5480]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb53c0..0xb53e0
+            - Range: 0xb5410..0xb5430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb5430..0xb54b0]
+      OutOfLinePCRanges: [0xb5480..0xb5500]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb5430..0xb5454
+            - Range: 0xb5480..0xb54a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -200,13 +214,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb54b0..0xb5540]
+      OutOfLinePCRanges: [0xb5500..0xb5590]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 34 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb54b0..0xb54d4
+            - Range: 0xb5500..0xb5524
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -218,25 +232,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb5540..0xb55c0]
+      OutOfLinePCRanges: [0xb5590..0xb5610]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 35 ArrayType [3]int
           Locations:
-            - Range: 0xb5540..0xb55c0
+            - Range: 0xb5590..0xb5610
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb55c0..0xb5650]
+      OutOfLinePCRanges: [0xb5610..0xb56a0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb55c0..0xb55e4
+            - Range: 0xb5610..0xb5634
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -248,144 +262,159 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb5650..0xb56d0]
+      OutOfLinePCRanges: [0xb56a0..0xb5720]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 37 ArrayType [3]string
           Locations:
-            - Range: 0xb5650..0xb56d0
+            - Range: 0xb56a0..0xb5720
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb56d0..0xb56e0]
+      OutOfLinePCRanges: [0xb5720..0xb5730]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 37 ArrayType [3]string
           Locations:
-            - Range: 0xb56d0..0xb56e0
+            - Range: 0xb5720..0xb5730
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb57a0..0xb5810]
+      OutOfLinePCRanges: [0xb57f0..0xb5860]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 38 GoMapType map[string]int
           Locations:
-            - Range: 0xb57a0..0xb57d8
+            - Range: 0xb57f0..0xb5828
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb5810..0xb58d0]
+      OutOfLinePCRanges: [0xb5860..0xb5920]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 45 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb5810..0xb5848
+            - Range: 0xb5860..0xb5898
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb5848..0xb58d0
+            - Range: 0xb5898..0xb5920
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0xb5920..0xb5ad0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 50 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0xb5920..0xb5ad0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 11
       Name: main.inlined
-      OutOfLinePCRanges: [0xb56e0..0xb5750]
+      OutOfLinePCRanges: [0xb5730..0xb57a0]
       InlinePCRanges:
-        - Ranges: [0xb514c..0xb518c]
-          RootRanges: [0xb4fb0..0xb53c0]
+        - Ranges: [0xb519c..0xb51dc]
+          RootRanges: [0xb5000..0xb5410]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb514c..0xb518c
+            - Range: 0xb519c..0xb51dc
               Pieces: []
-            - Range: 0xb56e0..0xb5700
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 11
-      Name: main.PointerChainArg
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xb5338..0xb5368]
-          RootRanges: [0xb4fb0..0xb53c0]
-      Variables:
-        - Name: ptr
-          Type: 50 PointerType *****int
-          Locations:
-            - Range: 0xb5310..0xb5358
+            - Range: 0xb5730..0xb5750
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xb5388..0xb53b8]
+          RootRanges: [0xb5000..0xb5410]
+      Variables:
+        - Name: ptr
+          Type: 55 PointerType *****int
+          Locations:
+            - Range: 0xb5360..0xb53a8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb5370..0xb53a0]
-          RootRanges: [0xb4fb0..0xb53c0]
+        - Ranges: [0xb53c0..0xb53f0]
+          RootRanges: [0xb5000..0xb5410]
       Variables:
         - Name: ptr
-          Type: 52 PointerType **int
+          Type: 57 PointerType **int
           Locations:
-            - Range: 0xb5370..0xb53a0
+            - Range: 0xb53c0..0xb53f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 50
+      ID: 55
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 32480
+      GoRuntimeType: 32960
       GoKind: 22
-      Pointee: 51 PointerType ****int
+      Pointee: 56 PointerType ****int
     - __kind: PointerType
-      ID: 51
+      ID: 56
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 32416
+      GoRuntimeType: 32896
       GoKind: 22
-      Pointee: 68 PointerType ***int
+      Pointee: 85 PointerType ***int
     - __kind: PointerType
-      ID: 68
+      ID: 85
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 32352
+      GoRuntimeType: 32832
       GoKind: 22
-      Pointee: 52 PointerType **int
+      Pointee: 57 PointerType **int
     - __kind: PointerType
-      ID: 52
+      ID: 57
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 32288
+      GoRuntimeType: 32768
       GoKind: 22
       Pointee: 28 PointerType *int
     - __kind: PointerType
-      ID: 56
+      ID: 61
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 55 GoSliceDataType []int.array
+      Pointee: 60 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 58
+      ID: 63
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 57 GoSliceDataType []string.array
+      Pointee: 62 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 26912
+      GoRuntimeType: 27392
       GoKind: 22
       Pointee: 4 BaseType bool
+    - __kind: PointerType
+      ID: 77
+      Name: '*bucket<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 78 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 41
       Name: '*bucket<string,int>'
@@ -397,26 +426,36 @@ Types:
       ByteSize: 8
       Pointee: 49 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
+      ID: 53
+      Name: '*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 54 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
       ID: 30
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 25824
+      GoRuntimeType: 26304
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 31
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 26784
+      GoRuntimeType: 27264
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 26848
+      GoRuntimeType: 27328
       GoKind: 22
       Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 75
+      Name: '*hash<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 76 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 39
       Name: '*hash<string,int>'
@@ -428,96 +467,101 @@ Types:
       ByteSize: 8
       Pointee: 47 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
+      ID: 51
+      Name: '*hash<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 52 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
       ID: 28
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 26464
+      GoRuntimeType: 26944
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 26208
+      GoRuntimeType: 26688
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 26336
+      GoRuntimeType: 26816
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 64
+      ID: 69
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 24224
+      GoRuntimeType: 24704
       GoKind: 22
-      Pointee: 65 StructureType main.bigStruct
+      Pointee: 70 StructureType main.bigStruct
     - __kind: PointerType
       ID: 43
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 29728
+      GoRuntimeType: 30208
       GoKind: 22
       Pointee: 44 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 25888
+      GoRuntimeType: 26368
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 54
+      ID: 59
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 53 GoStringDataType string.str
+      Pointee: 58 GoStringDataType string.str
     - __kind: PointerType
       ID: 32
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 26528
+      GoRuntimeType: 27008
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 33
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 26144
+      GoRuntimeType: 26624
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 26272
+      GoRuntimeType: 26752
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 29
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 26400
+      GoRuntimeType: 26880
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26016
+      GoRuntimeType: 26496
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 26592
+      GoRuntimeType: 27072
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 79
+      ID: 97
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -525,14 +569,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 50 PointerType *****int
+            Type: 55 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 80
+      ID: 98
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -540,14 +584,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 52 PointerType **int
+            Type: 57 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 77
+      ID: 94
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -562,7 +606,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 78
+      ID: 96
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -573,11 +617,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 69
+      ID: 86
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -592,7 +636,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 72
+      ID: 89
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -607,7 +651,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 71
+      ID: 88
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -622,7 +666,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 76
+      ID: 93
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -637,7 +681,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 70
+      ID: 87
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -652,7 +696,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 75
+      ID: 92
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -667,7 +711,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 74
+      ID: 91
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -682,7 +726,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 73
+      ID: 90
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -696,11 +740,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 95
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
-      ID: 67
+      ID: 84
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 41856
+      GoRuntimeType: 42688
       GoKind: 17
       Count: 128
       HasCount: true
@@ -709,7 +756,7 @@ Types:
       ID: 35
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 41376
+      GoRuntimeType: 42112
       GoKind: 17
       Count: 3
       HasCount: true
@@ -718,35 +765,45 @@ Types:
       ID: 37
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 41472
+      GoRuntimeType: 42208
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 59
+      ID: 64
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 41568
+      GoRuntimeType: 42304
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 62
+      ID: 83
+      Name: '[]bucket<int,main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 2048
+      Element: 78 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 67
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 42 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 66
+      ID: 71
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
       Element: 49 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 79
+      Name: '[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 2048
+      Element: 54 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 34
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 33952
+      GoRuntimeType: 34560
       GoKind: 23
       RawFields:
         - Name: array
@@ -758,24 +815,38 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 55 GoSliceDataType []int.array
+      Data: 60 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 55
+      ID: 60
       Name: '[]int.array'
       ByteSize: 2048
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 60
+      ID: 80
+      Name: '[]key<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 9 BaseType int
+    - __kind: ArrayType
+      ID: 65
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 10 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 72
+      Name: '[]key<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 34272
+      GoRuntimeType: 34880
       GoKind: 23
       RawFields:
         - Name: array
@@ -787,32 +858,65 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 57 GoSliceDataType []string.array
+      Data: 62 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 57
+      ID: 62
       Name: '[]string.array'
       ByteSize: 2048
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 61
+      ID: 66
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 63
+      ID: 81
+      Name: '[]val<main.aStructNotUsedAsAnArgument>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 82 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: ArrayType
+      ID: 68
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 64 PointerType *main.bigStruct
+      Element: 69 PointerType *main.bigStruct
+    - __kind: ArrayType
+      ID: 73
+      Name: '[]val<map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 74 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 38432
+      GoRuntimeType: 39168
       GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 78
+      Name: bucket<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 64 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 80 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 81 ArrayType []val<main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 136
+          Type: 77 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+      KeyType: 9 BaseType int
+      ValueType: 82 StructureType main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 42
       Name: bucket<string,int>
@@ -820,13 +924,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 59 ArrayType [8]uint8
+          Type: 64 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 60 ArrayType []key<string>
+          Type: 65 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 61 ArrayType []val<int>
+          Type: 66 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 41 PointerType *bucket<string,int>
@@ -839,35 +943,54 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 59 ArrayType [8]uint8
+          Type: 64 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 60 ArrayType []key<string>
+          Type: 65 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 63 ArrayType []val<main.bigStruct>
+          Type: 68 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 48 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 64 PointerType *main.bigStruct
+      ValueType: 69 PointerType *main.bigStruct
+    - __kind: GoHMapBucketType
+      ID: 54
+      Name: bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 88
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 64 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 72 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 73 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 80
+          Type: 53 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      KeyType: 3 BaseType uint8
+      ValueType: 74 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 38240
+      GoRuntimeType: 38976
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 38176
+      GoRuntimeType: 38912
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 58880
+      GoRuntimeType: 60192
       GoKind: 20
       RawFields:
         - Name: tab
@@ -880,14 +1003,48 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 38304
+      GoRuntimeType: 39040
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 38368
+      GoRuntimeType: 39104
       GoKind: 14
+    - __kind: GoHMapHeaderType
+      ID: 76
+      Name: hash<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 77 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 77 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 43 PointerType *runtime.mapextra
+      BucketType: 78 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      BucketsType: 83 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 40
       Name: hash<string,int>
@@ -921,7 +1078,7 @@ Types:
           Offset: 40
           Type: 43 PointerType *runtime.mapextra
       BucketType: 42 GoHMapBucketType bucket<string,int>
-      BucketsType: 62 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 67 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 47
       Name: hash<string,main.bigStruct>
@@ -955,42 +1112,83 @@ Types:
           Offset: 40
           Type: 43 PointerType *runtime.mapextra
       BucketType: 49 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 66 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 71 GoSliceDataType []bucket<string,main.bigStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 52
+      Name: hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 53 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 53 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 43 PointerType *runtime.mapextra
+      BucketType: 54 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 79 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 37984
+      GoRuntimeType: 38720
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 37600
+      GoRuntimeType: 38336
       GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 37728
+      GoRuntimeType: 38464
       GoKind: 5
     - __kind: BaseType
       ID: 14
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 37856
+      GoRuntimeType: 38592
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 37472
+      GoRuntimeType: 38208
       GoKind: 3
     - __kind: StructureType
-      ID: 65
+      ID: 82
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 64512
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
+    - __kind: StructureType
+      ID: 70
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 110400
+      GoRuntimeType: 112416
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -1016,21 +1214,35 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 67 ArrayType [128]uint8
+          Type: 84 ArrayType [128]uint8
+    - __kind: GoMapType
+      ID: 74
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 55552
+      GoKind: 21
+      HeaderType: 76 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 54528
+      GoRuntimeType: 55648
       GoKind: 21
       HeaderType: 40 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 45
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 54624
+      GoRuntimeType: 55744
       GoKind: 21
       HeaderType: 47 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 50
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 55936
+      GoKind: 21
+      HeaderType: 52 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
       ID: 44
       Name: runtime.mapextra
@@ -1039,62 +1251,62 @@ Types:
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 37408
+      GoRuntimeType: 38144
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 54 PointerType *string.str
+          Type: 59 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 53 GoStringDataType string.str
+      Data: 58 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 53
+      ID: 58
       Name: string.str
       ByteSize: 2048
     - __kind: BaseType
       ID: 12
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 38048
+      GoRuntimeType: 38784
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 37664
+      GoRuntimeType: 38400
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 37792
+      GoRuntimeType: 38528
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 37920
+      GoRuntimeType: 38656
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 37536
+      GoRuntimeType: 38272
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 38112
+      GoRuntimeType: 38848
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 38496
+      GoRuntimeType: 39232
       GoKind: 26
-MaxTypeID: 80
+MaxTypeID: 98
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,11 +11,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 87 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb51cc", Frameless: false}]
+        - ID: 12
+          Type: 115 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0xb520c", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -28,11 +28,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 88 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb5204", Frameless: false}]
+        - ID: 13
+          Type: 116 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0xb5244", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -44,8 +44,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 85 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb5690", Frameless: true}]
+          Type: 112 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0xb56d0", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -55,14 +55,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 11}
       events:
-        - ID: 10
-          Type: 86 EventRootType Probe[main.inlined]
+        - ID: 11
+          Type: 114 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb555c"
+            - PC: "0xb559c"
               Frameless: true
-            - PC: "0xb4fec"
+            - PC: "0xb502c"
               Frameless: false
           Condition: null
     - id: intArg
@@ -75,8 +75,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 77 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb525c", Frameless: true}]
+          Type: 104 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0xb529c", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -88,8 +88,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 80 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb53cc", Frameless: true}]
+          Type: 107 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0xb540c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -101,8 +101,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 83 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb5540", Frameless: true}]
+          Type: 110 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0xb5580", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -114,8 +114,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 79 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb534c", Frameless: true}]
+          Type: 106 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0xb538c", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -127,8 +127,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 84 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb561c", Frameless: true}]
+          Type: 111 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0xb565c", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -140,8 +140,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 78 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb52cc", Frameless: true}]
+          Type: 105 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb530c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -153,8 +153,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 82 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb54cc", Frameless: true}]
+          Type: 109 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0xb550c", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -166,31 +166,45 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 81 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb544c", Frameless: true}]
+          Type: 108 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb548c", Frameless: true}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 10
+          Type: 113 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb5790", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb5250..0xb52c0]
+      OutOfLinePCRanges: [0xb5290..0xb5300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb5250..0xb5270
+            - Range: 0xb5290..0xb52b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb52c0..0xb5340]
+      OutOfLinePCRanges: [0xb5300..0xb5380]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb52c0..0xb52e4
+            - Range: 0xb5300..0xb5324
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -200,13 +214,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb5340..0xb53c0]
+      OutOfLinePCRanges: [0xb5380..0xb5400]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 34 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb5340..0xb5364
+            - Range: 0xb5380..0xb53a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -218,25 +232,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb53c0..0xb5440]
+      OutOfLinePCRanges: [0xb5400..0xb5480]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 35 ArrayType [3]int
           Locations:
-            - Range: 0xb53c0..0xb5440
+            - Range: 0xb5400..0xb5480
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb5440..0xb54c0]
+      OutOfLinePCRanges: [0xb5480..0xb5500]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb5440..0xb5464
+            - Range: 0xb5480..0xb54a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -248,127 +262,142 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb54c0..0xb5540]
+      OutOfLinePCRanges: [0xb5500..0xb5580]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 37 ArrayType [3]string
           Locations:
-            - Range: 0xb54c0..0xb5540
+            - Range: 0xb5500..0xb5580
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb5540..0xb5550]
+      OutOfLinePCRanges: [0xb5580..0xb5590]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 37 ArrayType [3]string
           Locations:
-            - Range: 0xb5540..0xb5550
+            - Range: 0xb5580..0xb5590
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb5610..0xb5680]
+      OutOfLinePCRanges: [0xb5650..0xb56c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 38 GoMapType map[string]int
           Locations:
-            - Range: 0xb5610..0xb5648
+            - Range: 0xb5650..0xb5688
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb5680..0xb5740]
+      OutOfLinePCRanges: [0xb56c0..0xb5780]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 43 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb5680..0xb56b8
+            - Range: 0xb56c0..0xb56f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb56b8..0xb5740
+            - Range: 0xb56f8..0xb5780
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0xb5780..0xb5940]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 48 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0xb5780..0xb5940, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 11
       Name: main.inlined
-      OutOfLinePCRanges: [0xb5550..0xb55c0]
+      OutOfLinePCRanges: [0xb5590..0xb5600]
       InlinePCRanges:
-        - Ranges: [0xb4fec..0xb5028]
-          RootRanges: [0xb4e50..0xb5250]
+        - Ranges: [0xb502c..0xb5068]
+          RootRanges: [0xb4e90..0xb5290]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb4fec..0xb5028
+            - Range: 0xb502c..0xb5068
               Pieces: []
-            - Range: 0xb5550..0xb5570
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 11
-      Name: main.PointerChainArg
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xb51cc..0xb51fc]
-          RootRanges: [0xb4e50..0xb5250]
-      Variables:
-        - Name: ptr
-          Type: 48 PointerType *****int
-          Locations:
-            - Range: 0xb51a4..0xb51ec
+            - Range: 0xb5590..0xb55b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xb520c..0xb523c]
+          RootRanges: [0xb4e90..0xb5290]
+      Variables:
+        - Name: ptr
+          Type: 53 PointerType *****int
+          Locations:
+            - Range: 0xb51e4..0xb522c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb5204..0xb5234]
-          RootRanges: [0xb4e50..0xb5250]
+        - Ranges: [0xb5244..0xb5274]
+          RootRanges: [0xb4e90..0xb5290]
       Variables:
         - Name: ptr
-          Type: 50 PointerType **int
+          Type: 55 PointerType **int
           Locations:
-            - Range: 0xb5204..0xb5234
+            - Range: 0xb5244..0xb5274
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 48
+      ID: 53
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 35232
+      GoRuntimeType: 35520
       GoKind: 22
-      Pointee: 49 PointerType ****int
+      Pointee: 54 PointerType ****int
     - __kind: PointerType
-      ID: 49
+      ID: 54
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 35168
+      GoRuntimeType: 35456
       GoKind: 22
-      Pointee: 76 PointerType ***int
+      Pointee: 103 PointerType ***int
     - __kind: PointerType
-      ID: 76
+      ID: 103
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 35104
+      GoRuntimeType: 35392
       GoKind: 22
-      Pointee: 50 PointerType **int
+      Pointee: 55 PointerType **int
     - __kind: PointerType
-      ID: 50
+      ID: 55
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 35040
+      GoRuntimeType: 35328
       GoKind: 22
       Pointee: 28 PointerType *int
+    - __kind: PointerType
+      ID: 89
+      Name: '**table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 90 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 41
       Name: '**table<string,int>'
@@ -380,71 +409,81 @@ Types:
       ByteSize: 8
       Pointee: 47 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 54
+      ID: 51
+      Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 52 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 59
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 53 GoSliceDataType []int.array
+      Pointee: 58 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 56
+      ID: 61
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 55 GoSliceDataType []string.array
+      Pointee: 60 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 29536
+      GoRuntimeType: 29824
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 30
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 28448
+      GoRuntimeType: 28736
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 31
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 29408
+      GoRuntimeType: 29696
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 29472
+      GoRuntimeType: 29760
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 28
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29088
+      GoRuntimeType: 29376
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 28832
+      GoRuntimeType: 29120
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 28960
+      GoRuntimeType: 29248
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 71
+      ID: 76
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 26912
+      GoRuntimeType: 27200
       GoKind: 22
-      Pointee: 72 StructureType main.bigStruct
+      Pointee: 77 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 87
+      Name: '*map<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 88 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 39
       Name: '*map<string,int>'
@@ -456,81 +495,106 @@ Types:
       ByteSize: 8
       Pointee: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 59
+      ID: 49
+      Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 50 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 95
+      Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 96 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: PointerType
+      ID: 64
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 60 StructureType noalg.map.group[string]int
+      Pointee: 65 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 67
+      ID: 72
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 73 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 82
+      Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 83 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28512
+      GoRuntimeType: 28800
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 52
+      ID: 57
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 51 GoStringDataType string.str
+      Pointee: 56 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 90
+      Name: '*table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 93 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 42
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 57 StructureType table<string,int>
+      Pointee: 62 StructureType table<string,int>
     - __kind: PointerType
       ID: 47
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 65 StructureType table<string,main.bigStruct>
+      Pointee: 70 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 52
+      Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 80 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 32
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 29152
+      GoRuntimeType: 29440
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 33
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 28768
+      GoRuntimeType: 29056
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 28896
+      GoRuntimeType: 29184
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 29
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29024
+      GoRuntimeType: 29312
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 28640
+      GoRuntimeType: 28928
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 29216
+      GoRuntimeType: 29504
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 87
+      ID: 115
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -538,14 +602,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 48 PointerType *****int
+            Type: 53 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 88
+      ID: 116
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -553,14 +617,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 50 PointerType **int
+            Type: 55 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 85
+      ID: 112
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -575,7 +639,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 86
+      ID: 114
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -586,11 +650,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 77
+      ID: 104
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -605,7 +669,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 80
+      ID: 107
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -620,7 +684,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 79
+      ID: 106
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -635,7 +699,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 84
+      ID: 111
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -650,7 +714,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 78
+      ID: 105
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -665,7 +729,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 83
+      ID: 110
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -680,7 +744,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 82
+      ID: 109
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -695,7 +759,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 81
+      ID: 108
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -709,11 +773,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 113
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
-      ID: 75
+      ID: 102
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 46208
+      GoRuntimeType: 47456
       GoKind: 17
       Count: 128
       HasCount: true
@@ -722,7 +789,7 @@ Types:
       ID: 35
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 45920
+      GoRuntimeType: 47072
       GoKind: 17
       Count: 3
       HasCount: true
@@ -731,26 +798,36 @@ Types:
       ID: 37
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 46016
+      GoRuntimeType: 47168
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 63
+      ID: 100
+      Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 8192
+      Element: 90 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 68
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 42 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 78
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 47 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 91
+      Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 8192
+      Element: 52 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 34
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 37664
+      GoRuntimeType: 38144
       GoKind: 23
       RawFields:
         - Name: array
@@ -762,27 +839,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 53 GoSliceDataType []int.array
+      Data: 58 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 53
+      ID: 58
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 64
+      ID: 101
+      Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
+      ByteSize: 2048
+      Element: 96 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoSliceDataType
+      ID: 69
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 60 StructureType noalg.map.group[string]int
+      Element: 65 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 79
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[string]main.bigStruct
+      Element: 73 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceDataType
+      ID: 92
+      Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
+      ByteSize: 2048
+      Element: 83 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 37920
+      GoRuntimeType: 38400
       GoKind: 23
       RawFields:
         - Name: array
@@ -794,9 +881,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 55 GoSliceDataType []string.array
+      Data: 60 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 55
+      ID: 60
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -804,25 +891,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 42368
+      GoRuntimeType: 43168
       GoKind: 1
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 42176
+      GoRuntimeType: 42976
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 42112
+      GoRuntimeType: 42912
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 63040
+      GoRuntimeType: 64544
       GoKind: 20
       RawFields:
         - Name: tab
@@ -835,77 +922,112 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 42240
+      GoRuntimeType: 43040
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 42304
+      GoRuntimeType: 43104
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 58
+      ID: 94
+      Name: groupReference<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 95 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 96 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 101 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+    - __kind: GoSwissMapGroupsType
+      ID: 63
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 59 PointerType *noalg.map.group[string]int
+          Type: 64 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 60 StructureType noalg.map.group[string]int
-      GroupSliceType: 64 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 65 StructureType noalg.map.group[string]int
+      GroupSliceType: 69 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 66
+      ID: 71
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 67 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 72 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 73 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 81
+      Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 82 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 83 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 92 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 41920
+      GoRuntimeType: 42720
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 41536
+      GoRuntimeType: 42336
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 41664
+      GoRuntimeType: 42464
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 41792
+      GoRuntimeType: 42592
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 41408
+      GoRuntimeType: 42208
       GoKind: 3
     - __kind: StructureType
-      ID: 72
+      ID: 99
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 70784
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
+    - __kind: StructureType
+      ID: 77
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 119616
+      GoRuntimeType: 122400
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -931,7 +1053,39 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 75 ArrayType [128]uint8
+          Type: 102 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 88
+      Name: map<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 89 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 100 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 96 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 40
       Name: map<string,int>
@@ -962,8 +1116,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 63 GoSliceDataType []*table<string,int>.array
-      GroupType: 60 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 68 GoSliceDataType []*table<string,int>.array
+      GroupType: 65 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 45
       Name: map<string,main.bigStruct>
@@ -994,45 +1148,122 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 73 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 78 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 73 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 50
+      Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 51 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 91 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 83 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoMapType
+      ID: 86
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 68640
+      GoKind: 21
+      HeaderType: 88 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 67136
+      GoRuntimeType: 68768
       GoKind: 21
       HeaderType: 40 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 43
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 67264
+      GoRuntimeType: 68896
       GoKind: 21
       HeaderType: 45 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 48
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 69152
+      GoKind: 21
+      HeaderType: 50 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 69
+      ID: 97
+      Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 47264
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 98 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: ArrayType
+      ID: 74
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 46304
+      GoRuntimeType: 47552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 70 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 75 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 61
+      ID: 66
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 46112
+      GoRuntimeType: 47360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 62 StructureType noalg.struct { key string; elem int }
+      Element: 67 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 84
+      Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 47744
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 85 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 60
+      ID: 96
+      Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 76544
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 97 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 65
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 74528
+      GoRuntimeType: 76800
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1040,12 +1271,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 61 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 66 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 68
+      ID: 73
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 74784
+      GoRuntimeType: 77056
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1053,12 +1284,38 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 74 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 70
+      ID: 83
+      Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 77568
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 84 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 98
+      Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 76416
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 99 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: StructureType
+      ID: 75
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 74656
+      GoRuntimeType: 76928
       GoKind: 25
       RawFields:
         - Name: key
@@ -1066,12 +1323,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 71 PointerType *main.bigStruct
+          Type: 76 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 62
+      ID: 67
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 74400
+      GoRuntimeType: 76672
       GoKind: 25
       RawFields:
         - Name: key
@@ -1080,26 +1337,63 @@ Types:
         - Name: elem
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 85
+      Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 77440
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 86 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 41344
+      GoRuntimeType: 42144
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 52 PointerType *string.str
+          Type: 57 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 51 GoStringDataType string.str
+      Data: 56 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 51
+      ID: 56
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 57
+      ID: 93
+      Name: table<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 94 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+    - __kind: StructureType
+      ID: 62
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1121,9 +1415,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 58 GoSwissMapGroupsType groupReference<string,int>
+          Type: 63 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 65
+      ID: 70
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1145,49 +1439,73 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 71 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 80
+      Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 81 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 41984
+      GoRuntimeType: 42784
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 41600
+      GoRuntimeType: 42400
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 41728
+      GoRuntimeType: 42528
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 41856
+      GoRuntimeType: 42656
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 41472
+      GoRuntimeType: 42272
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 42048
+      GoRuntimeType: 42848
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 42432
+      GoRuntimeType: 43232
       GoKind: 26
-MaxTypeID: 88
+MaxTypeID: 116
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191340", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,11 +11,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 12}
       events:
-        - ID: 11
-          Type: 87 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb7d60", Frameless: false}]
+        - ID: 12
+          Type: 115 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0xb7da0", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -28,11 +28,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 13}
       events:
-        - ID: 12
-          Type: 88 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb7d94", Frameless: false}]
+        - ID: 13
+          Type: 116 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0xb7dd4", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -44,8 +44,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 85 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb81f0", Frameless: true}]
+          Type: 112 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0xb8230", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -55,14 +55,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 11}
       events:
-        - ID: 10
-          Type: 86 EventRootType Probe[main.inlined]
+        - ID: 11
+          Type: 114 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb80bc"
+            - PC: "0xb80fc"
               Frameless: true
-            - PC: "0xb7b88"
+            - PC: "0xb7bc8"
               Frameless: false
           Condition: null
     - id: intArg
@@ -75,8 +75,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 77 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb7dec", Frameless: true}]
+          Type: 104 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0xb7e2c", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -88,8 +88,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 80 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb7f4c", Frameless: true}]
+          Type: 107 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0xb7f8c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -101,8 +101,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 83 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb80a0", Frameless: true}]
+          Type: 110 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0xb80e0", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -114,8 +114,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 79 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb7ecc", Frameless: true}]
+          Type: 106 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0xb7f0c", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -127,8 +127,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 84 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb817c", Frameless: true}]
+          Type: 111 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0xb81bc", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -140,8 +140,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 78 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb7e5c", Frameless: true}]
+          Type: 105 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7e9c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -153,8 +153,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 82 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb803c", Frameless: true}]
+          Type: 109 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0xb807c", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -166,31 +166,45 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 81 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb7fbc", Frameless: true}]
+          Type: 108 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb7ffc", Frameless: true}]
+          Condition: null
+    - id: usesMapsOfMapsThatDoNotAppearAsArguments
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 10
+          Type: 113 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          InjectionPoints: [{PC: "0xb82e0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb7de0..0xb7e50]
+      OutOfLinePCRanges: [0xb7e20..0xb7e90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb7de0..0xb7e00
+            - Range: 0xb7e20..0xb7e40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb7e50..0xb7ec0]
+      OutOfLinePCRanges: [0xb7e90..0xb7f00]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb7e50..0xb7e74
+            - Range: 0xb7e90..0xb7eb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -200,13 +214,13 @@ Subprograms:
           IsReturn: false
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb7ec0..0xb7f40]
+      OutOfLinePCRanges: [0xb7f00..0xb7f80]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 34 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb7ec0..0xb7ee4
+            - Range: 0xb7f00..0xb7f24
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -218,25 +232,25 @@ Subprograms:
           IsReturn: false
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb7f40..0xb7fb0]
+      OutOfLinePCRanges: [0xb7f80..0xb7ff0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 35 ArrayType [3]int
           Locations:
-            - Range: 0xb7f40..0xb7fb0
+            - Range: 0xb7f80..0xb7ff0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb7fb0..0xb8030]
+      OutOfLinePCRanges: [0xb7ff0..0xb8070]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 36 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb7fb0..0xb7fd4
+            - Range: 0xb7ff0..0xb8014
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -248,127 +262,142 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb8030..0xb80a0]
+      OutOfLinePCRanges: [0xb8070..0xb80e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 37 ArrayType [3]string
           Locations:
-            - Range: 0xb8030..0xb80a0
+            - Range: 0xb8070..0xb80e0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb80a0..0xb80b0]
+      OutOfLinePCRanges: [0xb80e0..0xb80f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 37 ArrayType [3]string
           Locations:
-            - Range: 0xb80a0..0xb80b0
+            - Range: 0xb80e0..0xb80f0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb8170..0xb81e0]
+      OutOfLinePCRanges: [0xb81b0..0xb8220]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 38 GoMapType map[string]int
           Locations:
-            - Range: 0xb8170..0xb81a4
+            - Range: 0xb81b0..0xb81e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb81e0..0xb8290]
+      OutOfLinePCRanges: [0xb8220..0xb82d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 43 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb81e0..0xb8218
+            - Range: 0xb8220..0xb8258
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb8218..0xb8290
+            - Range: 0xb8258..0xb82d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
+      Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
+      OutOfLinePCRanges: [0xb82d0..0xb8480]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 48 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0xb82d0..0xb8480, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 11
       Name: main.inlined
-      OutOfLinePCRanges: [0xb80b0..0xb8120]
+      OutOfLinePCRanges: [0xb80f0..0xb8160]
       InlinePCRanges:
-        - Ranges: [0xb7b88..0xb7bbc]
-          RootRanges: [0xb7a00..0xb7de0]
+        - Ranges: [0xb7bc8..0xb7bfc]
+          RootRanges: [0xb7a40..0xb7e20]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb7b88..0xb7bbc
+            - Range: 0xb7bc8..0xb7bfc
               Pieces: []
-            - Range: 0xb80b0..0xb80d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 11
-      Name: main.PointerChainArg
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xb7d60..0xb7d8c]
-          RootRanges: [0xb7a00..0xb7de0]
-      Variables:
-        - Name: ptr
-          Type: 48 PointerType *****int
-          Locations:
-            - Range: 0xb7d38..0xb7d7c
+            - Range: 0xb80f0..0xb8110
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xb7da0..0xb7dcc]
+          RootRanges: [0xb7a40..0xb7e20]
+      Variables:
+        - Name: ptr
+          Type: 53 PointerType *****int
+          Locations:
+            - Range: 0xb7d78..0xb7dbc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb7d94..0xb7dc0]
-          RootRanges: [0xb7a00..0xb7de0]
+        - Ranges: [0xb7dd4..0xb7e00]
+          RootRanges: [0xb7a40..0xb7e20]
       Variables:
         - Name: ptr
-          Type: 50 PointerType **int
+          Type: 55 PointerType **int
           Locations:
-            - Range: 0xb7d94..0xb7dc0
+            - Range: 0xb7dd4..0xb7e00
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 48
+      ID: 53
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 36288
+      GoRuntimeType: 36608
       GoKind: 22
-      Pointee: 49 PointerType ****int
+      Pointee: 54 PointerType ****int
     - __kind: PointerType
-      ID: 49
+      ID: 54
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 36224
+      GoRuntimeType: 36544
       GoKind: 22
-      Pointee: 76 PointerType ***int
+      Pointee: 103 PointerType ***int
     - __kind: PointerType
-      ID: 76
+      ID: 103
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 36160
+      GoRuntimeType: 36480
       GoKind: 22
-      Pointee: 50 PointerType **int
+      Pointee: 55 PointerType **int
     - __kind: PointerType
-      ID: 50
+      ID: 55
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 36096
+      GoRuntimeType: 36416
       GoKind: 22
       Pointee: 27 PointerType *int
+    - __kind: PointerType
+      ID: 89
+      Name: '**table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 90 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 41
       Name: '**table<string,int>'
@@ -380,71 +409,81 @@ Types:
       ByteSize: 8
       Pointee: 47 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 54
+      ID: 51
+      Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 52 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 59
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 53 GoSliceDataType []int.array
+      Pointee: 58 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 56
+      ID: 61
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 55 GoSliceDataType []string.array
+      Pointee: 60 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30400
+      GoRuntimeType: 30720
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 30
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 29312
+      GoRuntimeType: 29632
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 31
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 30272
+      GoRuntimeType: 30592
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 30336
+      GoRuntimeType: 30656
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29952
+      GoRuntimeType: 30272
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29696
+      GoRuntimeType: 30016
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 29
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 29824
+      GoRuntimeType: 30144
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 71
+      ID: 76
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 27776
+      GoRuntimeType: 28096
       GoKind: 22
-      Pointee: 72 StructureType main.bigStruct
+      Pointee: 77 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 87
+      Name: '*map<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 88 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 39
       Name: '*map<string,int>'
@@ -456,81 +495,106 @@ Types:
       ByteSize: 8
       Pointee: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 59
+      ID: 49
+      Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 50 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: PointerType
+      ID: 95
+      Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 96 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: PointerType
+      ID: 64
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 60 StructureType noalg.map.group[string]int
+      Pointee: 65 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 67
+      ID: 72
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 73 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 82
+      Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
+      ByteSize: 8
+      Pointee: 83 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 29376
+      GoRuntimeType: 29696
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 52
+      ID: 57
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 51 GoStringDataType string.str
+      Pointee: 56 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 90
+      Name: '*table<int,main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 93 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 42
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 57 StructureType table<string,int>
+      Pointee: 62 StructureType table<string,int>
     - __kind: PointerType
       ID: 47
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 65 StructureType table<string,main.bigStruct>
+      Pointee: 70 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 52
+      Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 80 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 32
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 30016
+      GoRuntimeType: 30336
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 33
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29632
+      GoRuntimeType: 29952
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 29760
+      GoRuntimeType: 30080
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29888
+      GoRuntimeType: 30208
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29504
+      GoRuntimeType: 29824
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 30080
+      GoRuntimeType: 30400
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 87
+      ID: 115
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -538,14 +602,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 48 PointerType *****int
+            Type: 53 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 88
+      ID: 116
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -553,14 +617,14 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 50 PointerType **int
+            Type: 55 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: ptr}
+                  Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 85
+      ID: 112
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -575,7 +639,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 86
+      ID: 114
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -586,11 +650,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 77
+      ID: 104
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -605,7 +669,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 80
+      ID: 107
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -620,7 +684,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 79
+      ID: 106
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -635,7 +699,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 84
+      ID: 111
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -650,7 +714,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 78
+      ID: 105
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -665,7 +729,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 83
+      ID: 110
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -680,7 +744,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 82
+      ID: 109
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -695,7 +759,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 81
+      ID: 108
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -709,11 +773,14 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 113
+      Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: ArrayType
-      ID: 75
+      ID: 102
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 47648
+      GoRuntimeType: 48928
       GoKind: 17
       Count: 128
       HasCount: true
@@ -722,7 +789,7 @@ Types:
       ID: 35
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 47360
+      GoRuntimeType: 48544
       GoKind: 17
       Count: 3
       HasCount: true
@@ -731,26 +798,36 @@ Types:
       ID: 37
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 47456
+      GoRuntimeType: 48640
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 63
+      ID: 100
+      Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 8192
+      Element: 90 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 68
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 42 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 78
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 47 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceDataType
+      ID: 91
+      Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
+      ByteSize: 8192
+      Element: 52 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 34
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 38784
+      GoRuntimeType: 39296
       GoKind: 23
       RawFields:
         - Name: array
@@ -762,27 +839,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 53 GoSliceDataType []int.array
+      Data: 58 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 53
+      ID: 58
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 64
+      ID: 101
+      Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
+      ByteSize: 2048
+      Element: 96 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoSliceDataType
+      ID: 69
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 60 StructureType noalg.map.group[string]int
+      Element: 65 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 79
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[string]main.bigStruct
+      Element: 73 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceDataType
+      ID: 92
+      Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
+      ByteSize: 2048
+      Element: 83 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 39040
+      GoRuntimeType: 39552
       GoKind: 23
       RawFields:
         - Name: array
@@ -794,9 +881,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 55 GoSliceDataType []string.array
+      Data: 60 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 55
+      ID: 60
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -804,25 +891,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 43744
+      GoRuntimeType: 44576
       GoKind: 1
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 43552
+      GoRuntimeType: 44384
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 43488
+      GoRuntimeType: 44320
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 65728
+      GoRuntimeType: 67264
       GoKind: 20
       RawFields:
         - Name: tab
@@ -835,77 +922,112 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 43616
+      GoRuntimeType: 44448
       GoKind: 13
     - __kind: BaseType
       ID: 16
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 43680
+      GoRuntimeType: 44512
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 58
+      ID: 94
+      Name: groupReference<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 95 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 96 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 101 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+    - __kind: GoSwissMapGroupsType
+      ID: 63
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 59 PointerType *noalg.map.group[string]int
+          Type: 64 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 60 StructureType noalg.map.group[string]int
-      GroupSliceType: 64 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 65 StructureType noalg.map.group[string]int
+      GroupSliceType: 69 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 66
+      ID: 71
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 67 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 72 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 73 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 81
+      Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 82 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 83 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 92 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 43296
+      GoRuntimeType: 44128
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 42912
+      GoRuntimeType: 43744
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 43040
+      GoRuntimeType: 43872
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 43168
+      GoRuntimeType: 44000
       GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 42784
+      GoRuntimeType: 43616
       GoKind: 3
     - __kind: StructureType
-      ID: 72
+      ID: 99
+      Name: main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 73408
+      GoKind: 25
+      RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
+    - __kind: StructureType
+      ID: 77
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 124608
+      GoRuntimeType: 127424
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -931,7 +1053,42 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 75 ArrayType [128]uint8
+          Type: 102 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 88
+      Name: map<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 89 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 100 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 96 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 40
       Name: map<string,int>
@@ -965,8 +1122,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 63 GoSliceDataType []*table<string,int>.array
-      GroupType: 60 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 68 GoSliceDataType []*table<string,int>.array
+      GroupType: 65 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 45
       Name: map<string,main.bigStruct>
@@ -1000,45 +1157,125 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 73 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 78 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 73 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 50
+      Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 51 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 91 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 83 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+    - __kind: GoMapType
+      ID: 86
+      Name: map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 71488
+      GoKind: 21
+      HeaderType: 88 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 69952
+      GoRuntimeType: 71616
       GoKind: 21
       HeaderType: 40 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 43
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 70080
+      GoRuntimeType: 71744
       GoKind: 21
       HeaderType: 45 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 48
+      Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 72000
+      GoKind: 21
+      HeaderType: 50 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 69
+      ID: 97
+      Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 48736
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 98 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: ArrayType
+      ID: 74
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 47744
+      GoRuntimeType: 49024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 70 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 75 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 61
+      ID: 66
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 47552
+      GoRuntimeType: 48832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 62 StructureType noalg.struct { key string; elem int }
+      Element: 67 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 84
+      Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 128
+      GoRuntimeType: 49216
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 85 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 60
+      ID: 96
+      Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 79168
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 97 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 65
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 77120
+      GoRuntimeType: 79424
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1046,12 +1283,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 61 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 66 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 68
+      ID: 73
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 77376
+      GoRuntimeType: 79680
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -1059,12 +1296,38 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 74 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 70
+      ID: 83
+      Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 136
+      GoRuntimeType: 80192
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 84 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+    - __kind: StructureType
+      ID: 98
+      Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 79040
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 99 StructureType main.aStructNotUsedAsAnArgument
+    - __kind: StructureType
+      ID: 75
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 77248
+      GoRuntimeType: 79552
       GoKind: 25
       RawFields:
         - Name: key
@@ -1072,12 +1335,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 71 PointerType *main.bigStruct
+          Type: 76 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 62
+      ID: 67
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 76992
+      GoRuntimeType: 79296
       GoKind: 25
       RawFields:
         - Name: key
@@ -1086,26 +1349,63 @@ Types:
         - Name: elem
           Offset: 16
           Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 85
+      Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      ByteSize: 16
+      GoRuntimeType: 80064
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 3 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 86 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 42720
+      GoRuntimeType: 43552
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 52 PointerType *string.str
+          Type: 57 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 51 GoStringDataType string.str
+      Data: 56 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 51
+      ID: 56
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 57
+      ID: 93
+      Name: table<int,main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 94 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+    - __kind: StructureType
+      ID: 62
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1127,9 +1427,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 58 GoSwissMapGroupsType groupReference<string,int>
+          Type: 63 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 65
+      ID: 70
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1151,49 +1451,73 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 71 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 80
+      Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 81 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 43360
+      GoRuntimeType: 44192
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 42976
+      GoRuntimeType: 43808
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 43104
+      GoRuntimeType: 43936
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 43232
+      GoRuntimeType: 44064
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 42848
+      GoRuntimeType: 43680
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 43424
+      GoRuntimeType: 44256
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 43808
+      GoRuntimeType: 44640
       GoKind: 26
-MaxTypeID: 88
+MaxTypeID: 116
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1a13a0", TypesOffset: 296}

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -1,36 +1,39 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [110:111]
-		Arg: ptr: *****int (declared at line 0, available: [111-111])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [114:115]
-		Arg: ptr: **int (declared at line 0, available: [115-115])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:77]
-		Arg: x: int (declared at line 0, available: [75-76])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 131, available: )
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
+		Arg: ptr: *****int (declared at line 0, available: [112-112])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
+		Arg: ptr: **int (declared at line 0, available: [116-116])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
+		Arg: x: int (declared at line 0, available: [76-77])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
@@ -1,36 +1,38 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [110:111]
-		Arg: ptr: *****int (declared at line 0, available: [111-111])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [114:115]
-		Arg: ptr: **int (declared at line 0, available: [115-115])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:77]
-		Arg: x: int (declared at line 0, available: [75-76])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
+		Arg: ptr: *****int (declared at line 0, available: [112-112])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
+		Arg: ptr: **int (declared at line 0, available: [116-116])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
+		Arg: x: int (declared at line 0, available: [76-77])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
@@ -1,36 +1,38 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [110:111]
-		Arg: ptr: *****int (declared at line 0, available: [111-111])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [114:115]
-		Arg: ptr: **int (declared at line 0, available: [115-115])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:77]
-		Arg: x: int (declared at line 0, available: [75-76])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
+		Arg: ptr: *****int (declared at line 0, available: [112-112])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
+		Arg: ptr: **int (declared at line 0, available: [116-116])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
+		Arg: x: int (declared at line 0, available: [76-77])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -1,36 +1,39 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [110:111]
-		Arg: ptr: *****int (declared at line 0, available: [111-111])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [114:115]
-		Arg: ptr: **int (declared at line 0, available: [115-115])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:77]
-		Arg: x: int (declared at line 0, available: [75-76])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 131, available: )
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
+		Arg: ptr: *****int (declared at line 0, available: [112-112])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
+		Arg: ptr: **int (declared at line 0, available: [116-116])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
+		Arg: x: int (declared at line 0, available: [76-77])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
@@ -1,36 +1,38 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [110:111]
-		Arg: ptr: *****int (declared at line 0, available: [111-111])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [114:115]
-		Arg: ptr: **int (declared at line 0, available: [115-115])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:77]
-		Arg: x: int (declared at line 0, available: [75-76])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
+		Arg: ptr: *****int (declared at line 0, available: [112-112])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
+		Arg: ptr: **int (declared at line 0, available: [116-116])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
+		Arg: x: int (declared at line 0, available: [76-77])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
@@ -1,36 +1,38 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [110:111]
-		Arg: ptr: *****int (declared at line 0, available: [111-111])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [114:115]
-		Arg: ptr: **int (declared at line 0, available: [115-115])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:77]
-		Arg: x: int (declared at line 0, available: [75-76])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [111:112]
+		Arg: ptr: *****int (declared at line 0, available: [112-112])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [115:116]
+		Arg: ptr: **int (declared at line 0, available: [116-116])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [76:78]
+		Arg: x: int (declared at line 0, available: [76-77])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,30 +1,33 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 131, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,30 +1,32 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,30 +1,32 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,30 +1,33 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 131, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,30 +1,32 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,30 +1,32 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:40]
 		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-39])
-		Var: &ptr1: **int (declared at line 32, available: [14-39])
-		Var: &ptr2: ***int (declared at line 33, available: [14-39])
-		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &val: *int (declared at line 31, available: [14-40])
+		Var: &ptr1: **int (declared at line 32, available: [14-40])
+		Var: &ptr2: ***int (declared at line 33, available: [14-40])
+		Var: &ptr3: ****int (declared at line 34, available: [14-40])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
-		Arg: x: int (declared at line 42, available: [42-43])
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
-		Arg: s: string (declared at line 47, available: [47-48])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
-		Arg: s: []int (declared at line 52, available: [52-53])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
-		Arg: s: [3]int (declared at line 57, available: [57-59])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
-		Arg: s: []string (declared at line 62, available: [62-63])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
-		Arg: s: [3]string (declared at line 67, available: [67-69])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
-		Arg: s: [3]string (declared at line 72, available: [73-73])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
-		Arg: f: func(int) (declared at line 80, available: [80-81])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
-		Arg: m: map[string]int (declared at line 85, available: [85-86])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
-		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [43:45]
+		Arg: x: int (declared at line 43, available: [43-44])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [48:50]
+		Arg: s: string (declared at line 48, available: [48-49])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [53:55]
+		Arg: s: []int (declared at line 53, available: [53-54])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [58:60]
+		Arg: s: [3]int (declared at line 58, available: [58-60])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [63:65]
+		Arg: s: []string (declared at line 63, available: [63-64])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [68:70]
+		Arg: s: [3]string (declared at line 68, available: [68-70])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [74:74]
+		Arg: s: [3]string (declared at line 73, available: [74-74])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [81:83]
+		Arg: f: func(int) (declared at line 81, available: [81-82])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [86:88]
+		Arg: m: map[string]int (declared at line 86, available: [86-87])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [103:109]
+		Arg: m: map[string]main.bigStruct (declared at line 103, available: [103-109])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [128:138]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 128, available: )

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.PointerChainArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 111
+            "lineNumber": 112
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.PointerSmallChainArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 115
+            "lineNumber": 116
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.bigMapArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 102
+            "lineNumber": 103
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -18,7 +18,7 @@
           {
             "function": "main.inlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 76
+            "lineNumber": 77
           },
           {
             "function": "main.main",
@@ -75,12 +75,12 @@
           {
             "function": "main.inlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 75
+            "lineNumber": 76
           },
           {
             "function": "main.funcArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 42
+            "lineNumber": 43
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 57
+            "lineNumber": 58
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArgFrameless",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 73
+            "lineNumber": 74
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 52
+            "lineNumber": 53
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 47
+            "lineNumber": 48
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 67
+            "lineNumber": 68
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 62
+            "lineNumber": 63
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.mapArg",
+      "method": "main.usesMapsOfMapsThatDoNotAppearAsArguments",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.mapArg",
+            "function": "main.usesMapsOfMapsThatDoNotAppearAsArguments",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 86
+            "lineNumber": 128
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 29
+            "lineNumber": 39
           },
           {
             "function": "runtime.main",
@@ -37,31 +37,14 @@
           }
         ],
         "probe": {
-          "id": "mapArg",
+          "id": "usesMapsOfMapsThatDoNotAppearAsArguments",
           "location": {
-            "method": "main.mapArg"
+            "method": "main.usesMapsOfMapsThatDoNotAppearAsArguments"
           }
         },
         "captures": {
           "entry": {
-            "arguments": {
-              "m": {
-                "type": "map[string]int",
-                "size": "1",
-                "entries": [
-                  [
-                    {
-                      "type": "string",
-                      "value": "a"
-                    },
-                    {
-                      "type": "int",
-                      "value": "1"
-                    }
-                  ]
-                ]
-              }
-            }
+            "arguments": {}
           }
         }
       }

--- a/pkg/dyninst/testprogs/progs/simple/main.go
+++ b/pkg/dyninst/testprogs/progs/simple/main.go
@@ -36,6 +36,7 @@ func main() {
 	ptr5 := &ptr4
 	PointerChainArg(ptr5)
 	PointerSmallChainArg(ptr2)
+	usesMapsOfMapsThatDoNotAppearAsArguments()
 }
 
 //go:noinline
@@ -113,4 +114,27 @@ func PointerChainArg(ptr *****int) {
 
 func PointerSmallChainArg(ptr **int) {
 	fmt.Println(ptr)
+}
+
+type aStructNotUsedAsAnArgument struct {
+	a int
+}
+
+// This test tickles a bug where we didn't explore variable types when we
+// but we were adding them. At that point we violated an invariant regarding
+// the completion of internals of map types. This test reproduced that bug.
+//
+//go:noinline
+func usesMapsOfMapsThatDoNotAppearAsArguments() map[byte]map[int]aStructNotUsedAsAnArgument {
+	// The bug required a map of maps. We make a new type here to ensure
+	// that it's not a map type that could possibly exist elsewhere.
+	m := map[string]map[int]aStructNotUsedAsAnArgument{
+		"a": {0: aStructNotUsedAsAnArgument{a: 1}},
+	}
+	if m["b"] != nil {
+		m["b"][0] = aStructNotUsedAsAnArgument{a: 2}
+	}
+	return map[byte]map[int]aStructNotUsedAsAnArgument{
+		'a': m["a"],
+	}
 }

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -67,3 +67,8 @@ probes:
     methodName: main.PointerSmallChainArg
   capture:
     maxReferenceDepth: 5
+- id: usesMapsOfMapsThatDoNotAppearAsArguments
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments


### PR DESCRIPTION
### What does this PR do?

This PR fixes issues in irgen found in real-world binaries from testing. In particular:

* it stops exploring local variables (we don't capture them)
* it always runs type expansion on all types (at least to a level of 0) -- this more deeply upholds an invariant
* it allows and warns about bogus DW_AT_GO_runtime_type dwarf attributes

### Motivation

The ir generation needs to succeed on all the binaries we can find. This fixes issues found with real binaries.

### Describe how you validated your changes

Added automated testing and ran the generation on real, large binaries.

