### PR TITLE
[CONTP-988] Prioritize LocalData over ExternalData for Tag Enrichment

### DIFF
--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -761,3 +761,57 @@ func TestEnrichTags(t *testing.T) {
 		})
 	}
 }
+
+func TestEnrichTagsContainerIDMismatch(t *testing.T) {
+	mockReq := MockRequires{
+		Config:    configmock.New(t),
+		Log:       logmock.New(t),
+		Telemetry: fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule()),
+	}
+	mockReq.WorkloadMeta = fxutil.Test[workloadmeta.Component](t,
+		fx.Provide(func() config.Component { return mockReq.Config }),
+		fx.Provide(func() log.Component { return mockReq.Log }),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	)
+	fakeTagger := NewMock(mockReq).Comp
+
+	localContainerID, externalContainerID, podUID := "local-container-id", "external-container-id", "pod-uid"
+	containerName := "container-name"
+
+	fakeTagger.SetTags(types.NewEntityID(types.KubernetesPodUID, podUID), "kubelet", []string{"pod-low"}, nil, nil, nil)
+	fakeTagger.SetTags(types.NewEntityID(types.ContainerID, localContainerID), "kubelet", []string{"local-container-low"}, nil, nil, nil)
+	fakeTagger.SetTags(types.NewEntityID(types.ContainerID, externalContainerID), "kubelet", []string{"external-container-low"}, nil, nil, nil)
+
+	// Set up fake metrics provider that returns a different container ID than the local data
+	mockMetricsProvider := collectormock.NewMetricsProvider()
+	externalContainerMetaCollector := collectormock.MetaCollector{
+		ContainerID:           externalContainerID,
+		CIDFromPodUIDContName: map[string]string{fmt.Sprint(podUID, "/", containerName): externalContainerID},
+	}
+	mockMetricsProvider.RegisterMetaCollector(&externalContainerMetaCollector)
+	cleanUp := setupFakeMetricsProvider(mockMetricsProvider)
+	defer cleanUp()
+
+	t.Run("container ID mismatch - external data ignored", func(t *testing.T) {
+		tb := tagset.NewHashingTagsAccumulator()
+		originInfo := taggertypes.OriginInfo{
+			ProductOrigin: origindetection.ProductOriginAPM,
+			LocalData: origindetection.LocalData{
+				ContainerID: localContainerID, // Local data has one container ID
+				PodUID:      podUID,
+			},
+			ExternalData: origindetection.ExternalData{
+				Init:          false,
+				ContainerName: containerName, // External data resolves to different container ID
+				PodUID:        podUID,
+			},
+			Cardinality: "high",
+		}
+		fakeTagger.EnrichTags(tb, originInfo)
+		actualTags := tb.Get()
+
+		assert.Contains(t, actualTags, "local-container-low")
+		assert.Contains(t, actualTags, "pod-low")
+		assert.NotContains(t, actualTags, "external-container-low")
+	})
+}

--- a/releasenotes/notes/fix-tag-enrichment-edge-case-625d7c6ee46e19ad.yaml
+++ b/releasenotes/notes/fix-tag-enrichment-edge-case-625d7c6ee46e19ad.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Ignore ExternalData for tag enrichment in edge cases where
+    ExternalData is not consistent with LocalData.


### PR DESCRIPTION
### What does this PR do?

Prioritizes the use of LocalData over ExternalData if there is any mismatch between the containerIDs used to query for tags in the tagger.

### Motivation

Avoid adding improper tag information to tagger enriched telemetry. During high process/container turnover, there are a few cases in which external data may resolve an incorrect containerID which results in another workload's tags being added to telemetry. This can cause monitors and alarms to trigger when unexpected tag contexts are emitted.

### Describe how you validated your changes

CI and Unit Tests

### Additional Notes
