### PR TITLE
[CWS] collectorv2/dpkg: ignore md5sums in status.d directory

### DIFF
--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -87,6 +87,12 @@ func (s *dpkgScanner) listInstalledPkgs(root *os.Root) ([]sbomtypes.Package, err
 		}
 
 		for _, statusFile := range statusFiles {
+			// on distroless images, there are some md5sums files in the status.d directory
+			// ignore them
+			if strings.HasSuffix(statusFile.Name(), md5sumsSuffix) {
+				continue
+			}
+
 			fullPath := filepath.Join(statusDPath, statusFile.Name())
 			pkg, err := s.parseStatusFile(root, fullPath)
 			if err != nil {


### PR DESCRIPTION
### What does this PR do?

On [distroless](https://github.com/GoogleContainerTools/distroless) images, all the status files and the md5sums files are in the `status.d` directory. This is handled correctly by the v2 collector when listing the installed files for packages, but we also currently try to read md5sums files when trying to read status files in `status.d`. This PR fixes this by skipping md5sums files when reading the status files.

### Motivation

### Describe how you validated your changes

### Additional Notes
