### PR TITLE
[CWS] add more tests for SBOM version related fields

### DIFF
--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -47,15 +47,10 @@ func (s *dpkgScanner) ListPackages(_ context.Context, root *os.Root) ([]sbomtype
 
 	pkgsWithFiles := make([]sbomtypes.PackageWithInstalledFiles, 0, len(pkgs))
 	for _, pkg := range pkgs {
-		pkg := sbomtypes.PackageWithInstalledFiles{
-			Package: sbomtypes.Package{
-				Name:       pkg.Name,
-				Version:    pkg.Version,
-				SrcVersion: pkg.SrcVersion,
-			},
+		pkgsWithFiles = append(pkgsWithFiles, sbomtypes.PackageWithInstalledFiles{
+			Package:        pkg,
 			InstalledFiles: installedFiles[pkg.Name],
-		}
-		pkgsWithFiles = append(pkgsWithFiles, pkg)
+		})
 	}
 
 	return pkgsWithFiles, nil

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -13,10 +13,13 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/avast/retry-go/v4"
 )
@@ -33,6 +36,11 @@ func TestSBOM(t *testing.T) {
 
 func testSBOMWithCollector(t *testing.T, useV2collector bool) {
 	SkipIfNotAvailable(t)
+
+	kv, err := kernel.NewKernelVersion()
+	if err != nil {
+		t.Fatalf("failed to get kernel version: %s", err)
+	}
 
 	if _, err := whichNonFatal("docker"); err != nil {
 		t.Skip("Skip test where docker is unavailable")
@@ -107,7 +115,31 @@ func testSBOMWithCollector(t *testing.T, useV2collector bool) {
 			assertFieldEqual(t, event, "process.file.package.name", "coreutils")
 			assertFieldEqual(t, event, "container.id", "", "container id should be empty")
 
+			if kv.IsUbuntuKernel() || kv.IsDebianKernel() {
+				checkVersionAgainstApt(t, event, "coreutils")
+			}
+
 			test.validateOpenSchema(t, event)
 		})
 	})
+}
+
+func checkVersionAgainstApt(tb testing.TB, event *model.Event, pkgName string) {
+	version, _ := event.GetFieldValue("process.file.package.version")
+	release, _ := event.GetFieldValue("process.file.package.release")
+	epoch, _ := event.GetFieldValue("process.file.package.epoch")
+	v := buildDebianVersion(version.(string), release.(string), epoch.(int))
+
+	out, err := exec.Command("apt-cache", "policy", pkgName).CombinedOutput()
+	require.NoError(tb, err, "failed to get package version: %s", string(out))
+
+	assert.Contains(tb, string(out), fmt.Sprintf("Installed: %s", v), "package version doesn't match")
+}
+
+func buildDebianVersion(version, release string, epoch int) string {
+	v := version + "-" + release
+	if epoch > 0 {
+		v = fmt.Sprintf("%d:%s", epoch, v)
+	}
+	return v
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds additional testing related to the version reported by the CWS SBOM resolver ensuring it matches the one on the host.

This PR also fixes a small bug about versions specifically, where the collector v2 was not reporting the release/epoch correctly (first commit).

### Motivation

### Describe how you validated your changes

### Additional Notes
