### PR TITLE
[CWS] Fix panic when enabling CWS eBPFless mode

### DIFF
--- a/pkg/security/rules/engine_linux.go
+++ b/pkg/security/rules/engine_linux.go
@@ -64,7 +64,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 					Value: scopedValue,
 				}
 			})
-		} else if strings.HasPrefix(name, "cgroup.") {
+		} else if !e.probe.Opts.EBPFLessEnabled && strings.HasPrefix(name, "cgroup.") {
 			scopedVariable := value.(eval.ScopedVariable)
 
 			cgr := e.probe.PlatformProbe.(*probe.EBPFProbe).Resolvers.CGroupResolver


### PR DESCRIPTION
### What does this PR do?

Fix panic when starting system-probe with CWS eBPFless mode enabled.

```
2025-09-22 13:45:53 UTC | SYS-PROBE | INFO | (pkg/security/rconfig/policies.go:91 in Start) | remote-config policies provider started
2025-09-22 13:45:53 UTC | SYS-PROBE | INFO | (pkg/security/module/cws.go:196 in Start) | runtime security started
2025-09-22 13:45:53 UTC | SYS-PROBE | INFO | (pkg/security/probe/probe_ebpfless.go:598 in Start) | starting listening for ebpf less events on : localhost:5678
2025-09-22 13:45:53 UTC | SYS-PROBE | INFO | (pkg/system-probe/api/module/loader.go:103 in Register) | module event_monitor started
panic: interface conversion: probe.PlatformProbe is *probe.EBPFLessProbe, not *probe.EBPFProbe

goroutine 323 [running]:
github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).GetSECLVariables(0xc001738180)
        github.com/DataDog/datadog-agent/pkg/security/rules/engine_linux.go:70 +0x345
github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).GetSECLVariables(...)
        github.com/DataDog/datadog-agent/pkg/security/module/server.go:626
github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).GetStatus(0xc000560a00, {0x21ee2e0?, 0x0?}, 0x27?)
        github.com/DataDog/datadog-agent/pkg/security/module/server.go:656 +0x11b
github.com/DataDog/datadog-agent/pkg/security/module.(*CWSConsumer).GetStatus(0x232cc80?, {0x5f5b2a0?, 0x7957880?})
        github.com/DataDog/datadog-agent/pkg/security/module/cws.go:397 +0x38
github.com/DataDog/datadog-agent/pkg/eventmonitor.(*EventMonitor).GetStats(0xc00129c640)
        github.com/DataDog/datadog-agent/pkg/eventmonitor/eventmonitor.go:232 +0x18d
github.com/DataDog/datadog-agent/pkg/system-probe/api/module.updateStats.func1({0x270d598, 0xd}, {0x5f53690?, 0xc00129c640?})
        github.com/DataDog/datadog-agent/pkg/system-probe/api/module/loader.go:202 +0x2f
github.com/DataDog/datadog-agent/pkg/system-probe/api/module.(*loader).forEachModule.func1()
        github.com/DataDog/datadog-agent/pkg/system-probe/api/module/loader.go:49 +0x27
github.com/DataDog/datadog-agent/pkg/system-probe/api/module.withModule.func1({0x5f5b498?, 0xc00146c030?})
        github.com/DataDog/datadog-agent/pkg/system-probe/api/module/loader.go:56 +0x13
runtime/pprof.Do({0x5f5b2a0?, 0x7957880?}, {{0xc0008b4000?, 0xc0013a1d38?, 0x407b85?}}, 0xc002166d30)
        runtime/pprof/runtime.go:51 +0x8c
github.com/DataDog/datadog-agent/pkg/system-probe/api/module.withModule({0x270d598?, 0x72490d945f30?}, 0xc002166d88)
        github.com/DataDog/datadog-agent/pkg/system-probe/api/module/loader.go:55 +0x96
github.com/DataDog/datadog-agent/pkg/system-probe/api/module.(*loader).forEachModule(0x37e11d600?, 0x5cce178)
        github.com/DataDog/datadog-agent/pkg/system-probe/api/module/loader.go:48 +0xc5
github.com/DataDog/datadog-agent/pkg/system-probe/api/module.updateStats()
        github.com/DataDog/datadog-agent/pkg/system-probe/api/module/loader.go:201 +0x229
created by github.com/DataDog/datadog-agent/pkg/system-probe/api/module.Register in goroutine 1
        github.com/DataDog/datadog-agent/pkg/system-probe/api/module/loader.go:115 +0x7b6
system-probe exited with code 2, signal 0, restarting in 2 seconds
```

### Motivation

### Describe how you validated your changes

### Additional Notes
