### PR TITLE
[CWS] introduce `NewEventZeroer` instead of `event.Zero()`

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -66,6 +66,8 @@ var probeTelemetry = struct {
 	totalVariables: metrics.NewITGauge(metrics.MetricSECLTotalVariables, []string{"type", "scope"}, "Number of instantiated variables"),
 }
 
+var probeEventZeroer = model.NewEventZeroer()
+
 // EventConsumer defines a probe event consumer
 type EventConsumer struct {
 	consumer     EventConsumerHandler

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1045,7 +1045,7 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 }
 
 func (p *EBPFProbe) zeroEvent() *model.Event {
-	p.event.Zero()
+	probeEventZeroer(p.event)
 	p.event.FieldHandlers = p.fieldHandlers
 	p.event.Origin = EBPFOrigin
 	return p.event

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -696,7 +696,7 @@ func (p *EBPFLessProbe) GetEventTags(containerID containerutils.ContainerID) []s
 }
 
 func (p *EBPFLessProbe) zeroEvent() *model.Event {
-	p.event.Zero()
+	probeEventZeroer(p.event)
 	p.event.FieldHandlers = p.fieldHandlers
 	p.event.Origin = EBPFLessOrigin
 	return p.event

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1563,7 +1563,7 @@ func (p *WindowsProbe) GetEventTags(_ containerutils.ContainerID) []string {
 }
 
 func (p *WindowsProbe) zeroEvent() *model.Event {
-	p.event.Zero()
+	probeEventZeroer(p.event)
 	p.event.FieldHandlers = p.fieldHandlers
 	return p.event
 }

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -411,8 +411,10 @@ func (e *RuleEngine) newSECLVariableEventPreparator() *seclVariableEventPreparat
 	}
 }
 
+var eventZeroer = model.NewEventZeroer()
+
 func (p *seclVariableEventPreparator) get(f func(event *model.Event)) *eval.Context {
-	p.event.Zero()
+	eventZeroer(p.event)
 	f(p.event)
 	return p.ctxPool.Get(p.event)
 }

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -157,14 +157,17 @@ type Event struct {
 	UnshareMountNS   UnshareMountNSEvent   `field:"-"`
 }
 
-var eventZero = Event{CGroupContext: &CGroupContext{}, BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}, Os: runtime.GOOS}}
 var cgroupContextZero CGroupContext
 
-// Zero the event
-func (e *Event) Zero() {
-	*e = eventZero
-	*e.BaseEvent.ContainerContext = containerContextZero
-	*e.CGroupContext = cgroupContextZero
+// NewEventZeroer returns a function that can be used to zero an Event
+func NewEventZeroer() func(*Event) {
+	var eventZero = Event{CGroupContext: &CGroupContext{}, BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}, Os: runtime.GOOS}}
+
+	return func(e *Event) {
+		*e = eventZero
+		*e.BaseEvent.ContainerContext = containerContextZero
+		*e.CGroupContext = cgroupContextZero
+	}
 }
 
 // CGroupContext holds the cgroup context of an event

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -94,12 +94,14 @@ type Event struct {
 	ChangePermission ChangePermissionEvent `field:"change_permission" event:"change_permission" ` // [7.55] [Registry] A permission change was made
 }
 
-var eventZero = Event{BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}, Os: runtime.GOOS}}
+// NewEventZeroer returns a function that can be used to zero an Event
+func NewEventZeroer() func(*Event) {
+	var eventZero = Event{BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}, Os: runtime.GOOS}}
 
-// Zero the event
-func (e *Event) Zero() {
-	*e = eventZero
-	*e.BaseEvent.ContainerContext = containerContextZero
+	return func(e *Event) {
+		*e = eventZero
+		*e.BaseEvent.ContainerContext = containerContextZero
+	}
 }
 
 // FileEvent is the common file event type

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -94,12 +94,14 @@ type Event struct {
 	ChangePermission ChangePermissionEvent `field:"change_permission" event:"change_permission" ` // [7.55] [Registry] A permission change was made
 }
 
-var eventZero = Event{BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}, Os: runtime.GOOS}}
+// NewEventZeroer returns a function that can be used to zero an Event
+func NewEventZeroer() func(*Event) {
+	var eventZero = Event{BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}, Os: runtime.GOOS}}
 
-// Zero the event
-func (e *Event) Zero() {
-	*e = eventZero
-	*e.BaseEvent.ContainerContext = containerContextZero
+	return func(e *Event) {
+		*e = eventZero
+		*e.BaseEvent.ContainerContext = containerContextZero
+	}
 }
 
 // FileEvent is the common file event type


### PR DESCRIPTION
### What does this PR do?

Using `event.Zero()` is not safe because it makes multiple users of it use the same cgroup and container context. This was not a problem until recently because only the probe was using it, but now that https://github.com/DataDog/datadog-agent/pull/40797 introduced another usage of it this needs to be fixed.

This PR replaces the `event.Zero()` by a new `NewEventZeroer` that returns a new function with it's own event storage allowing to have the probe use one set of cgroup container context and the status fetcher another one, without interaction.

### Motivation

### Describe how you validated your changes

### Additional Notes
