### PR TITLE
Fix tagger error logs for kubelet entity (#41199)

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -128,8 +128,7 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 		switch ev.Type {
 		case workloadmeta.EventTypeSet:
 
-			if entityID.Kind == workloadmeta.KindKubeletMetrics ||
-				entityID.Kind == workloadmeta.KindKubelet {
+			if entityID.Kind == workloadmeta.KindKubelet {
 				// No tags. Ignore
 				continue
 			}

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -127,6 +127,13 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 
 		switch ev.Type {
 		case workloadmeta.EventTypeSet:
+
+			if entityID.Kind == workloadmeta.KindKubeletMetrics ||
+				entityID.Kind == workloadmeta.KindKubelet {
+				// No tags. Ignore
+				continue
+			}
+
 			taggerEntityID := common.BuildTaggerEntityID(entityID)
 
 			// keep track of children of this entity from previous

--- a/comp/core/tagger/common/entity_id_builder.go
+++ b/comp/core/tagger/common/entity_id_builder.go
@@ -31,6 +31,8 @@ func BuildTaggerEntityID(entityID workloadmeta.EntityID) types.EntityID {
 		return types.NewEntityID(types.KubernetesMetadata, entityID.ID)
 	case workloadmeta.KindGPU:
 		return types.NewEntityID(types.GPU, entityID.ID)
+	case workloadmeta.KindKubelet:
+		return types.NewEntityID(types.Kubelet, entityID.ID)
 	default:
 		log.Errorf("can't recognize entity %q with kind %q; trying %s://%s as tagger entity",
 			entityID.ID, entityID.Kind, entityID.ID, entityID.Kind)


### PR DESCRIPTION
The kubelet entity is currently only used to generate a tag on kubernetes check metrics, it has no tags of its own.

(cherry picked from commit 34f0e21351effc42274a6054232898ef040cf808)

### What does this PR do?
Fixes the error logs that occur when trying to build the kubelet's tagger entity ID

### Motivation
Reduce error logs

### Describe how you validated your changes
1. Deploy RC 7 and run `agent check kubelet` to kickoff the workloadmeta kubelet collector
```
root@justin-lesko-minikube:/# agent check kubelet | grep "kubelet-id"
2025-09-23 19:05:49 UTC | CORE | ERROR | (comp/core/tagger/common/entity_id_builder.go:35 in BuildTaggerEntityID) | can't recognize entity "kubelet-id" with kind "kubelet"; trying kubelet-id://kubelet as tagger entity
2025-09-23 19:05:49 UTC | CORE | ERROR | (comp/core/tagger/collectors/workloadmeta_extract.go:161 in processEvents) | cannot handle event for entity "kubelet-id" with kind "kubelet"
```

2. Deploy this branch and observe no more errors
```
root@justin-lesko-minikube:/# agent check kubelet | grep "kubelet-id"
root@justin-lesko-minikube:/#
```

### Additional Notes
