### PR TITLE
tasks/kmt.py: fix kmt.test -p with ... or multiple pkgs

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -977,10 +977,12 @@ def build_run_config(run: str | None, packages: list[str]):
 
     for p in packages:
         p = p.removeprefix("./")
+        if "filters" not in c:
+            c["filters"] = {}
         if run is not None:
-            c["filters"] = {p: {"run-only": [run]}}
+            c["filters"][p] = {"run-only": [run]}
         else:
-            c["filters"] = {p: {"exclude": False}}
+            c["filters"][p] = {"exclude": False}
 
     return c
 


### PR DESCRIPTION
### What does this PR do?

In #30529 we fixed -p working with a single package, but broke it for multiple package. This fixes that issue.

### Motivation

Tried to run `dda inv kmt.test -p pkg/dyninst/...` and it only ran one package

### Describe how you validated your changes

Used it
