### PR TITLE
[NDM] fix snmp version conflict

### DIFF
--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -318,7 +318,7 @@ func (a *Authentication) BuildSNMPParams(deviceIP string, port uint16) (*gosnmp.
 	var version gosnmp.SnmpVersion
 	if a.Version == "1" {
 		version = gosnmp.Version1
-	} else if a.Version == "2" || (a.Version == "" && a.Community != "") {
+	} else if a.Version == "2" || a.Version == "2c" || (a.Version == "" && a.Community != "") {
 		version = gosnmp.Version2c
 	} else if a.Version == "3" || (a.Version == "" && a.User != "") {
 		version = gosnmp.Version3

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -318,7 +318,7 @@ func (a *Authentication) BuildSNMPParams(deviceIP string, port uint16) (*gosnmp.
 	var version gosnmp.SnmpVersion
 	if a.Version == "1" {
 		version = gosnmp.Version1
-	} else if a.Version == "2" || a.Version == "2c" || (a.Version == "" && a.Community != "") {
+	} else if a.Version == "2" || (a.Version == "" && a.Community != "") {
 		version = gosnmp.Version2c
 	} else if a.Version == "3" || (a.Version == "" && a.User != "") {
 		version = gosnmp.Version3

--- a/pkg/snmp/snmpparse/constants.go
+++ b/pkg/snmp/snmpparse/constants.go
@@ -39,6 +39,7 @@ var PrivOpts = NewOptions(OptPairs[gosnmp.SnmpV3PrivProtocol]{
 // VersionOpts maps string names to gosnmp versions
 var VersionOpts = NewOptions(OptPairs[gosnmp.SnmpVersion]{
 	{"1", gosnmp.Version1},
+	{"2", gosnmp.Version2c},
 	{"2c", gosnmp.Version2c},
 	{"3", gosnmp.Version3},
 })


### PR DESCRIPTION
### What does this PR do?

The snmp scan does not work for snmp v2
the scan in the agent first [checks](https://github.com/DataDog/datadog-agent/blob/main/pkg/snmp/snmpparse/constants.go#L39-L44) that the version is either 1, 2c or 3
but the [snmp check](https://github.com/DataDog/datadog-agent/blob/main/pkg/snmp/snmp.go#L313-L327) only supports version 1, 2 or 3
this leads to this [kind of error](https://app.datadoghq.com/devices/profiles/edit?isOOTB=false&profileId=profile-377a81b5-bfe9-4961-9c0b-a41d7ecba532) on the device profile page

### Motivation

### Describe how you validated your changes

### Additional Notes
