### PR TITLE
discovery: use ServiceType type instead of string

### DIFF
--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/servicetype"
 	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	pkgcontainersimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
@@ -1566,7 +1567,7 @@ type Service struct {
 	APMInstrumentation string
 
 	// Type is the service type (e.g., "web_service")
-	Type string
+	Type servicetype.ServiceType
 }
 
 // UST contains Unified Service Tagging environment variables

--- a/pkg/collector/corechecks/servicediscovery/model/model.go
+++ b/pkg/collector/corechecks/servicediscovery/model/model.go
@@ -7,6 +7,7 @@
 package model
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/servicetype"
 	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
 )
 
@@ -23,7 +24,7 @@ type Service struct {
 	UDPPorts                 []uint16                        `json:"udp_ports,omitempty"`
 	APMInstrumentation       string                          `json:"apm_instrumentation"`
 	Language                 string                          `json:"language"`
-	Type                     string                          `json:"service_type"`
+	Type                     servicetype.ServiceType         `json:"service_type"`
 	CommandLine              []string                        `json:"cmdline"`
 	UST                      UST                             `json:"ust"`
 }

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -581,7 +581,7 @@ func (s *discovery) getServiceWithoutRetry(context parsingContext, pid int32) *m
 	service.TCPPorts = tcpPorts
 	service.UDPPorts = udpPorts
 	service.LogFiles = getLogFiles(pid, openFileInfo.logs)
-	service.Type = string(servicetype.Detect(tcpPorts, udpPorts))
+	service.Type = servicetype.Detect(tcpPorts, udpPorts)
 
 	return service
 }


### PR DESCRIPTION
### What does this PR do?

Use the ServiceType type directly instead of casting to a string.

### Motivation

Avoid unnecessary cast.

### Describe how you validated your changes

### Additional Notes
