### PR TITLE
fix(DJM): Support databricks installation in containers

### DIFF
--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -26,6 +26,7 @@ const (
 	envSite                  = "DD_SITE"
 	envRemoteUpdates         = "DD_REMOTE_UPDATES"
 	envOTelCollectorEnabled  = "DD_OTELCOLLECTOR_ENABLED"
+	envInstallOnly           = "DD_INSTALL_ONLY"
 	envMirror                = "DD_INSTALLER_MIRROR"
 	envRegistryURL           = "DD_INSTALLER_REGISTRY_URL"
 	envRegistryAuth          = "DD_INSTALLER_REGISTRY_AUTH"
@@ -78,6 +79,7 @@ var defaultEnv = Env{
 	Site:                 "datadoghq.com",
 	RemoteUpdates:        false,
 	OTelCollectorEnabled: false,
+	InstallOnly:          false,
 	Mirror:               "",
 
 	RegistryOverride:            "",
@@ -154,6 +156,7 @@ type Env struct {
 	Site                 string
 	RemoteUpdates        bool
 	OTelCollectorEnabled bool
+	InstallOnly          bool
 
 	Mirror                      string
 	RegistryOverride            string
@@ -226,6 +229,7 @@ func FromEnv() *Env {
 		Site:                 getEnvOrDefault(envSite, defaultEnv.Site),
 		RemoteUpdates:        strings.ToLower(os.Getenv(envRemoteUpdates)) == "true",
 		OTelCollectorEnabled: strings.ToLower(os.Getenv(envOTelCollectorEnabled)) == "true",
+		InstallOnly:          strings.ToLower(os.Getenv(envInstallOnly)) == "true",
 
 		Mirror:                      getEnvOrDefault(envMirror, defaultEnv.Mirror),
 		RegistryOverride:            getEnvOrDefault(envRegistryURL, defaultEnv.RegistryOverride),
@@ -328,6 +332,9 @@ func (e *Env) ToEnv() []string {
 	}
 	if e.OTelCollectorEnabled {
 		env = append(env, envOTelCollectorEnabled+"=true")
+	}
+	if e.InstallOnly {
+		env = append(env, envInstallOnly+"=true")
 	}
 	env = appendStringEnv(env, envMirror, e.Mirror, "")
 	env = appendStringEnv(env, envRegistryURL, e.RegistryOverride, "")

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -218,6 +218,9 @@ func postInstallDatadogAgent(ctx HookContext) (err error) {
 	if err := integrations.RestoreCustomIntegrations(ctx, ctx.PackagePath); err != nil {
 		log.Warnf("failed to restore custom integrations: %s", err)
 	}
+	if val, ok := os.LookupEnv("DD_INSTALL_ONLY"); ok && strings.ToLower(val) == "true" {
+		return nil
+	}
 	if err := agentService.WriteStable(ctx); err != nil {
 		return fmt.Errorf("failed to write stable units: %s", err)
 	}

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -192,7 +192,7 @@ var ExecuteCommandWithTimeout = func(s *Setup, command string, args ...string) (
 	if err != nil {
 		span.SetTag("command_error", err.Error())
 		span.Finish(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to execute command (%w): %s", err, output)
 	}
 	return output, nil
 }

--- a/pkg/fleet/installer/setup/defaultscript/default_script.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script.go
@@ -40,7 +40,6 @@ var (
 		"DD_INSTALLER",
 		"DD_AGENT_FLAVOR",
 		"DD_UPGRADE",
-		"DD_INSTALL_ONLY",
 		"DD_FIPS_MODE",
 	}
 
@@ -67,6 +66,7 @@ var (
 		"DD_HOSTNAME",
 		"DD_PROXY_HTTP",
 		"DD_PROXY_HTTPS",
+		"DD_INSTALL_ONLY",
 		"DD_PROXY_NO_PROXY",
 	}
 )
@@ -183,6 +183,9 @@ func installAgentPackage(s *common.Setup) {
 	// Agent install
 	if _, ok := os.LookupEnv("DD_NO_AGENT_INSTALL"); !ok {
 		s.Packages.Install(common.DatadogAgentPackage, agentVersion())
+	}
+	if _, ok := os.LookupEnv("DD_INSTALL_ONLY"); ok {
+		s.Env.InstallOnly = true
 	}
 }
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -94,6 +94,7 @@ func SetupDatabricks(s *common.Setup) error {
 	if err != nil {
 		return fmt.Errorf("failed to get hostname: %w", err)
 	}
+	s.Env.InstallOnly = true
 	s.Config.DatadogYAML.Hostname = hostname
 	s.Config.DatadogYAML.DJM.Enabled = true
 	s.Config.DatadogYAML.ExpectedTagsDuration = "10m"


### PR DESCRIPTION
### What does this PR do?
Databricks allows its customers to use containers as hosts. As such, the current installation script doesn't work, as it expects `systemd` to be running as PID 0.

This PR allows more flexibility in DJM's Databricks installation by:
1. Supporting `DD_INSTALL_ONLY` in the Agent post install script that prevents the Agent units from being written / starting
2. Setting `DD_INSTALL_ONLY` in the Databricks script
3. Having a custom restart logic at the end of the Databricks script leveraging `service`. 

### Motivation
Supporting all Databricks setups

### Describe how you validated your changes
E2E, manual QA on Databricks

### Additional Notes
