### PR TITLE
[trace-agent] Remove deprecated http client config

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -417,8 +417,6 @@ type AgentConfig struct {
 	// case, the sender will drop failed payloads when it is unable to enqueue
 	// them for another retry.
 	MaxSenderRetries int
-	// HTTP client used in writer connections. If nil, default client values will be used.
-	HTTPClientFunc func() *http.Client `json:"-"`
 	// HTTP Transport used in writer connections. If nil, default transport values will be used.
 	HTTPTransportFunc func() *http.Transport `json:"-"`
 	// ClientStatsFlushInterval specifies the frequency at which the client stats aggregator will flush its buffer.
@@ -694,10 +692,6 @@ func (c *AgentConfig) UpdateAPIKey(val string) {
 // NewHTTPClient returns a new http.Client to be used for outgoing connections to the
 // Datadog API.
 func (c *AgentConfig) NewHTTPClient() *ResetClient {
-	// If a custom HTTPClientFunc been set, use it. Otherwise use default client values
-	if c.HTTPClientFunc != nil {
-		return NewResetClient(c.ConnectionResetInterval, c.HTTPClientFunc)
-	}
 	return NewResetClient(c.ConnectionResetInterval, func() *http.Client {
 		return &http.Client{
 			Timeout:   10 * time.Second,


### PR DESCRIPTION
### What does this PR do?
Work for https://datadoghq.atlassian.net/browse/APMSP-1715

Related datadog-exporter PR (merged): https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42896

Remove HTTPClientFunc from trace-agent configuration. This setting was deprecated in favor of HTTPTransportFunc, which is now used in both the trace-agent and the OTel exporter. It is safe to remove it from the codebase.

### Motivation
See above

### Describe how you validated your changes
Existing tests. This setting is unused.

### Additional Notes
