### PR TITLE
[OTAGENT-534] Replace the build tag `hostprofiler` in favor of `linux`.

### DIFF
--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 package command
 

--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package command contains the top-level Cobra command for the host profiler.
 package command
 
 import (
@@ -15,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/version"
 )
 
-// MakeCommand makes the top-level Cobra command for this app.
+// MakeRootCommand makes the top-level Cobra command for this app.
 func MakeRootCommand() *cobra.Command {
 	hostProfiler := &cobra.Command{
 		Use:   "host-profiler [command]",

--- a/cmd/host-profiler/globalparams/globalparams.go
+++ b/cmd/host-profiler/globalparams/globalparams.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 package globalparams
 

--- a/cmd/host-profiler/globalparams/globalparams.go
+++ b/cmd/host-profiler/globalparams/globalparams.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package globalparams contains the global CLI parameters for the host profiler.
 package globalparams
 
 // GlobalParams contains the values of host profiler global Cobra flags.

--- a/cmd/host-profiler/main.go
+++ b/cmd/host-profiler/main.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 // host-profiler is a standalone binary that runs the Host Profiler.
 package main

--- a/cmd/host-profiler/subcommands/run/command.go
+++ b/cmd/host-profiler/subcommands/run/command.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 package run
 

--- a/cmd/host-profiler/subcommands/run/command.go
+++ b/cmd/host-profiler/subcommands/run/command.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package run is the run host-profiler subcommand
 package run
 
 import (
@@ -41,7 +42,7 @@ func MakeCommand(globalConfGetter func() *globalparams.GlobalParams) []*cobra.Co
 	return []*cobra.Command{cmd}
 }
 
-func runHostProfilerCommand(ctx context.Context, cliParams *cliParams) error {
+func runHostProfilerCommand(_ context.Context, cliParams *cliParams) error {
 	return fxutil.Run(
 		hostprofiler.Bundle(collectorimpl.NewParams(cliParams.GlobalParams.ConfFilePath)),
 		fx.Invoke(func(collector collector.Component) error {

--- a/cmd/host-profiler/subcommands/run/command_test.go
+++ b/cmd/host-profiler/subcommands/run/command_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 package run
 

--- a/cmd/host-profiler/subcommands/run/command_test.go
+++ b/cmd/host-profiler/subcommands/run/command_test.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
+	"github.com/DataDog/datadog-agent/cmd/host-profiler/globalparams"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -19,7 +19,7 @@ import (
 func TestFxRun(t *testing.T) {
 	fxutil.TestRun(t, func() error {
 		params := &cliParams{
-			GlobalParams: &subcommands.GlobalParams{},
+			GlobalParams: &globalparams.GlobalParams{},
 		}
 		return runHostProfilerCommand(context.Background(), params)
 	})

--- a/comp/host-profiler/bundle.go
+++ b/comp/host-profiler/bundle.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 // Package hostprofiler implements the "host-profiler" bundle,
 package hostprofiler

--- a/comp/host-profiler/bundle_test.go
+++ b/comp/host-profiler/bundle_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 package hostprofiler
 

--- a/comp/host-profiler/collector/def/component.go
+++ b/comp/host-profiler/collector/def/component.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 // Package collector defines the host profiler collector component.
 //

--- a/comp/host-profiler/collector/fx/fx.go
+++ b/comp/host-profiler/collector/fx/fx.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 // Package fx provides the fx module for the collector component.
 //

--- a/comp/host-profiler/collector/impl/collector.go
+++ b/comp/host-profiler/collector/impl/collector.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build hostprofiler
+//go:build linux
 
 // Package collectorimpl implements the collector component interface
 package collectorimpl

--- a/comp/host-profiler/collector/impl/collector.go
+++ b/comp/host-profiler/collector/impl/collector.go
@@ -22,10 +22,12 @@ import (
 	ebpfcollector "go.opentelemetry.io/ebpf-profiler/collector"
 )
 
+// Params contains the parameters for the collector component.
 type Params struct {
 	uri string
 }
 
+// NewParams creates a new Params instance.
 func NewParams(uri string) Params {
 	return Params{
 		uri: uri,
@@ -49,7 +51,10 @@ type collectorImpl struct {
 // NewComponent creates a new collector component
 func NewComponent(reqs Requires) (Provides, error) {
 	// Enable profiles support (disabled by default)
-	featuregate.GlobalRegistry().Set("service.profilesSupport", true)
+	err := featuregate.GlobalRegistry().Set("service.profilesSupport", true)
+	if err != nil {
+		return Provides{}, err
+	}
 
 	settings, err := newCollectorSettings(reqs.Params.uri)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR replace the build tag `hostprofiler` in favor of `linux`.
it also fixes some linter issues. 

### Motivation

### Describe how you validated your changes
Run unit test and linters.

### Additional Notes
