### PR TITLE
Wait a bit longer for datadog-agent to be ready on macos

### DIFF
--- a/test/new-e2e/tests/agent-platform/macos/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/macos/install_script_test.go
@@ -48,5 +48,5 @@ func (m *macosInstallSuite) TestInstallAgent() {
 	m.EventuallyWithT(func(c *assert.CollectT) {
 		_, err := macosTestClient.Execute("/usr/local/bin/datadog-agent status")
 		assert.NoError(c, err)
-	}, 10*time.Second, 1*time.Second)
+	}, 20*time.Second, 1*time.Second)
 }


### PR DESCRIPTION
### What does this PR do?

With only 10 seconds, the agent is not always ready. Let's bump a bit the max wait time, to make sure the agent is ready

### Motivation

### Describe how you validated your changes

### Additional Notes
