### PR TITLE
Fix missing tags from container check metrics

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/check_test.go
+++ b/pkg/collector/corechecks/containers/containerd/check_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	taggerUtils "github.com/DataDog/datadog-agent/comp/core/tagger/utils"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/generic"
@@ -62,6 +63,9 @@ func TestContainerdCheckGenericPart(t *testing.T) {
 		"cID100": mock.GetFullSampleContainerEntry(),
 		"cID101": mock.GetFullSampleContainerEntry(),
 	}
+
+	fakeTagger.SetTags(taggertypes.NewEntityID("container_id", "cID100"), "foo", []string{"container_id:cID100"}, nil, nil, nil)
+	fakeTagger.SetTags(taggertypes.NewEntityID("container_id", "cID101"), "foo", []string{"container_id:cID101"}, nil, nil, nil)
 
 	// Inject mock processor in check
 	mockSender, processor, _ := generic.CreateTestProcessor(containersMeta, containersStats, metricsAdapter{}, getProcessorFilter(nil, nil), fakeTagger, false)

--- a/pkg/collector/corechecks/containers/cri/check_test.go
+++ b/pkg/collector/corechecks/containers/cri/check_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/generic"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/cri"
@@ -38,6 +39,9 @@ func TestCriCheck(t *testing.T) {
 		"cID101": mock.GetFullSampleContainerEntry(),
 	}
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+
+	fakeTagger.SetTags(taggertypes.NewEntityID("container_id", "cID100"), "foo", []string{"container_id:cID100"}, nil, nil, nil)
+	fakeTagger.SetTags(taggertypes.NewEntityID("container_id", "cID101"), "foo", []string{"container_id:cID101"}, nil, nil, nil)
 
 	// Inject mock processor in check
 	mockCri := &crimock.MockCRIClient{}

--- a/pkg/collector/corechecks/containers/docker/check_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_test.go
@@ -49,6 +49,9 @@ func TestDockerCheckGenericPart(t *testing.T) {
 		"cID101": mock.GetFullSampleContainerEntry(),
 	}
 
+	fakeTagger.SetTags(types.NewEntityID("container_id", "cID100"), "foo", []string{"container_id:cID100"}, nil, nil, nil)
+	fakeTagger.SetTags(types.NewEntityID("container_id", "cID101"), "foo", []string{"container_id:cID101"}, nil, nil, nil)
+
 	// Inject mock processor in check
 	mockSender, processor, _ := generic.CreateTestProcessor(containersMeta, containersStats, metricsAdapter{}, getProcessorFilter(nil, nil), fakeTagger, false)
 	processor.RegisterExtension("docker-custom-metrics", &dockerCustomMetricsExtension{})
@@ -306,6 +309,10 @@ func TestContainersRunning(t *testing.T) {
 
 func TestProcess_CPUSharesMetric(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+
+	fakeTagger.SetTags(types.NewEntityID("container_id", "cID100"), "foo", []string{"container_id:cID100"}, nil, nil, nil)
+	fakeTagger.SetTags(types.NewEntityID("container_id", "cID101"), "foo", []string{"container_id:cID101"}, nil, nil, nil)
+	fakeTagger.SetTags(types.NewEntityID("container_id", "cID102"), "foo", []string{"container_id:cID102"}, nil, nil, nil)
 
 	containersMeta := []*workloadmeta.Container{
 		generic.CreateContainerMeta("docker", "cID100"),

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -84,6 +84,10 @@ func (p *Processor) Run(sender sender.Sender, cacheValidity time.Duration) error
 			log.Errorf("Could not collect tags for container %q, err: %v", container.ID[:12], err)
 			continue
 		}
+		if len(tags) == 0 {
+			log.Debugf("No tags detected for container %q, dropping metrics", container.ID)
+			continue
+		}
 		tags = p.metricsAdapter.AdaptTags(tags, container)
 
 		collector := p.metricsProvider.GetCollector(provider.NewRuntimeMetadata(

--- a/releasenotes/notes/container-drop-tagless-metrics-6e155ecd90da19cf.yaml
+++ b/releasenotes/notes/container-drop-tagless-metrics-6e155ecd90da19cf.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an issue which would result in some `container.*` metrics showing up
+    without any container-related tags associated with them.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a case where, sometimes, `container.*` metrics would be emitted with no associated container or pod tags. This would result in unexpected spikes in data when looking at container metrics at node-level or cluster-level

### Motivation

Attached support ticket

### Describe how you validated your changes

This case is covered by the changes to the unit tests

### Additional Notes
