### PR TITLE
[Backport 7.71.x][AGENTRUN-724] Scrub JMX metadata before sending payload

### DIFF
--- a/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
-	"github.com/DataDog/datadog-agent/pkg/status/jmx"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"

--- a/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go
@@ -14,6 +14,8 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
+	"github.com/DataDog/datadog-agent/pkg/status/jmx"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 )
@@ -36,6 +38,15 @@ func (ic *inventorychecksImpl) getJMXChecksMetadata() (jmxMetadata map[string][]
 				ic.log.Warnf("could not marshal JMX init_config for %s: %v", jmxName, err)
 				continue
 			}
+
+			// Scrub the init_config YAML
+			scrubbedInitConfigYaml, err := scrubber.ScrubYaml(initConfigYaml)
+			if err != nil {
+				ic.log.Warnf("could not scrub JMX init_config for %s: %v", jmxName, err)
+				// Return early if scrubbing fails to avoid sending unscrubbed data
+				continue
+			}
+
 			instances := jmxIntegration["instances"].([]integration.JSONMap)
 			for _, instance := range instances {
 				configHash := jmxName
@@ -45,6 +56,15 @@ func (ic *inventorychecksImpl) getJMXChecksMetadata() (jmxMetadata map[string][]
 					ic.log.Warnf("could not marshal JMX instance config for %s: %v", jmxName, err)
 					continue
 				}
+
+				// Scrub the instance YAML
+				scrubbedInstanceYaml, err := scrubber.ScrubYaml(instanceYaml)
+				if err != nil {
+					ic.log.Warnf("could not scrub JMX instance config for %s: %v", jmxName, err)
+					// Continue to next instance if scrubbing fails in order to avoid sending unscrubbed data
+					continue
+				}
+
 				if instance["name"] != nil {
 					configHash = fmt.Sprintf("%s:%s", jmxName, fmt.Sprint(instance["name"]))
 				}
@@ -60,8 +80,8 @@ func (ic *inventorychecksImpl) getJMXChecksMetadata() (jmxMetadata map[string][]
 				}
 
 				jmxMetadata[jmxName] = append(jmxMetadata[jmxName], metadata{
-					"init_config":     string(initConfigYaml),
-					"instance":        string(instanceYaml),
+					"init_config":     string(scrubbedInitConfigYaml),
+					"instance":        string(scrubbedInstanceYaml),
 					"config.provider": provider,
 					"config.hash":     configHash,
 					"config.source":   source,

--- a/pkg/util/scrubber/json_scrubber_test.go
+++ b/pkg/util/scrubber/json_scrubber_test.go
@@ -48,6 +48,11 @@ func TestScrubJSON(t *testing.T) {
 			input:    []byte(`{}`),
 			expected: []byte(`{}`),
 		},
+		{
+			name:     "complex config with password and tags",
+			input:    []byte(`{"host": "localhost", "password": "secret123", "port": 9003, "tags": ["service: api", "partner: aa", "stage: prod", "source: tomcat-jmx"], "user": "admin"}`),
+			expected: []byte(`{"host": "localhost", "password": "********", "port": 9003, "tags": ["service: api", "partner: aa", "stage: prod", "source: tomcat-jmx"], "user": "admin"}`),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/releasenotes/notes/add-jmx-scrubber-74fb937da5e19378.yaml
+++ b/releasenotes/notes/add-jmx-scrubber-74fb937da5e19378.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add scrubber to JMX integration config and metadata.


### PR DESCRIPTION
### What does this PR do?

This PR aims to scrub JMX metadatas and config before sending them to Datadog

### Motivation

#incident-43053

### Describe how you validated your changes

CI

### Additional Notes
