### PR TITLE
[OTAGENT-536] Refactor remote tagger parameters

### DIFF
--- a/cmd/agent/common/tagger_params.go
+++ b/cmd/agent/common/tagger_params.go
@@ -23,17 +23,17 @@ func DualTaggerParams() (tagger.DualParams, tagger.RemoteParams) {
 			UseRemote: func(c config.Component) bool {
 				return pkgconfigsetup.IsCLCRunner(c) && c.GetBool("clc_runner_remote_tagger_enabled")
 			},
-		}, tagger.RemoteParams{
-			RemoteTarget: func(config.Component) (string, error) {
+		}, tagger.NewRemoteParams(
+			tagger.WithRemoteTarget(func(config.Component) (string, error) {
 				target, err := utils.GetClusterAgentEndpoint()
 				if err != nil {
 					return "", err
 				}
 				return strings.TrimPrefix(target, "https://"), nil
-			},
-			RemoteFilter: types.NewFilterBuilder().Exclude(types.KubernetesPodUID).Build(types.HighCardinality),
+			}),
+			tagger.WithRemoteFilter(types.NewFilterBuilder().Exclude(types.KubernetesPodUID).Build(types.HighCardinality)),
 
-			OverrideTLSConfigGetter: pkgapiutil.GetCrossNodeClientTLSConfig,
-			OverrideAuthTokenGetter: security.GetClusterAgentAuthToken,
-		}
+			tagger.WithOverrideTLSConfigGetter(pkgapiutil.GetCrossNodeClientTLSConfig),
+			tagger.WithOverrideAuthTokenGetter(security.GetClusterAgentAuthToken),
+		)
 }

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -33,7 +33,6 @@ import (
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerFx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
-	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
@@ -206,10 +205,7 @@ func runOTelAgentCommand(ctx context.Context, params *cliParams, opts ...fx.Opti
 		}),
 
 		configsyncimpl.Module(configsyncimpl.NewParams(params.SyncTimeout, true, params.SyncOnInitTimeout)),
-		remoteTaggerFx.Module(tagger.RemoteParams{
-			RemoteTarget: func(c coreconfig.Component) (string, error) { return fmt.Sprintf(":%v", c.GetInt("cmd_port")), nil },
-			RemoteFilter: taggerTypes.NewMatchAllFilter(),
-		}),
+		remoteTaggerFx.Module(tagger.NewRemoteParams()),
 		telemetryimpl.Module(),
 		fx.Provide(func(cfg traceconfig.Component) telemetry.TelemetryCollector {
 			return telemetry.NewCollector(cfg.Object())

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -34,7 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
-	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	wmcatalogremote "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
@@ -169,12 +168,7 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 			AgentType: workloadmeta.Remote,
 		}),
 
-		remoteTaggerfx.Module(tagger.RemoteParams{
-			RemoteTarget: func(c config.Component) (string, error) {
-				return fmt.Sprintf(":%v", c.GetInt("cmd_port")), nil
-			},
-			RemoteFilter: taggerTypes.NewMatchAllFilter(),
-		}),
+		remoteTaggerfx.Module(tagger.NewRemoteParams()),
 
 		// Provides specific features to our own fx wrapper (logging, lifecycle, shutdowner)
 		fxutil.FxAgentBase(),

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -29,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
-	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	wmcatalogremote "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
@@ -162,12 +161,7 @@ func MakeCommand(globalParamsGetter func() *command.GlobalParams, name string, a
 				}),
 
 				// Tagger must be initialized after agent config has been setup
-				remoteTaggerfx.Module(tagger.RemoteParams{
-					RemoteTarget: func(c config.Component) (string, error) {
-						return fmt.Sprintf(":%v", c.GetInt("cmd_port")), nil
-					},
-					RemoteFilter: taggerTypes.NewMatchAllFilter(),
-				}),
+				remoteTaggerfx.Module(tagger.NewRemoteParams()),
 				processComponent.Bundle(),
 				// InitSharedContainerProvider must be called before the application starts so the workloadmeta collector can be initiailized correctly.
 				// Since the tagger depends on the workloadmeta collector, we can not make the tagger a dependency of workloadmeta as it would create a circular dependency.

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -45,7 +45,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
-	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -105,12 +104,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				workloadmetafx.Module(workloadmeta.Params{
 					AgentType: workloadmeta.Remote,
 				}),
-				remoteTaggerfx.Module(tagger.RemoteParams{
-					RemoteTarget: func(c config.Component) (string, error) {
-						return fmt.Sprintf(":%v", c.GetInt("cmd_port")), nil
-					},
-					RemoteFilter: taggerTypes.NewMatchAllFilter(),
-				}),
+				remoteTaggerfx.Module(tagger.NewRemoteParams()),
 				fx.Provide(func() startstop.Stopper {
 					return startstop.NewSerialStopper()
 				}),

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -45,7 +45,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerFx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
-	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
@@ -127,10 +126,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				ipcfx.ModuleReadWrite(),
 				// Provide tagger module
-				remoteTaggerFx.Module(tagger.RemoteParams{
-					RemoteTarget: func(c config.Component) (string, error) { return fmt.Sprintf(":%v", c.GetInt("cmd_port")), nil },
-					RemoteFilter: taggerTypes.NewMatchAllFilter(),
-				}),
+				remoteTaggerFx.Module(tagger.NewRemoteParams()),
 				autoexitimpl.Module(),
 				pidimpl.Module(),
 				fx.Supply(pidimpl.NewParams(cliParams.pidfilePath)),
@@ -312,10 +308,7 @@ func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
 		}),
 		ipcfx.ModuleReadWrite(),
 		// Provide tagger module
-		remoteTaggerFx.Module(tagger.RemoteParams{
-			RemoteTarget: func(c config.Component) (string, error) { return fmt.Sprintf(":%v", c.GetInt("cmd_port")), nil },
-			RemoteFilter: taggerTypes.NewMatchAllFilter(),
-		}),
+		remoteTaggerFx.Module(tagger.NewRemoteParams()),
 		systemprobeloggerfx.Module(),
 		fx.Provide(func(sysprobeconfig sysprobeconfig.Component) settings.Params {
 			profilingGoRoutines := commonsettings.NewProfilingGoroutines()

--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -9,7 +9,6 @@ package run
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -26,7 +25,6 @@ import (
 	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	optionalRemoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-optional-remote"
-	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/comp/trace"
@@ -102,12 +100,7 @@ func runTraceAgentProcess(ctx context.Context, cliParams *Params, defaultConfPat
 				// tagger instead.
 				Disable: serverlessenv.IsAzureAppServicesExtension,
 			},
-			tagger.RemoteParams{
-				RemoteTarget: func(c coreconfig.Component) (string, error) {
-					return fmt.Sprintf(":%v", c.GetInt("cmd_port")), nil
-				},
-				RemoteFilter: taggerTypes.NewMatchAllFilter(),
-			}),
+			tagger.NewRemoteParams()),
 		fx.Invoke(func(_ config.Component) {}),
 		// Required to avoid cyclic imports.
 		fx.Provide(func(cfg config.Component) telemetry.TelemetryCollector { return telemetry.NewCollector(cfg.Object()) }),

--- a/comp/core/tagger/impl-remote/remote_test.go
+++ b/comp/core/tagger/impl-remote/remote_test.go
@@ -45,9 +45,9 @@ func TestNewComponent(t *testing.T) {
 		Lc:     compdef.NewTestLifecycle(t),
 		Config: configmock.New(t),
 		Log:    logmock.New(t),
-		Params: tagger.RemoteParams{
-			RemoteTarget: func(config.Component) (string, error) { return ":5001", nil },
-		},
+		Params: tagger.NewRemoteParams(
+			tagger.WithRemoteTarget(func(config.Component) (string, error) { return ":5001", nil }),
+		),
 		Telemetry: nooptelemetry.GetCompatComponent(),
 		IPC:       ipcmock.New(t),
 	}
@@ -62,9 +62,9 @@ func TestNewComponentNonBlocking(t *testing.T) {
 		Lc:     compdef.NewTestLifecycle(t),
 		Config: configmock.New(t),
 		Log:    logmock.New(t),
-		Params: tagger.RemoteParams{
-			RemoteTarget: func(config.Component) (string, error) { return ":5001", nil },
-		},
+		Params: tagger.NewRemoteParams(
+			tagger.WithRemoteTarget(func(config.Component) (string, error) { return ":5001", nil }),
+		),
 		Telemetry: nooptelemetry.GetCompatComponent(),
 		IPC:       ipcmock.New(t),
 	}
@@ -79,9 +79,9 @@ func TestNewComponentSetsTaggerListEndpoint(t *testing.T) {
 		Lc:     compdef.NewTestLifecycle(t),
 		Config: configmock.New(t),
 		Log:    logmock.New(t),
-		Params: tagger.RemoteParams{
-			RemoteTarget: func(config.Component) (string, error) { return ":5001", nil },
-		},
+		Params: tagger.NewRemoteParams(
+			tagger.WithRemoteTarget(func(config.Component) (string, error) { return ":5001", nil }),
+		),
 		Telemetry: nooptelemetry.GetCompatComponent(),
 		IPC:       ipcmock.New(t),
 	}
@@ -124,18 +124,18 @@ func TestNewComponentWithOverride(t *testing.T) {
 			Lc:     compdef.NewTestLifecycle(t),
 			Config: configmock.New(t),
 			Log:    logmock.New(t),
-			Params: tagger.RemoteParams{
-				RemoteTarget: func(config.Component) (string, error) { return server.URL, nil },
-				OverrideTLSConfigGetter: func() (*tls.Config, error) {
+			Params: tagger.NewRemoteParams(
+				tagger.WithRemoteTarget(func(config.Component) (string, error) { return server.URL, nil }),
+				tagger.WithOverrideTLSConfigGetter(func() (*tls.Config, error) {
 					return &tls.Config{
 						InsecureSkipVerify: true,
 					}, nil
-				},
-				OverrideAuthTokenGetter: func(_ configmodel.Reader) (string, error) {
+				}),
+				tagger.WithOverrideAuthTokenGetter(func(_ configmodel.Reader) (string, error) {
 					time.Sleep(2 * time.Second)
 					return "test-token", nil
-				},
-			},
+				}),
+			),
 			Telemetry: nooptelemetry.GetCompatComponent(),
 			IPC:       ipcComp,
 		}
@@ -151,17 +151,17 @@ func TestNewComponentWithOverride(t *testing.T) {
 			Lc:     compdef.NewTestLifecycle(t),
 			Config: configmock.New(t),
 			Log:    logmock.New(t),
-			Params: tagger.RemoteParams{
-				RemoteTarget: func(config.Component) (string, error) { return server.URL, nil },
-				OverrideTLSConfigGetter: func() (*tls.Config, error) {
+			Params: tagger.NewRemoteParams(
+				tagger.WithRemoteTarget(func(config.Component) (string, error) { return server.URL, nil }),
+				tagger.WithOverrideTLSConfigGetter(func() (*tls.Config, error) {
 					return &tls.Config{
 						InsecureSkipVerify: true,
 					}, nil
-				},
-				OverrideAuthTokenGetter: func(_ configmodel.Reader) (string, error) {
+				}),
+
+				tagger.WithOverrideAuthTokenGetter(func(_ configmodel.Reader) (string, error) {
 					return "", fmt.Errorf("auth token getter always fails")
-				},
-			},
+				})),
 			Telemetry: nooptelemetry.GetCompatComponent(),
 			IPC:       ipcComp,
 		}

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
@@ -7,7 +7,6 @@ package infraattributesprocessor
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"go.uber.org/fx"
@@ -59,12 +58,7 @@ func (f *factory) getOrCreateData() (*data, error) {
 		logfx.Module(),
 		telemetryModule(),
 		fxutil.FxAgentBase(),
-		remoteTaggerfx.Module(tagger.RemoteParams{
-			RemoteTarget: func(c config.Component) (string, error) {
-				return fmt.Sprintf(":%v", c.GetInt("cmd_port")), nil
-			},
-			RemoteFilter: taggerTypes.NewMatchAllFilter(),
-		}),
+		remoteTaggerfx.Module(tagger.NewRemoteParams()),
 		fx.Provide(func(t tagger.Component) taggerTypes.TaggerClient {
 			return t
 		}),


### PR DESCRIPTION
### What does this PR do?
Refactor remote tagger parameters to use functional options as default values are most of the time the same.

This is pure refactoring without any code changes.

### Motivation

### Describe how you validated your changes

Run unit tests and e2e tests.

### Additional Notes
