### PR TITLE
Make tags on tests and their utils match

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/local/recommender_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build kubeapiserver
+//go:build kubeapiserver && test
 
 package local
 

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build kubeapiserver
+//go:build kubeapiserver && test
 
 package local
 


### PR DESCRIPTION
With tags on tests different than those on test utils its possible to attempt to run tests with utils excluded from the build which will test to fail to compile

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
