### PR TITLE
[EBPF-810] update(ebpfcheck): use precise map mem usage when available

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -15,8 +15,6 @@ import (
 	"hash/fnv"
 	"io"
 	"math/rand"
-	"os"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -603,7 +601,7 @@ func (k *Probe) readSingleMap(mapid ebpf.MapID) (*model.EBPFMapStats, error) {
 			return nil, err
 		}
 	case ebpf.Hash, ebpf.LRUHash, ebpf.PerCPUHash, ebpf.LRUCPUHash, ebpf.HashOfMaps:
-		baseMapStats.MaxSize, baseMapStats.RSS = hashMapMemoryUsage(mp.FD(), info, uint64(k.nrcpus))
+		baseMapStats.MaxSize, baseMapStats.RSS = hashMapMemoryUsage(info, uint64(k.nrcpus))
 		if module != "unknown" {
 			// hashMapNumberOfEntries might allocate memory, so we only do it if we have a module name, as
 			// unknown modules get discarded anyway (only RSS is used for total counts)
@@ -706,23 +704,12 @@ func isLRU(typ ebpf.MapType) bool {
 	return false
 }
 
-func hashMapMemoryUsage(fd int, info *ebpf.MapInfo, nrCPUS uint64) (max uint64, rss uint64) {
-	prealloc := (info.Flags & unix.BPF_F_NO_PREALLOC) == 0
-
-	// memory usage is hard to approximate for non-preallocated maps, so we need to read it from fdinfo.
-	// support for precise memory footprint counting has been introduced since kernel 6.4+
-	if !prealloc && preciseMapMemUsageSupported() {
-		usage := readPreciseMapMemUsageFromFdInfo(fd)
-		if usage != 0 {
-			return usage, usage
-		}
-	}
-
-	// as a fallback we approximate memory usage by mimic-ing the kernel's logic
+func hashMapMemoryUsage(info *ebpf.MapInfo, nrCPUS uint64) (max uint64, rss uint64) {
 	valueSize := uint64(roundUpPow2(info.ValueSize, 8))
 	keySize := uint64(roundUpPow2(info.KeySize, 8))
 	perCPU := isPerCPU(info.Type)
 	lru := isLRU(info.Type)
+	prealloc := (info.Flags & unix.BPF_F_NO_PREALLOC) == 0
 	hasExtraElems := !perCPU && !lru
 
 	nBuckets := uint64(roundUpNearestPow2(info.MaxEntries))
@@ -750,6 +737,15 @@ func hashMapMemoryUsage(fd int, info *ebpf.MapInfo, nrCPUS uint64) (max uint64, 
 		usage += sizeOfPointer * nrCPUS
 	}
 
+	// for non-preallocated maps, try reading RSS from fdinfo when precise counting is supported (kernel 6.4+)
+	if !prealloc {
+		if memlock, ok := info.Memlock(); ok && preciseMapMemUsageSupported() {
+			return usage, memlock
+		}
+		return usage, 0
+	}
+
+	// for preallocated maps, we approximate RSS being equal to max memory usage
 	return usage, usage
 }
 
@@ -1207,30 +1203,4 @@ func preciseMapMemUsageSupported() bool {
 	}
 
 	return kv >= kernel.VersionCode(6, 4, 0)
-}
-
-// https://elixir.bootlin.com/linux/v6.4/source/kernel/bpf/syscall.c#L804
-func readPreciseMapMemUsageFromFdInfo(fd int) uint64 {
-	fdInfo, err := os.ReadFile(fmt.Sprintf("/proc/self/fdinfo/%d", fd))
-	if err != nil {
-		return 0
-	}
-
-	for _, line := range strings.SplitN(string(fdInfo), "\n", 10) {
-		if !strings.HasPrefix(line, "memlock:") {
-			continue
-		}
-
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
-
-		memUsage, err := strconv.ParseUint(fields[1], 10, 64)
-		if err == nil {
-			return memUsage
-		}
-	}
-
-	return 0
 }


### PR DESCRIPTION
### What does this PR do?

Here we update the memory usage estimation of ebpf hash maps for ebpf-checks, so that the `BPF_F_NO_PREALLOC` flag is properly handled. This is achieved by checking reading the fdinfo of maps from procfs, in which precise memory usage counting is exposed by recent kernel versions (6.4+). In all other cases, we fallback to the already existing method.

### Motivation

With ebpf maps with the `BPF_F_NO_PREALLOC` flag, using an heuristics based on max entries would be pessimistically misleading due to the fact that memory footprint of maps could grow at runtime.

### Describe how you validated your changes

For now, running locally the system-probe unit tests suite.

### Additional Notes
