### PR TITLE
dyninst: fix parsing of generated range functions

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 100
           Type: 1191 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd07bca", Frameless: false}]
+          InjectionPoints: [{PC: "0xd07d2a", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -278,7 +278,7 @@ Probes:
       events:
         - ID: 90
           Type: 1181 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd07780", Frameless: true}]
+          InjectionPoints: [{PC: "0xd078e0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,7 +292,7 @@ Probes:
       events:
         - ID: 93
           Type: 1184 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd077e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07940", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -307,7 +307,7 @@ Probes:
       events:
         - ID: 109
           Type: 1200 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd07d00", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07e60", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -321,7 +321,7 @@ Probes:
       events:
         - ID: 113
           Type: 1204 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd08140", Frameless: true}]
+          InjectionPoints: [{PC: "0xd082a0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -334,7 +334,7 @@ Probes:
       events:
         - ID: 114
           Type: 1205 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xd08160", Frameless: true}]
+          InjectionPoints: [{PC: "0xd082c0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - ID: 106
           Type: 1197 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd07cc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07e20", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -925,7 +925,7 @@ Probes:
       events:
         - ID: 107
           Type: 1198 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd07cc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07e20", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -967,7 +967,7 @@ Probes:
       events:
         - ID: 97
           Type: 1188 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd07860", Frameless: true}]
+          InjectionPoints: [{PC: "0xd079c0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -981,7 +981,7 @@ Probes:
       events:
         - ID: 94
           Type: 1185 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd07800", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07960", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -995,7 +995,7 @@ Probes:
       events:
         - ID: 96
           Type: 1187 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd07840", Frameless: true}]
+          InjectionPoints: [{PC: "0xd079a0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1009,7 +1009,7 @@ Probes:
       events:
         - ID: 105
           Type: 1196 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd07ca0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07e00", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1219,7 +1219,7 @@ Probes:
       events:
         - ID: 101
           Type: 1192 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd07c20", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07d80", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1303,7 +1303,7 @@ Probes:
       events:
         - ID: 91
           Type: 1182 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd077a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07900", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1359,7 +1359,7 @@ Probes:
       events:
         - ID: 95
           Type: 1186 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd07820", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07980", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1401,7 +1401,7 @@ Probes:
       events:
         - ID: 112
           Type: 1203 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd07fc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd08120", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1415,7 +1415,7 @@ Probes:
       events:
         - ID: 92
           Type: 1183 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd077c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07920", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1442,7 +1442,7 @@ Probes:
       events:
         - ID: 111
           Type: 1202 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xd07e80", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07fe0", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1455,7 +1455,7 @@ Probes:
       events:
         - ID: 110
           Type: 1201 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xd07e60", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07fc0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1483,7 +1483,7 @@ Probes:
       events:
         - ID: 102
           Type: 1193 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd07c40", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07da0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1497,7 +1497,7 @@ Probes:
       events:
         - ID: 103
           Type: 1194 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd07c60", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07dc0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1511,7 +1511,7 @@ Probes:
       events:
         - ID: 104
           Type: 1195 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd07c80", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07de0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1623,7 +1623,7 @@ Probes:
       events:
         - ID: 89
           Type: 1180 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd07760", Frameless: true}]
+          InjectionPoints: [{PC: "0xd078c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1637,7 +1637,7 @@ Probes:
       events:
         - ID: 108
           Type: 1199 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd07ce0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd07e40", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1679,7 +1679,7 @@ Probes:
       events:
         - ID: 98
           Type: 1189 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd07880", Frameless: true}]
+          InjectionPoints: [{PC: "0xd079e0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -1693,7 +1693,7 @@ Probes:
       events:
         - ID: 99
           Type: 1190 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd07880", Frameless: true}]
+          InjectionPoints: [{PC: "0xd079e0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2917,13 +2917,13 @@ Subprograms:
           IsReturn: false
     - ID: 88
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd07760..0xd07761]
+      OutOfLinePCRanges: [0xd078c0..0xd078c1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd07760..0xd07761
+            - Range: 0xd078c0..0xd078c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2935,13 +2935,13 @@ Subprograms:
           IsReturn: false
     - ID: 89
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd07780..0xd07781]
+      OutOfLinePCRanges: [0xd078e0..0xd078e1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd07780..0xd07781
+            - Range: 0xd078e0..0xd078e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2953,13 +2953,13 @@ Subprograms:
           IsReturn: false
     - ID: 90
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd077a0..0xd077a1]
+      OutOfLinePCRanges: [0xd07900..0xd07901]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 227 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xd077a0..0xd077a1
+            - Range: 0xd07900..0xd07901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2971,13 +2971,13 @@ Subprograms:
           IsReturn: false
     - ID: 91
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd077c0..0xd077c1]
+      OutOfLinePCRanges: [0xd07920..0xd07921]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd077c0..0xd077c1
+            - Range: 0xd07920..0xd07921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2990,19 +2990,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd077c0..0xd077c1
+            - Range: 0xd07920..0xd07921
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd077e0..0xd077e1]
+      OutOfLinePCRanges: [0xd07940..0xd07941]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd077e0..0xd077e1
+            - Range: 0xd07940..0xd07941
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3015,19 +3015,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd077e0..0xd077e1
+            - Range: 0xd07940..0xd07941
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 93
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd07800..0xd07801]
+      OutOfLinePCRanges: [0xd07960..0xd07961]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd07800..0xd07801
+            - Range: 0xd07960..0xd07961
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3040,19 +3040,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07800..0xd07801
+            - Range: 0xd07960..0xd07961
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 94
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd07820..0xd07821]
+      OutOfLinePCRanges: [0xd07980..0xd07981]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 232 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd07820..0xd07821
+            - Range: 0xd07980..0xd07981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3064,20 +3064,20 @@ Subprograms:
           IsReturn: false
     - ID: 95
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd07840..0xd07841]
+      OutOfLinePCRanges: [0xd079a0..0xd079a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd07840..0xd07841
+            - Range: 0xd079a0..0xd079a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 233 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd07840..0xd07841
+            - Range: 0xd079a0..0xd079a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3090,19 +3090,19 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd07840..0xd07841
+            - Range: 0xd079a0..0xd079a1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 96
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd07860..0xd07861]
+      OutOfLinePCRanges: [0xd079c0..0xd079c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd07860..0xd07861
+            - Range: 0xd079c0..0xd079c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3114,13 +3114,13 @@ Subprograms:
           IsReturn: false
     - ID: 97
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd07880..0xd07881]
+      OutOfLinePCRanges: [0xd079e0..0xd079e1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd07880..0xd07881
+            - Range: 0xd079e0..0xd079e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3132,23 +3132,23 @@ Subprograms:
           IsReturn: false
     - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0xd07bc0..0xd07c12]
+      OutOfLinePCRanges: [0xd07d20..0xd07d72]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd07bc0..0xd07c12, Pieces: []}]
+          Locations: [{Range: 0xd07d20..0xd07d72, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 99
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd07c20..0xd07c21]
+      OutOfLinePCRanges: [0xd07d80..0xd07d81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07c20..0xd07c21
+            - Range: 0xd07d80..0xd07d81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3158,13 +3158,13 @@ Subprograms:
           IsReturn: false
     - ID: 100
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd07c40..0xd07c41]
+      OutOfLinePCRanges: [0xd07da0..0xd07da1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07c40..0xd07c41
+            - Range: 0xd07da0..0xd07da1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3175,7 +3175,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07c40..0xd07c41
+            - Range: 0xd07da0..0xd07da1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3186,7 +3186,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07c40..0xd07c41
+            - Range: 0xd07da0..0xd07da1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3196,13 +3196,13 @@ Subprograms:
           IsReturn: false
     - ID: 101
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd07c60..0xd07c7f]
+      OutOfLinePCRanges: [0xd07dc0..0xd07ddf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 235 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd07c60..0xd07c7f
+            - Range: 0xd07dc0..0xd07ddf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3220,37 +3220,37 @@ Subprograms:
           IsReturn: false
     - ID: 102
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd07c80..0xd07c81]
+      OutOfLinePCRanges: [0xd07de0..0xd07de1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 236 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd07c80..0xd07c81
+            - Range: 0xd07de0..0xd07de1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd07ca0..0xd07ca1]
+      OutOfLinePCRanges: [0xd07e00..0xd07e01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 237 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd07ca0..0xd07ca1
+            - Range: 0xd07e00..0xd07e01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd07cc0..0xd07cc1]
+      OutOfLinePCRanges: [0xd07e20..0xd07e21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07cc0..0xd07cc1
+            - Range: 0xd07e20..0xd07e21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3260,13 +3260,13 @@ Subprograms:
           IsReturn: false
     - ID: 105
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd07ce0..0xd07ce1]
+      OutOfLinePCRanges: [0xd07e40..0xd07e41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07ce0..0xd07ce1
+            - Range: 0xd07e40..0xd07e41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3276,13 +3276,13 @@ Subprograms:
           IsReturn: false
     - ID: 106
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd07d00..0xd07d01]
+      OutOfLinePCRanges: [0xd07e60..0xd07e61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07d00..0xd07d01
+            - Range: 0xd07e60..0xd07e61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3292,25 +3292,25 @@ Subprograms:
           IsReturn: false
     - ID: 107
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd07e60..0xd07e61]
+      OutOfLinePCRanges: [0xd07fc0..0xd07fc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd07e60..0xd07e61
+            - Range: 0xd07fc0..0xd07fc1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 108
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd07e80..0xd07e9f]
+      OutOfLinePCRanges: [0xd07fe0..0xd07fff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd07e80..0xd07e9f
+            - Range: 0xd07fe0..0xd07fff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3328,13 +3328,13 @@ Subprograms:
           IsReturn: false
     - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd07fc0..0xd07fe3]
+      OutOfLinePCRanges: [0xd08120..0xd08143]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 283 StructureType main.aStruct
           Locations:
-            - Range: 0xd07fc0..0xd07fe3
+            - Range: 0xd08120..0xd08143
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3354,23 +3354,23 @@ Subprograms:
           IsReturn: false
     - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd08140..0xd08141]
+      OutOfLinePCRanges: [0xd082a0..0xd082a1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 285 StructureType main.emptyStruct
-          Locations: [{Range: 0xd08140..0xd08141, Pieces: []}]
+          Locations: [{Range: 0xd082a0..0xd082a1, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd08160..0xd08161]
+      OutOfLinePCRanges: [0xd082c0..0xd082c1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 286 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd08160..0xd08161
+            - Range: 0xd082c0..0xd082c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -8435,7 +8435,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 629760
+      GoRuntimeType: 629856
       GoKind: 17
       Count: 4
       HasCount: true
@@ -8461,7 +8461,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 635200
+      GoRuntimeType: 635296
       GoKind: 17
       Count: 6
       HasCount: true
@@ -8479,7 +8479,7 @@ Types:
       ID: 298
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 619872
+      GoRuntimeType: 619968
       GoKind: 17
       Count: 8
       HasCount: true

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 100
           Type: 1346 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd906a", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd912a", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -278,7 +278,7 @@ Probes:
       events:
         - ID: 90
           Type: 1336 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8ce0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,7 +292,7 @@ Probes:
       events:
         - ID: 93
           Type: 1339 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd8c80", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8d40", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -307,7 +307,7 @@ Probes:
       events:
         - ID: 109
           Type: 1355 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd9260", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -321,7 +321,7 @@ Probes:
       events:
         - ID: 113
           Type: 1359 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd95e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd96a0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -334,7 +334,7 @@ Probes:
       events:
         - ID: 114
           Type: 1360 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcd9600", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd96c0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - ID: 106
           Type: 1352 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd9220", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -925,7 +925,7 @@ Probes:
       events:
         - ID: 107
           Type: 1353 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd9220", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -967,7 +967,7 @@ Probes:
       events:
         - ID: 97
           Type: 1343 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd8d00", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8dc0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -981,7 +981,7 @@ Probes:
       events:
         - ID: 94
           Type: 1340 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8d60", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -995,7 +995,7 @@ Probes:
       events:
         - ID: 96
           Type: 1342 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd8ce0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8da0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1009,7 +1009,7 @@ Probes:
       events:
         - ID: 105
           Type: 1351 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd9200", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1219,7 +1219,7 @@ Probes:
       events:
         - ID: 101
           Type: 1347 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1303,7 +1303,7 @@ Probes:
       events:
         - ID: 91
           Type: 1337 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8d00", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1359,7 +1359,7 @@ Probes:
       events:
         - ID: 95
           Type: 1341 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd8cc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8d80", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1401,7 +1401,7 @@ Probes:
       events:
         - ID: 112
           Type: 1358 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd9460", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd9520", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1415,7 +1415,7 @@ Probes:
       events:
         - ID: 92
           Type: 1338 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8d20", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1442,7 +1442,7 @@ Probes:
       events:
         - ID: 111
           Type: 1357 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd93e0", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1455,7 +1455,7 @@ Probes:
       events:
         - ID: 110
           Type: 1356 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcd9300", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd93c0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1483,7 +1483,7 @@ Probes:
       events:
         - ID: 102
           Type: 1348 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1497,7 +1497,7 @@ Probes:
       events:
         - ID: 103
           Type: 1349 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1511,7 +1511,7 @@ Probes:
       events:
         - ID: 104
           Type: 1350 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd91e0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1623,7 +1623,7 @@ Probes:
       events:
         - ID: 89
           Type: 1335 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8cc0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1637,7 +1637,7 @@ Probes:
       events:
         - ID: 108
           Type: 1354 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd9240", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1679,7 +1679,7 @@ Probes:
       events:
         - ID: 98
           Type: 1344 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd8d20", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8de0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -1693,7 +1693,7 @@ Probes:
       events:
         - ID: 99
           Type: 1345 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd8d20", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8de0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2917,140 +2917,11 @@ Subprograms:
           IsReturn: false
     - ID: 88
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 229 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd8c00..0xcd8c01
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 89
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd8c20..0xcd8c21]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 229 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd8c20..0xcd8c21
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 90
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd8c40..0xcd8c41]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 230 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcd8c40..0xcd8c41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 91
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 232 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd8c60..0xcd8c61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd8c60..0xcd8c61
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd8c80..0xcd8c81]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 232 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd8c80..0xcd8c81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd8c80..0xcd8c81
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 93
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcd8ca0..0xcd8ca1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 232 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd8ca0..0xcd8ca1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd8ca0..0xcd8ca1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 94
-      Name: main.testStringSlice
       OutOfLinePCRanges: [0xcd8cc0..0xcd8cc1]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 235 GoSliceHeaderType []string
+        - Name: u
+          Type: 229 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd8cc0..0xcd8cc1
               Pieces:
@@ -3062,22 +2933,151 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+    - ID: 89
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcd8ce0..0xcd8ce1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 229 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcd8ce0..0xcd8ce1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcd8d00..0xcd8d01]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 230 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcd8d00..0xcd8d01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcd8d20..0xcd8d21]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 232 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8d20..0xcd8d21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8d20..0xcd8d21
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcd8d40..0xcd8d41]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 232 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8d40..0xcd8d41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8d40..0xcd8d41
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcd8d60..0xcd8d61]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 232 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8d60..0xcd8d61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8d60..0xcd8d61
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcd8d80..0xcd8d81]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 235 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcd8d80..0xcd8d81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
     - ID: 95
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcd8ce0..0xcd8ce1]
+      OutOfLinePCRanges: [0xcd8da0..0xcd8da1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd8ce0..0xcd8ce1
+            - Range: 0xcd8da0..0xcd8da1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 236 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcd8ce0..0xcd8ce1
+            - Range: 0xcd8da0..0xcd8da1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3090,19 +3090,19 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8ce0..0xcd8ce1
+            - Range: 0xcd8da0..0xcd8da1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 96
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd8d00..0xcd8d01]
+      OutOfLinePCRanges: [0xcd8dc0..0xcd8dc1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 237 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcd8d00..0xcd8d01
+            - Range: 0xcd8dc0..0xcd8dc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3114,13 +3114,13 @@ Subprograms:
           IsReturn: false
     - ID: 97
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd8d20..0xcd8d21]
+      OutOfLinePCRanges: [0xcd8de0..0xcd8de1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd8d20..0xcd8d21
+            - Range: 0xcd8de0..0xcd8de1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3132,23 +3132,23 @@ Subprograms:
           IsReturn: false
     - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd9060..0xcd90b2]
+      OutOfLinePCRanges: [0xcd9120..0xcd9172]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd9060..0xcd90b2, Pieces: []}]
+          Locations: [{Range: 0xcd9120..0xcd9172, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 99
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd90c0..0xcd90c1]
+      OutOfLinePCRanges: [0xcd9180..0xcd9181]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd90c0..0xcd90c1
+            - Range: 0xcd9180..0xcd9181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3158,13 +3158,13 @@ Subprograms:
           IsReturn: false
     - ID: 100
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd90e0..0xcd90e1]
+      OutOfLinePCRanges: [0xcd91a0..0xcd91a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd90e0..0xcd90e1
+            - Range: 0xcd91a0..0xcd91a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3175,7 +3175,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd90e0..0xcd90e1
+            - Range: 0xcd91a0..0xcd91a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3186,7 +3186,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd90e0..0xcd90e1
+            - Range: 0xcd91a0..0xcd91a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3196,13 +3196,13 @@ Subprograms:
           IsReturn: false
     - ID: 101
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd9100..0xcd911f]
+      OutOfLinePCRanges: [0xcd91c0..0xcd91df]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 238 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcd9100..0xcd911f
+            - Range: 0xcd91c0..0xcd91df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3220,37 +3220,37 @@ Subprograms:
           IsReturn: false
     - ID: 102
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd9120..0xcd9121]
+      OutOfLinePCRanges: [0xcd91e0..0xcd91e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcd9120..0xcd9121
+            - Range: 0xcd91e0..0xcd91e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd9140..0xcd9141]
+      OutOfLinePCRanges: [0xcd9200..0xcd9201]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 240 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcd9140..0xcd9141
+            - Range: 0xcd9200..0xcd9201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcd9160..0xcd9161]
+      OutOfLinePCRanges: [0xcd9220..0xcd9221]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9160..0xcd9161
+            - Range: 0xcd9220..0xcd9221
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3260,13 +3260,13 @@ Subprograms:
           IsReturn: false
     - ID: 105
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcd9180..0xcd9181]
+      OutOfLinePCRanges: [0xcd9240..0xcd9241]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9180..0xcd9181
+            - Range: 0xcd9240..0xcd9241
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3276,13 +3276,13 @@ Subprograms:
           IsReturn: false
     - ID: 106
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd91a0..0xcd91a1]
+      OutOfLinePCRanges: [0xcd9260..0xcd9261]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd91a0..0xcd91a1
+            - Range: 0xcd9260..0xcd9261
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3292,25 +3292,25 @@ Subprograms:
           IsReturn: false
     - ID: 107
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcd9300..0xcd9301]
+      OutOfLinePCRanges: [0xcd93c0..0xcd93c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcd9300..0xcd9301
+            - Range: 0xcd93c0..0xcd93c1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 108
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcd9320..0xcd933f]
+      OutOfLinePCRanges: [0xcd93e0..0xcd93ff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcd9320..0xcd933f
+            - Range: 0xcd93e0..0xcd93ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3328,13 +3328,13 @@ Subprograms:
           IsReturn: false
     - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcd9460..0xcd9483]
+      OutOfLinePCRanges: [0xcd9520..0xcd9543]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 286 StructureType main.aStruct
           Locations:
-            - Range: 0xcd9460..0xcd9483
+            - Range: 0xcd9520..0xcd9543
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3354,23 +3354,23 @@ Subprograms:
           IsReturn: false
     - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd95e0..0xcd95e1]
+      OutOfLinePCRanges: [0xcd96a0..0xcd96a1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 288 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd95e0..0xcd95e1, Pieces: []}]
+          Locations: [{Range: 0xcd96a0..0xcd96a1, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcd9600..0xcd9601]
+      OutOfLinePCRanges: [0xcd96c0..0xcd96c1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 289 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcd9600..0xcd9601
+            - Range: 0xcd96c0..0xcd96c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -8504,7 +8504,7 @@ Types:
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 681920
+      GoRuntimeType: 682016
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -8726,7 +8726,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 687296
+      GoRuntimeType: 687392
       GoKind: 17
       Count: 4
       HasCount: true
@@ -8752,7 +8752,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 693024
+      GoRuntimeType: 693120
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13803,7 +13803,7 @@ Types:
       ID: 315
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 676640
+      GoRuntimeType: 676736
       GoKind: 17
       Count: 8
       HasCount: true

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 100
           Type: 1365 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcdd8ca", Frameless: false}]
+          InjectionPoints: [{PC: "0xcdd96a", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -278,7 +278,7 @@ Probes:
       events:
         - ID: 90
           Type: 1355 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcdd480", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd520", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,7 +292,7 @@ Probes:
       events:
         - ID: 93
           Type: 1358 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdd4e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -307,7 +307,7 @@ Probes:
       events:
         - ID: 109
           Type: 1374 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
+          InjectionPoints: [{PC: "0xcddaa0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -321,7 +321,7 @@ Probes:
       events:
         - ID: 113
           Type: 1378 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcdde40", Frameless: true}]
+          InjectionPoints: [{PC: "0xcddee0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -334,7 +334,7 @@ Probes:
       events:
         - ID: 114
           Type: 1379 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcdde60", Frameless: true}]
+          InjectionPoints: [{PC: "0xcddf00", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - ID: 106
           Type: 1371 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdda60", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -925,7 +925,7 @@ Probes:
       events:
         - ID: 107
           Type: 1372 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdda60", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -967,7 +967,7 @@ Probes:
       events:
         - ID: 97
           Type: 1362 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdd560", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd600", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -981,7 +981,7 @@ Probes:
       events:
         - ID: 94
           Type: 1359 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcdd500", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd5a0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -995,7 +995,7 @@ Probes:
       events:
         - ID: 96
           Type: 1361 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdd540", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd5e0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1009,7 +1009,7 @@ Probes:
       events:
         - ID: 105
           Type: 1370 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcdd9a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdda40", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1219,7 +1219,7 @@ Probes:
       events:
         - ID: 101
           Type: 1366 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1303,7 +1303,7 @@ Probes:
       events:
         - ID: 91
           Type: 1356 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcdd4a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd540", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1359,7 +1359,7 @@ Probes:
       events:
         - ID: 95
           Type: 1360 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdd520", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd5c0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1401,7 +1401,7 @@ Probes:
       events:
         - ID: 112
           Type: 1377 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcddcc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcddd60", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1415,7 +1415,7 @@ Probes:
       events:
         - ID: 92
           Type: 1357 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcdd4c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd560", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1442,7 +1442,7 @@ Probes:
       events:
         - ID: 111
           Type: 1376 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcddb80", Frameless: true}]
+          InjectionPoints: [{PC: "0xcddc20", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1455,7 +1455,7 @@ Probes:
       events:
         - ID: 110
           Type: 1375 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcddb60", Frameless: true}]
+          InjectionPoints: [{PC: "0xcddc00", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1483,7 +1483,7 @@ Probes:
       events:
         - ID: 102
           Type: 1367 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd9e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1497,7 +1497,7 @@ Probes:
       events:
         - ID: 103
           Type: 1368 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcdd960", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1511,7 +1511,7 @@ Probes:
       events:
         - ID: 104
           Type: 1369 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcdd980", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdda20", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1623,7 +1623,7 @@ Probes:
       events:
         - ID: 89
           Type: 1354 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd500", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1637,7 +1637,7 @@ Probes:
       events:
         - ID: 108
           Type: 1373 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcdd9e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdda80", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1679,7 +1679,7 @@ Probes:
       events:
         - ID: 98
           Type: 1363 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd620", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -1693,7 +1693,7 @@ Probes:
       events:
         - ID: 99
           Type: 1364 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
+          InjectionPoints: [{PC: "0xcdd620", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2917,13 +2917,13 @@ Subprograms:
           IsReturn: false
     - ID: 88
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdd460..0xcdd461]
+      OutOfLinePCRanges: [0xcdd500..0xcdd501]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd460..0xcdd461
+            - Range: 0xcdd500..0xcdd501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2935,122 +2935,11 @@ Subprograms:
           IsReturn: false
     - ID: 89
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdd480..0xcdd481]
+      OutOfLinePCRanges: [0xcdd520..0xcdd521]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 231 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdd480..0xcdd481
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 90
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdd4a0..0xcdd4a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 232 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcdd4a0..0xcdd4a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 91
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdd4c0..0xcdd4c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 234 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd4c0..0xcdd4c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd4c0..0xcdd4c1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdd4e0..0xcdd4e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 234 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd4e0..0xcdd4e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd4e0..0xcdd4e1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 93
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdd500..0xcdd501]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 234 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdd500..0xcdd501
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd500..0xcdd501
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 94
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdd520..0xcdd521]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 237 GoSliceHeaderType []string
           Locations:
             - Range: 0xcdd520..0xcdd521
               Pieces:
@@ -3062,22 +2951,133 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+    - ID: 90
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcdd540..0xcdd541]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 232 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcdd540..0xcdd541
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcdd560..0xcdd561]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 234 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd560..0xcdd561
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd560..0xcdd561
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcdd580..0xcdd581]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 234 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd580..0xcdd581
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd580..0xcdd581
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcdd5a0..0xcdd5a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 234 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd5a0..0xcdd5a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd5a0..0xcdd5a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcdd5c0..0xcdd5c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 237 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcdd5c0..0xcdd5c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
     - ID: 95
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdd540..0xcdd541]
+      OutOfLinePCRanges: [0xcdd5e0..0xcdd5e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcdd540..0xcdd541
+            - Range: 0xcdd5e0..0xcdd5e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 238 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdd540..0xcdd541
+            - Range: 0xcdd5e0..0xcdd5e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3090,19 +3090,19 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdd540..0xcdd541
+            - Range: 0xcdd5e0..0xcdd5e1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 96
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdd560..0xcdd561]
+      OutOfLinePCRanges: [0xcdd600..0xcdd601]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 239 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcdd560..0xcdd561
+            - Range: 0xcdd600..0xcdd601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3114,13 +3114,13 @@ Subprograms:
           IsReturn: false
     - ID: 97
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdd580..0xcdd581]
+      OutOfLinePCRanges: [0xcdd620..0xcdd621]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd580..0xcdd581
+            - Range: 0xcdd620..0xcdd621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3132,23 +3132,23 @@ Subprograms:
           IsReturn: false
     - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0xcdd8c0..0xcdd912]
+      OutOfLinePCRanges: [0xcdd960..0xcdd9b2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcdd8c0..0xcdd912, Pieces: []}]
+          Locations: [{Range: 0xcdd960..0xcdd9b2, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 99
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcdd920..0xcdd921]
+      OutOfLinePCRanges: [0xcdd9c0..0xcdd9c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd920..0xcdd921
+            - Range: 0xcdd9c0..0xcdd9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3158,13 +3158,13 @@ Subprograms:
           IsReturn: false
     - ID: 100
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcdd940..0xcdd941]
+      OutOfLinePCRanges: [0xcdd9e0..0xcdd9e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd940..0xcdd941
+            - Range: 0xcdd9e0..0xcdd9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3175,7 +3175,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd940..0xcdd941
+            - Range: 0xcdd9e0..0xcdd9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3186,7 +3186,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd940..0xcdd941
+            - Range: 0xcdd9e0..0xcdd9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3196,13 +3196,13 @@ Subprograms:
           IsReturn: false
     - ID: 101
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcdd960..0xcdd97f]
+      OutOfLinePCRanges: [0xcdda00..0xcdda1f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 240 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcdd960..0xcdd97f
+            - Range: 0xcdda00..0xcdda1f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3220,37 +3220,37 @@ Subprograms:
           IsReturn: false
     - ID: 102
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcdd980..0xcdd981]
+      OutOfLinePCRanges: [0xcdda20..0xcdda21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcdd980..0xcdd981
+            - Range: 0xcdda20..0xcdda21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcdd9a0..0xcdd9a1]
+      OutOfLinePCRanges: [0xcdda40..0xcdda41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcdd9a0..0xcdd9a1
+            - Range: 0xcdda40..0xcdda41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcdd9c0..0xcdd9c1]
+      OutOfLinePCRanges: [0xcdda60..0xcdda61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd9c0..0xcdd9c1
+            - Range: 0xcdda60..0xcdda61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3260,13 +3260,13 @@ Subprograms:
           IsReturn: false
     - ID: 105
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcdd9e0..0xcdd9e1]
+      OutOfLinePCRanges: [0xcdda80..0xcdda81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdd9e0..0xcdd9e1
+            - Range: 0xcdda80..0xcdda81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3276,13 +3276,13 @@ Subprograms:
           IsReturn: false
     - ID: 106
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcdda00..0xcdda01]
+      OutOfLinePCRanges: [0xcddaa0..0xcddaa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdda00..0xcdda01
+            - Range: 0xcddaa0..0xcddaa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3292,25 +3292,25 @@ Subprograms:
           IsReturn: false
     - ID: 107
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcddb60..0xcddb61]
+      OutOfLinePCRanges: [0xcddc00..0xcddc01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcddb60..0xcddb61
+            - Range: 0xcddc00..0xcddc01
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 108
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcddb80..0xcddb9f]
+      OutOfLinePCRanges: [0xcddc20..0xcddc3f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcddb80..0xcddb9f
+            - Range: 0xcddc20..0xcddc3f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3328,13 +3328,13 @@ Subprograms:
           IsReturn: false
     - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcddcc0..0xcddce3]
+      OutOfLinePCRanges: [0xcddd60..0xcddd83]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 288 StructureType main.aStruct
           Locations:
-            - Range: 0xcddcc0..0xcddce3
+            - Range: 0xcddd60..0xcddd83
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3354,23 +3354,23 @@ Subprograms:
           IsReturn: false
     - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcdde40..0xcdde41]
+      OutOfLinePCRanges: [0xcddee0..0xcddee1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 290 StructureType main.emptyStruct
-          Locations: [{Range: 0xcdde40..0xcdde41, Pieces: []}]
+          Locations: [{Range: 0xcddee0..0xcddee1, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcdde60..0xcdde61]
+      OutOfLinePCRanges: [0xcddf00..0xcddf01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 291 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcdde60..0xcdde61
+            - Range: 0xcddf00..0xcddf01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -8784,7 +8784,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 691040
+      GoRuntimeType: 691136
       GoKind: 17
       Count: 4
       HasCount: true
@@ -8810,7 +8810,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 696672
+      GoRuntimeType: 696768
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13999,7 +13999,7 @@ Types:
       ID: 320
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 680384
+      GoRuntimeType: 680480
       GoKind: 17
       Count: 8
       HasCount: true

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 100
           Type: 1191 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x8901ac", Frameless: true}]
+          InjectionPoints: [{PC: "0x89032c", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -278,7 +278,7 @@ Probes:
       events:
         - ID: 90
           Type: 1181 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x88fe50", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ffd0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,7 +292,7 @@ Probes:
       events:
         - ID: 93
           Type: 1184 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x88fe80", Frameless: true}]
+          InjectionPoints: [{PC: "0x890000", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -307,7 +307,7 @@ Probes:
       events:
         - ID: 109
           Type: 1200 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x890290", Frameless: true}]
+          InjectionPoints: [{PC: "0x890410", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -321,7 +321,7 @@ Probes:
       events:
         - ID: 113
           Type: 1204 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x8905e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890760", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -334,7 +334,7 @@ Probes:
       events:
         - ID: 114
           Type: 1205 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x8905f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890770", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - ID: 106
           Type: 1197 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x890270", Frameless: true}]
+          InjectionPoints: [{PC: "0x8903f0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -925,7 +925,7 @@ Probes:
       events:
         - ID: 107
           Type: 1198 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x890270", Frameless: true}]
+          InjectionPoints: [{PC: "0x8903f0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -967,7 +967,7 @@ Probes:
       events:
         - ID: 97
           Type: 1188 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x88fec0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890040", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -981,7 +981,7 @@ Probes:
       events:
         - ID: 94
           Type: 1185 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x88fe90", Frameless: true}]
+          InjectionPoints: [{PC: "0x890010", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -995,7 +995,7 @@ Probes:
       events:
         - ID: 96
           Type: 1187 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x88feb0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890030", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1009,7 +1009,7 @@ Probes:
       events:
         - ID: 105
           Type: 1196 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x890260", Frameless: true}]
+          InjectionPoints: [{PC: "0x8903e0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1219,7 +1219,7 @@ Probes:
       events:
         - ID: 101
           Type: 1192 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x890210", Frameless: true}]
+          InjectionPoints: [{PC: "0x890390", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1303,7 +1303,7 @@ Probes:
       events:
         - ID: 91
           Type: 1182 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x88fe60", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ffe0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1359,7 +1359,7 @@ Probes:
       events:
         - ID: 95
           Type: 1186 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x88fea0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890020", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1401,7 +1401,7 @@ Probes:
       events:
         - ID: 112
           Type: 1203 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x8904e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890660", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1415,7 +1415,7 @@ Probes:
       events:
         - ID: 92
           Type: 1183 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x88fe70", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fff0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1442,7 +1442,7 @@ Probes:
       events:
         - ID: 111
           Type: 1202 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x8903f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890570", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1455,7 +1455,7 @@ Probes:
       events:
         - ID: 110
           Type: 1201 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x8903e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890560", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1483,7 +1483,7 @@ Probes:
       events:
         - ID: 102
           Type: 1193 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x890220", Frameless: true}]
+          InjectionPoints: [{PC: "0x8903a0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1497,7 +1497,7 @@ Probes:
       events:
         - ID: 103
           Type: 1194 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x890230", Frameless: true}]
+          InjectionPoints: [{PC: "0x8903b0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1511,7 +1511,7 @@ Probes:
       events:
         - ID: 104
           Type: 1195 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x890250", Frameless: true}]
+          InjectionPoints: [{PC: "0x8903d0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1623,7 +1623,7 @@ Probes:
       events:
         - ID: 89
           Type: 1180 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x88fe40", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ffc0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1637,7 +1637,7 @@ Probes:
       events:
         - ID: 108
           Type: 1199 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x890280", Frameless: true}]
+          InjectionPoints: [{PC: "0x890400", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1679,7 +1679,7 @@ Probes:
       events:
         - ID: 98
           Type: 1189 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x88fed0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890050", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -1693,7 +1693,7 @@ Probes:
       events:
         - ID: 99
           Type: 1190 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x88fed0", Frameless: true}]
+          InjectionPoints: [{PC: "0x890050", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2917,13 +2917,13 @@ Subprograms:
           IsReturn: false
     - ID: 88
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x88fe40..0x88fe50]
+      OutOfLinePCRanges: [0x88ffc0..0x88ffd0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88fe40..0x88fe50
+            - Range: 0x88ffc0..0x88ffd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2935,13 +2935,13 @@ Subprograms:
           IsReturn: false
     - ID: 89
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x88fe50..0x88fe60]
+      OutOfLinePCRanges: [0x88ffd0..0x88ffe0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88fe50..0x88fe60
+            - Range: 0x88ffd0..0x88ffe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2953,13 +2953,13 @@ Subprograms:
           IsReturn: false
     - ID: 90
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x88fe60..0x88fe70]
+      OutOfLinePCRanges: [0x88ffe0..0x88fff0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 227 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x88fe60..0x88fe70
+            - Range: 0x88ffe0..0x88fff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2971,13 +2971,13 @@ Subprograms:
           IsReturn: false
     - ID: 91
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x88fe70..0x88fe80]
+      OutOfLinePCRanges: [0x88fff0..0x890000]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x88fe70..0x88fe80
+            - Range: 0x88fff0..0x890000
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2990,19 +2990,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88fe70..0x88fe80
+            - Range: 0x88fff0..0x890000
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x88fe80..0x88fe90]
+      OutOfLinePCRanges: [0x890000..0x890010]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x88fe80..0x88fe90
+            - Range: 0x890000..0x890010
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3015,19 +3015,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88fe80..0x88fe90
+            - Range: 0x890000..0x890010
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 93
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x88fe90..0x88fea0]
+      OutOfLinePCRanges: [0x890010..0x890020]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x88fe90..0x88fea0
+            - Range: 0x890010..0x890020
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3040,19 +3040,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88fe90..0x88fea0
+            - Range: 0x890010..0x890020
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 94
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x88fea0..0x88feb0]
+      OutOfLinePCRanges: [0x890020..0x890030]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 232 GoSliceHeaderType []string
           Locations:
-            - Range: 0x88fea0..0x88feb0
+            - Range: 0x890020..0x890030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3064,20 +3064,20 @@ Subprograms:
           IsReturn: false
     - ID: 95
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x88feb0..0x88fec0]
+      OutOfLinePCRanges: [0x890030..0x890040]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x88feb0..0x88fec0
+            - Range: 0x890030..0x890040
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 233 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x88feb0..0x88fec0
+            - Range: 0x890030..0x890040
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3090,19 +3090,19 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88feb0..0x88fec0
+            - Range: 0x890030..0x890040
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 96
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x88fec0..0x88fed0]
+      OutOfLinePCRanges: [0x890040..0x890050]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x88fec0..0x88fed0
+            - Range: 0x890040..0x890050
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3114,13 +3114,13 @@ Subprograms:
           IsReturn: false
     - ID: 97
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x88fed0..0x88fee0]
+      OutOfLinePCRanges: [0x890050..0x890060]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88fed0..0x88fee0
+            - Range: 0x890050..0x890060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3132,23 +3132,23 @@ Subprograms:
           IsReturn: false
     - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0x8901a0..0x890210]
+      OutOfLinePCRanges: [0x890320..0x890390]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x8901a0..0x890210, Pieces: []}]
+          Locations: [{Range: 0x890320..0x890390, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 99
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x890210..0x890220]
+      OutOfLinePCRanges: [0x890390..0x8903a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890210..0x890220
+            - Range: 0x890390..0x8903a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3158,13 +3158,13 @@ Subprograms:
           IsReturn: false
     - ID: 100
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x890220..0x890230]
+      OutOfLinePCRanges: [0x8903a0..0x8903b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890220..0x890230
+            - Range: 0x8903a0..0x8903b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3175,7 +3175,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890220..0x890230
+            - Range: 0x8903a0..0x8903b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3186,7 +3186,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890220..0x890230
+            - Range: 0x8903a0..0x8903b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3196,13 +3196,13 @@ Subprograms:
           IsReturn: false
     - ID: 101
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x890230..0x890250]
+      OutOfLinePCRanges: [0x8903b0..0x8903d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 235 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x890230..0x890250
+            - Range: 0x8903b0..0x8903d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3220,37 +3220,37 @@ Subprograms:
           IsReturn: false
     - ID: 102
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x890250..0x890260]
+      OutOfLinePCRanges: [0x8903d0..0x8903e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 236 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x890250..0x890260
+            - Range: 0x8903d0..0x8903e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x890260..0x890270]
+      OutOfLinePCRanges: [0x8903e0..0x8903f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 237 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x890260..0x890270
+            - Range: 0x8903e0..0x8903f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x890270..0x890280]
+      OutOfLinePCRanges: [0x8903f0..0x890400]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890270..0x890280
+            - Range: 0x8903f0..0x890400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3260,13 +3260,13 @@ Subprograms:
           IsReturn: false
     - ID: 105
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x890280..0x890290]
+      OutOfLinePCRanges: [0x890400..0x890410]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890280..0x890290
+            - Range: 0x890400..0x890410
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3276,13 +3276,13 @@ Subprograms:
           IsReturn: false
     - ID: 106
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x890290..0x8902a0]
+      OutOfLinePCRanges: [0x890410..0x890420]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890290..0x8902a0
+            - Range: 0x890410..0x890420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3292,25 +3292,25 @@ Subprograms:
           IsReturn: false
     - ID: 107
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x8903e0..0x8903f0]
+      OutOfLinePCRanges: [0x890560..0x890570]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x8903e0..0x8903f0
+            - Range: 0x890560..0x890570
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 108
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x8903f0..0x890410]
+      OutOfLinePCRanges: [0x890570..0x890590]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x8903f0..0x890410
+            - Range: 0x890570..0x890590
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3328,13 +3328,13 @@ Subprograms:
           IsReturn: false
     - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0x8904e0..0x890500]
+      OutOfLinePCRanges: [0x890660..0x890680]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 283 StructureType main.aStruct
           Locations:
-            - Range: 0x8904e0..0x890500
+            - Range: 0x890660..0x890680
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3354,23 +3354,23 @@ Subprograms:
           IsReturn: false
     - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8905e0..0x8905f0]
+      OutOfLinePCRanges: [0x890760..0x890770]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 285 StructureType main.emptyStruct
-          Locations: [{Range: 0x8905e0..0x8905f0, Pieces: []}]
+          Locations: [{Range: 0x890760..0x890770, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8905f0..0x890600]
+      OutOfLinePCRanges: [0x890770..0x890780]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 286 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8905f0..0x890600
+            - Range: 0x890770..0x890780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -8435,7 +8435,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 630048
+      GoRuntimeType: 630144
       GoKind: 17
       Count: 4
       HasCount: true
@@ -8461,7 +8461,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 635488
+      GoRuntimeType: 635584
       GoKind: 17
       Count: 6
       HasCount: true
@@ -8479,7 +8479,7 @@ Types:
       ID: 298
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 620064
+      GoRuntimeType: 620160
       GoKind: 17
       Count: 8
       HasCount: true

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 100
           Type: 1346 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84d92c", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d9ec", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -278,7 +278,7 @@ Probes:
       events:
         - ID: 90
           Type: 1336 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d690", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,7 +292,7 @@ Probes:
       events:
         - ID: 93
           Type: 1339 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84d600", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d6c0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -307,7 +307,7 @@ Probes:
       events:
         - ID: 109
           Type: 1355 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84da10", Frameless: true}]
+          InjectionPoints: [{PC: "0x84dad0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -321,7 +321,7 @@ Probes:
       events:
         - ID: 113
           Type: 1359 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84dd60", Frameless: true}]
+          InjectionPoints: [{PC: "0x84de20", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -334,7 +334,7 @@ Probes:
       events:
         - ID: 114
           Type: 1360 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x84dd70", Frameless: true}]
+          InjectionPoints: [{PC: "0x84de30", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - ID: 106
           Type: 1352 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84d9f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84dab0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -925,7 +925,7 @@ Probes:
       events:
         - ID: 107
           Type: 1353 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84d9f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84dab0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -967,7 +967,7 @@ Probes:
       events:
         - ID: 97
           Type: 1343 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84d640", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d700", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -981,7 +981,7 @@ Probes:
       events:
         - ID: 94
           Type: 1340 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84d610", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d6d0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -995,7 +995,7 @@ Probes:
       events:
         - ID: 96
           Type: 1342 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84d630", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d6f0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1009,7 +1009,7 @@ Probes:
       events:
         - ID: 105
           Type: 1351 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84d9e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84daa0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1219,7 +1219,7 @@ Probes:
       events:
         - ID: 101
           Type: 1347 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84d990", Frameless: true}]
+          InjectionPoints: [{PC: "0x84da50", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1303,7 +1303,7 @@ Probes:
       events:
         - ID: 91
           Type: 1337 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d6a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1359,7 +1359,7 @@ Probes:
       events:
         - ID: 95
           Type: 1341 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84d620", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d6e0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1401,7 +1401,7 @@ Probes:
       events:
         - ID: 112
           Type: 1358 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84dc60", Frameless: true}]
+          InjectionPoints: [{PC: "0x84dd20", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1415,7 +1415,7 @@ Probes:
       events:
         - ID: 92
           Type: 1338 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84d5f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d6b0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1442,7 +1442,7 @@ Probes:
       events:
         - ID: 111
           Type: 1357 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x84db70", Frameless: true}]
+          InjectionPoints: [{PC: "0x84dc30", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1455,7 +1455,7 @@ Probes:
       events:
         - ID: 110
           Type: 1356 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x84db60", Frameless: true}]
+          InjectionPoints: [{PC: "0x84dc20", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1483,7 +1483,7 @@ Probes:
       events:
         - ID: 102
           Type: 1348 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84d9a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84da60", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1497,7 +1497,7 @@ Probes:
       events:
         - ID: 103
           Type: 1349 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84d9b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84da70", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1511,7 +1511,7 @@ Probes:
       events:
         - ID: 104
           Type: 1350 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84d9d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84da90", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1623,7 +1623,7 @@ Probes:
       events:
         - ID: 89
           Type: 1335 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d680", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1637,7 +1637,7 @@ Probes:
       events:
         - ID: 108
           Type: 1354 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84da00", Frameless: true}]
+          InjectionPoints: [{PC: "0x84dac0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1679,7 +1679,7 @@ Probes:
       events:
         - ID: 98
           Type: 1344 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84d650", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d710", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -1693,7 +1693,7 @@ Probes:
       events:
         - ID: 99
           Type: 1345 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84d650", Frameless: true}]
+          InjectionPoints: [{PC: "0x84d710", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2917,13 +2917,13 @@ Subprograms:
           IsReturn: false
     - ID: 88
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84d5c0..0x84d5d0]
+      OutOfLinePCRanges: [0x84d680..0x84d690]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 229 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84d5c0..0x84d5d0
+            - Range: 0x84d680..0x84d690
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2935,13 +2935,13 @@ Subprograms:
           IsReturn: false
     - ID: 89
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
+      OutOfLinePCRanges: [0x84d690..0x84d6a0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 229 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84d5d0..0x84d5e0
+            - Range: 0x84d690..0x84d6a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2953,13 +2953,13 @@ Subprograms:
           IsReturn: false
     - ID: 90
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84d5e0..0x84d5f0]
+      OutOfLinePCRanges: [0x84d6a0..0x84d6b0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 230 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x84d5e0..0x84d5f0
+            - Range: 0x84d6a0..0x84d6b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2971,13 +2971,13 @@ Subprograms:
           IsReturn: false
     - ID: 91
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84d5f0..0x84d600]
+      OutOfLinePCRanges: [0x84d6b0..0x84d6c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 232 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84d5f0..0x84d600
+            - Range: 0x84d6b0..0x84d6c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2990,19 +2990,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d5f0..0x84d600
+            - Range: 0x84d6b0..0x84d6c0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84d600..0x84d610]
+      OutOfLinePCRanges: [0x84d6c0..0x84d6d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 232 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84d600..0x84d610
+            - Range: 0x84d6c0..0x84d6d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3015,19 +3015,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d600..0x84d610
+            - Range: 0x84d6c0..0x84d6d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 93
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84d610..0x84d620]
+      OutOfLinePCRanges: [0x84d6d0..0x84d6e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 232 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84d610..0x84d620
+            - Range: 0x84d6d0..0x84d6e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3040,19 +3040,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d610..0x84d620
+            - Range: 0x84d6d0..0x84d6e0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 94
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84d620..0x84d630]
+      OutOfLinePCRanges: [0x84d6e0..0x84d6f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 235 GoSliceHeaderType []string
           Locations:
-            - Range: 0x84d620..0x84d630
+            - Range: 0x84d6e0..0x84d6f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3064,20 +3064,20 @@ Subprograms:
           IsReturn: false
     - ID: 95
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84d630..0x84d640]
+      OutOfLinePCRanges: [0x84d6f0..0x84d700]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84d630..0x84d640
+            - Range: 0x84d6f0..0x84d700
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 236 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84d630..0x84d640
+            - Range: 0x84d6f0..0x84d700
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3090,19 +3090,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d630..0x84d640
+            - Range: 0x84d6f0..0x84d700
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 96
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84d640..0x84d650]
+      OutOfLinePCRanges: [0x84d700..0x84d710]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 237 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84d640..0x84d650
+            - Range: 0x84d700..0x84d710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3114,13 +3114,13 @@ Subprograms:
           IsReturn: false
     - ID: 97
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84d650..0x84d660]
+      OutOfLinePCRanges: [0x84d710..0x84d720]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84d650..0x84d660
+            - Range: 0x84d710..0x84d720
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3132,23 +3132,23 @@ Subprograms:
           IsReturn: false
     - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0x84d920..0x84d990]
+      OutOfLinePCRanges: [0x84d9e0..0x84da50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84d920..0x84d990, Pieces: []}]
+          Locations: [{Range: 0x84d9e0..0x84da50, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 99
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84d990..0x84d9a0]
+      OutOfLinePCRanges: [0x84da50..0x84da60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d990..0x84d9a0
+            - Range: 0x84da50..0x84da60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3158,13 +3158,13 @@ Subprograms:
           IsReturn: false
     - ID: 100
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84d9a0..0x84d9b0]
+      OutOfLinePCRanges: [0x84da60..0x84da70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d9a0..0x84d9b0
+            - Range: 0x84da60..0x84da70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3175,7 +3175,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d9a0..0x84d9b0
+            - Range: 0x84da60..0x84da70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3186,7 +3186,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d9a0..0x84d9b0
+            - Range: 0x84da60..0x84da70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3196,13 +3196,13 @@ Subprograms:
           IsReturn: false
     - ID: 101
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84d9b0..0x84d9d0]
+      OutOfLinePCRanges: [0x84da70..0x84da90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 238 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84d9b0..0x84d9d0
+            - Range: 0x84da70..0x84da90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3220,37 +3220,37 @@ Subprograms:
           IsReturn: false
     - ID: 102
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84d9d0..0x84d9e0]
+      OutOfLinePCRanges: [0x84da90..0x84daa0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84d9d0..0x84d9e0
+            - Range: 0x84da90..0x84daa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84d9e0..0x84d9f0]
+      OutOfLinePCRanges: [0x84daa0..0x84dab0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 240 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84d9e0..0x84d9f0
+            - Range: 0x84daa0..0x84dab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84d9f0..0x84da00]
+      OutOfLinePCRanges: [0x84dab0..0x84dac0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84d9f0..0x84da00
+            - Range: 0x84dab0..0x84dac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3260,13 +3260,13 @@ Subprograms:
           IsReturn: false
     - ID: 105
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84da00..0x84da10]
+      OutOfLinePCRanges: [0x84dac0..0x84dad0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84da00..0x84da10
+            - Range: 0x84dac0..0x84dad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3276,13 +3276,13 @@ Subprograms:
           IsReturn: false
     - ID: 106
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84da10..0x84da20]
+      OutOfLinePCRanges: [0x84dad0..0x84dae0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84da10..0x84da20
+            - Range: 0x84dad0..0x84dae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3292,25 +3292,25 @@ Subprograms:
           IsReturn: false
     - ID: 107
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x84db60..0x84db70]
+      OutOfLinePCRanges: [0x84dc20..0x84dc30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x84db60..0x84db70
+            - Range: 0x84dc20..0x84dc30
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 108
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x84db70..0x84db90]
+      OutOfLinePCRanges: [0x84dc30..0x84dc50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x84db70..0x84db90
+            - Range: 0x84dc30..0x84dc50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3328,13 +3328,13 @@ Subprograms:
           IsReturn: false
     - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0x84dc60..0x84dc80]
+      OutOfLinePCRanges: [0x84dd20..0x84dd40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 286 StructureType main.aStruct
           Locations:
-            - Range: 0x84dc60..0x84dc80
+            - Range: 0x84dd20..0x84dd40
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3354,23 +3354,23 @@ Subprograms:
           IsReturn: false
     - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84dd60..0x84dd70]
+      OutOfLinePCRanges: [0x84de20..0x84de30]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 288 StructureType main.emptyStruct
-          Locations: [{Range: 0x84dd60..0x84dd70, Pieces: []}]
+          Locations: [{Range: 0x84de20..0x84de30, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x84dd70..0x84dd80]
+      OutOfLinePCRanges: [0x84de30..0x84de40]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 289 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x84dd70..0x84dd80
+            - Range: 0x84de30..0x84de40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -8504,7 +8504,7 @@ Types:
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 681696
+      GoRuntimeType: 681792
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -8726,7 +8726,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 687072
+      GoRuntimeType: 687168
       GoKind: 17
       Count: 4
       HasCount: true
@@ -8752,7 +8752,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 692800
+      GoRuntimeType: 692896
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13803,7 +13803,7 @@ Types:
       ID: 315
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 676416
+      GoRuntimeType: 676512
       GoKind: 17
       Count: 8
       HasCount: true

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 100
           Type: 1365 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x809fac", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a05c", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -278,7 +278,7 @@ Probes:
       events:
         - ID: 90
           Type: 1355 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x809c80", Frameless: true}]
+          InjectionPoints: [{PC: "0x809d30", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -292,7 +292,7 @@ Probes:
       events:
         - ID: 93
           Type: 1358 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x809cb0", Frameless: true}]
+          InjectionPoints: [{PC: "0x809d60", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -307,7 +307,7 @@ Probes:
       events:
         - ID: 109
           Type: 1374 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x80a070", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a120", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -321,7 +321,7 @@ Probes:
       events:
         - ID: 113
           Type: 1378 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x80a340", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a3f0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -334,7 +334,7 @@ Probes:
       events:
         - ID: 114
           Type: 1379 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x80a350", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a400", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - ID: 106
           Type: 1371 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80a050", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a100", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -925,7 +925,7 @@ Probes:
       events:
         - ID: 107
           Type: 1372 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80a050", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a100", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -967,7 +967,7 @@ Probes:
       events:
         - ID: 97
           Type: 1362 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x809cf0", Frameless: true}]
+          InjectionPoints: [{PC: "0x809da0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -981,7 +981,7 @@ Probes:
       events:
         - ID: 94
           Type: 1359 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
+          InjectionPoints: [{PC: "0x809d70", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -995,7 +995,7 @@ Probes:
       events:
         - ID: 96
           Type: 1361 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x809ce0", Frameless: true}]
+          InjectionPoints: [{PC: "0x809d90", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1009,7 +1009,7 @@ Probes:
       events:
         - ID: 105
           Type: 1370 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x80a040", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a0f0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1219,7 +1219,7 @@ Probes:
       events:
         - ID: 101
           Type: 1366 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x80a000", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a0b0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1303,7 +1303,7 @@ Probes:
       events:
         - ID: 91
           Type: 1356 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x809c90", Frameless: true}]
+          InjectionPoints: [{PC: "0x809d40", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1359,7 +1359,7 @@ Probes:
       events:
         - ID: 95
           Type: 1360 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x809cd0", Frameless: true}]
+          InjectionPoints: [{PC: "0x809d80", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1401,7 +1401,7 @@ Probes:
       events:
         - ID: 112
           Type: 1377 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80a270", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a320", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1415,7 +1415,7 @@ Probes:
       events:
         - ID: 92
           Type: 1357 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
+          InjectionPoints: [{PC: "0x809d50", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1442,7 +1442,7 @@ Probes:
       events:
         - ID: 111
           Type: 1376 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x80a1c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a270", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1455,7 +1455,7 @@ Probes:
       events:
         - ID: 110
           Type: 1375 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x80a1b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a260", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1483,7 +1483,7 @@ Probes:
       events:
         - ID: 102
           Type: 1367 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x80a010", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a0c0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1497,7 +1497,7 @@ Probes:
       events:
         - ID: 103
           Type: 1368 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x80a020", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a0d0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1511,7 +1511,7 @@ Probes:
       events:
         - ID: 104
           Type: 1369 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x80a030", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a0e0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1623,7 +1623,7 @@ Probes:
       events:
         - ID: 89
           Type: 1354 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x809c70", Frameless: true}]
+          InjectionPoints: [{PC: "0x809d20", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1637,7 +1637,7 @@ Probes:
       events:
         - ID: 108
           Type: 1373 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x80a060", Frameless: true}]
+          InjectionPoints: [{PC: "0x80a110", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1679,7 +1679,7 @@ Probes:
       events:
         - ID: 98
           Type: 1363 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x809d00", Frameless: true}]
+          InjectionPoints: [{PC: "0x809db0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -1693,7 +1693,7 @@ Probes:
       events:
         - ID: 99
           Type: 1364 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x809d00", Frameless: true}]
+          InjectionPoints: [{PC: "0x809db0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2917,13 +2917,13 @@ Subprograms:
           IsReturn: false
     - ID: 88
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x809c70..0x809c80]
+      OutOfLinePCRanges: [0x809d20..0x809d30]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x809c70..0x809c80
+            - Range: 0x809d20..0x809d30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2935,13 +2935,13 @@ Subprograms:
           IsReturn: false
     - ID: 89
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x809c80..0x809c90]
+      OutOfLinePCRanges: [0x809d30..0x809d40]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x809c80..0x809c90
+            - Range: 0x809d30..0x809d40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2953,13 +2953,13 @@ Subprograms:
           IsReturn: false
     - ID: 90
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x809c90..0x809ca0]
+      OutOfLinePCRanges: [0x809d40..0x809d50]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 232 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x809c90..0x809ca0
+            - Range: 0x809d40..0x809d50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2971,13 +2971,13 @@ Subprograms:
           IsReturn: false
     - ID: 91
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x809ca0..0x809cb0]
+      OutOfLinePCRanges: [0x809d50..0x809d60]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x809ca0..0x809cb0
+            - Range: 0x809d50..0x809d60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2990,19 +2990,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809ca0..0x809cb0
+            - Range: 0x809d50..0x809d60
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 92
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x809cb0..0x809cc0]
+      OutOfLinePCRanges: [0x809d60..0x809d70]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x809cb0..0x809cc0
+            - Range: 0x809d60..0x809d70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3015,19 +3015,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809cb0..0x809cc0
+            - Range: 0x809d60..0x809d70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 93
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x809cc0..0x809cd0]
+      OutOfLinePCRanges: [0x809d70..0x809d80]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x809cc0..0x809cd0
+            - Range: 0x809d70..0x809d80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3040,19 +3040,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809cc0..0x809cd0
+            - Range: 0x809d70..0x809d80
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 94
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x809cd0..0x809ce0]
+      OutOfLinePCRanges: [0x809d80..0x809d90]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 237 GoSliceHeaderType []string
           Locations:
-            - Range: 0x809cd0..0x809ce0
+            - Range: 0x809d80..0x809d90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3064,20 +3064,20 @@ Subprograms:
           IsReturn: false
     - ID: 95
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x809ce0..0x809cf0]
+      OutOfLinePCRanges: [0x809d90..0x809da0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x809ce0..0x809cf0
+            - Range: 0x809d90..0x809da0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 238 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x809ce0..0x809cf0
+            - Range: 0x809d90..0x809da0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3090,19 +3090,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809ce0..0x809cf0
+            - Range: 0x809d90..0x809da0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 96
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x809cf0..0x809d00]
+      OutOfLinePCRanges: [0x809da0..0x809db0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 239 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x809cf0..0x809d00
+            - Range: 0x809da0..0x809db0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3114,13 +3114,13 @@ Subprograms:
           IsReturn: false
     - ID: 97
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x809d00..0x809d10]
+      OutOfLinePCRanges: [0x809db0..0x809dc0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x809d00..0x809d10
+            - Range: 0x809db0..0x809dc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3132,23 +3132,23 @@ Subprograms:
           IsReturn: false
     - ID: 98
       Name: main.stackC
-      OutOfLinePCRanges: [0x809fa0..0x80a000]
+      OutOfLinePCRanges: [0x80a050..0x80a0b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x809fa0..0x80a000, Pieces: []}]
+          Locations: [{Range: 0x80a050..0x80a0b0, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 99
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80a000..0x80a010]
+      OutOfLinePCRanges: [0x80a0b0..0x80a0c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a000..0x80a010
+            - Range: 0x80a0b0..0x80a0c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3158,13 +3158,13 @@ Subprograms:
           IsReturn: false
     - ID: 100
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80a010..0x80a020]
+      OutOfLinePCRanges: [0x80a0c0..0x80a0d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a010..0x80a020
+            - Range: 0x80a0c0..0x80a0d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3175,7 +3175,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a010..0x80a020
+            - Range: 0x80a0c0..0x80a0d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3186,7 +3186,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a010..0x80a020
+            - Range: 0x80a0c0..0x80a0d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3196,13 +3196,13 @@ Subprograms:
           IsReturn: false
     - ID: 101
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80a020..0x80a030]
+      OutOfLinePCRanges: [0x80a0d0..0x80a0e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 240 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80a020..0x80a030
+            - Range: 0x80a0d0..0x80a0e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3220,37 +3220,37 @@ Subprograms:
           IsReturn: false
     - ID: 102
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80a030..0x80a040]
+      OutOfLinePCRanges: [0x80a0e0..0x80a0f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80a030..0x80a040
+            - Range: 0x80a0e0..0x80a0f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80a040..0x80a050]
+      OutOfLinePCRanges: [0x80a0f0..0x80a100]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80a040..0x80a050
+            - Range: 0x80a0f0..0x80a100
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80a050..0x80a060]
+      OutOfLinePCRanges: [0x80a100..0x80a110]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a050..0x80a060
+            - Range: 0x80a100..0x80a110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3260,13 +3260,13 @@ Subprograms:
           IsReturn: false
     - ID: 105
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80a060..0x80a070]
+      OutOfLinePCRanges: [0x80a110..0x80a120]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a060..0x80a070
+            - Range: 0x80a110..0x80a120
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3276,13 +3276,13 @@ Subprograms:
           IsReturn: false
     - ID: 106
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80a070..0x80a080]
+      OutOfLinePCRanges: [0x80a120..0x80a130]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a070..0x80a080
+            - Range: 0x80a120..0x80a130
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3292,25 +3292,25 @@ Subprograms:
           IsReturn: false
     - ID: 107
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80a1b0..0x80a1c0]
+      OutOfLinePCRanges: [0x80a260..0x80a270]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80a1b0..0x80a1c0
+            - Range: 0x80a260..0x80a270
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 108
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80a1c0..0x80a1d0]
+      OutOfLinePCRanges: [0x80a270..0x80a280]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80a1c0..0x80a1d0
+            - Range: 0x80a270..0x80a280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3328,13 +3328,13 @@ Subprograms:
           IsReturn: false
     - ID: 109
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80a270..0x80a290]
+      OutOfLinePCRanges: [0x80a320..0x80a340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 288 StructureType main.aStruct
           Locations:
-            - Range: 0x80a270..0x80a290
+            - Range: 0x80a320..0x80a340
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3354,23 +3354,23 @@ Subprograms:
           IsReturn: false
     - ID: 110
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80a340..0x80a350]
+      OutOfLinePCRanges: [0x80a3f0..0x80a400]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 290 StructureType main.emptyStruct
-          Locations: [{Range: 0x80a340..0x80a350, Pieces: []}]
+          Locations: [{Range: 0x80a3f0..0x80a400, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 111
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80a350..0x80a360]
+      OutOfLinePCRanges: [0x80a400..0x80a410]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 291 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80a350..0x80a360
+            - Range: 0x80a400..0x80a410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -8784,7 +8784,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 690816
+      GoRuntimeType: 690912
       GoKind: 17
       Count: 4
       HasCount: true
@@ -8810,7 +8810,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 696448
+      GoRuntimeType: 696544
       GoKind: 17
       Count: 6
       HasCount: true
@@ -13999,7 +13999,7 @@ Types:
       ID: 320
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 680160
+      GoRuntimeType: 680256
       GoKind: 17
       Count: 8
       HasCount: true

--- a/pkg/dyninst/symdb/func_name.go
+++ b/pkg/dyninst/symdb/func_name.go
@@ -36,7 +36,9 @@ var (
 	methodWithValueReceiverRETypeIdx = methodWithValueReceiverRE.SubexpIndex("type")
 	methodWithValueReceiverRENameIdx = methodWithValueReceiverRE.SubexpIndex("name")
 
-	anonymousFuncRE = regexp.MustCompile(`^(func)?\d+`)
+	// If a function's name starts with func1 or ends with -range1, it's an
+	// anonymous function (as opposed to a method).
+	anonymousFuncRE = regexp.MustCompile(`(^(func)?\d+)|(-range\d+$)`)
 
 	standaloneFuncRE = regexp.MustCompile(
 		pkgNameRegex + `(?P<name>.*)$`)

--- a/pkg/dyninst/symdb/func_name_test.go
+++ b/pkg/dyninst/symdb/func_name_test.go
@@ -127,7 +127,18 @@ func TestParseFuncName(t *testing.T) {
 					Type:    "",
 					Name:    "newBuffer",
 				},
-			}},
+			},
+		},
+		{"range iterator function", "github.com/redis/rueidis/internal/cmds.HmsetFieldValue.FieldValueIter-range1",
+			// Taken from: https://github.com/redis/rueidis/blob/f05dbebcb0216e4ef09a712b3b5e9a2e2d8df786/internal/cmds/iter.go#L11
+			parseFuncNameResult{
+				funcName: funcName{
+					Package: "github.com/redis/rueidis/internal/cmds",
+					Type:    "",
+					Name:    "HmsetFieldValue.FieldValueIter-range1",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
@@ -205,9 +205,10 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -437,6 +438,8 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18]
+		Arg: value: int (declared at line 16, available: [16-17])
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
@@ -665,6 +668,10 @@ Package: main
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
+			Var: #yield1: func(int) bool (declared at line 0, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -204,8 +204,9 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -652,6 +653,9 @@ Package: main
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
@@ -203,8 +203,9 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -651,6 +652,9 @@ Package: main
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
@@ -205,9 +205,10 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -437,6 +438,8 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18]
+		Arg: value: int (declared at line 16, available: [16-17])
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
@@ -665,6 +668,10 @@ Package: main
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
+			Var: #yield1: func(int) bool (declared at line 0, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -204,8 +204,9 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -652,6 +653,9 @@ Package: main
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
@@ -203,8 +203,9 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -651,6 +652,9 @@ Package: main
 			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -205,9 +205,10 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -437,6 +438,8 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18]
+		Arg: value: int (declared at line 16, available: [16-17])
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
@@ -651,6 +654,10 @@ Package: main
 	Type: main.behavior
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
+			Var: #yield1: func(int) bool (declared at line 0, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -204,8 +204,9 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -638,6 +639,9 @@ Package: main
 	Type: main.behavior
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -203,8 +203,9 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -637,6 +638,9 @@ Package: main
 	Type: main.behavior
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -205,9 +205,10 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -437,6 +438,8 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18]
+		Arg: value: int (declared at line 16, available: [16-17])
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
@@ -651,6 +654,10 @@ Package: main
 	Type: main.behavior
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
+			Var: #yield1: func(int) bool (declared at line 0, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -204,8 +204,9 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -638,6 +639,9 @@ Package: main
 	Type: main.behavior
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -203,8 +203,9 @@ Package: main
 			Var: structWithAny2: main.structWithAny (declared at line 118, available: )
 			Var: structWithAny3: main.structWithAny (declared at line 119, available: )
 			Var: structWithAny4: main.structWithAny (declared at line 120, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:50]
+		Var: it: main.iterExample (declared at line 41, available: [19-50])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-50])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -637,6 +638,9 @@ Package: main
 	Type: main.behavior
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.iterExample
+		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19]
+			Arg: ~p0: main.iterExample (declared at line 15, available: )
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node

--- a/pkg/dyninst/testdata/decoded/sample/.testSingleUint32.json.1588158266.tmp.json
+++ b/pkg/dyninst/testdata/decoded/sample/.testSingleUint32.json.1588158266.tmp.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testMapMassive",
+      "method": "main.testSingleUint32",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,19 +16,19 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testMapMassive",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
-            "lineNumber": 54
+            "function": "main.testSingleUint32",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 55
           },
           {
-            "function": "main.executeMapFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
-            "lineNumber": 158
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 84
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 47
+            "lineNumber": 27
           },
           {
             "function": "runtime.main",
@@ -42,19 +42,17 @@
           }
         ],
         "probe": {
-          "id": "testMapMassive",
+          "id": "testSingleUint32",
           "location": {
-            "method": "main.testMapMassive"
+            "method": "main.testSingleUint32"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "redactMyEntries": {
-                "type": "map[string][]main.structWithMap",
-                "size": "150",
-                "entries": "[redacted-entries]",
-                "notCapturedReason": "pruned"
+              "x": {
+                "type": "uint32",
+                "value": "32"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -95,7 +95,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -162,7 +162,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -229,7 +229,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -296,7 +296,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -363,7 +363,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -430,7 +430,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -496,7 +496,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -563,7 +563,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -631,7 +631,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -90,7 +90,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -157,7 +157,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -225,7 +225,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -293,7 +293,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -367,7 +367,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -100,7 +100,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -173,7 +173,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -245,7 +245,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -318,7 +318,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",
@@ -385,7 +385,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 46
+            "lineNumber": 48
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 45
+            "lineNumber": 47
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -38,6 +38,8 @@ func main() {
 	lib_v2.FooV2()
 	var t lib_v2.V2Type
 	t.MyMethod()
+	var it iterExample
+	it.rangeOverIterator()
 
 	// unsupported for MVP, should not cause failures
 	executeEsoteric()

--- a/pkg/dyninst/testprogs/progs/sample/ranges.go
+++ b/pkg/dyninst/testprogs/progs/sample/ranges.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package main
+
+import (
+	"fmt"
+	"slices"
+)
+
+type iterExample struct{}
+
+func (iterExample) rangeOverIterator() {
+	for value := range slices.Values([]int{10, 20}) {
+		fmt.Printf("Value: %d\n", value)
+	}
+}


### PR DESCRIPTION
The Go compiler generates functions to be passed to iterators for code
like `for x := range <iter.Seq> {...}`. These functions seem to have
names that end in "-range<number>". Parse these functions as anonymous
functions, not as methods.