### PR TITLE
[CONTP-982] Expose services in verbose configcheck command

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -608,13 +608,15 @@ func (ac *AutoConfig) getActiveServices() map[string]integration.ServiceResponse
 		}
 
 		serviceResp[svcID] = integration.ServiceResponse{
-			ServiceID:     svcID,
-			ADIdentifiers: svc.GetADIdentifiers(),
-			Hosts:         hosts,
-			Ports:         ports,
-			PID:           pid,
-			Hostname:      hostname,
-			IsReady:       svc.IsReady(),
+			ServiceID:      svcID,
+			ADIdentifiers:  svc.GetADIdentifiers(),
+			Hosts:          hosts,
+			Ports:          ports,
+			PID:            pid,
+			Hostname:       hostname,
+			IsReady:        svc.IsReady(),
+			FiltersLogs:    svc.HasFilter(workloadfilter.LogsFilter),
+			FiltersMetrics: svc.HasFilter(workloadfilter.MetricsFilter),
 		}
 	}
 	return serviceResp

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
@@ -592,7 +591,7 @@ func (ac *AutoConfig) getActiveServices() map[string]integration.ServiceResponse
 			ac.logs.Debugf("showing empty ports because not supported for service %s: %v", svcID, err)
 		} else {
 			ports = slices.Map(containerPorts, func(port listeners.ContainerPort) string {
-				return fmt.Sprintf(":%s", strconv.Itoa(port.Port))
+				return strconv.Itoa(port.Port)
 			})
 		}
 

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
@@ -48,6 +48,9 @@ type configManager interface {
 
 	// getActiveConfigs returns the currently active configs
 	getActiveConfigs() map[string]integration.Config
+
+	// getActiveServices returns the currently active services
+	getActiveServices() map[string]listeners.Service
 }
 
 // serviceAndADIDs bundles a service and its associated AD identifiers.
@@ -303,6 +306,17 @@ func (cm *reconcilingConfigManager) getActiveConfigs() map[string]integration.Co
 	res := make(map[string]integration.Config, len(cm.activeConfigs))
 	for k, v := range cm.activeConfigs {
 		res[k] = v
+	}
+	return res
+}
+
+func (cm *reconcilingConfigManager) getActiveServices() map[string]listeners.Service {
+	cm.m.Lock()
+	defer cm.m.Unlock()
+
+	res := make(map[string]listeners.Service, len(cm.activeServices))
+	for k, v := range cm.activeServices {
+		res[k] = v.svc
 	}
 	return res
 }

--- a/comp/core/autodiscovery/integration/response.go
+++ b/comp/core/autodiscovery/integration/response.go
@@ -28,9 +28,9 @@ type ServiceResponse struct {
 
 // ConfigCheckResponse holds the config check response
 type ConfigCheckResponse struct {
-	Configs         []ConfigResponse           `json:"configs"`
-	ResolveWarnings map[string][]string        `json:"resolve_warnings"`
-	ConfigErrors    map[string]string          `json:"config_errors"`
-	Unresolved      map[string]Config          `json:"unresolved"`
-	Services        map[string]ServiceResponse `json:"services,omitempty"`
+	Configs         []ConfigResponse    `json:"configs"`
+	ResolveWarnings map[string][]string `json:"resolve_warnings"`
+	ConfigErrors    map[string]string   `json:"config_errors"`
+	Unresolved      map[string]Config   `json:"unresolved"`
+	Services        []ServiceResponse   `json:"services,omitempty"`
 }

--- a/comp/core/autodiscovery/integration/response.go
+++ b/comp/core/autodiscovery/integration/response.go
@@ -13,10 +13,22 @@ type ConfigResponse struct {
 	Config      Config   `json:"config"`
 }
 
+// ServiceResponse holds information about a tracked service
+type ServiceResponse struct {
+	ServiceID     string            `json:"service_id"`
+	ADIdentifiers []string          `json:"ad_identifiers"`
+	Hosts         map[string]string `json:"hosts,omitempty"`
+	Ports         []string          `json:"ports,omitempty"`
+	PID           int               `json:"pid,omitempty"`
+	Hostname      string            `json:"hostname,omitempty"`
+	IsReady       bool              `json:"is_ready"`
+}
+
 // ConfigCheckResponse holds the config check response
 type ConfigCheckResponse struct {
-	Configs         []ConfigResponse    `json:"configs"`
-	ResolveWarnings map[string][]string `json:"resolve_warnings"`
-	ConfigErrors    map[string]string   `json:"config_errors"`
-	Unresolved      map[string]Config   `json:"unresolved"`
+	Configs         []ConfigResponse           `json:"configs"`
+	ResolveWarnings map[string][]string        `json:"resolve_warnings"`
+	ConfigErrors    map[string]string          `json:"config_errors"`
+	Unresolved      map[string]Config          `json:"unresolved"`
+	Services        map[string]ServiceResponse `json:"services,omitempty"`
 }

--- a/comp/core/autodiscovery/integration/response.go
+++ b/comp/core/autodiscovery/integration/response.go
@@ -15,13 +15,15 @@ type ConfigResponse struct {
 
 // ServiceResponse holds information about a tracked service
 type ServiceResponse struct {
-	ServiceID     string            `json:"service_id"`
-	ADIdentifiers []string          `json:"ad_identifiers"`
-	Hosts         map[string]string `json:"hosts,omitempty"`
-	Ports         []string          `json:"ports,omitempty"`
-	PID           int               `json:"pid,omitempty"`
-	Hostname      string            `json:"hostname,omitempty"`
-	IsReady       bool              `json:"is_ready"`
+	ServiceID      string            `json:"service_id"`
+	ADIdentifiers  []string          `json:"ad_identifiers"`
+	Hosts          map[string]string `json:"hosts,omitempty"`
+	Ports          []string          `json:"ports,omitempty"`
+	PID            int               `json:"pid,omitempty"`
+	Hostname       string            `json:"hostname,omitempty"`
+	IsReady        bool              `json:"is_ready"`
+	FiltersMetrics bool              `json:"filters_metrics"`
+	FiltersLogs    bool              `json:"filters_logs"`
 }
 
 // ConfigCheckResponse holds the config check response

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -53,10 +53,10 @@ func PrintConfigCheck(w io.Writer, cr integration.ConfigCheckResponse, withDebug
 		}
 
 		if len(cr.Services) > 0 {
-			fmt.Fprintf(w, "\n=== Services (matched and unmatched) ===\n")
-			for _, service := range cr.Services {
-				fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Service ID"), color.YellowString(service.ServiceID))
-				fmt.Fprintf(w, "AD Identifiers: \n")
+			fmt.Fprintf(w, "\n=== %s (matched and unmatched) ===\n", color.MagentaString("Services"))
+			for svcID, service := range cr.Services {
+				fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Service ID"), color.YellowString(svcID))
+				fmt.Fprintf(w, "ADIdentifiers:\n")
 				for _, id := range service.ADIdentifiers {
 					fmt.Fprintf(w, "- %s\n", id)
 				}
@@ -66,13 +66,13 @@ func PrintConfigCheck(w io.Writer, cr integration.ConfigCheckResponse, withDebug
 					fmt.Fprintf(w, "Hostname: %s\n", service.Hostname)
 				}
 				if len(service.Hosts) > 0 {
-					fmt.Fprintf(w, "Host:\n")
+					fmt.Fprintf(w, "Hosts:\n")
 					for key, value := range service.Hosts {
 						fmt.Fprintf(w, "- %s: %s\n", key, value)
 					}
 				}
 				if len(service.Ports) > 0 {
-					fmt.Fprintf(w, "Pods: %s\n", strings.Join(service.Ports, ", "))
+					fmt.Fprintf(w, "Ports: %s\n", strings.Join(service.Ports, ", "))
 				}
 				if service.PID > 0 {
 					fmt.Fprintf(w, "PID: %d\n", service.PID)

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -8,6 +8,7 @@ package flare
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/fatih/color"
@@ -168,8 +169,12 @@ func PrintClusterCheckConfig(w io.Writer, c integration.Config, checkName string
 }
 
 func printServiceDetails(w io.Writer, cr integration.ConfigCheckResponse) {
-	for svcID, service := range cr.Services {
-		fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Service ID"), color.YellowString(svcID))
+	slices.SortFunc(cr.Services, func(a, b integration.ServiceResponse) int {
+		return strings.Compare(a.ServiceID, b.ServiceID)
+	})
+
+	for _, service := range cr.Services {
+		fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Service ID"), color.YellowString(service.ServiceID))
 		fmt.Fprintf(w, "ADIdentifiers:\n")
 		for _, id := range service.ADIdentifiers {
 			fmt.Fprintf(w, "- %s\n", id)

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -51,6 +51,34 @@ func PrintConfigCheck(w io.Writer, cr integration.ConfigCheckResponse, withDebug
 				fmt.Fprintln(w, config.String())
 			}
 		}
+
+		if len(cr.Services) > 0 {
+			fmt.Fprintf(w, "\n=== Services (matched and unmatched) ===\n")
+			for _, service := range cr.Services {
+				fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Service ID"), color.YellowString(service.ServiceID))
+				fmt.Fprintf(w, "AD Identifiers: \n")
+				for _, id := range service.ADIdentifiers {
+					fmt.Fprintf(w, "- %s\n", id)
+				}
+				fmt.Fprintf(w, "Ready: %t\n", service.IsReady)
+
+				if service.Hostname != "" {
+					fmt.Fprintf(w, "Hostname: %s\n", service.Hostname)
+				}
+				if len(service.Hosts) > 0 {
+					fmt.Fprintf(w, "Host:\n")
+					for key, value := range service.Hosts {
+						fmt.Fprintf(w, "- %s: %s\n", key, value)
+					}
+				}
+				if len(service.Ports) > 0 {
+					fmt.Fprintf(w, "Pods: %s\n", strings.Join(service.Ports, ", "))
+				}
+				if service.PID > 0 {
+					fmt.Fprintf(w, "PID: %d\n", service.PID)
+				}
+			}
+		}
 	}
 }
 

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -54,30 +54,7 @@ func PrintConfigCheck(w io.Writer, cr integration.ConfigCheckResponse, withDebug
 
 		if len(cr.Services) > 0 {
 			fmt.Fprintf(w, "\n=== %s (matched and unmatched) ===\n", color.MagentaString("Services"))
-			for svcID, service := range cr.Services {
-				fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Service ID"), color.YellowString(svcID))
-				fmt.Fprintf(w, "ADIdentifiers:\n")
-				for _, id := range service.ADIdentifiers {
-					fmt.Fprintf(w, "- %s\n", id)
-				}
-				fmt.Fprintf(w, "Ready: %t\n", service.IsReady)
-
-				if service.Hostname != "" {
-					fmt.Fprintf(w, "Hostname: %s\n", service.Hostname)
-				}
-				if len(service.Hosts) > 0 {
-					fmt.Fprintf(w, "Hosts:\n")
-					for key, value := range service.Hosts {
-						fmt.Fprintf(w, "- %s: %s\n", key, value)
-					}
-				}
-				if len(service.Ports) > 0 {
-					fmt.Fprintf(w, "Ports: %s\n", strings.Join(service.Ports, ", "))
-				}
-				if service.PID > 0 {
-					fmt.Fprintf(w, "PID: %d\n", service.PID)
-				}
-			}
+			printServiceDetails(w, cr)
 		}
 	}
 }
@@ -188,6 +165,34 @@ func PrintClusterCheckConfig(w io.Writer, c integration.Config, checkName string
 		fmt.Fprintf(w, "%s: %s\n", color.BlueString("State"), color.CyanString(state))
 	}
 	fmt.Fprintln(w, "===")
+}
+
+func printServiceDetails(w io.Writer, cr integration.ConfigCheckResponse) {
+	for svcID, service := range cr.Services {
+		fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Service ID"), color.YellowString(svcID))
+		fmt.Fprintf(w, "ADIdentifiers:\n")
+		for _, id := range service.ADIdentifiers {
+			fmt.Fprintf(w, "- %s\n", id)
+		}
+		fmt.Fprintf(w, "Ready: %t\n", service.IsReady)
+
+		if service.Hostname != "" {
+			fmt.Fprintf(w, "Hostname: %s\n", service.Hostname)
+		}
+		if len(service.Hosts) > 0 {
+			fmt.Fprintf(w, "Hosts:\n")
+			for key, value := range service.Hosts {
+				fmt.Fprintf(w, "- %s: %s\n", key, value)
+			}
+		}
+		if len(service.Ports) > 0 {
+			fmt.Fprintf(w, "Ports: %s\n", strings.Join(service.Ports, ", "))
+		}
+		if service.PID > 0 {
+			fmt.Fprintf(w, "PID: %d\n", service.PID)
+		}
+		fmt.Fprintf(w, "Filters: metrics=%t, logs=%t\n", service.FiltersMetrics, service.FiltersLogs)
+	}
 }
 
 func printContainerExclusionRulesInfo(w io.Writer, c *integration.Config) {

--- a/pkg/flare/config_check_test.go
+++ b/pkg/flare/config_check_test.go
@@ -51,8 +51,8 @@ func TestPrintConfigCheck(t *testing.T) {
 				Instances:     []integration.Data{integration.Data("{unresolved:sad}")},
 			},
 		},
-		Services: map[string]integration.ServiceResponse{
-			"svc1": {
+		Services: []integration.ServiceResponse{
+			{
 				ServiceID:      "svc1",
 				ADIdentifiers:  []string{"test-ad-identifier"},
 				Hosts:          map[string]string{"host1": "192.168.1.1"},

--- a/pkg/flare/config_check_test.go
+++ b/pkg/flare/config_check_test.go
@@ -53,13 +53,15 @@ func TestPrintConfigCheck(t *testing.T) {
 		},
 		Services: map[string]integration.ServiceResponse{
 			"svc1": {
-				ServiceID:     "svc1",
-				ADIdentifiers: []string{"test-ad-identifier"},
-				Hosts:         map[string]string{"host1": "192.168.1.1"},
-				Ports:         []string{"8080", "9090"},
-				PID:           1234,
-				Hostname:      "test-hostname",
-				IsReady:       true,
+				ServiceID:      "svc1",
+				ADIdentifiers:  []string{"test-ad-identifier"},
+				Hosts:          map[string]string{"host1": "192.168.1.1"},
+				Ports:          []string{"8080", "9090"},
+				PID:            1234,
+				Hostname:       "test-hostname",
+				IsReady:        true,
+				FiltersLogs:    true,
+				FiltersMetrics: false,
 			},
 		},
 	}
@@ -117,6 +119,7 @@ Hosts:
 - host1: 192.168.1.1
 Ports: 8080, 9090
 PID: 1234
+Filters: metrics=false, logs=true
 `,
 		},
 		{

--- a/pkg/flare/config_check_test.go
+++ b/pkg/flare/config_check_test.go
@@ -51,6 +51,17 @@ func TestPrintConfigCheck(t *testing.T) {
 				Instances:     []integration.Data{integration.Data("{unresolved:sad}")},
 			},
 		},
+		Services: map[string]integration.ServiceResponse{
+			"svc1": {
+				ServiceID:     "svc1",
+				ADIdentifiers: []string{"test-ad-identifier"},
+				Hosts:         map[string]string{"host1": "192.168.1.1"},
+				Ports:         []string{"8080", "9090"},
+				PID:           1234,
+				Hostname:      "test-hostname",
+				IsReady:       true,
+			},
+		},
 	}
 
 	testCases := []struct {
@@ -94,6 +105,18 @@ instances:
 - unresolved:sad: null
 logs_config: null
 
+
+=== Services (matched and unmatched) ===
+
+Service ID: svc1
+ADIdentifiers:
+- test-ad-identifier
+Ready: true
+Hostname: test-hostname
+Hosts:
+- host1: 192.168.1.1
+Ports: 8080, 9090
+PID: 1234
 `,
 		},
 		{

--- a/releasenotes/notes/add_services_to_configcheck-c2769a75c6d9c073.yaml
+++ b/releasenotes/notes/add_services_to_configcheck-c2769a75c6d9c073.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Print service details in the agent configcheck verbose command output.
+

--- a/releasenotes/notes/add_services_to_configcheck-c2769a75c6d9c073.yaml
+++ b/releasenotes/notes/add_services_to_configcheck-c2769a75c6d9c073.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    Print service details in the agent configcheck verbose command output.
+    Print service details in the Agent configcheck verbose command output.
 


### PR DESCRIPTION
### What does this PR do?

Prints out the list of active services identified by autodiscovery when using the `agent configcheck -v` command. get

### Motivation

Provides more insight into the state of agent autodiscovery in relation to to the checks that are (un)matched.

### Describe how you validated your changes

- Updated `TestPrintConfigCheck` test case.
- Manually QAd by running `agent configcheck -v`
<img width="1233" height="445" alt="image" src="https://github.com/user-attachments/assets/71dabbd3-35b5-4805-bb13-b91b2ab4ceba" />

### Additional Notes

This change also impacts flare output since `configcheck` is called with debug/verbose mode enabled when generating a flare.
