### PR TITLE
Autoscaling: fallback direction in code required for older CRs

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -274,6 +274,11 @@ func (hr *horizontalController) computeScaleAction(
 }
 
 func isFallbackScalingDirectionEnabled(fallbackEnabledDirection datadoghq.DatadogPodAutoscalerFallbackDirection, scaleDirection common.ScaleDirection) bool {
+	if fallbackEnabledDirection == "" {
+		// Default to ScaleUp if not set
+		fallbackEnabledDirection = datadoghq.DatadogPodAutoscalerFallbackDirectionScaleUp
+	}
+
 	if fallbackEnabledDirection == datadoghq.DatadogPodAutoscalerFallbackDirectionAll {
 		return true
 	}

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
@@ -276,6 +276,24 @@ func TestHorizontalControllerSyncPrerequisites(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
+	// Test case: Fallback scaling direction unset
+	fakePai.Spec.Fallback = &datadoghq.DatadogFallbackPolicy{
+		Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{},
+	}
+	fakePai.Spec.ApplyPolicy = &datadoghq.DatadogPodAutoscalerApplyPolicy{
+		Mode: datadoghq.DatadogPodAutoscalerApplyModeApply,
+	}
+	result, err = f.testScalingDecision(horizontalScalingTestArgs{
+		fakePai:         fakePai,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerLocalValueSource,
+		currentReplicas: 6,
+		statusReplicas:  6,
+		recReplicas:     7,
+		scaleReplicas:   7,
+	})
+	assert.Equal(t, autoscaling.NoRequeue, result)
+	assert.NoError(t, err)
+
 	// Tests disabled until we add back Manual capability in the CRD
 	// // Test case: Automatic scaling values disabled by policy
 	// fakePai.Spec.ApplyPolicy = &datadoghq.DatadogPodAutoscalerApplyPolicy{


### PR DESCRIPTION
### What does this PR do?

Fixes a case where the CR does not contain any value preventing from applying any fallback.
Fixes feature introduced in https://github.com/DataDog/datadog-agent/issues/40542

### Motivation

Bugfix

### Describe how you validated your changes

Use a 7.71+ Agent version with an outdated CRs or CRD, local fallback should still happen instead of being refused due to scaling direction disabled.

### Additional Notes

Cluster Agent impact only