### PR TITLE
usm: Disable map no_prealloc if kernel is prior to 6.1

### DIFF
--- a/pkg/network/config/usm_config_linux_test.go
+++ b/pkg/network/config/usm_config_linux_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+)
+
+func TestDisableMapPreallocation(t *testing.T) {
+	t.Run("via yaml", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.disable_map_preallocation", false)
+		cfg := New()
+
+		assert.False(t, cfg.DisableMapPreallocation)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_DISABLE_MAP_PREALLOCATION", "false")
+		cfg := New()
+
+		assert.False(t, cfg.DisableMapPreallocation)
+	})
+
+	t.Run("default value", func(t *testing.T) {
+		kversion, err := kernel.HostVersion()
+		require.NoError(t, err)
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.Equal(t, cfg.DisableMapPreallocation, kversion >= kernel.VersionCode(6, 1, 0))
+	})
+}

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -109,31 +109,6 @@ func TestUSMDataChannelSize(t *testing.T) {
 	})
 }
 
-func TestDisableMapPreallocation(t *testing.T) {
-	t.Run("via yaml", func(t *testing.T) {
-		mockSystemProbe := mock.NewSystemProbe(t)
-		mockSystemProbe.SetWithoutSource("service_monitoring_config.disable_map_preallocation", false)
-		cfg := New()
-
-		assert.False(t, cfg.DisableMapPreallocation)
-	})
-
-	t.Run("via ENV variable", func(t *testing.T) {
-		mock.NewSystemProbe(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_DISABLE_MAP_PREALLOCATION", "false")
-		cfg := New()
-
-		assert.False(t, cfg.DisableMapPreallocation)
-	})
-
-	t.Run("default value", func(t *testing.T) {
-		mock.NewSystemProbe(t)
-		cfg := New()
-
-		assert.True(t, cfg.DisableMapPreallocation)
-	})
-}
-
 func TestMaxUSMConcurrentRequests(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
 		mock.NewSystemProbe(t)

--- a/pkg/system-probe/config/adjust_usm.go
+++ b/pkg/system-probe/config/adjust_usm.go
@@ -83,4 +83,12 @@ func adjustUSM(cfg model.Config) {
 	})
 
 	limitMaxInt64(cfg, smNS("http", "max_request_fragment"), maxHTTPFrag)
+
+	if cfg.GetBool(smNS("disable_map_preallocation")) && !eBPFMapPreallocationSupported() {
+		if flavor.GetFlavor() == flavor.SystemProbe {
+			// Only log in system-probe, as we cannot reliably know this in the agent
+			log.Warn("using preallocaed eBPF map for USM as it is supported for this kernel version")
+		}
+		cfg.Set(smNS("disable_map_preallocation"), false, model.SourceAgentRuntime)
+	}
 }

--- a/pkg/system-probe/config/config_darwin.go
+++ b/pkg/system-probe/config/config_darwin.go
@@ -9,6 +9,11 @@ package config
 
 import "github.com/DataDog/datadog-agent/pkg/config/model"
 
+// eBPFMapPreallocationSupported returns false on non linux_bpf systems.
+func eBPFMapPreallocationSupported() bool {
+	return false
+}
+
 // ProcessEventDataStreamSupported returns true if process event data stream is supported
 func ProcessEventDataStreamSupported() bool {
 	return false

--- a/pkg/system-probe/config/config_linux.go
+++ b/pkg/system-probe/config/config_linux.go
@@ -11,6 +11,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
+// eBPFMapPreallocationSupported returns false on non linux_bpf systems.
+func eBPFMapPreallocationSupported() bool {
+	return false
+}
+
 // ProcessEventDataStreamSupported returns true if process event data stream is supported
 func ProcessEventDataStreamSupported() bool {
 	return false

--- a/pkg/system-probe/config/config_linux_bpf.go
+++ b/pkg/system-probe/config/config_linux_bpf.go
@@ -19,6 +19,19 @@ var (
 	allowPrecompiledFallbackKey = spNS("allow_precompiled_fallback")
 )
 
+// eBPFMapPreallocationSupported return true if the kernel has the BPF memory allocator, without it, using NO_PREALLOC
+// can lead to performance implications, as the allocator takes care of caching allocations.
+func eBPFMapPreallocationSupported() bool {
+	kernelVersion, err := ebpfkernel.NewKernelVersion()
+
+	if err != nil {
+		log.Warnf("unable to detect the kernel version: %s", err)
+		return false
+	}
+
+	return kernelVersion.Code >= ebpfkernel.Kernel6_1
+}
+
 // ProcessEventDataStreamSupported returns true if process event data stream is supported
 func ProcessEventDataStreamSupported() bool {
 	kernelVersion, err := ebpfkernel.NewKernelVersion()

--- a/pkg/system-probe/config/config_unsupported.go
+++ b/pkg/system-probe/config/config_unsupported.go
@@ -22,6 +22,11 @@ func ValidateSocketAddress(sockPath string) error {
 	return errors.New("system-probe unsupported")
 }
 
+// eBPFMapPreallocationSupported returns false on non linux_bpf systems.
+func eBPFMapPreallocationSupported() bool {
+	return false
+}
+
 // ProcessEventDataStreamSupported returns true if process event data stream is supported
 func ProcessEventDataStreamSupported() bool {
 	return false

--- a/pkg/system-probe/config/config_windows.go
+++ b/pkg/system-probe/config/config_windows.go
@@ -39,6 +39,11 @@ func ValidateSocketAddress(sockAddress string) error {
 	return nil
 }
 
+// eBPFMapPreallocationSupported returns false on non linux_bpf systems.
+func eBPFMapPreallocationSupported() bool {
+	return false
+}
+
 // ProcessEventDataStreamSupported returns true if process event data stream is supported
 func ProcessEventDataStreamSupported() bool {
 	return true


### PR DESCRIPTION
### What does this PR do?

Disable map no_prealloc on kernels prior to 6.1

### Motivation

On kernel 6.1, bpf memory allocator was introduced, it takes care of caching allocations, without it, we can lead the system into a bad performance.

### Describe how you validated your changes

### Additional Notes
