### PR TITLE
[OTAGENT-544] Infrattributes processor profile

### DIFF
--- a/comp/otelcol/ddflareextension/impl/testdata/simple-dd/config-enhanced-result.yaml
+++ b/comp/otelcol/ddflareextension/impl/testdata/simple-dd/config-enhanced-result.yaml
@@ -107,12 +107,6 @@ processors:
   infraattributes/dd-autoconfigured:
     allow_hostname_override: false
     cardinality: 0
-    logs:
-      log: []
-    metrics:
-      metric: []
-    traces:
-      span: []
 receivers:
   otlp:
     protocols:

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.go
@@ -13,9 +13,10 @@ import (
 
 // Config defines configuration for processor.
 type Config struct {
-	Metrics MetricInfraAttributes `mapstructure:"metrics"`
-	Logs    LogInfraAttributes    `mapstructure:"logs"`
-	Traces  TraceInfraAttributes  `mapstructure:"traces"`
+	Metrics  MetricInfraAttributes  `mapstructure:"metrics"`
+	Logs     LogInfraAttributes     `mapstructure:"logs"`
+	Traces   TraceInfraAttributes   `mapstructure:"traces"`
+	Profiles ProfileInfraAttributes `mapstructure:"profiles"`
 
 	Cardinality           types.TagCardinality `mapstructure:"cardinality"`
 	AllowHostnameOverride bool                 `mapstructure:"allow_hostname_override"`
@@ -34,6 +35,11 @@ type TraceInfraAttributes struct {
 // LogInfraAttributes - configuration for logs.
 type LogInfraAttributes struct {
 	LogInfraAttributes []string `mapstructure:"log"`
+}
+
+// ProfileInfraAttributes - configuration for profiles.
+type ProfileInfraAttributes struct {
+	ProfileInfraAttributes []string `mapstructure:"profile"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/config.go
@@ -13,33 +13,8 @@ import (
 
 // Config defines configuration for processor.
 type Config struct {
-	Metrics  MetricInfraAttributes  `mapstructure:"metrics"`
-	Logs     LogInfraAttributes     `mapstructure:"logs"`
-	Traces   TraceInfraAttributes   `mapstructure:"traces"`
-	Profiles ProfileInfraAttributes `mapstructure:"profiles"`
-
 	Cardinality           types.TagCardinality `mapstructure:"cardinality"`
 	AllowHostnameOverride bool                 `mapstructure:"allow_hostname_override"`
-}
-
-// MetricInfraAttributes - configuration for metrics.
-type MetricInfraAttributes struct {
-	MetricInfraAttributes []string `mapstructure:"metric"`
-}
-
-// TraceInfraAttributes - configuration for trace spans.
-type TraceInfraAttributes struct {
-	SpanInfraAttributes []string `mapstructure:"span"`
-}
-
-// LogInfraAttributes - configuration for logs.
-type LogInfraAttributes struct {
-	LogInfraAttributes []string `mapstructure:"log"`
-}
-
-// ProfileInfraAttributes - configuration for profiles.
-type ProfileInfraAttributes struct {
-	ProfileInfraAttributes []string `mapstructure:"profile"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/config_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/config_test.go
@@ -7,9 +7,10 @@ package infraattributesprocessor
 
 import (
 	"context"
-	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,10 +29,8 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id: component.MustNewIDWithName("filter", "empty"),
-			expected: &Config{
-				Logs: LogInfraAttributes{},
-			},
+			id:       component.MustNewIDWithName("filter", "empty"),
+			expected: &Config{},
 		},
 	}
 

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
@@ -17,8 +17,11 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper"
+	"go.opentelemetry.io/collector/processor/xprocessor"
 
 	logfx "github.com/DataDog/datadog-agent/comp/core/log/fx"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -86,23 +89,24 @@ func NewFactory() processor.Factory {
 type SourceProviderFunc func(context.Context) (string, error)
 
 // NewFactoryForAgent returns a new factory for the InfraAttributes processor.
-func NewFactoryForAgent(tagger taggerTypes.TaggerClient, hostGetter SourceProviderFunc) processor.Factory {
+func NewFactoryForAgent(tagger taggerTypes.TaggerClient, hostGetter SourceProviderFunc) xprocessor.Factory {
 	return newFactoryForAgent(&data{
 		infraTags: newInfraTagsProcessor(tagger, option.New(hostGetter)),
 	})
 }
 
-func newFactoryForAgent(data *data) processor.Factory {
+func newFactoryForAgent(data *data) xprocessor.Factory {
 	f := &factory{
 		data: data,
 	}
 
-	return processor.NewFactory(
+	return xprocessor.NewFactory(
 		Type,
 		f.createDefaultConfig,
-		processor.WithMetrics(f.createMetricsProcessor, MetricsStability),
-		processor.WithLogs(f.createLogsProcessor, LogsStability),
-		processor.WithTraces(f.createTracesProcessor, TracesStability),
+		xprocessor.WithMetrics(f.createMetricsProcessor, MetricsStability),
+		xprocessor.WithLogs(f.createLogsProcessor, LogsStability),
+		xprocessor.WithTraces(f.createTracesProcessor, TracesStability),
+		xprocessor.WithProfiles(f.createProfilesProcessor, ProfilesStability),
 	)
 }
 
@@ -180,4 +184,27 @@ func (f *factory) createTracesProcessor(
 		nextConsumer,
 		iap.processTraces,
 		processorhelper.WithCapabilities(processorCapabilities))
+}
+
+func (f *factory) createProfilesProcessor(
+	ctx context.Context,
+	set processor.Settings,
+	cfg component.Config,
+	nextConsumer xconsumer.Profiles,
+) (xprocessor.Profiles, error) {
+	data, err := f.getOrCreateData()
+	if err != nil {
+		return nil, err
+	}
+	iap, err := newInfraAttributesProfileProcessor(set, data.infraTags, cfg.(*Config))
+	if err != nil {
+		return nil, err
+	}
+	return xprocessorhelper.NewProfiles(
+		ctx,
+		set,
+		cfg,
+		nextConsumer,
+		iap.processProfiles,
+		xprocessorhelper.WithCapabilities(processorCapabilities))
 }

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.mod
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.mod
@@ -23,10 +23,14 @@ require (
 	go.opentelemetry.io/collector/confmap/xconfmap v0.135.0
 	go.opentelemetry.io/collector/consumer v1.41.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.135.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.135.0
 	go.opentelemetry.io/collector/pdata v1.41.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.135.0
 	go.opentelemetry.io/collector/processor v1.41.0
 	go.opentelemetry.io/collector/processor/processorhelper v0.135.0
+	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.135.0
 	go.opentelemetry.io/collector/processor/processortest v0.135.0
+	go.opentelemetry.io/collector/processor/xprocessor v0.135.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/metric v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
@@ -148,13 +152,10 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.135.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.135.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.41.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.135.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.135.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.135.0 // indirect
 	go.opentelemetry.io/collector/pipeline v1.41.0 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.135.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.12.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 // indirect
 	go.opentelemetry.io/otel/log v0.14.0 // indirect

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.sum
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.sum
@@ -333,6 +333,8 @@ go.opentelemetry.io/collector/processor v1.41.0 h1:LDQyPBP/fl7BujDzShYTywDe4GmOj
 go.opentelemetry.io/collector/processor v1.41.0/go.mod h1:NwY+XSP3sDxCVJ8aB9PkP8ahJmp6GAtq1JwyXu9M318=
 go.opentelemetry.io/collector/processor/processorhelper v0.135.0 h1:N9yoAK3gAWIC1WCeIuUo0QxitfJ5DBnx6HgfB3mNgzA=
 go.opentelemetry.io/collector/processor/processorhelper v0.135.0/go.mod h1:NRR2TkqrizlOumQg9Ai4cvtJjprAV2QS/VefrCR+F8w=
+go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.135.0 h1:RQ2Zojw/f68prZl3p5pecTGnV4rbwAao2CbCmCdbOws=
+go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.135.0/go.mod h1:3ST+gfAvfFuK/dkM35hSDiyxhFSLtLIaziuga4wKNLo=
 go.opentelemetry.io/collector/processor/processortest v0.135.0 h1:sq5fZVp1RRoKzG10ZdRRKh/LawmyR2iHUudnHkmBaZY=
 go.opentelemetry.io/collector/processor/processortest v0.135.0/go.mod h1:+tmZUAZmR833IgJi0+QOexrtOWTEG/5Oidv8zPUMYOU=
 go.opentelemetry.io/collector/processor/xprocessor v0.135.0 h1:BPxzWElfiLXcL1sUmvNDSRXsYmcopY8ajBpuERm0jx4=

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs_test.go
@@ -184,7 +184,6 @@ func TestInfraAttributesLogProcessor(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			next := new(consumertest.LogsSink)
 			cfg := &Config{
-				Logs:        LogInfraAttributes{},
 				Cardinality: types.LowCardinality,
 			}
 			tc := testutil.NewTestTaggerClient()

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metadata.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metadata.go
@@ -23,6 +23,8 @@ const (
 	MetricsStability = component.StabilityLevelAlpha
 	// LogsStability - stability level for logs.
 	LogsStability = component.StabilityLevelAlpha
+	// ProfilesStability - stability level for profiles.
+	ProfilesStability = component.StabilityLevelAlpha
 )
 
 // Meter for infra attributes processor.

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics_test.go
@@ -188,7 +188,6 @@ func TestInfraAttributesMetricProcessor(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			next := new(consumertest.MetricsSink)
 			cfg := &Config{
-				Metrics:     MetricInfraAttributes{},
 				Cardinality: types.LowCardinality,
 			}
 			tc := testutil.NewTestTaggerClient()

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/profiles.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/profiles.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package infraattributesprocessor implements the same logic for profiles as metrics and traces.
+package infraattributesprocessor
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+)
+
+type infraAttributesProfileProcessor struct {
+	infraTags   infraTagsProcessor
+	logger      *zap.Logger
+	cardinality types.TagCardinality
+	cfg         *Config
+}
+
+func newInfraAttributesProfileProcessor(
+	set processor.Settings,
+	infraTags infraTagsProcessor,
+	cfg *Config,
+) (*infraAttributesProfileProcessor, error) {
+	iapp := &infraAttributesProfileProcessor{
+		infraTags:   infraTags,
+		logger:      set.Logger,
+		cardinality: cfg.Cardinality,
+		cfg:         cfg,
+	}
+	set.Logger.Info("Profile Infra Attributes Processor configured")
+	return iapp, nil
+}
+
+func (iapp *infraAttributesProfileProcessor) processProfiles(_ context.Context, pd pprofile.Profiles) (pprofile.Profiles, error) {
+	rps := pd.ResourceProfiles()
+	for i := 0; i < rps.Len(); i++ {
+		resourceAttributes := rps.At(i).Resource().Attributes()
+		iapp.infraTags.ProcessTags(iapp.logger, iapp.cardinality, resourceAttributes, iapp.cfg.AllowHostnameOverride)
+	}
+	return pd, nil
+}

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/profiles_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/profiles_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package infraattributesprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/processor/processortest"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+)
+
+func TestInfraAttributesProfileProcessor(t *testing.T) {
+	cfg := &Config{
+		Profiles:              ProfileInfraAttributes{},
+		Cardinality:           types.LowCardinality,
+		AllowHostnameOverride: true,
+	}
+
+	factory := NewFactoryForAgent(testutil.NewTestTaggerClient(), func(_ context.Context) (string, error) { return "test-host", nil })
+	next := new(consumertest.ProfilesSink)
+	fpp, err := factory.CreateProfiles(context.Background(), processortest.NewNopSettings(Type), cfg, next)
+	require.NoError(t, err)
+	require.NoError(t, fpp.Start(context.Background(), nil))
+
+	profiles := pprofile.NewProfiles()
+	profiles.ResourceProfiles().AppendEmpty().Resource().Attributes().FromRaw(map[string]any{})
+	fpp.ConsumeProfiles(context.Background(), profiles)
+	require.NoError(t, fpp.Shutdown(context.Background()))
+
+	require.Len(t, next.AllProfiles(), 1)
+	require.EqualValues(t, map[string]any{"datadog.host.name": "test-host"}, next.AllProfiles()[0].ResourceProfiles().At(0).Resource().Attributes().AsRaw())
+
+}

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/profiles_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/profiles_test.go
@@ -21,7 +21,6 @@ import (
 
 func TestInfraAttributesProfileProcessor(t *testing.T) {
 	cfg := &Config{
-		Profiles:              ProfileInfraAttributes{},
 		Cardinality:           types.LowCardinality,
 		AllowHostnameOverride: true,
 	}

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/testdata/logs_strict.yaml
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/testdata/logs_strict.yaml
@@ -3,7 +3,4 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2024-present Datadog, Inc.
 
-infraattributes/empty:
-  logs:
-    log:
-      - aa
+infraattributes/empty: {}

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/traces_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/traces_test.go
@@ -184,7 +184,6 @@ func TestInfraAttributesTraceProcessor(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			next := new(consumertest.TracesSink)
 			cfg := &Config{
-				Traces:      TraceInfraAttributes{},
 				Cardinality: types.LowCardinality,
 			}
 			tc := testutil.NewTestTaggerClient()

--- a/test/new-e2e/tests/otel/otel-agent/testdata/minimal-full-config.yml
+++ b/test/new-e2e/tests/otel/otel-agent/testdata/minimal-full-config.yml
@@ -124,12 +124,6 @@ processors:
   infraattributes/dd-autoconfigured:
     allow_hostname_override: false
     cardinality: 0
-    logs:
-      log: []
-    metrics:
-      metric: []
-    traces:
-      span: []
   filter/drop-prometheus-internal-metrics/dd-autoconfigured:
     error_mode: propagate
     logs:


### PR DESCRIPTION
### What does this PR do?

This PR adds the support of profile signal  to infra attribute processor.
It also removes unused fields in [infraattributesprocessor/config.go](https://github.com/DataDog/datadog-agent/pull/41233/files#diff-61b15c52c94ee44d71da5a6a15fc6dc57a710a81e82c5ca3b2422648f51d475bL16-L19)

### Motivation

### Describe how you validated your changes
Ran the host profiler with the code of this PR.


### Additional Notes
