### PR TITLE
Fix merging ID tags in SNMP profiles

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
@@ -109,9 +109,7 @@ func mergeProfileDefinition(targetDefinition *profiledefinition.ProfileDefinitio
 			targetDefinition.Metadata[baseResName] = profiledefinition.NewMetadataResourceConfig()
 		}
 		if resource, ok := targetDefinition.Metadata[baseResName]; ok {
-			for _, tagConfig := range baseResource.IDTags {
-				resource.IDTags = append(targetDefinition.Metadata[baseResName].IDTags, tagConfig)
-			}
+			resource.IDTags = append(resource.IDTags, baseResource.IDTags...)
 
 			if resource.Fields == nil {
 				resource.Fields = make(map[string]profiledefinition.MetadataField, len(baseResource.Fields))

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
@@ -218,6 +218,20 @@ func Test_mergeProfileDefinition(t *testing.T) {
 							Name: "ifAlias",
 						},
 					},
+					{
+						Tag: "idTag1",
+						Symbol: profiledefinition.SymbolConfigCompat{
+							OID:  "1.2.3.4.5.6.1",
+							Name: "idTag1",
+						},
+					},
+					{
+						Tag: "idTag2",
+						Symbol: profiledefinition.SymbolConfigCompat{
+							OID:  "1.2.3.4.5.6.2",
+							Name: "idTag2",
+						},
+					},
 				},
 			},
 		},
@@ -341,6 +355,20 @@ func Test_mergeProfileDefinition(t *testing.T) {
 									Name: "ifAlias",
 								},
 							},
+							{
+								Tag: "idTag1",
+								Symbol: profiledefinition.SymbolConfigCompat{
+									OID:  "1.2.3.4.5.6.1",
+									Name: "idTag1",
+								},
+							},
+							{
+								Tag: "idTag2",
+								Symbol: profiledefinition.SymbolConfigCompat{
+									OID:  "1.2.3.4.5.6.2",
+									Name: "idTag2",
+								},
+							},
 						},
 					},
 				},
@@ -437,6 +465,20 @@ func Test_mergeProfileDefinition(t *testing.T) {
 								Symbol: profiledefinition.SymbolConfigCompat{
 									OID:  "1.3.6.1.2.1.31.1.1.1.1",
 									Name: "ifAlias",
+								},
+							},
+							{
+								Tag: "idTag1",
+								Symbol: profiledefinition.SymbolConfigCompat{
+									OID:  "1.2.3.4.5.6.1",
+									Name: "idTag1",
+								},
+							},
+							{
+								Tag: "idTag2",
+								Symbol: profiledefinition.SymbolConfigCompat{
+									OID:  "1.2.3.4.5.6.2",
+									Name: "idTag2",
 								},
 							},
 						},


### PR DESCRIPTION
### What does this PR do?

This PR fixes the merging of ID tags during SNMP profiles merging by appending to the correct slice.

### Motivation

### Describe how you validated your changes

### Additional Notes
