### PR TITLE
[CWS] handle correctly md5sums files with just one space

### DIFF
--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -180,10 +180,16 @@ func (s *dpkgScanner) parseInfoFile(root *os.Root, path string) ([]string, error
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		_, installedPath, ok := strings.Cut(scanner.Text(), "  ")
+		// according to the doc the md5sums file are formatted as:
+		// <md5sum><2 spaces><path>
+		// https: //man7.org/linux/man-pages/man5/deb-md5sums.5.html
+		// but some files have a single space, especially mongodb-database-tools
+		// so we cut on the first space and then trim the path
+		_, installedPath, ok := strings.Cut(scanner.Text(), " ")
 		if !ok {
 			return nil, fmt.Errorf("failed to parse installed file line, bad format")
 		}
+		installedPath = strings.TrimSpace(installedPath)
 		installedFiles = append(installedFiles, "/"+installedPath)
 	}
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue when parsing the `mongodb-database-tools.md5sums` file in SBOM collector v2. Those files are slightly malformed, and while [trivy doesn't parse them correctly](https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/analyzer/pkg/dpkg/dpkg.go#L131) we can handle them correctly in the collector v2.

This was visible internally with the following log:
```
2025-09-24 12:35:03 UTC | SYS-PROBE | WARN | (pkg/security/resolvers/sbom/collectorv2/dpkg.go:159 in listInstalledFilesFromDir) | failed to parse dpkg info file (mongodb-database-tools.md5sums): failed to parse installed file line, bad format
```

### Motivation

### Describe how you validated your changes

### Additional Notes
