### PR TITLE
fix(check_issue_status): Add missing return

### DIFF
--- a/.github/workflows/check_issue_status.yml
+++ b/.github/workflows/check_issue_status.yml
@@ -37,6 +37,7 @@ jobs:
                 throw error;
               }
             }
+            return commented;
       - name: Remove the pending label when issue is commented
         if: steps.datadog-comment.outputs.result == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
### What does this PR do?
The removal of the `pending` label depends of the output of the first step. This step was missing its return directive, so the workflow is currently [ineffficient](https://github.com/DataDog/datadog-agent/actions/runs/17976713066/job/51131912176?pr=41129).

### Motivation
Fix the workflow

### Describe how you validated your changes
Local validation with a `node` execution of the script

### Additional Notes
