### PR TITLE
[SBOM] allow SBOM running metrics to be indexed

### DIFF
--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -154,7 +154,6 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, 
 	}
 
 	c.sender = sender
-	sender.SetNoIndex(true)
 
 	if c.processor, err = newProcessor(
 		c.workloadmetaStore,


### PR DESCRIPTION
### What does this PR do?

This PR removes the "no index" configuration from the SBOM check allowing the following metrics to be indexed (i.e. to be directly queryable from the UI and visible in the metrics explorer):
```
datadog.agent.sbom.container_images.running
datadog.agent.sbom.hosts.running
```

### Motivation

### Describe how you validated your changes

### Additional Notes
