### PR TITLE
[EBPF] gpu: reset structs retrieved from pools

### DIFF
--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -207,6 +207,8 @@ func (sh *StreamHandler) handleKernelLaunch(event *gpuebpf.CudaKernelLaunch) {
 	enrichedLaunch := memPools.enrichedKernelLaunchPool.Get()
 	enrichedLaunch.CudaKernelLaunch = *event // Copy events, as the memory can be overwritten in the ring buffer after the function returns
 	enrichedLaunch.stream = sh
+	enrichedLaunch.kernel = nil
+	enrichedLaunch.err = nil
 
 	// Trigger the background kernel data loading, we don't care about the result here
 	_, err := enrichedLaunch.getKernelData()
@@ -305,6 +307,7 @@ func (sh *StreamHandler) getCurrentKernelSpan(maxTime uint64) *kernelSpan {
 	span.startKtime = math.MaxUint64
 	span.endKtime = maxTime
 	span.numKernels = 0
+	span.avgThreadCount = 0
 
 	// Reset the memory usage map
 	for allocType := range span.avgMemoryUsage {

--- a/pkg/gpu/testutil.go
+++ b/pkg/gpu/testutil.go
@@ -32,8 +32,9 @@ func (m *memoryPools) reset() {
 }
 
 func withTelemetryEnabledPools(t *testing.T, tm telemetry.Component) {
-	// reset the sync.Once for the pools
+	// reset the pools and the telemetry for them
 	memPools.reset()
+	ddsync.ResetGlobalPoolTelemetry()
 
 	// so that now we can call ensureInit with the telemetry component
 	memPools.ensureInit(tm)
@@ -41,6 +42,7 @@ func withTelemetryEnabledPools(t *testing.T, tm telemetry.Component) {
 	// after the current test is finished, reset the sync.Once and restore to non-telemetry enabled pools
 	t.Cleanup(func() {
 		memPools.reset()
+		ddsync.ResetGlobalPoolTelemetry()
 		memPools.ensureInitNoTelemetry()
 	})
 }

--- a/pkg/util/sync/testutil.go
+++ b/pkg/util/sync/testutil.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+// Package sync is utilities for synchronization
+package sync
+
+import "github.com/DataDog/datadog-agent/pkg/util/funcs"
+
+// ResetGlobalPoolTelemetry resets the global pool telemetry to the default value, useful for testing
+// to avoid telemetry values being set by other tests
+func ResetGlobalPoolTelemetry() {
+	globalPoolTelemetry = funcs.MemoizeArgNoError(newPoolTelemetry)
+}


### PR DESCRIPTION
### What does this PR do?

Properly resets all of the fields in structs retrieved from pools.

### Motivation

Some fields were not being reset completely, and they were causing errors in tests.

Related flaky test tickets:

https://datadoghq.atlassian.net/browse/EBPF-816
https://datadoghq.atlassian.net/browse/EBPF-817
https://datadoghq.atlassian.net/browse/EBPF-818
https://datadoghq.atlassian.net/browse/EBPF-821

### Describe how you validated your changes

Reproduced locally running multiple test sequentially, and validated that after the fixes the test pass. Also checked that there are no flaky tests reported in KMT.

### Additional Notes
