### PR TITLE
Fix deploy_installer_packages after removal of installer package

### DIFF
--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -54,7 +54,6 @@ deploy_installer_packages_windows-x64:
   tags: ["arch:amd64", "specific:true"]
   needs: ["powershell_script_signing"]
   before_script:
-    - ls $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID
     - ls $WINDOWS_POWERSHELL_DIR
   script:
     - $S3_CP_CMD $WINDOWS_POWERSHELL_DIR/Install-Datadog.ps1 $S3_RELEASE_INSTALLER_ARTIFACTS_URI/scripts/Install-Datadog.ps1


### PR DESCRIPTION
### What does this PR do?


The merge of https://github.com/DataDog/datadog-agent/pull/41039 broke the nightly job that deploy installer.
Fix it by removing the `ls` in a folder that no longer exists

Failure: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1140112082 

### Motivation

### Describe how you validated your changes

### Additional Notes
