### PR TITLE
Bump memory bound for quality gate logs experiment

### DIFF
--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_pss_bytes
-      upper_bound: "241 MiB"
+      upper_bound: "250 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?

- bumps memory bound for `quality_gate_logs` to 250 MiB

### Motivation

The limit currently set is overly tight, based on a mis-prediction of Agent worst-case behavior. Discussed as a part of incident 43363, adjusted from a larger dataset than our previous limit adjustment. 

### Describe how you validated your changes

Will let the regression detector run and complete.

### Additional Notes
