### PR TITLE
dyninst/procmon: fix shutdown panic

### DIFF
--- a/pkg/dyninst/procmon/process_monitor.go
+++ b/pkg/dyninst/procmon/process_monitor.go
@@ -261,6 +261,9 @@ const queueBackpressureLimit = 64 // arbitrary limit
 func handleEvent[Ev any](pm *ProcessMonitor, f func(*state, Ev), ev Ev) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
+	if pm.mu.isClosed {
+		return
+	}
 	f(&pm.mu.state, ev)
 	pm.mu.state.analyzeOrReport((*lockedProcessMonitor)(pm))
 	if pm.mu.syncing && len(pm.mu.state.queued) == 0 {

--- a/pkg/dyninst/procmon/process_monitor_test.go
+++ b/pkg/dyninst/procmon/process_monitor_test.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessMonitorCloseWhileAnalyzing tests that the process monitor can be
+// closed while it is analyzing a process and no panics occur.
+func TestProcessMonitorCloseWhileAnalyzing(t *testing.T) {
+	analyzer := &blockingAnalyzer{
+		analyzeChan: make(chan chan struct{}),
+	}
+	os.MkdirAll(t.TempDir(), 0o755)
+	defer os.RemoveAll(t.TempDir())
+	procRoot := filepath.Join(t.TempDir(), "proc")
+	const pid = 10000
+	{
+		pidDir := filepath.Join(procRoot, strconv.Itoa(int(pid)))
+		require.NoError(t, os.MkdirAll(pidDir, 0o755))
+		require.NoError(t, os.Symlink(os.Args[0], filepath.Join(pidDir, "exe")))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(pidDir, "environ"),
+			[]byte(strings.Join([]string{
+				ddServiceEnvVar + "=test",
+				ddEnvironmentEnvVar + "=test",
+				ddVersionEnvVar + "=1.0.0",
+				ddDynInstEnabledEnvVar + "=true",
+			}, "\x00")),
+			0o644,
+		))
+	}
+	pm, analyzeCh := newProcessMonitor(testHandler{}, procRoot, testResolver{}, analyzer)
+	go pm.startAnalyzerWorker(analyzeCh)
+	pm.NotifyExec(pid)
+	pm.NotifyExec(pid + 1)
+	req := <-analyzer.analyzeChan
+	// Analysis is now blocked on req.
+
+	// Shut down the process monitor while analysis is blocked.
+	closeDone := make(chan struct{})
+	go func() { pm.Close(); close(closeDone) }()
+
+	// Make sure that the process monitor is closed.
+	require.Eventually(t, func() bool {
+		pm.mu.Lock()
+		defer pm.mu.Unlock()
+		return pm.mu.isClosed
+	}, time.Second, 1*time.Millisecond)
+
+	// Make sure that the Close call is still blocked on the analysis worker.
+	select {
+	case <-closeDone:
+		t.Fatalf("process monitor closed unexpectedly")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	req <- struct{}{} // allow analysis to complete
+	<-closeDone       // ensure that the Close call returns
+}
+
+type blockingAnalyzer struct {
+	analyzeChan chan chan struct{}
+}
+
+var _ executableAnalyzer = (*blockingAnalyzer)(nil)
+
+func (a *blockingAnalyzer) checkFileKeyCache(FileKey) (interesting bool, known bool) {
+	return false, false
+}
+
+func (a *blockingAnalyzer) isInteresting(*os.File, FileKey) (bool, error) {
+	req := make(chan struct{})
+	a.analyzeChan <- req
+	<-req
+	return false, nil
+}


### PR DESCRIPTION
### What does this PR do?

Before this change, if there was a queued process for analysis and analysis of a process completed while shutdown occurred, then the monitor would panic with:

```
panic: send on closed channel

goroutine 82 [running]:
github.com/DataDog/datadog-agent/pkg/dyninst/procmon.(*lockedProcessMonitor).analyzeProcess(0xc00080c5a0, 0x1f00670?)
	/home/andrew/src/github.com/DataDog/datadog-agent/pkg/dyninst/procmon/process_monitor.go:323 +0x2c
github.com/DataDog/datadog-agent/pkg/dyninst/procmon.(*state).analyzeOrReport(0xc00080c628, {0x110a4a8, 0xc00080c5a0})
	/home/andrew/src/github.com/DataDog/datadog-agent/pkg/dyninst/procmon/state.go:149 +0xfc
github.com/DataDog/datadog-agent/pkg/dyninst/procmon.handleEvent[...](0xc00080c5a0?, 0x110a480, {0x2710, {0x0, 0x0}, {{0xc0002a9e28, 0x4}, {0xc0002a9e30, 0x5}, {0xc0002a9e2c, ...}, ...}})
	/home/andrew/src/github.com/DataDog/datadog-agent/pkg/dyninst/procmon/process_monitor.go:265 +0x105
github.com/DataDog/datadog-agent/pkg/dyninst/procmon.(*ProcessMonitor).analyzeProcess(0xc00080c5a0, 0x2710)
	/home/andrew/src/github.com/DataDog/datadog-agent/pkg/dyninst/procmon/process_monitor.go:312 +0x3ae
github.com/DataDog/datadog-agent/pkg/dyninst/procmon.(*ProcessMonitor).startAnalyzerWorker.func1()
	/home/andrew/src/github.com/DataDog/datadog-agent/pkg/dyninst/procmon/process_monitor.go:172 +0x71
created by github.com/DataDog/datadog-agent/pkg/dyninst/procmon.(*ProcessMonitor).startAnalyzerWorker in goroutine 49
	/home/andrew/src/github.com/DataDog/datadog-agent/pkg/dyninst/procmon/process_monitor.go:169 +0x78
```

This commit fixes that issue by checking whether the monitor is shutting down before handling the analysis result event (or, well, any event).

The test added in this commit demonstrated the problem and verified it is fixed.

### Motivation

This panic was seen in QA testing for the release.

### Describe how you validated your changes

Testing was added that reproduced the issue.
