### PR TITLE
[CONTINT-4776] Emit k8s cloud provider tag

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -393,10 +393,10 @@ func start(log log.Component,
 		}
 		pkglog.Warn("Failed to auto-detect a Kubernetes cluster name. We recommend you set it manually via the cluster_name config option")
 	}
-	// determine cloud provider for that node.
-	cloudProvider := cloudprovider.DCAGetName(mainCtx)
+	// determine kube distribution for that node.
+	kubeDistro := cloudprovider.DCAGetName(mainCtx)
 
-	pkglog.Infof("Cluster ID: %s, Cluster Name: %s, Kube Cloud Provider: %s", clusterID, clusterName, cloudProvider)
+	pkglog.Infof("Cluster ID: %s, Cluster Name: %s, Kube Distribution: %s", clusterID, clusterName, kubeDistro)
 
 	// Initialize and start remote configuration client
 	var rcClient *rcclient.Client

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -101,6 +101,7 @@ import (
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -335,7 +336,7 @@ func start(log log.Component,
 	// Getting connection to APIServer, it's done before Hostname resolution
 	// as hostname resolution may call APIServer
 	pkglog.Info("Waiting to obtain APIClient connection")
-	apiCl, err := apiserver.WaitForAPIClient(context.Background()) // make sure we can connect to the apiserver
+	apiCl, err := apiserver.WaitForAPIClient(mainCtx) // make sure we can connect to the apiserver
 	if err != nil {
 		return fmt.Errorf("Fatal error: Cannot connect to the apiserver: %v", err)
 	}
@@ -392,7 +393,10 @@ func start(log log.Component,
 		}
 		pkglog.Warn("Failed to auto-detect a Kubernetes cluster name. We recommend you set it manually via the cluster_name config option")
 	}
-	pkglog.Infof("Cluster ID: %s, Cluster Name: %s", clusterID, clusterName)
+	// determine cloud provider for that node.
+	cloudProvider := cloudprovider.DCAGetName(mainCtx)
+
+	pkglog.Infof("Cluster ID: %s, Cluster Name: %s, Kube Cloud Provider: %s", clusterID, clusterName, cloudProvider)
 
 	// Initialize and start remote configuration client
 	var rcClient *rcclient.Client

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -7,6 +7,7 @@ package collectors
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"github.com/gobwas/glob"
@@ -20,6 +21,7 @@ import (
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	tagutil "github.com/DataDog/datadog-agent/pkg/util/tags"
@@ -97,17 +99,25 @@ func (c *WorkloadMetaCollector) Run(ctx context.Context) {
 }
 
 func (c *WorkloadMetaCollector) collectStaticGlobalTags(ctx context.Context, datadogConfig config.Component) {
-	c.staticTags = tagutil.GetStaticTags(ctx, datadogConfig)
+	staticTags := tagutil.GetStaticTags(ctx, datadogConfig)
+	// staticTags could be nil if no static tags are configured so we copy to
+	// existing non-nil map. That simplifies code down below.
+	maps.Copy(c.staticTags, staticTags)
+
 	if _, exists := c.staticTags[clusterTagNamePrefix]; flavor.GetFlavor() == flavor.ClusterAgent && !exists {
 		// If we are running the cluster agent, we want to set the kube_cluster_name tag as a global tag if we are able
 		// to read it, for the instances where we are running in an environment where hostname cannot be detected.
 		if cluster := clustername.GetClusterNameTagValue(ctx, ""); cluster != "" {
-			if c.staticTags == nil {
-				c.staticTags = make(map[string][]string, 1)
-			}
 			c.staticTags[clusterTagNamePrefix] = []string{cluster}
 		}
+
+		// determine for kube_cloud_provider global tag
+		cloudProvider := cloudprovider.DCAGetName(ctx)
+		if cloudProvider != "" {
+			c.staticTags[tags.KubeCloudProvider] = []string{cloudProvider}
+		}
 	}
+
 	// These are the global tags that should only be applied to the internal global entity on DCA.
 	// Whereas the static tags are applied to containers and pods directly as well.
 	globalEnvTags := tagutil.GetClusterAgentStaticTags(datadogConfig)
@@ -175,6 +185,7 @@ func NewWorkloadMetaCollector(ctx context.Context, cfg config.Component, store w
 		tagProcessor:                      p,
 		store:                             store,
 		children:                          make(map[types.EntityID]map[types.EntityID]struct{}),
+		staticTags:                        make(map[string][]string),
 		collectEC2ResourceTags:            cfg.GetBool("ecs_collect_resource_tags_ec2"),
 		collectPersistentVolumeClaimsTags: cfg.GetBool("kubernetes_persistent_volume_claims_as_tags"),
 	}

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -21,7 +21,6 @@ import (
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	tagutil "github.com/DataDog/datadog-agent/pkg/util/tags"
@@ -110,17 +109,11 @@ func (c *WorkloadMetaCollector) collectStaticGlobalTags(ctx context.Context, dat
 		if cluster := clustername.GetClusterNameTagValue(ctx, ""); cluster != "" {
 			c.staticTags[clusterTagNamePrefix] = []string{cluster}
 		}
-
-		// determine for kube_cloud_provider global tag
-		cloudProvider := cloudprovider.DCAGetName(ctx)
-		if cloudProvider != "" {
-			c.staticTags[tags.KubeCloudProvider] = []string{cloudProvider}
-		}
 	}
 
 	// These are the global tags that should only be applied to the internal global entity on DCA.
 	// Whereas the static tags are applied to containers and pods directly as well.
-	globalEnvTags := tagutil.GetClusterAgentStaticTags(datadogConfig)
+	globalEnvTags := tagutil.GetClusterAgentStaticTags(ctx, datadogConfig)
 
 	tagList := taglist.NewTagList()
 

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -35,6 +35,8 @@ const (
 	KubeClusterName = "kube_cluster_name"
 	// OrchClusterID is the tag for the orchestrator cluster ID
 	OrchClusterID = "orch_cluster_id"
+	// KubeCloudProvider is the tag for the managed Kubernetes cloud provider: aws, gcp, azure
+	KubeCloudProvider = "kube_cloud_provider"
 
 	// ImageName is the tag for the image name
 	ImageName = "image_name"

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -35,8 +35,8 @@ const (
 	KubeClusterName = "kube_cluster_name"
 	// OrchClusterID is the tag for the orchestrator cluster ID
 	OrchClusterID = "orch_cluster_id"
-	// KubeCloudProvider is the tag for the managed Kubernetes cloud provider: aws, gcp, azure
-	KubeCloudProvider = "kube_cloud_provider"
+	// KubeDistribution is the tag for the managed Kubernetes cloud provider: eks, gke, aks
+	KubeDistribution = "kube_distribution"
 
 	// ImageName is the tag for the image name
 	ImageName = "image_name"

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -143,7 +143,7 @@ func TestNewServerExtraTags(t *testing.T) {
 	requireStart(t, s)
 
 	require.ElementsMatch(
-		[]string{"hello:world", "extra:tags", "hello:world2"},
+		[]string{"hello:world", "extra:tags", "hello:world2", "kube_cloud_provider:aws"},
 		s.extraTags,
 		"both tag sources should have been combined",
 	)

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -28,7 +28,6 @@ func TestNewServer(t *testing.T) {
 
 	deps := fulfillDepsWithConfigOverride(t, cfg)
 	requireStart(t, deps.Server)
-
 }
 
 func TestHistogramMetricNamesFilter(t *testing.T) {
@@ -143,7 +142,7 @@ func TestNewServerExtraTags(t *testing.T) {
 	requireStart(t, s)
 
 	require.ElementsMatch(
-		[]string{"hello:world", "extra:tags", "hello:world2", "kube_cloud_provider:aws"},
+		[]string{"hello:world", "extra:tags", "hello:world2", "kube_distribution:eks"},
 		s.extraTags,
 		"both tag sources should have been combined",
 	)

--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -149,7 +149,7 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 		hostTags = appendToHostTags(hostTags, []string{tags.OrchClusterID + ":" + clusterID})
 	}
 
-	if providerName, err := cloudprovider.GetName(); err == nil && providerName != "" {
+	if providerName, err := cloudprovider.GetName(ctx); err == nil && providerName != "" {
 		hostTags = appendToHostTags(hostTags, []string{tags.KubeCloudProvider + ":" + providerName})
 	}
 

--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -149,8 +149,8 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 		hostTags = appendToHostTags(hostTags, []string{tags.OrchClusterID + ":" + clusterID})
 	}
 
-	if providerName, err := cloudprovider.GetName(ctx); err == nil && providerName != "" {
-		hostTags = appendToHostTags(hostTags, []string{tags.KubeCloudProvider + ":" + providerName})
+	if kubeDistro, err := cloudprovider.GetName(ctx); err == nil && kubeDistro != "" {
+		hostTags = appendToHostTags(hostTags, []string{tags.KubeDistribution + ":" + kubeDistro})
 	}
 
 	gceTags := []string{}

--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	ec2tags "github.com/DataDog/datadog-agent/pkg/util/ec2/tags"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	k8s "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -146,6 +147,10 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 
 	if clusterID, err := clustername.GetClusterID(); err == nil && clusterID != "" {
 		hostTags = appendToHostTags(hostTags, []string{tags.OrchClusterID + ":" + clusterID})
+	}
+
+	if providerName, err := cloudprovider.GetName(); err == nil && providerName != "" {
+		hostTags = appendToHostTags(hostTags, []string{tags.KubeCloudProvider + ":" + providerName})
 	}
 
 	gceTags := []string{}

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -76,7 +76,7 @@ func newDispatcher(tagger tagger.Component) *dispatcher {
 
 	clusterIDTagValue, err := clustername.GetClusterID()
 	if err != nil {
-		log.Errorf("Failed to get cluster ID: %v", err)
+		log.Warnf("Failed to get cluster ID: %v", err)
 	}
 	if clusterIDTagValue != "" {
 		d.extraTags = append(d.extraTags, tags.OrchClusterID+":"+clusterIDTagValue)

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -74,7 +74,10 @@ func newDispatcher(tagger tagger.Component) *dispatcher {
 		d.extraTags = append(d.extraTags, tags.KubeClusterName+":"+clusterTagValue)
 	}
 
-	clusterIDTagValue, _ := clustername.GetClusterID()
+	clusterIDTagValue, err := clustername.GetClusterID()
+	if err != nil {
+		log.Errorf("Failed to get cluster ID: %v", err)
+	}
 	if clusterIDTagValue != "" {
 		d.extraTags = append(d.extraTags, tags.OrchClusterID+":"+clusterIDTagValue)
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -48,7 +48,6 @@ import (
 	hostnameUtil "github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -233,24 +232,23 @@ type KSMConfig struct {
 // KSMCheck wraps the config and the metric stores needed to run the check
 type KSMCheck struct {
 	core.CheckBase
-	agentConfig           model.Config
-	instance              *KSMConfig
-	allStores             [][]cache.Store
-	telemetry             *telemetryCache
-	tagger                tagger.Component
-	cancel                context.CancelFunc
-	isCLCRunner           bool
-	isRunningOnNodeAgent  bool
-	clusterIDTagValue     string
-	cloudProviderTagValue string
-	clusterNameTagValue   string
-	clusterNameRFC1123    string
-	metricNamesMapper     map[string]string
-	metricAggregators     map[string]metricAggregator
-	metricTransformers    map[string]metricTransformerFunc
-	metadataMetricsRegex  *regexp.Regexp
-	initRetry             retry.Retrier
-	workloadmetaStore     workloadmeta.Component
+	agentConfig          model.Config
+	instance             *KSMConfig
+	allStores            [][]cache.Store
+	telemetry            *telemetryCache
+	tagger               tagger.Component
+	cancel               context.CancelFunc
+	isCLCRunner          bool
+	isRunningOnNodeAgent bool
+	clusterIDTagValue    string
+	clusterNameTagValue  string
+	clusterNameRFC1123   string
+	metricNamesMapper    map[string]string
+	metricAggregators    map[string]metricAggregator
+	metricTransformers   map[string]metricTransformerFunc
+	metadataMetricsRegex *regexp.Regexp
+	initRetry            retry.Retrier
+	workloadmetaStore    workloadmeta.Component
 }
 
 // JoinsConfigWithoutLabelsMapping contains the config parameters for label joins
@@ -305,9 +303,6 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 
 	// Retrieve the ClusterID from the cluster-agent
 	k.getClusterID()
-
-	// Retrieve the cloud provider name from the cluster-agent
-	k.getCloudProviderName()
 
 	// Initialize global tags and check tags
 	k.initTags()
@@ -980,10 +975,6 @@ func (k *KSMCheck) getClusterID() {
 	k.clusterIDTagValue = clusterID
 }
 
-func (k *KSMCheck) getCloudProviderName() {
-	k.cloudProviderTagValue = cloudprovider.DCAGetName(context.Background())
-}
-
 // initTags avoids keeping a nil Tags field in the check instance
 // Sets the kube_cluster_name tag for all metrics.
 // Sets the orch_cluster_id tag for all metrics.
@@ -995,10 +986,6 @@ func (k *KSMCheck) initTags() {
 
 	if k.clusterIDTagValue != "" {
 		k.instance.Tags = append(k.instance.Tags, tags.OrchClusterID+":"+k.clusterIDTagValue)
-	}
-
-	if k.cloudProviderTagValue != "" {
-		k.instance.Tags = append(k.instance.Tags, tags.KubeCloudProvider+":"+k.cloudProviderTagValue)
 	}
 
 	if !k.instance.DisableGlobalTags {

--- a/pkg/config/setup/constants/constants.go
+++ b/pkg/config/setup/constants/constants.go
@@ -11,6 +11,6 @@ const (
 	DefaultEBPFLessProbeAddr = "localhost:5678"
 	// ClusterIDCacheKey is the key name for the orchestrator cluster id in the agent in-mem cache
 	ClusterIDCacheKey = "orchestratorClusterID"
-	// NodeCloudProviderKey is the key name for the node cloud provider in the agent in-mem cache
-	NodeCloudProviderKey = "nodeCloudProvider"
+	// NodeKubeDistributionKey is the key name for the node kube distribution in the agent in-mem cache
+	NodeKubeDistributionKey = "nodeKubeDistribution"
 )

--- a/pkg/config/setup/constants/constants.go
+++ b/pkg/config/setup/constants/constants.go
@@ -11,4 +11,6 @@ const (
 	DefaultEBPFLessProbeAddr = "localhost:5678"
 	// ClusterIDCacheKey is the key name for the orchestrator cluster id in the agent in-mem cache
 	ClusterIDCacheKey = "orchestratorClusterID"
+	// NodeCloudProviderKey is the key name for the node cloud provider in the agent in-mem cache
+	NodeCloudProviderKey = "nodeCloudProvider"
 )

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -56,7 +56,7 @@ type Metadata struct {
 	Labels      map[string]string
 }
 
-// DCAClientInterface  is required to query the API of Datadog cluster agent
+// DCAClientInterface is required to query the API of Datadog cluster agent
 type DCAClientInterface interface {
 	Version(withRefresh bool) version.Version
 	ClusterAgentAPIEndpoint() string

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudprovider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
+)
+
+// ErrCloudProviderIndetermined is returned when a function is unable to determine the cloud provider
+var ErrCloudProviderIndetermined = errors.New("node cloud provider indetermined")
+
+// GetName returns the name of the cloud provider for the current node
+func GetName() (string, error) {
+	cacheKey := cache.BuildAgentKey(constants.NodeCloudProviderKey)
+	if cloudProvider, found := cache.Cache.Get(cacheKey); found {
+		return cloudProvider.(string), nil
+	}
+
+	ni, err := hostinfo.NewNodeInfo()
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(2*time.Second))
+	defer cancel()
+
+	nl, err := ni.GetNodeLabels(ctx)
+	if err != nil {
+		return "", err
+	}
+	cloudProvider := ""
+
+out:
+	for labelName, labelValue := range nl {
+		switch labelName {
+		case "topology.k8s.aws/zone-id",
+			"eks.amazonaws.com/nodegroup",
+			"eks.amazonaws.com/compute-type",
+			"alpha.eksctl.io/cluster-name":
+			cloudProvider = "aws"
+			break out
+		case "topology.gke.io/zone",
+			"cloud.google.com/gke-boot-disk":
+			cloudProvider = "gcp"
+			break out
+		case "kubernetes.azure.com/nodepool-type",
+			"kubernetes.azure.com/mode":
+			cloudProvider = "azure"
+			break out
+		case "kubernetes.io/hostname":
+			if strings.HasPrefix(labelValue, "aks") {
+				cloudProvider = "azure"
+				break out
+			}
+		}
+	}
+
+	// If somehow node is missing those labels, try to get cloud provider from nodeinfo
+	if cloudProvider == "" {
+		// todo(dp): if this error is hit implement nodeInfo getters
+		return "", ErrCloudProviderIndetermined
+	}
+
+	cache.Cache.Set(cacheKey, cloudProvider, cache.NoExpiration)
+	return cloudProvider, nil
+}

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider.go
@@ -14,10 +14,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
 )
 
-// GetName returns the name of the cloud provider for the current node.
+// GetName returns the name of the kube distribution for the current node.
 // GetName shouldn't be used on DCA. For DCA please refer to DCAGetName.
 func GetName(ctx context.Context) (string, error) {
-	cacheKey := cache.BuildAgentKey(constants.NodeCloudProviderKey)
+	cacheKey := cache.BuildAgentKey(constants.NodeKubeDistributionKey)
 	if cloudProvider, found := cache.Cache.Get(cacheKey); found {
 		return cloudProvider.(string), nil
 	}
@@ -42,27 +42,27 @@ func GetName(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	cloudProvider := getProvideNameFromNodeLabels(nl)
+	kubeDistro := getKubeDistributionNameFromNodeLabels(nl)
 
-	cache.Cache.Set(cacheKey, cloudProvider, cache.NoExpiration)
-	return cloudProvider, nil
+	cache.Cache.Set(cacheKey, kubeDistro, cache.NoExpiration)
+	return kubeDistro, nil
 }
 
-// getProvideNameFromNodeLabels checks certain node labels to determine the kube cloud provider.
+// getKubeDistributionNameFromNodeLabels checks certain node labels to determine the kube cloud provider.
 // Returns an empty string if no provider is determined.
-func getProvideNameFromNodeLabels(nl map[string]string) string {
+func getKubeDistributionNameFromNodeLabels(nl map[string]string) string {
 	for labelName := range nl {
 		switch labelName {
 		case "eks.amazonaws.com/nodegroup",
 			"eks.amazonaws.com/compute-type",
 			"alpha.eksctl.io/cluster-name":
-			return "aws"
+			return "eks"
 		case "cloud.google.com/gke-boot-disk":
-			return "gcp"
+			return "gke"
 		case "kubernetes.azure.com/nodepool-type",
 			"kubernetes.azure.com/mode",
 			"kubernetes.azure.com/cluster":
-			return "azure"
+			return "aks"
 		}
 	}
 	return ""

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package cloudprovider
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DCAGetName returns the name of the cloud provider for the current node.
+func DCAGetName(ctx context.Context) string {
+	cacheKey := cache.BuildAgentKey(constants.NodeCloudProviderKey)
+	if cloudProvider, found := cache.Cache.Get(cacheKey); found {
+		return cloudProvider.(string)
+	}
+
+	nodeName, err := apiserver.HostNodeName(ctx)
+	if err != nil {
+		log.Warnf("Unable to get node name from apiserver: %v", err)
+		return ""
+	}
+
+	nl := getNodeLabels(ctx, nodeName)
+	providerName := getProvideNameFromNodeLabels(nl)
+
+	// It is fine to save empty tag to avoid querying API server over and over again.
+	// Empty tag are ignored.
+	cache.Cache.Set(cacheKey, providerName, cache.NoExpiration)
+	return providerName
+}
+
+// getNodeLabels retrieves the labels of the node with the given name for cluster agent.
+func getNodeLabels(ctx context.Context, nodeName string) map[string]string {
+	cl, err := apiserver.GetAPIClient()
+	if err != nil {
+		log.Warnf("Unable to get apiserver: %v", err)
+		return nil
+	}
+	nodeCl := cl.Cl.CoreV1().Nodes()
+
+	node, err := nodeCl.Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Warnf("Unable to get self node: %v", err)
+		return nil
+	}
+	if node == nil {
+		return nil
+	}
+	return node.Labels
+}

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
@@ -17,9 +17,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DCAGetName returns the name of the cloud provider for the current node.
+// DCAGetName returns the name of the kube distribution for the current node.
 func DCAGetName(ctx context.Context) string {
-	cacheKey := cache.BuildAgentKey(constants.NodeCloudProviderKey)
+	cacheKey := cache.BuildAgentKey(constants.NodeKubeDistributionKey)
 	if cloudProvider, found := cache.Cache.Get(cacheKey); found {
 		return cloudProvider.(string)
 	}
@@ -31,7 +31,7 @@ func DCAGetName(ctx context.Context) string {
 	}
 
 	nl := getNodeLabels(ctx, nodeName)
-	providerName := getProvideNameFromNodeLabels(nl)
+	providerName := getKubeDistributionNameFromNodeLabels(nl)
 
 	// It is fine to save empty tag to avoid querying API server over and over again.
 	// Empty tag are ignored.

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
@@ -39,7 +39,7 @@ func DCAGetName(ctx context.Context) string {
 	return providerName
 }
 
-// getNodeLabels retrieves the labels of the node with the given name for cluster agent.
+// getNodeLabels retrieves node labels for provided nodeName in cluster agent.
 func getNodeLabels(ctx context.Context, nodeName string) map[string]string {
 	cl, err := apiserver.GetAPIClient()
 	if err != nil {

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_no.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_no.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+package cloudprovider
+
+import "context"
+
+// DCAGetName returns empty string in this build.
+func DCAGetName(_ context.Context) string {
+	return ""
+}

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
@@ -11,22 +11,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCloudProviderName(t *testing.T) {
+func TestKubeDistributionName(t *testing.T) {
 	// Test cases for cloud provider name
 	testCases := []struct {
 		name     string
 		expected string
 		labels   map[string]string
 	}{
-		{"AWS", "aws", map[string]string{"eks.amazonaws.com/compute-type": "large5n"}},
-		{"GCP", "gcp", map[string]string{"cloud.google.com/gke-boot-disk": "/dev/ssd0n1"}},
-		{"Azure", "azure", map[string]string{"kubernetes.azure.com/mode": "managed-azure"}},
+		{"AWS", "eks", map[string]string{"eks.amazonaws.com/compute-type": "large5n"}},
+		{"GCP", "gke", map[string]string{"cloud.google.com/gke-boot-disk": "/dev/ssd0n1"}},
+		{"Azure", "aks", map[string]string{"kubernetes.azure.com/mode": "managed-azure"}},
 		{"Unknown", "", map[string]string{"cloud.provider": "unknown"}},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			provider := getProvideNameFromNodeLabels(tc.labels)
+			provider := getKubeDistributionNameFromNodeLabels(tc.labels)
 			assert.Equal(t, tc.expected, provider)
 		})
 	}

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudProviderName(t *testing.T) {
+	// Test cases for cloud provider name
+	testCases := []struct {
+		name     string
+		expected string
+		labels   map[string]string
+	}{
+		{"AWS", "aws", map[string]string{"eks.amazonaws.com/compute-type": "large5n"}},
+		{"GCP", "gcp", map[string]string{"cloud.google.com/gke-boot-disk": "/dev/ssd0n1"}},
+		{"Azure", "azure", map[string]string{"kubernetes.azure.com/mode": "managed-azure"}},
+		{"Unknown", "", map[string]string{"cloud.provider": "unknown"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := getProvideNameFromNodeLabels(tc.labels)
+			assert.Equal(t, tc.expected, provider)
+		})
+	}
+}

--- a/pkg/util/kubernetes/cloudprovider/doc.go
+++ b/pkg/util/kubernetes/cloudprovider/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package cloudprovider provides several helpers to get managed kubernetes cloud provider name.
+package cloudprovider

--- a/pkg/util/kubernetes/hostinfo/no_node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/no_node_labels.go
@@ -10,8 +10,7 @@ package hostinfo
 import "context"
 
 // NodeInfo is use to get Kubernetes Node metadata information
-type NodeInfo struct {
-}
+type NodeInfo struct{}
 
 // NewNodeInfo return a new NodeInfo instance
 // return an error if it fails to access the kubelet client.
@@ -24,4 +23,9 @@ func NewNodeInfo() (*NodeInfo, error) {
 //nolint:revive // TODO(CINT) Fix revive linter
 func (n *NodeInfo) GetNodeLabels(_ context.Context) (map[string]string, error) {
 	return nil, nil
+}
+
+// GetNodeName returns the node name for this host
+func (n *NodeInfo) GetNodeName(ctx context.Context) (string, error) {
+	return "", nil
 }

--- a/pkg/util/kubernetes/hostinfo/no_node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/no_node_labels.go
@@ -26,6 +26,6 @@ func (n *NodeInfo) GetNodeLabels(_ context.Context) (map[string]string, error) {
 }
 
 // GetNodeName returns the node name for this host
-func (n *NodeInfo) GetNodeName(ctx context.Context) (string, error) {
+func (n *NodeInfo) GetNodeName(_ context.Context) (string, error) {
 	return "", nil
 }

--- a/pkg/util/kubernetes/hostinfo/node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/node_labels.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
-// NodeInfo is use to get Kubernetes Node metadata information
+// NodeInfo is used to get Kubernetes Node metadata information
 type NodeInfo struct {
 	// client use to get NodeName from the "/pods" kubelet api.
 	client kubelet.KubeUtilInterface

--- a/pkg/util/tags/static_tags.go
+++ b/pkg/util/tags/static_tags.go
@@ -61,9 +61,8 @@ func getFargateStaticTags(ctx context.Context, datadogConfig config.Reader) []st
 			tags = append(tags, taggertags.OrchClusterID+":"+clusterIDValue)
 		}
 
-		if providerName, err := cloudprovider.GetName(ctx); err != nil && providerName != "" {
-			tags = append(tags, taggertags.KubeCloudProvider+":"+providerName)
-		}
+		// hard code for now because EKS Fargate means EKS
+		tags = append(tags, taggertags.KubeCloudProvider+":aws")
 	}
 
 	return tags

--- a/pkg/util/tags/static_tags.go
+++ b/pkg/util/tags/static_tags.go
@@ -16,6 +16,7 @@ import (
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -58,6 +59,10 @@ func getFargateStaticTags(ctx context.Context, datadogConfig config.Reader) []st
 		clusterIDValue, _ := clustername.GetClusterID()
 		if clusterIDValue != "" {
 			tags = append(tags, taggertags.OrchClusterID+":"+clusterIDValue)
+		}
+
+		if providerName, err := cloudprovider.GetName(); err != nil && providerName != "" {
+			tags = append(tags, taggertags.KubeCloudProvider+":"+providerName)
 		}
 	}
 

--- a/pkg/util/tags/static_tags.go
+++ b/pkg/util/tags/static_tags.go
@@ -112,7 +112,7 @@ func GetClusterAgentStaticTags(ctx context.Context, config config.Reader) map[st
 	// DD_CLUSTER_CHECKS_EXTRA_TAGS / DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS
 	tags = append(tags, configUtils.GetConfiguredDCATags(config)...)
 
-	// determine for kube_cloud_provider global tag
+	// determine for kube_distribution global tag
 	kubeDistro := cloudprovider.DCAGetName(ctx)
 	if kubeDistro != "" {
 		tags = append(tags, taggertags.KubeDistribution+":"+kubeDistro)

--- a/pkg/util/tags/static_tags.go
+++ b/pkg/util/tags/static_tags.go
@@ -62,7 +62,7 @@ func getFargateStaticTags(ctx context.Context, datadogConfig config.Reader) []st
 		}
 
 		// hard code for now because EKS Fargate means EKS
-		tags = append(tags, taggertags.KubeCloudProvider+":aws")
+		tags = append(tags, taggertags.KubeDistribution+":eks")
 	}
 
 	return tags
@@ -113,9 +113,9 @@ func GetClusterAgentStaticTags(ctx context.Context, config config.Reader) map[st
 	tags = append(tags, configUtils.GetConfiguredDCATags(config)...)
 
 	// determine for kube_cloud_provider global tag
-	cloudProvider := cloudprovider.DCAGetName(ctx)
-	if cloudProvider != "" {
-		tags = append(tags, taggertags.KubeCloudProvider+":"+cloudProvider)
+	kubeDistro := cloudprovider.DCAGetName(ctx)
+	if kubeDistro != "" {
+		tags = append(tags, taggertags.KubeDistribution+":"+kubeDistro)
 	}
 
 	if tags == nil {

--- a/pkg/util/tags/static_tags_test.go
+++ b/pkg/util/tags/static_tags_test.go
@@ -29,10 +29,10 @@ func TestStaticTags(t *testing.T) {
 		defer mockConfig.SetWithoutSource("tags", []string{})
 		staticTags := GetStaticTags(context.Background(), mockConfig)
 		assert.Equal(t, map[string][]string{
-			"some":                {"tag"},
-			"another":             {"tag"},
-			"eks_fargate_node":    {"eksnode"},
-			"kube_cloud_provider": {"aws"},
+			"some":              {"tag"},
+			"another":           {"tag"},
+			"eks_fargate_node":  {"eksnode"},
+			"kube_distribution": {"eks"},
 		}, staticTags)
 	})
 
@@ -43,10 +43,10 @@ func TestStaticTags(t *testing.T) {
 		defer mockConfig.SetWithoutSource("extra_tags", []string{})
 		staticTags := GetStaticTags(context.Background(), mockConfig)
 		assert.Equal(t, map[string][]string{
-			"some":                {"tag"},
-			"extra":               {"tag"},
-			"eks_fargate_node":    {"eksnode"},
-			"kube_cloud_provider": {"aws"},
+			"some":              {"tag"},
+			"extra":             {"tag"},
+			"eks_fargate_node":  {"eksnode"},
+			"kube_distribution": {"eks"},
 		}, staticTags)
 	})
 
@@ -55,9 +55,9 @@ func TestStaticTags(t *testing.T) {
 		defer mockConfig.SetWithoutSource("tags", []string{})
 		staticTags := GetStaticTags(context.Background(), mockConfig)
 		assert.Equal(t, map[string][]string{
-			"eks_fargate_node":    {"eksnode"},
-			"kube_cluster_name":   {"foo"},
-			"kube_cloud_provider": {"aws"},
+			"eks_fargate_node":  {"eksnode"},
+			"kube_cluster_name": {"foo"},
+			"kube_distribution": {"eks"},
 		}, staticTags)
 	})
 }
@@ -87,7 +87,7 @@ func TestStaticTagsSlice(t *testing.T) {
 			"some:tag",
 			"another:tag",
 			"eks_fargate_node:eksnode",
-			"kube_cloud_provider:aws",
+			"kube_distribution:eks",
 		}, staticTags)
 	})
 
@@ -103,7 +103,7 @@ func TestStaticTagsSlice(t *testing.T) {
 			"some:tag",
 			"extra:tag",
 			"eks_fargate_node:eksnode",
-			"kube_cloud_provider:aws",
+			"kube_distribution:eks",
 		}, staticTags)
 	})
 }

--- a/pkg/util/tags/static_tags_test.go
+++ b/pkg/util/tags/static_tags_test.go
@@ -29,9 +29,10 @@ func TestStaticTags(t *testing.T) {
 		defer mockConfig.SetWithoutSource("tags", []string{})
 		staticTags := GetStaticTags(context.Background(), mockConfig)
 		assert.Equal(t, map[string][]string{
-			"some":             {"tag"},
-			"another":          {"tag"},
-			"eks_fargate_node": {"eksnode"},
+			"some":                {"tag"},
+			"another":             {"tag"},
+			"eks_fargate_node":    {"eksnode"},
+			"kube_cloud_provider": {"aws"},
 		}, staticTags)
 	})
 
@@ -42,9 +43,10 @@ func TestStaticTags(t *testing.T) {
 		defer mockConfig.SetWithoutSource("extra_tags", []string{})
 		staticTags := GetStaticTags(context.Background(), mockConfig)
 		assert.Equal(t, map[string][]string{
-			"some":             {"tag"},
-			"extra":            {"tag"},
-			"eks_fargate_node": {"eksnode"},
+			"some":                {"tag"},
+			"extra":               {"tag"},
+			"eks_fargate_node":    {"eksnode"},
+			"kube_cloud_provider": {"aws"},
 		}, staticTags)
 	})
 
@@ -53,8 +55,9 @@ func TestStaticTags(t *testing.T) {
 		defer mockConfig.SetWithoutSource("tags", []string{})
 		staticTags := GetStaticTags(context.Background(), mockConfig)
 		assert.Equal(t, map[string][]string{
-			"eks_fargate_node":  {"eksnode"},
-			"kube_cluster_name": {"foo"},
+			"eks_fargate_node":    {"eksnode"},
+			"kube_cluster_name":   {"foo"},
+			"kube_cloud_provider": {"aws"},
 		}, staticTags)
 	})
 }
@@ -84,6 +87,7 @@ func TestStaticTagsSlice(t *testing.T) {
 			"some:tag",
 			"another:tag",
 			"eks_fargate_node:eksnode",
+			"kube_cloud_provider:aws",
 		}, staticTags)
 	})
 
@@ -99,6 +103,7 @@ func TestStaticTagsSlice(t *testing.T) {
 			"some:tag",
 			"extra:tag",
 			"eks_fargate_node:eksnode",
+			"kube_cloud_provider:aws",
 		}, staticTags)
 	})
 }

--- a/pkg/util/tags/static_tags_test.go
+++ b/pkg/util/tags/static_tags_test.go
@@ -121,13 +121,13 @@ func TestClusterAgentGlobalTags(t *testing.T) {
 
 	t.Run("Agent extraGlobalTags", func(t *testing.T) {
 		flavor.SetFlavor(flavor.DefaultAgent)
-		globalTags := GetClusterAgentStaticTags(mockConfig)
+		globalTags := GetClusterAgentStaticTags(t.Context(), mockConfig)
 		assert.Equal(t, map[string][]string(nil), globalTags)
 	})
 
 	t.Run("ClusterAgent extraGlobalTags", func(t *testing.T) {
 		flavor.SetFlavor(flavor.ClusterAgent)
-		globalTags := GetClusterAgentStaticTags(mockConfig)
+		globalTags := GetClusterAgentStaticTags(t.Context(), mockConfig)
 		assert.Equal(t, map[string][]string{
 			"some":    {"tag"},
 			"extra":   {"tag"},

--- a/releasenotes/notes/add-kube-cloud-provider-tag-d74b15705701b85e.yaml
+++ b/releasenotes/notes/add-kube-cloud-provider-tag-d74b15705701b85e.yaml
@@ -8,4 +8,5 @@
 ---
 features:
   - |
-    The Agent now emits the `kube_cloud_provider` tag based on labels in managed Kubernetes installations.
+    The Agent now emits the `kube_distribution` tag based on labels in managed Kubernetes installations
+    with values: eks, gke and aks.

--- a/releasenotes/notes/add-kube-cloud-provider-tag-d74b15705701b85e.yaml
+++ b/releasenotes/notes/add-kube-cloud-provider-tag-d74b15705701b85e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Emit kube_cloud_provider tag based on labels for managed k8s installations.

--- a/releasenotes/notes/add-kube-cloud-provider-tag-d74b15705701b85e.yaml
+++ b/releasenotes/notes/add-kube-cloud-provider-tag-d74b15705701b85e.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Emit kube_cloud_provider tag based on labels for managed k8s installations.
+    The Agent now emits the `kube_cloud_provider` tag based on labels in managed Kubernetes installations.

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -210,7 +210,7 @@ func (suite *eksSuite) TestNginxFargate() {
 			Name: "network.http.response_time",
 			Tags: []string{
 				`^kube_namespace:workload-nginx-fargate$`,
-				`^kube_cloud_provider:.*`,
+				`^kube_cloud_provider:`,
 			},
 		},
 		Expect: testMetricExpectArgs{

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -39,6 +39,7 @@ func TestEKSSuite(t *testing.T) {
 func (suite *eksSuite) SetupSuite() {
 	suite.k8sSuite.SetupSuite()
 	suite.Fakeintake = suite.Env().FakeIntake.Client()
+	suite.envSpecificClusterTags = []string{"^kube_cloud_provider:aws$"}
 }
 
 func (suite *eksSuite) TestEKSFargate() {
@@ -54,6 +55,7 @@ func (suite *eksSuite) TestEKSFargate() {
 			Tags: &[]string{
 				`^eks_fargate_node:fargate-ip-.*\.ec2\.internal$`,
 				`^kube_cluster_name:`,
+				"^kube_cloud_provider:aws$",
 				`^kube_deployment:dogstatsd-fargate$`,
 				`^kube_namespace:workload-dogstatsd-fargate$`,
 				`^kube_ownerref_kind:replicaset$`,
@@ -85,6 +87,7 @@ func (suite *eksSuite) TestEKSFargate() {
 			Tags: &[]string{
 				`^eks_fargate_node:fargate-ip-.*\.ec2\.internal$`,
 				`^kube_cluster_name:`,
+				"^kube_cloud_provider:aws$",
 				`^kube_deployment:dogstatsd-fargate$`,
 				`^kube_namespace:workload-dogstatsd-fargate$`,
 				`^kube_ownerref_kind:replicaset$`,
@@ -116,6 +119,7 @@ func (suite *eksSuite) TestEKSFargate() {
 			Tags: &[]string{
 				`^eks_fargate_node:fargate-ip-.*\.ec2\.internal$`,
 				`^kube_cluster_name:`,
+				"^kube_cloud_provider:aws$",
 				`^kube_deployment:dogstatsd-fargate$`,
 				`^kube_namespace:workload-dogstatsd-fargate$`,
 				`^kube_ownerref_kind:replicaset$`,
@@ -149,6 +153,7 @@ func (suite *eksSuite) TestDogstatsdFargate() {
 			Tags: &[]string{
 				`^eks_fargate_node:fargate-ip-.*\.ec2\.internal$`,
 				`^kube_cluster_name:`,
+				"^kube_cloud_provider:aws$",
 				`^kube_deployment:dogstatsd-fargate$`,
 				`^kube_namespace:workload-dogstatsd-fargate$`,
 				`^kube_ownerref_kind:replicaset$`,
@@ -183,6 +188,7 @@ func (suite *eksSuite) TestNginxFargate() {
 				`^image_name:ghcr\.io/datadog/apps-nginx-server$`,
 				`^image_tag:` + regexp.QuoteMeta(apps.Version) + `$`,
 				`^kube_cluster_name:`,
+				"^kube_cloud_provider:aws$",
 				`^kube_container_name:nginx$`,
 				`^kube_deployment:nginx$`,
 				`^kube_namespace:workload-nginx-fargate$`,
@@ -218,6 +224,7 @@ func (suite *eksSuite) TestNginxFargate() {
 				`^cluster_name:`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
+				"^kube_cloud_provider:aws$",
 				`^orch_cluster_id:`,
 				`^kube_namespace:workload-nginx-fargate$`,
 				`^kube_service:nginx$`,
@@ -244,6 +251,7 @@ func (suite *eksSuite) TestNginxFargate() {
 				`^image_name:ghcr\.io/datadog/apps-nginx-server$`,
 				`^image_tag:` + regexp.QuoteMeta(apps.Version) + `$`,
 				`^kube_cluster_name:`,
+				"^kube_cloud_provider:aws$",
 				`^kube_container_name:nginx$`,
 				`^kube_deployment:nginx$`,
 				`^kube_namespace:workload-nginx-fargate$`,

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -164,7 +164,6 @@ func (suite *eksSuite) TestDogstatsdFargate() {
 }
 
 func (suite *eksSuite) TestNginxFargate() {
-
 	// `nginx` check is configured via AD annotation on pods
 	// Test it is properly scheduled
 	suite.testMetric(&testMetricArgs{
@@ -211,6 +210,7 @@ func (suite *eksSuite) TestNginxFargate() {
 			Name: "network.http.response_time",
 			Tags: []string{
 				`^kube_namespace:workload-nginx-fargate$`,
+				`^kube_cloud_provider:.*`,
 			},
 		},
 		Expect: testMetricExpectArgs{

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -39,7 +39,7 @@ func TestEKSSuite(t *testing.T) {
 func (suite *eksSuite) SetupSuite() {
 	suite.k8sSuite.SetupSuite()
 	suite.Fakeintake = suite.Env().FakeIntake.Client()
-	suite.envSpecificClusterTags = []string{"^kube_cloud_provider:aws$"}
+	suite.envSpecificClusterTags = []string{"^kube_distribution:eks$"}
 }
 
 func (suite *eksSuite) TestEKSFargate() {
@@ -55,7 +55,7 @@ func (suite *eksSuite) TestEKSFargate() {
 			Tags: &[]string{
 				`^eks_fargate_node:fargate-ip-.*\.ec2\.internal$`,
 				`^kube_cluster_name:`,
-				"^kube_cloud_provider:aws$",
+				"^kube_distribution:eks$",
 				`^kube_deployment:dogstatsd-fargate$`,
 				`^kube_namespace:workload-dogstatsd-fargate$`,
 				`^kube_ownerref_kind:replicaset$`,
@@ -87,7 +87,7 @@ func (suite *eksSuite) TestEKSFargate() {
 			Tags: &[]string{
 				`^eks_fargate_node:fargate-ip-.*\.ec2\.internal$`,
 				`^kube_cluster_name:`,
-				"^kube_cloud_provider:aws$",
+				"^kube_distribution:eks$",
 				`^kube_deployment:dogstatsd-fargate$`,
 				`^kube_namespace:workload-dogstatsd-fargate$`,
 				`^kube_ownerref_kind:replicaset$`,
@@ -119,7 +119,7 @@ func (suite *eksSuite) TestEKSFargate() {
 			Tags: &[]string{
 				`^eks_fargate_node:fargate-ip-.*\.ec2\.internal$`,
 				`^kube_cluster_name:`,
-				"^kube_cloud_provider:aws$",
+				"^kube_distribution:eks$",
 				`^kube_deployment:dogstatsd-fargate$`,
 				`^kube_namespace:workload-dogstatsd-fargate$`,
 				`^kube_ownerref_kind:replicaset$`,
@@ -153,7 +153,7 @@ func (suite *eksSuite) TestDogstatsdFargate() {
 			Tags: &[]string{
 				`^eks_fargate_node:fargate-ip-.*\.ec2\.internal$`,
 				`^kube_cluster_name:`,
-				"^kube_cloud_provider:aws$",
+				"^kube_distribution:eks$",
 				`^kube_deployment:dogstatsd-fargate$`,
 				`^kube_namespace:workload-dogstatsd-fargate$`,
 				`^kube_ownerref_kind:replicaset$`,
@@ -188,7 +188,7 @@ func (suite *eksSuite) TestNginxFargate() {
 				`^image_name:ghcr\.io/datadog/apps-nginx-server$`,
 				`^image_tag:` + regexp.QuoteMeta(apps.Version) + `$`,
 				`^kube_cluster_name:`,
-				"^kube_cloud_provider:aws$",
+				"^kube_distribution:eks$",
 				`^kube_container_name:nginx$`,
 				`^kube_deployment:nginx$`,
 				`^kube_namespace:workload-nginx-fargate$`,
@@ -216,7 +216,6 @@ func (suite *eksSuite) TestNginxFargate() {
 			Name: "network.http.response_time",
 			Tags: []string{
 				`^kube_namespace:workload-nginx-fargate$`,
-				`^kube_cloud_provider:`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -224,7 +223,7 @@ func (suite *eksSuite) TestNginxFargate() {
 				`^cluster_name:`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
-				"^kube_cloud_provider:aws$",
+				"^kube_distribution:eks$",
 				`^orch_cluster_id:`,
 				`^kube_namespace:workload-nginx-fargate$`,
 				`^kube_service:nginx$`,
@@ -251,7 +250,7 @@ func (suite *eksSuite) TestNginxFargate() {
 				`^image_name:ghcr\.io/datadog/apps-nginx-server$`,
 				`^image_tag:` + regexp.QuoteMeta(apps.Version) + `$`,
 				`^kube_cluster_name:`,
-				"^kube_cloud_provider:aws$",
+				"^kube_distribution:eks$",
 				`^kube_container_name:nginx$`,
 				`^kube_deployment:nginx$`,
 				`^kube_namespace:workload-nginx-fargate$`,

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -609,7 +609,6 @@ func (suite *k8sSuite) TestNginx() {
 			Name: "network.http.response_time",
 			Tags: []string{
 				`^kube_namespace:workload-nginx$`,
-				`^kube_cloud_provider:`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -632,7 +631,6 @@ func (suite *k8sSuite) TestNginx() {
 			Tags: []string{
 				"^kube_deployment:nginx$",
 				"^kube_namespace:workload-nginx$",
-				`^kube_cloud_provider:`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -739,7 +737,6 @@ func (suite *k8sSuite) TestRedis() {
 			Tags: []string{
 				"^kube_deployment:redis$",
 				"^kube_namespace:workload-redis$",
-				`^kube_cloud_provider:`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -963,7 +960,6 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
-				`^kube_cloud_provider:`,
 				`^kube_namespace:workload-nginx$`,
 				`^org:agent-org$`,
 				`^team:contp$`,
@@ -991,7 +987,6 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
-				`^kube_cloud_provider:`,
 				`^kube_namespace:workload-redis$`,
 				`^kube_instance_tag:static$`,                            // This is applied via KSM core check instance config
 				`^stackid:` + regexp.QuoteMeta(suite.clusterName) + `$`, // Pulumi applies this via DD_TAGS env var
@@ -1012,7 +1007,6 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
-				`^kube_cloud_provider:`,
 				`^customresource_group:datadoghq.com$`,
 				`^customresource_version:v1alpha1$`,
 				`^customresource_kind:DatadogMetric`,

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -608,7 +608,7 @@ func (suite *k8sSuite) TestNginx() {
 			Name: "network.http.response_time",
 			Tags: []string{
 				`^kube_namespace:workload-nginx$`,
-				`^kube_cloud_provider:.*`,
+				`^kube_cloud_provider:`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -631,7 +631,7 @@ func (suite *k8sSuite) TestNginx() {
 			Tags: []string{
 				"^kube_deployment:nginx$",
 				"^kube_namespace:workload-nginx$",
-				`^kube_cloud_provider:.*`,
+				`^kube_cloud_provider:`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -738,7 +738,7 @@ func (suite *k8sSuite) TestRedis() {
 			Tags: []string{
 				"^kube_deployment:redis$",
 				"^kube_namespace:workload-redis$",
-				`^kube_cloud_provider:.*`,
+				`^kube_cloud_provider:`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -962,7 +962,7 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
-				`^kube_cloud_provider:.*`,
+				`^kube_cloud_provider:`,
 				`^kube_namespace:workload-nginx$`,
 				`^org:agent-org$`,
 				`^team:contp$`,
@@ -990,7 +990,7 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
-				`^kube_cloud_provider:.*`,
+				`^kube_cloud_provider:`,
 				`^kube_namespace:workload-redis$`,
 				`^kube_instance_tag:static$`,                            // This is applied via KSM core check instance config
 				`^stackid:` + regexp.QuoteMeta(suite.clusterName) + `$`, // Pulumi applies this via DD_TAGS env var
@@ -1011,7 +1011,7 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
-				`^kube_cloud_provider:.*`,
+				`^kube_cloud_provider:`,
 				`^customresource_group:datadoghq.com$`,
 				`^customresource_version:v1alpha1$`,
 				`^customresource_kind:DatadogMetric`,

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -379,7 +379,7 @@ func (suite *k8sSuite) testAgentCLI() {
 }
 
 func (suite *k8sSuite) testClusterAgentCLI() {
-	leaderDcaPodName := suite.testDCALeaderElection(false) //check cluster agent leaderelection without restart
+	leaderDcaPodName := suite.testDCALeaderElection(false) // check cluster agent leaderelection without restart
 	suite.Require().NotEmpty(leaderDcaPodName, "Leader DCA pod name should not be empty")
 
 	suite.Run("cluster-agent status", func() {
@@ -608,6 +608,7 @@ func (suite *k8sSuite) TestNginx() {
 			Name: "network.http.response_time",
 			Tags: []string{
 				`^kube_namespace:workload-nginx$`,
+				`^kube_cloud_provider:.*`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -630,6 +631,7 @@ func (suite *k8sSuite) TestNginx() {
 			Tags: []string{
 				"^kube_deployment:nginx$",
 				"^kube_namespace:workload-nginx$",
+				`^kube_cloud_provider:.*`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -736,6 +738,7 @@ func (suite *k8sSuite) TestRedis() {
 			Tags: []string{
 				"^kube_deployment:redis$",
 				"^kube_namespace:workload-redis$",
+				`^kube_cloud_provider:.*`,
 			},
 		},
 		Expect: testMetricExpectArgs{
@@ -959,6 +962,7 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
+				`^kube_cloud_provider:.*`,
 				`^kube_namespace:workload-nginx$`,
 				`^org:agent-org$`,
 				`^team:contp$`,
@@ -986,6 +990,7 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
+				`^kube_cloud_provider:.*`,
 				`^kube_namespace:workload-redis$`,
 				`^kube_instance_tag:static$`,                            // This is applied via KSM core check instance config
 				`^stackid:` + regexp.QuoteMeta(suite.clusterName) + `$`, // Pulumi applies this via DD_TAGS env var
@@ -1006,6 +1011,7 @@ func (suite *k8sSuite) TestKSM() {
 				`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
 				`^orch_cluster_id:`,
+				`^kube_cloud_provider:.*`,
 				`^customresource_group:datadoghq.com$`,
 				`^customresource_version:v1alpha1$`,
 				`^customresource_kind:DatadogMetric`,
@@ -1308,7 +1314,6 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 			}, volumeMounts["datadog-auto-instrumentation"])
 		}
 	}
-
 }
 
 func (suite *k8sSuite) TestContainerImage() {


### PR DESCRIPTION
### What does this PR do?
Emit `kube_distribution` tag to signify that the current cluster is a managed cluster.

### Motivation
Tag resources that belong to certain cloud providers

### Describe how you validated your changes
Deployed a custom built agent and checked that `kube_distribution` is attached to the metrics from a cluster.
It was tested on local `kind` cluster with different node labels.