### PR TITLE
[CWS] add compatibility check between hash file field and rule event type

### DIFF
--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -117,7 +117,6 @@ const (
 // ActionDefinitionInterface is an interface that describes a rule action section
 type ActionDefinitionInterface interface {
 	PreCheck(opts PolicyLoaderOpts) error
-	PostCheck(rule *eval.Rule) error
 	IsActionSupported(eventTypeEnabled map[eval.EventType]bool) error
 }
 
@@ -188,23 +187,6 @@ func (a *ActionDefinition) PreCheck(opts PolicyLoaderOpts) error {
 	return nil
 }
 
-// PostCheck returns an error if the action is invalid after parsing
-func (a *ActionDefinition) PostCheck(rule *eval.Rule) error {
-	candidateActions := a.getCandidateActions()
-	actions := 0
-
-	for _, action := range candidateActions {
-		if !reflect.ValueOf(action).IsNil() {
-			if err := action.PostCheck(rule); err != nil {
-				return err
-			}
-			actions++
-		}
-	}
-
-	return nil
-}
-
 // IsActionSupported returns true if the action is supported given a list of enabled event type
 func (a *ActionDefinition) IsActionSupported(eventTypeEnabled map[eval.EventType]bool) error {
 	candidateActions := a.getCandidateActions()
@@ -227,11 +209,6 @@ type DefaultActionDefinition struct{}
 
 // PreCheck returns an error if the action is invalid before parsing
 func (a *DefaultActionDefinition) PreCheck(_ PolicyLoaderOpts) error {
-	return nil
-}
-
-// PostCheck returns an error if the action is invalid after parsing
-func (a *DefaultActionDefinition) PostCheck(_ *eval.Rule) error {
 	return nil
 }
 

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -339,6 +339,18 @@ func (h *HashDefinition) PostCheck(rule *eval.Rule) error {
 		return err
 	}
 
+	// check that the field is compatible with the rule event type
+	fieldPathForMetadata := h.Field + ".path"
+	fieldEventType, _, _, err := ev.GetFieldMetadata(fieldPathForMetadata)
+	if err != nil {
+		return fmt.Errorf("failed to get event type for field '%s': %w", fieldPathForMetadata, err)
+	}
+
+	// if the field has an event type, we check it matches the rule event type
+	if fieldEventType != "" && fieldEventType != ruleEventType {
+		return fmt.Errorf("field '%s' is not compatible with '%s' rules", h.Field, ruleEventType)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a compatibility check between the hash file field and the rule event type. Preventing for example an open rule to have a hash action asking to hash the `chmod.file` which doesn't make any sense.

### Motivation

### Describe how you validated your changes

### Additional Notes
