### PR TITLE
Fixed Jira JQL

### DIFF
--- a/tasks/libs/notify/jira_failing_tests.py
+++ b/tasks/libs/notify/jira_failing_tests.py
@@ -20,7 +20,7 @@ except ImportError:
 def get_jira():
     username = os.environ['ATLASSIAN_USERNAME']
     password = os.environ['ATLASSIAN_PASSWORD']
-    jira = Jira(url="https://datadoghq.atlassian.net", username=username, password=password)
+    jira = Jira(url="https://datadoghq.atlassian.net", username=username, password=password, cloud=True)
 
     return jira
 

--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -250,7 +250,7 @@ def list_not_closed_qa_cards(version):
     password = os.environ['ATLASSIAN_PASSWORD']
     from atlassian import Jira
 
-    jira = Jira(url="https://datadoghq.atlassian.net", username=username, password=password)
+    jira = Jira(url="https://datadoghq.atlassian.net", username=username, password=password, cloud=True)
     jql = f'labels in (ddqa) and labels not in (test_ignore) and labels in ({version}-qa) and status not in ((Done, DONE, "Won\'t Fix", "WON\'T FIX", "In Progress", "Testing/Review", "In review", "✅ Done", "won\'t do", Duplicate, Closed, "NOT DOING", not-do, canceled, QA)) order by created desc'
     response = jira.enhanced_jql(jql)
     return response['issues']

--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -251,6 +251,6 @@ def list_not_closed_qa_cards(version):
     from atlassian import Jira
 
     jira = Jira(url="https://datadoghq.atlassian.net", username=username, password=password)
-    jql = f'labels in (ddqa) and labels not in (test_ignore) and labels in ({version}-qa)  and status not in ((Done, DONE, "Won\'t Fix", "WON\'T FIX", "In Progress", "Testing/Review", "In review", "✅ Done", "won\'t do", Duplicate, Closed, "NOT DOING", not-do, canceled, QA)) order by created desc'
+    jql = f'labels in (ddqa) and labels not in (test_ignore) and labels in ({version}-qa) and status not in ((Done, DONE, "Won\'t Fix", "WON\'T FIX", "In Progress", "Testing/Review", "In review", "✅ Done", "won\'t do", Duplicate, Closed, "NOT DOING", not-do, canceled, QA)) order by created desc'
     response = jira.enhanced_jql(jql)
-    return response['results']
+    return response['issues']


### PR DESCRIPTION
### What does this PR do?

We need to pass `cloud` parameter to be able to use `enhanced_jql`, tested locally.
The chase for qa cards will be fixed now.

### Motivation

### Describe how you validated your changes

### Additional Notes
