### PR TITLE
Add new metric origins to the Agent for BentoML, Hugging Face TGI, and IBM Spectrum LSF

### DIFF
--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -329,6 +329,9 @@ const (
 	MetricSourceSupabase
 	MetricSourceKeda
 	MetricSourceDuckdb
+	MetricSourceBentoMl
+	MetricSourceHuggingFaceTgi
+	MetricSourceIbmSpectrumLsf
 
 	// OpenTelemetry Collector receivers
 	MetricSourceOpenTelemetryCollectorUnknown
@@ -992,6 +995,12 @@ func (ms MetricSource) String() string {
 		return "keda"
 	case MetricSourceDuckdb:
 		return "duckdb"
+	case MetricSourceBentoMl:
+		return "bentoml"
+	case MetricSourceHuggingFaceTgi:
+		return "hugging_face_tgi"
+	case MetricSourceIbmSpectrumLsf:
+		return "ibm_spectrum_lsf"
 	case MetricSourceOpenTelemetryCollectorUnknown:
 		return "opentelemetry_collector_unknown"
 	case MetricSourceOpenTelemetryCollectorDockerstatsReceiver:
@@ -1678,6 +1687,18 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceProxmox
 	case "resilience4j":
 		return MetricSourceResilience4j
+	case "supabase":
+		return MetricSourceSupabase
+	case "keda":
+		return MetricSourceKeda
+	case "duckdb":
+		return MetricSourceDuckdb
+	case "bentoml":
+		return MetricSourceBentoMl
+	case "hugging_face_tgi":
+		return MetricSourceHuggingFaceTgi
+	case "ibm_spectrum_lsf":
+		return MetricSourceIbmSpectrumLsf
 	case "opentelemetry_collector_unknown":
 		return MetricSourceOpenTelemetryCollectorUnknown
 	case "opentelemetry_collector_dockerstatsreceiver":

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -358,7 +358,10 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceSupabase,
 		metrics.MetricSourceKeda,
 		metrics.MetricSourceDuckdb,
-		metrics.MetricSourceResilience4j:
+		metrics.MetricSourceResilience4j,
+		metrics.MetricSourceBentoMl,
+		metrics.MetricSourceHuggingFaceTgi,
+		metrics.MetricSourceIbmSpectrumLsf:
 		return 11 // integrationMetrics
 	case metrics.MetricSourceGPU:
 		return 72 // ref: https://github.com/DataDog/dd-source/blob/276882b71d84785ec89c31973046ab66d5a01807/domains/metrics/shared/libs/proto/origin/origin.proto#L427
@@ -1115,6 +1118,12 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 483
 	case metrics.MetricSourceWindowsCertificateStore:
 		return 484
+	case metrics.MetricSourceBentoMl:
+		return 494
+	case metrics.MetricSourceHuggingFaceTgi:
+		return 495
+	case metrics.MetricSourceIbmSpectrumLsf:
+		return 496
 	default:
 		return 0
 	}

--- a/releasenotes/notes/add-metric-origins-d91cfa8ac128c020.yaml
+++ b/releasenotes/notes/add-metric-origins-d91cfa8ac128c020.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Add new metric origins to the Agent for BentoML, Hugging Face TGI, and IBM Spectrum LSF.


### PR DESCRIPTION
### What does this PR do?
Metric Origin entries for:
- BentoML
- Hugging Face TGI
- IBM Spectrum LSF

And added some mappings that were missed here:
https://github.com/DataDog/datadog-agent/commit/e1d209a3bb5b740ed25b0ed071a478d51ff01124

Linked pr:
https://github.com/DataDog/dd-source/pull/269879
