### PR TITLE
[NDM] Fix use_remote_config_profiles not used on autodiscovery

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -1,9 +1,15 @@
+## This file is managed by Datadog.
+## Please do not edit it manually.
+#
 ad_identifiers:
   - snmp
 init_config:
+  - ## @param use_remote_config_profiles - boolean - optional - default: false
+    ## Whether to apply device profiles from the SNMP Profile Manager.
+    #
+    use_remote_config_profiles: "%%extra_use_remote_config_profiles%%"
 instances:
-  -
-    ## @param ip_address - string - optional
+  - ## @param ip_address - string - optional
     ## The IP address of the device to monitor.
     #
     ip_address: "%%host%%"

--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -4,11 +4,10 @@
 ad_identifiers:
   - snmp
 init_config:
-  -
-    ## @param use_remote_config_profiles - boolean - optional - default: false
-    ## Whether to apply device profiles from the SNMP Profile Manager.
-    #
-    use_remote_config_profiles: "%%extra_use_remote_config_profiles%%"
+  ## @param use_remote_config_profiles - boolean - optional - default: false
+  ## Whether to apply device profiles from the SNMP Profile Manager.
+  #
+  use_remote_config_profiles: "%%extra_use_remote_config_profiles%%"
 instances:
   - ## @param ip_address - string - optional
     ## The IP address of the device to monitor.

--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -4,7 +4,8 @@
 ad_identifiers:
   - snmp
 init_config:
-  - ## @param use_remote_config_profiles - boolean - optional - default: false
+  -
+    ## @param use_remote_config_profiles - boolean - optional - default: false
     ## Whether to apply device profiles from the SNMP Profile Manager.
     #
     use_remote_config_profiles: "%%extra_use_remote_config_profiles%%"

--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -9,7 +9,8 @@ init_config:
   #
   use_remote_config_profiles: "%%extra_use_remote_config_profiles%%"
 instances:
-  - ## @param ip_address - string - optional
+  -
+    ## @param ip_address - string - optional
     ## The IP address of the device to monitor.
     #
     ip_address: "%%host%%"

--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -701,6 +701,8 @@ func (s *SNMPService) GetExtraConfig(key string) (string, error) {
 		}
 
 		return string(pingCfgJSON), nil
+	case "use_remote_config_profiles":
+		return strconv.FormatBool(s.config.UseRemoteConfigProfiles), nil
 	}
 	return "", ErrNotSupported
 }

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -203,6 +203,7 @@ func TestExtraConfig(t *testing.T) {
 			Timeout:  &sixPtr,
 			Count:    &threePtr,
 		},
+		UseRemoteConfigProfiles: true,
 	}
 
 	svc := SNMPService{
@@ -303,6 +304,10 @@ func TestExtraConfig(t *testing.T) {
 	info, err = svc.GetExtraConfig("ping")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, `{"linux":{"use_raw_socket":true},"enabled":true,"interval":5,"timeout":6,"count":3}`, info)
+
+	info, err = svc.GetExtraConfig("use_remote_config_profiles")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "true", info)
 
 	svc = SNMPService{
 		adIdentifier: "snmp",

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -85,7 +85,7 @@ type DeviceDigest string
 // InitConfig is used to deserialize integration init config
 type InitConfig struct {
 	Profiles              profile.ProfileConfigMap          `yaml:"profiles"`
-	UseRCProfiles         bool                              `yaml:"use_remote_config_profiles"`
+	UseRCProfiles         Boolean                           `yaml:"use_remote_config_profiles"`
 	GlobalMetrics         []profiledefinition.MetricsConfig `yaml:"global_metrics"`
 	OidBatchSize          Number                            `yaml:"oid_batch_size"`
 	BulkMaxRepetitions    Number                            `yaml:"bulk_max_repetitions"`
@@ -124,6 +124,7 @@ type InstanceConfig struct {
 	UseDeviceIDAsHostname *Boolean                            `yaml:"use_device_id_as_hostname"`
 	PingConfig            snmpintegration.PackedPingConfig    `yaml:"ping"`
 	Loader                string                              `yaml:"loader"`
+	UseRCProfiles         *Boolean                            `yaml:"use_remote_config_profiles"`
 
 	// ExtraTags is a workaround to pass tags from snmp listener to snmp integration via AD template
 	// (see cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml) that only works with strings.
@@ -443,7 +444,14 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		return nil, err
 	}
 
-	if initConfig.UseRCProfiles {
+	var useRCProfiles bool
+	if instance.UseRCProfiles != nil {
+		useRCProfiles = bool(*instance.UseRCProfiles)
+	} else {
+		useRCProfiles = bool(initConfig.UseRCProfiles)
+	}
+
+	if useRCProfiles {
 		if rcClient == nil {
 			return nil, fmt.Errorf("rc client not initialized, cannot use rc profiles")
 		}

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -76,6 +76,8 @@ type Config struct {
 	CollectTopology             bool
 	CollectVPNConfig            *bool `mapstructure:"collect_vpn"`
 	CollectVPN                  bool
+	UseDeviceIDAsHostnameConfig *bool `mapstructure:"use_device_id_as_hostname"`
+	UseDeviceIDAsHostname       bool
 	Namespace                   string   `mapstructure:"namespace"`
 	Tags                        []string `mapstructure:"tags"`
 	MinCollectionInterval       uint     `mapstructure:"min_collection_interval"`
@@ -84,9 +86,6 @@ type Config struct {
 	InterfaceConfigs map[string][]snmpintegration.InterfaceConfig `mapstructure:"interface_configs"`
 
 	PingConfig snmpintegration.PingConfig `mapstructure:"ping"`
-
-	UseRemoteConfigProfilesConfig *bool `mapstructure:"use_remote_config_profiles"`
-	UseRemoteConfigProfiles       bool
 
 	// Legacy
 	NetworkLegacy      string `mapstructure:"network"`
@@ -175,6 +174,12 @@ func NewListenerConfig() (ListenerConfig, error) {
 			config.CollectVPN = snmpConfig.CollectVPN
 		}
 
+		if config.UseDeviceIDAsHostnameConfig != nil {
+			config.UseDeviceIDAsHostname = *config.UseDeviceIDAsHostnameConfig
+		} else {
+			config.UseDeviceIDAsHostname = snmpConfig.UseDeviceISAsHostname
+		}
+
 		if config.Loader == "" {
 			config.Loader = snmpConfig.Loader
 		}
@@ -224,12 +229,6 @@ func NewListenerConfig() (ListenerConfig, error) {
 			if config.Authentications[authIndex].Retries == 0 {
 				config.Authentications[authIndex].Retries = defaultRetries
 			}
-		}
-
-		if config.UseRemoteConfigProfilesConfig != nil {
-			config.UseRemoteConfigProfiles = *config.UseRemoteConfigProfilesConfig
-		} else {
-			config.UseRemoteConfigProfiles = snmpConfig.UseRemoteConfigProfiles
 		}
 	}
 	return snmpConfig, nil

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -86,6 +86,8 @@ type Config struct {
 	InterfaceConfigs map[string][]snmpintegration.InterfaceConfig `mapstructure:"interface_configs"`
 
 	PingConfig snmpintegration.PingConfig `mapstructure:"ping"`
+	UseRemoteConfigProfilesConfig *bool `mapstructure:"use_remote_config_profiles"`
+	UseRemoteConfigProfiles       bool
 
 	// Legacy
 	NetworkLegacy      string `mapstructure:"network"`
@@ -229,6 +231,12 @@ func NewListenerConfig() (ListenerConfig, error) {
 			if config.Authentications[authIndex].Retries == 0 {
 				config.Authentications[authIndex].Retries = defaultRetries
 			}
+		}
+
+		if config.UseRemoteConfigProfilesConfig != nil {
+			config.UseRemoteConfigProfiles = *config.UseRemoteConfigProfilesConfig
+		} else {
+			config.UseRemoteConfigProfiles = snmpConfig.UseRemoteConfigProfiles
 		}
 	}
 	return snmpConfig, nil

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -31,20 +31,20 @@ const (
 
 // ListenerConfig holds global configuration for SNMP discovery
 type ListenerConfig struct {
-	Workers               int                        `mapstructure:"workers"`
-	DiscoveryInterval     int                        `mapstructure:"discovery_interval"`
-	AllowedFailures       int                        `mapstructure:"discovery_allowed_failures"`
-	Loader                string                     `mapstructure:"loader"`
-	CollectDeviceMetadata bool                       `mapstructure:"collect_device_metadata"`
-	CollectTopology       bool                       `mapstructure:"collect_topology"`
-	CollectVPN            bool                       `mapstructure:"collect_vpn"`
-	MinCollectionInterval uint                       `mapstructure:"min_collection_interval"`
-	Namespace             string                     `mapstructure:"namespace"`
-	UseDeviceISAsHostname bool                       `mapstructure:"use_device_id_as_hostname"`
-	Configs               []Config                   `mapstructure:"configs"`
-	PingConfig            snmpintegration.PingConfig `mapstructure:"ping"`
-	Deduplicate           bool                       `mapstructure:"use_deduplication"`
-	UseRemoteConfigProfiles bool `mapstructure:"use_remote_config_profiles"`
+	Workers                 int                        `mapstructure:"workers"`
+	DiscoveryInterval       int                        `mapstructure:"discovery_interval"`
+	AllowedFailures         int                        `mapstructure:"discovery_allowed_failures"`
+	Loader                  string                     `mapstructure:"loader"`
+	CollectDeviceMetadata   bool                       `mapstructure:"collect_device_metadata"`
+	CollectTopology         bool                       `mapstructure:"collect_topology"`
+	CollectVPN              bool                       `mapstructure:"collect_vpn"`
+	MinCollectionInterval   uint                       `mapstructure:"min_collection_interval"`
+	Namespace               string                     `mapstructure:"namespace"`
+	UseDeviceISAsHostname   bool                       `mapstructure:"use_device_id_as_hostname"`
+	Configs                 []Config                   `mapstructure:"configs"`
+	PingConfig              snmpintegration.PingConfig `mapstructure:"ping"`
+	Deduplicate             bool                       `mapstructure:"use_deduplication"`
+	UseRemoteConfigProfiles bool                       `mapstructure:"use_remote_config_profiles"`
 
 	// legacy
 	AllowedFailuresLegacy int `mapstructure:"allowed_failures"`
@@ -85,8 +85,8 @@ type Config struct {
 	// InterfaceConfigs is a map of IP to a list of snmpintegration.InterfaceConfig
 	InterfaceConfigs map[string][]snmpintegration.InterfaceConfig `mapstructure:"interface_configs"`
 
-	PingConfig snmpintegration.PingConfig `mapstructure:"ping"`
-	UseRemoteConfigProfilesConfig *bool `mapstructure:"use_remote_config_profiles"`
+	PingConfig                    snmpintegration.PingConfig `mapstructure:"ping"`
+	UseRemoteConfigProfilesConfig *bool                      `mapstructure:"use_remote_config_profiles"`
 	UseRemoteConfigProfiles       bool
 
 	// Legacy

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -85,9 +85,8 @@ type Config struct {
 	// InterfaceConfigs is a map of IP to a list of snmpintegration.InterfaceConfig
 	InterfaceConfigs map[string][]snmpintegration.InterfaceConfig `mapstructure:"interface_configs"`
 
-	PingConfig                    snmpintegration.PingConfig `mapstructure:"ping"`
-	UseRemoteConfigProfilesConfig *bool                      `mapstructure:"use_remote_config_profiles"`
-	UseRemoteConfigProfiles       bool
+	PingConfig              snmpintegration.PingConfig `mapstructure:"ping"`
+	UseRemoteConfigProfiles bool
 
 	// Legacy
 	NetworkLegacy      string `mapstructure:"network"`
@@ -232,12 +231,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 				config.Authentications[authIndex].Retries = defaultRetries
 			}
 		}
-
-		if config.UseRemoteConfigProfilesConfig != nil {
-			config.UseRemoteConfigProfiles = *config.UseRemoteConfigProfilesConfig
-		} else {
-			config.UseRemoteConfigProfiles = snmpConfig.UseRemoteConfigProfiles
-		}
+		config.UseRemoteConfigProfiles = snmpConfig.UseRemoteConfigProfiles
 	}
 	return snmpConfig, nil
 }

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -44,6 +44,7 @@ type ListenerConfig struct {
 	Configs               []Config                   `mapstructure:"configs"`
 	PingConfig            snmpintegration.PingConfig `mapstructure:"ping"`
 	Deduplicate           bool                       `mapstructure:"use_deduplication"`
+	UseRemoteConfigProfiles bool `mapstructure:"use_remote_config_profiles"`
 
 	// legacy
 	AllowedFailuresLegacy int `mapstructure:"allowed_failures"`
@@ -75,8 +76,6 @@ type Config struct {
 	CollectTopology             bool
 	CollectVPNConfig            *bool `mapstructure:"collect_vpn"`
 	CollectVPN                  bool
-	UseDeviceIDAsHostnameConfig *bool `mapstructure:"use_device_id_as_hostname"`
-	UseDeviceIDAsHostname       bool
 	Namespace                   string   `mapstructure:"namespace"`
 	Tags                        []string `mapstructure:"tags"`
 	MinCollectionInterval       uint     `mapstructure:"min_collection_interval"`
@@ -85,6 +84,9 @@ type Config struct {
 	InterfaceConfigs map[string][]snmpintegration.InterfaceConfig `mapstructure:"interface_configs"`
 
 	PingConfig snmpintegration.PingConfig `mapstructure:"ping"`
+
+	UseRemoteConfigProfilesConfig *bool `mapstructure:"use_remote_config_profiles"`
+	UseRemoteConfigProfiles       bool
 
 	// Legacy
 	NetworkLegacy      string `mapstructure:"network"`
@@ -173,12 +175,6 @@ func NewListenerConfig() (ListenerConfig, error) {
 			config.CollectVPN = snmpConfig.CollectVPN
 		}
 
-		if config.UseDeviceIDAsHostnameConfig != nil {
-			config.UseDeviceIDAsHostname = *config.UseDeviceIDAsHostnameConfig
-		} else {
-			config.UseDeviceIDAsHostname = snmpConfig.UseDeviceISAsHostname
-		}
-
 		if config.Loader == "" {
 			config.Loader = snmpConfig.Loader
 		}
@@ -228,6 +224,12 @@ func NewListenerConfig() (ListenerConfig, error) {
 			if config.Authentications[authIndex].Retries == 0 {
 				config.Authentications[authIndex].Retries = defaultRetries
 			}
+		}
+
+		if config.UseRemoteConfigProfilesConfig != nil {
+			config.UseRemoteConfigProfiles = *config.UseRemoteConfigProfilesConfig
+		} else {
+			config.UseRemoteConfigProfiles = snmpConfig.UseRemoteConfigProfiles
 		}
 	}
 	return snmpConfig, nil


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue where the snmp autodiscovery does not use `use_remote_config_profiles` config
it also allows to configure it at the instance level

### Motivation

### Describe how you validated your changes

### Additional Notes
