### PR TITLE
system-probe: do not enable event monitor if di is enabled

### DIFF
--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -139,8 +139,7 @@ func load() (*types.Config, error) {
 		cfg.GetBool(evNS("process.enabled")) ||
 		(usmEnabled && cfg.GetBool(smNS("enable_event_stream"))) ||
 		(c.ModuleIsEnabled(NetworkTracerModule) && cfg.GetBool(evNS("network_process.enabled"))) ||
-		gpuEnabled ||
-		diEnabled {
+		gpuEnabled {
 		c.EnabledModules[EventMonitorModule] = struct{}{}
 	}
 	complianceEnabled := cfg.GetBool(compNS("enabled")) ||


### PR DESCRIPTION
### What does this PR do?

After https://github.com/DataDog/datadog-agent/pull/41062 and https://github.com/DataDog/datadog-agent/pull/41064 go di is no longer using the event monitor process stream. No need to enable the event monitor module if only go di is enabled. This PR fixes this. 

### Motivation

### Describe how you validated your changes

### Additional Notes
