### PR TITLE
drop context from detached process

### DIFF
--- a/pkg/fleet/installer/exec/installer_exec.go
+++ b/pkg/fleet/installer/exec/installer_exec.go
@@ -46,18 +46,40 @@ type installerCmd struct {
 	ctx  context.Context
 }
 
+func (i *InstallerExec) newInstallerCmdCustomPathDetached(ctx context.Context, command string, path string, args ...string) *installerCmd {
+	span, ctx := telemetry.StartSpanFromContext(ctx, fmt.Sprintf("installer.%s", command))
+	span.SetTag("args", strings.Join(args, " "))
+	// NOTE: We very intentionally don't provide ctx to exec.Command.
+	//       exec.Command will kill the process if the context is cancelled. We don't want that here since
+	//       it is supposed to be a detached process that may live longer than the current process.
+	cmd := exec.Command(path, append([]string{command}, args...)...)
+	// We're running this process in the background, so we don't intend to collect any output from it.
+	// We set channels to nil here because os/exec waits on these pipes to close even after
+	// the process terminates which can cause us (or our parent) to be forever blocked
+	// by this child process or any children it creates, which may inherit any of these handles
+	// and keep them open.
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return i.setupInstallerCmd(ctx, span, cmd)
+}
+
 func (i *InstallerExec) newInstallerCmdCustomPath(ctx context.Context, command string, path string, args ...string) *installerCmd {
-	env := i.env.ToEnv()
-	// Enforce the use of the installer when it is bundled with the agent.
-	env = append(env, "DD_BUNDLED_AGENT=installer")
 	span, ctx := telemetry.StartSpanFromContext(ctx, fmt.Sprintf("installer.%s", command))
 	span.SetTag("args", strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, path, append([]string{command}, args...)...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return i.setupInstallerCmd(ctx, span, cmd)
+}
+
+func (i *InstallerExec) setupInstallerCmd(ctx context.Context, span *telemetry.Span, cmd *exec.Cmd) *installerCmd {
+	env := i.env.ToEnv()
+	// Enforce the use of the installer when it is bundled with the agent.
+	env = append(env, "DD_BUNDLED_AGENT=installer")
 	env = append(os.Environ(), env...)
 	env = append(env, telemetry.EnvFromContext(ctx)...)
 	cmd.Env = env
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
 	cmd = i.newInstallerCmdPlatform(cmd)
 	return &installerCmd{
 		Cmd:  cmd,
@@ -68,6 +90,10 @@ func (i *InstallerExec) newInstallerCmdCustomPath(ctx context.Context, command s
 
 func (i *InstallerExec) newInstallerCmd(ctx context.Context, command string, args ...string) *installerCmd {
 	return i.newInstallerCmdCustomPath(ctx, command, i.installerBinPath, args...)
+}
+
+func (i *InstallerExec) newInstallerCmdDetached(ctx context.Context, command string, args ...string) *installerCmd {
+	return i.newInstallerCmdCustomPathDetached(ctx, command, i.installerBinPath, args...)
 }
 
 // Install installs a package.
@@ -344,15 +370,7 @@ func (i *InstallerExec) RunHook(ctx context.Context, hookContext string) (err er
 
 // StartPackageCommandDetached starts a package-specific command for a given package in the background with detached standard IO.
 func (i *InstallerExec) StartPackageCommandDetached(ctx context.Context, packageName string, command string) (err error) {
-	cmd := i.newInstallerCmd(ctx, "package-command", packageName, command)
+	cmd := i.newInstallerCmdDetached(ctx, "package-command", packageName, command)
 	defer func() { cmd.span.Finish(err) }()
-	// We're running this process in the background, so we don't intend to collect any output from it.
-	// We set channels to nil here because os/exec waits on these pipes to close even after
-	// the process terminates which can cause us (or our parent) to be forever blocked
-	// by this child process or any children it creates, which may inherit any of these handles
-	// and keep them open.
-	cmd.Stdin = nil
-	cmd.Stdout = nil
-	cmd.Stderr = nil
 	return cmd.Start()
 }

--- a/pkg/fleet/installer/exec/installer_exec.go
+++ b/pkg/fleet/installer/exec/installer_exec.go
@@ -343,11 +343,8 @@ func (i *InstallerExec) RunHook(ctx context.Context, hookContext string) (err er
 }
 
 // StartPackageCommandDetached starts a package-specific command for a given package in the background with detached standard IO.
-func (i *InstallerExec) StartPackageCommandDetached(packageName string, command string) (err error) {
-	// NOTE: We very intentionally don't use a caller provided context here.
-	//       exec.Cmd will kill the process if the context is cancelled. We don't want that here since
-	//       it is supposed to be a detached process that may live longer than the current process.
-	cmd := i.newInstallerCmd(context.Background(), "package-command", packageName, command)
+func (i *InstallerExec) StartPackageCommandDetached(ctx context.Context, packageName string, command string) (err error) {
+	cmd := i.newInstallerCmd(ctx, "package-command", packageName, command)
 	defer func() { cmd.span.Finish(err) }()
 	// We're running this process in the background, so we don't intend to collect any output from it.
 	// We set channels to nil here because os/exec waits on these pipes to close even after

--- a/pkg/fleet/installer/exec/installer_exec.go
+++ b/pkg/fleet/installer/exec/installer_exec.go
@@ -343,8 +343,11 @@ func (i *InstallerExec) RunHook(ctx context.Context, hookContext string) (err er
 }
 
 // StartPackageCommandDetached starts a package-specific command for a given package in the background with detached standard IO.
-func (i *InstallerExec) StartPackageCommandDetached(ctx context.Context, packageName string, command string) (err error) {
-	cmd := i.newInstallerCmd(ctx, "package-command", packageName, command)
+func (i *InstallerExec) StartPackageCommandDetached(packageName string, command string) (err error) {
+	// NOTE: We very intentionally don't use a caller provided context here.
+	//       exec.Cmd will kill the process if the context is cancelled. We don't want that here since
+	//       it is supposed to be a detached process that may live longer than the current process.
+	cmd := i.newInstallerCmd(context.Background(), "package-command", packageName, command)
 	defer func() { cmd.span.Finish(err) }()
 	// We're running this process in the background, so we don't intend to collect any output from it.
 	// We set channels to nil here because os/exec waits on these pipes to close even after

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -118,13 +118,13 @@ func preStartExperimentDatadogAgent(_ HookContext) error {
 }
 
 // postStartExperimentDatadogAgent stops the watchdog and launches a new process to start the experiment in the background.
-func postStartExperimentDatadogAgent(_ HookContext) error {
+func postStartExperimentDatadogAgent(ctx HookContext) error {
 	// open event that signal the end of the experiment
 	// this will terminate other running instances of the watchdog
 	// this allows for running multiple experiments in sequence
 	_ = setWatchdogStopEvent()
 
-	return launchPackageCommandInBackground(getenv(), "postStartExperimentBackground")
+	return launchPackageCommandInBackground(ctx.Context, getenv(), "postStartExperimentBackground")
 }
 
 // postStartExperimentDatadogAgentBackground uninstalls the Agent, installs the experiment,
@@ -201,13 +201,13 @@ func postStartExperimentDatadogAgentBackground(ctx context.Context) error {
 }
 
 // postStopExperimentDatadogAgent stops the watchdog and launches a new process to stop the experiment.
-func postStopExperimentDatadogAgent(_ HookContext) (err error) {
+func postStopExperimentDatadogAgent(ctx HookContext) (err error) {
 	// set watchdog stop to make sure the watchdog stops
 	// don't care if it fails cause we will proceed with the stop anyway
 	// this will just stop a watchdog that is running
 	_ = setWatchdogStopEvent()
 
-	return launchPackageCommandInBackground(getenv(), "postStopExperimentBackground")
+	return launchPackageCommandInBackground(ctx.Context, getenv(), "postStopExperimentBackground")
 }
 
 // postStopExperimentDatadogAgentBackground uninstalls the Agent and then reinstalls the stable Agent,
@@ -640,7 +640,7 @@ func setFleetPoliciesDir(path string) error {
 
 // postStartConfigExperimentDatadogAgent stops the watchdog, sets the fleet_policies_dir to experiment,
 // and launches a new process to start the experiment in the background.
-func postStartConfigExperimentDatadogAgent(_ HookContext) error {
+func postStartConfigExperimentDatadogAgent(ctx HookContext) error {
 	// open event that signal the end of the experiment
 	// this will terminate other running instances of the watchdog
 	// this allows for running multiple experiments in sequence
@@ -653,7 +653,7 @@ func postStartConfigExperimentDatadogAgent(_ HookContext) error {
 		return err
 	}
 
-	return launchPackageCommandInBackground(getenv(), "postStartConfigExperimentBackground")
+	return launchPackageCommandInBackground(ctx.Context, getenv(), "postStartConfigExperimentBackground")
 }
 
 // postStartConfigExperimentDatadogAgentBackground restarts the Agent services and then
@@ -726,7 +726,7 @@ func restoreStableConfigFromExperiment(ctx context.Context) error {
 
 // preStopConfigExperimentDatadogAgent stops the watchdog, sets the fleet_policies_dir to stable,
 // and launches a new process to stop the experiment in the background.
-func preStopConfigExperimentDatadogAgent(_ HookContext) error {
+func preStopConfigExperimentDatadogAgent(ctx HookContext) error {
 	// set watchdog stop to make sure the watchdog stops
 	// don't care if it fails cause we will proceed with the stop anyway
 	// this will just stop a watchdog that is running
@@ -739,7 +739,7 @@ func preStopConfigExperimentDatadogAgent(_ HookContext) error {
 		return err
 	}
 
-	return launchPackageCommandInBackground(getenv(), "preStopConfigExperimentBackground")
+	return launchPackageCommandInBackground(ctx.Context, getenv(), "preStopConfigExperimentBackground")
 }
 
 // preStopConfigExperimentDatadogAgentBackground restarts the Agent services.
@@ -754,7 +754,7 @@ func preStopConfigExperimentDatadogAgentBackground(ctx context.Context) error {
 
 // postPromoteConfigExperimentDatadogAgent stops the watchdog, sets the fleet_policies_dir to stable,
 // and launches a new process to promote the experiment in the background.
-func postPromoteConfigExperimentDatadogAgent(_ HookContext) error {
+func postPromoteConfigExperimentDatadogAgent(ctx HookContext) error {
 	err := setWatchdogStopEvent()
 	if err != nil {
 		// if we can't set the event it means the watchdog has failed
@@ -770,7 +770,7 @@ func postPromoteConfigExperimentDatadogAgent(_ HookContext) error {
 		return err
 	}
 
-	return launchPackageCommandInBackground(getenv(), "postPromoteConfigExperimentBackground")
+	return launchPackageCommandInBackground(ctx.Context, getenv(), "postPromoteConfigExperimentBackground")
 }
 
 // postPromoteConfigExperimentDatadogAgentBackground restarts the Agent services.
@@ -824,13 +824,13 @@ func runDatadogAgentPackageCommand(ctx context.Context, command string) (err err
 }
 
 // launchPackageCommandInBackground launches a package command in the background using the installer.
-func launchPackageCommandInBackground(env *env.Env, command string) error {
+func launchPackageCommandInBackground(ctx context.Context, env *env.Env, command string) error {
 	installer, err := newInstallerExec(env)
 	if err != nil {
 		return fmt.Errorf("failed to create installer exec: %w", err)
 	}
 
-	err = installer.StartPackageCommandDetached(datadogAgent, command)
+	err = installer.StartPackageCommandDetached(ctx, datadogAgent, command)
 	if err != nil {
 		return fmt.Errorf("failed to start background process: %w", err)
 	}

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -118,13 +118,13 @@ func preStartExperimentDatadogAgent(_ HookContext) error {
 }
 
 // postStartExperimentDatadogAgent stops the watchdog and launches a new process to start the experiment in the background.
-func postStartExperimentDatadogAgent(ctx HookContext) error {
+func postStartExperimentDatadogAgent(_ HookContext) error {
 	// open event that signal the end of the experiment
 	// this will terminate other running instances of the watchdog
 	// this allows for running multiple experiments in sequence
 	_ = setWatchdogStopEvent()
 
-	return launchPackageCommandInBackground(ctx.Context, getenv(), "postStartExperimentBackground")
+	return launchPackageCommandInBackground(getenv(), "postStartExperimentBackground")
 }
 
 // postStartExperimentDatadogAgentBackground uninstalls the Agent, installs the experiment,
@@ -201,13 +201,13 @@ func postStartExperimentDatadogAgentBackground(ctx context.Context) error {
 }
 
 // postStopExperimentDatadogAgent stops the watchdog and launches a new process to stop the experiment.
-func postStopExperimentDatadogAgent(ctx HookContext) (err error) {
+func postStopExperimentDatadogAgent(_ HookContext) (err error) {
 	// set watchdog stop to make sure the watchdog stops
 	// don't care if it fails cause we will proceed with the stop anyway
 	// this will just stop a watchdog that is running
 	_ = setWatchdogStopEvent()
 
-	return launchPackageCommandInBackground(ctx.Context, getenv(), "postStopExperimentBackground")
+	return launchPackageCommandInBackground(getenv(), "postStopExperimentBackground")
 }
 
 // postStopExperimentDatadogAgentBackground uninstalls the Agent and then reinstalls the stable Agent,
@@ -640,7 +640,7 @@ func setFleetPoliciesDir(path string) error {
 
 // postStartConfigExperimentDatadogAgent stops the watchdog, sets the fleet_policies_dir to experiment,
 // and launches a new process to start the experiment in the background.
-func postStartConfigExperimentDatadogAgent(ctx HookContext) error {
+func postStartConfigExperimentDatadogAgent(_ HookContext) error {
 	// open event that signal the end of the experiment
 	// this will terminate other running instances of the watchdog
 	// this allows for running multiple experiments in sequence
@@ -653,7 +653,7 @@ func postStartConfigExperimentDatadogAgent(ctx HookContext) error {
 		return err
 	}
 
-	return launchPackageCommandInBackground(ctx.Context, getenv(), "postStartConfigExperimentBackground")
+	return launchPackageCommandInBackground(getenv(), "postStartConfigExperimentBackground")
 }
 
 // postStartConfigExperimentDatadogAgentBackground restarts the Agent services and then
@@ -726,7 +726,7 @@ func restoreStableConfigFromExperiment(ctx context.Context) error {
 
 // preStopConfigExperimentDatadogAgent stops the watchdog, sets the fleet_policies_dir to stable,
 // and launches a new process to stop the experiment in the background.
-func preStopConfigExperimentDatadogAgent(ctx HookContext) error {
+func preStopConfigExperimentDatadogAgent(_ HookContext) error {
 	// set watchdog stop to make sure the watchdog stops
 	// don't care if it fails cause we will proceed with the stop anyway
 	// this will just stop a watchdog that is running
@@ -739,7 +739,7 @@ func preStopConfigExperimentDatadogAgent(ctx HookContext) error {
 		return err
 	}
 
-	return launchPackageCommandInBackground(ctx.Context, getenv(), "preStopConfigExperimentBackground")
+	return launchPackageCommandInBackground(getenv(), "preStopConfigExperimentBackground")
 }
 
 // preStopConfigExperimentDatadogAgentBackground restarts the Agent services.
@@ -754,7 +754,7 @@ func preStopConfigExperimentDatadogAgentBackground(ctx context.Context) error {
 
 // postPromoteConfigExperimentDatadogAgent stops the watchdog, sets the fleet_policies_dir to stable,
 // and launches a new process to promote the experiment in the background.
-func postPromoteConfigExperimentDatadogAgent(ctx HookContext) error {
+func postPromoteConfigExperimentDatadogAgent(_ HookContext) error {
 	err := setWatchdogStopEvent()
 	if err != nil {
 		// if we can't set the event it means the watchdog has failed
@@ -770,7 +770,7 @@ func postPromoteConfigExperimentDatadogAgent(ctx HookContext) error {
 		return err
 	}
 
-	return launchPackageCommandInBackground(ctx.Context, getenv(), "postPromoteConfigExperimentBackground")
+	return launchPackageCommandInBackground(getenv(), "postPromoteConfigExperimentBackground")
 }
 
 // postPromoteConfigExperimentDatadogAgentBackground restarts the Agent services.
@@ -824,13 +824,13 @@ func runDatadogAgentPackageCommand(ctx context.Context, command string) (err err
 }
 
 // launchPackageCommandInBackground launches a package command in the background using the installer.
-func launchPackageCommandInBackground(ctx context.Context, env *env.Env, command string) error {
+func launchPackageCommandInBackground(env *env.Env, command string) error {
 	installer, err := newInstallerExec(env)
 	if err != nil {
 		return fmt.Errorf("failed to create installer exec: %w", err)
 	}
 
-	err = installer.StartPackageCommandDetached(ctx, datadogAgent, command)
+	err = installer.StartPackageCommandDetached(datadogAgent, command)
 	if err != nil {
 		return fmt.Errorf("failed to start background process: %w", err)
 	}

--- a/releasenotes/notes/windows-fleet-fix-detached-7a389e4a9aaacd94.yaml
+++ b/releasenotes/notes/windows-fleet-fix-detached-7a389e4a9aaacd94.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix race condition that in rare cases caused remote updates on Windows to fail without an error.
+
+    The Go context used when creating a detached subprocess was closed on exit. This triggered an async
+    action to kill the detached subprocess, which in rare cases completed before the process exited.


### PR DESCRIPTION
### What does this PR do?
don't pass context when launching detached process

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1666
https://datadoghq.atlassian.net/browse/WINA-1707
fix bug that can cause fleet upgrades to fail

### Describe how you validated your changes
existing E2E tests fail due to this issue once every few days

manual test: added sleep after `i.stop()` to give time for background terminate process to finish

### Additional Notes
before returning from main, `hookCommand` calls defer `i.stop(err)`
https://github.com/DataDog/datadog-agent/blob/4c3ba894409b1fde22ed134e0b7a2eb518b80297/pkg/fleet/installer/commands/hooks.go#L37-L38
`i.stop` calls `c.stopsighandler`
https://github.com/DataDog/datadog-agent/blob/4c3ba894409b1fde22ed134e0b7a2eb518b80297/pkg/fleet/installer/commands/command.go#L73-L80
which is the context cancelfunc
https://github.com/DataDog/datadog-agent/blob/4c3ba894409b1fde22ed134e0b7a2eb518b80297/pkg/fleet/installer/commands/command.go#L46-L55

Since this context was passed to `exec.CommandContext` when launching the detached `postStartExperimentBackground` subprocess, it sees `ctx.Done()` and sends a kill signal to the subprocess.