### PR TITLE
Fix flaky configuration e2e test

### DIFF
--- a/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_aws_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_aws_win_test.go
@@ -36,8 +36,8 @@ secret_backend_config:
 		),
 	)
 
-	assert.EventuallyWithT(v.T(), func(_ *assert.CollectT) {
+	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		secretOutput := v.Env().Agent.Client.Secret()
-		require.Contains(v.T(), secretOutput, "embedded_secret_key")
+		require.Contains(t, secretOutput, "embedded_secret_key")
 	}, 30*time.Second, 2*time.Second)
 }


### PR DESCRIPTION
### What does this PR do?
Fix flaky configuration e2e test by using correct test assertion receiver in `EventuallyWithT`. 

### Motivation
I've seen this test fail, probably because `require.Contains(v.T(), secretOutput, "embedded_secret_key")` makes the whole test fail instead of just the run of `Eventually`.

### Describe how you validated your changes
CI

### Additional Notes
