### PR TITLE
[CWS] fix glob matching with with '/' path

### DIFF
--- a/pkg/security/secl/compiler/eval/glob.go
+++ b/pkg/security/secl/compiler/eval/glob.go
@@ -68,6 +68,10 @@ func (g *Glob) matchesPrefix(filename string) bool {
 	// normalize */ == /*/
 	if g.prefix[0].pattern == "*" {
 		filename = filename[1:]
+
+		if len(filename) == 0 && len(g.prefix) > 1 {
+			return false
+		}
 	}
 
 	var (

--- a/pkg/security/secl/compiler/eval/glob_test.go
+++ b/pkg/security/secl/compiler/eval/glob_test.go
@@ -259,6 +259,18 @@ func TestGlobMatches(t *testing.T) {
 	if glob, _ := NewGlob("/sys/**/abs/cgr*", false, false); glob.Matches("/sys/fs/test/cgroup") {
 		t.Error("shouldn't match the filename")
 	}
+
+	if glob, _ := NewGlob("*/tmp/*", false, false); glob.Matches("/") {
+		t.Error("shouldn't match the filename")
+	}
+
+	if glob, _ := NewGlob("*", false, false); !glob.Matches("/") {
+		t.Error("should match the filename")
+	}
+
+	if glob, _ := NewGlob("*/*", false, false); glob.Matches("/") {
+		t.Error("shouldn't match the filename")
+	}
 }
 
 func FuzzGlob(f *testing.F) {


### PR DESCRIPTION
### What does this PR do?

Fix glob incorrectly  matching with 

pattern : "*/bin/*"
path : "/"

### Motivation

### Describe how you validated your changes

### Additional Notes
