### PR TITLE
shorten windows transient paths

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -30,6 +30,7 @@
   retry: 0
   variables:
     GIT_DEPTH: 2
+    BAZEL_OUTPUT_USER_ROOT: "C:/tmpbzl"
   script:
     - |-
       $FailFast = @'


### PR DESCRIPTION
### What does this PR do?
Make the path base for bazel output on windows very short.  E.g.
```
C:\Users\ContainerAdministrator\AppData\Local\Temp\Bazel.runfiles_7ghfo0_s\
```
to
```
c:\tmpbzl.runfiles_7ghfo0_s
```

Except, this may not work. Because the temp files might be a different path
And, maybe this should be done in .bazelrc. If we need it in CI, we need it from the command line too.


### Motivation
Helps with the long path problem. E.g.
```
FileNotFoundError: [WinError 206] The filename or extension is too long:
'C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\Bazel.runfiles_7ghfo0_s\\runfiles\\rules_python++python+python_3_11_x86_64-pc-windows-msvc\\Lib\\site-packages\\pkg_resources\\tests\\data\\my-test-package_unpacked-egg\\my_test_package-1.0-py3.7.egg\\EGG-INFO'
```