### PR TITLE
(fleet) set the installer umask to 022

### DIFF
--- a/pkg/fleet/installer/commands/umask_nix.go
+++ b/pkg/fleet/installer/commands/umask_nix.go
@@ -13,8 +13,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 )
 
-// setInstallerUmask sets umask 0 to override any inherited umask
+// setInstallerUmask sets umask 022 to override any inherited umask
 func setInstallerUmask(span *telemetry.Span) {
-	oldmask := syscall.Umask(0)
+	oldmask := syscall.Umask(022)
 	span.SetTag("inherited_umask", oldmask)
 }

--- a/pkg/fleet/installer/packages/integrations/integrations.go
+++ b/pkg/fleet/installer/packages/integrations/integrations.go
@@ -35,12 +35,7 @@ func executePythonScript(ctx context.Context, installPath, scriptName string, ar
 	}
 
 	pythonCmd := append([]string{scriptPath}, args...)
-	fullCmd := append([]string{pythonPath}, pythonCmd...)
-	// Set umask to 022 before running the command.
-	// This ensures that the files created by the Python script have the correct permissions.
-	bashCmd := "umask 022; " + strings.Join(fullCmd, " ")
-
-	cmd := exec.CommandContext(ctx, "bash", "-c", bashCmd)
+	cmd := exec.CommandContext(ctx, pythonPath, pythonCmd...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
This PR sets the installer umask to 022. This avoids being subjected to the environment umask during installation which has caused issues in the past while still providing a baseline security layer (022 is the default value in most environments).

e2e should be enough to cover this but let's keep our eyes open on any permission issues due to those change, especially with non-default features (SSI, system-probe?, etc...)
