### PR TITLE
Merge node trees more efficiently in nodetreemodel

### DIFF
--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -573,3 +573,42 @@ my_feature:
 		assert.Equal(t, []string{"enabled", "name", "targets", "version"}, fields)
 	})
 }
+
+func TestInvalidFileData(t *testing.T) {
+	configData := `
+fruit:
+  apple:
+  banana:
+  cherry:
+  donut:
+    dozen: 12
+`
+
+	t.Setenv("DD_FRUIT_CHERRY_SEED_NUM", "5")
+	viperConf, ntmConf := constructBothConfigs(configData, false, func(cfg model.Setup) {
+		cfg.BindEnvAndSetDefault("fruit.apple.core.seeds", 2) // default wins over invalid file
+		cfg.BindEnv("fruit.banana.peel.color")                // file only (missing default)
+		cfg.BindEnv("fruit.cherry.seed.num")                  // env wins over file
+	})
+
+	expectAppleMap := map[string]interface{}{
+		"core": map[string]interface{}{
+			"seeds": 2,
+		},
+	}
+
+	assert.Equal(t, expectAppleMap, viperConf.Get("fruit.apple"))
+	assert.Equal(t, nil, viperConf.Get("fruit.banana"))
+	assert.Equal(t, 2, viperConf.GetInt("fruit.apple.core.seeds"))
+	assert.Equal(t, "", viperConf.GetString("fruit.banana.peel.color"))
+	assert.Equal(t, 5, viperConf.GetInt("fruit.cherry.seed.num"))
+	assert.Equal(t, 12, viperConf.GetInt("fruit.donut.dozen"))
+
+	assert.Equal(t, expectAppleMap, ntmConf.Get("fruit.apple"))
+	assert.Equal(t, nil, ntmConf.Get("fruit.banana"))
+	assert.Equal(t, 2, ntmConf.GetInt("fruit.apple.core.seeds"))
+	assert.Equal(t, "", ntmConf.GetString("fruit.banana.peel.color"))
+	assert.Equal(t, 5, ntmConf.GetInt("fruit.cherry.seed.num"))
+	// TODO: difference, unknown key doesn't get stored
+	assert.Equal(t, 0, ntmConf.GetInt("fruit.donut.dozen"))
+}

--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -586,9 +586,14 @@ fruit:
 
 	t.Setenv("DD_FRUIT_CHERRY_SEED_NUM", "5")
 	viperConf, ntmConf := constructBothConfigs(configData, false, func(cfg model.Setup) {
-		cfg.BindEnvAndSetDefault("fruit.apple.core.seeds", 2) // default wins over invalid file
-		cfg.BindEnv("fruit.banana.peel.color")                // file only (missing default)
-		cfg.BindEnv("fruit.cherry.seed.num")                  // env wins over file
+		// default wins over invalid file
+		cfg.BindEnvAndSetDefault("fruit.apple.core.seeds", 2)
+
+		// file only (missing default)
+		cfg.BindEnv("fruit.banana.peel.color") //nolint:forbidigo // legit usage, testing compatibility with viper
+
+		// env wins over file
+		cfg.BindEnv("fruit.cherry.seed.num") //nolint:forbidigo // legit usage, testing compatibility with viper
 	})
 
 	expectAppleMap := map[string]interface{}{

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -242,8 +242,7 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 func (c *ntmConfig) insertValueIntoTree(key string, value interface{}, source model.Source) (Node, error) {
 	tree, err := c.getTreeBySource(source)
 	if err != nil {
-		log.Errorf("Set invalid source: %s", source)
-		return nil, fmt.Errorf("invalid source: %s", source)
+		return nil, log.Errorf("Set invalid source: %s", source)
 	}
 
 	parts := splitKey(key)

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -152,13 +152,14 @@ func (c *ntmConfig) OnUpdate(callback model.NotificationReceiver) {
 
 func (c *ntmConfig) addToSchema(key string, source model.Source) {
 	parts := splitKey(key)
-	_, _ = c.schema.SetAt(parts, nil, source)
-
+	_ = c.schema.SetAt(parts, nil, source)
 	c.addToKnownKeys(key)
 }
 
 func (c *ntmConfig) getTreeBySource(source model.Source) (InnerNode, error) {
 	switch source {
+	case "root":
+		return c.root, nil
 	case model.SourceDefault:
 		return c.defaults, nil
 	case model.SourceUnknown:
@@ -178,7 +179,7 @@ func (c *ntmConfig) getTreeBySource(source model.Source) (InnerNode, error) {
 	case model.SourceCLI:
 		return c.cli, nil
 	}
-	return nil, fmt.Errorf("invalid source tree: %s", source)
+	return nil, fmt.Errorf("invalid source: %s", source)
 }
 
 // SetTestOnlyDynamicSchema allows more flexible usage of the config, should only be used by tests
@@ -196,15 +197,12 @@ func (c *ntmConfig) RevertFinishedBackToBuilder() model.BuildableConfig {
 
 // Set assigns the newValue to the given key and marks it as originating from the given source
 func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
+	c.Lock()
+	defer c.Unlock()
+
 	c.maybeRebuild()
 
-	tree, err := c.getTreeBySource(source)
-	if err != nil {
-		log.Errorf("Set invalid source: %s", source)
-		return
-	}
-
-	if !c.IsKnown(key) {
+	if !c.isKnownKey(key) {
 		if c.allowDynamicSchema.Load() {
 			log.Errorf("set value for unknown key '%s'", key)
 		} else {
@@ -215,26 +213,21 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 	// convert the key to lower case for the logs line and the notification
 	key = strings.ToLower(key)
 
-	c.Lock()
-	defer c.Unlock()
 	previousValue := c.leafAtPathFromNode(key, c.root).Get()
 
-	parts := splitKey(key)
-
-	_, err = tree.SetAt(parts, newValue, source)
+	newTree, err := c.insertValueIntoTree(key, newValue, source)
 	if err != nil {
-		log.Errorf("could not set '%s' invalid key: %s", key, err)
-	}
-
-	updated, err := c.root.SetAt(parts, newValue, source)
-	if err != nil {
-		log.Errorf("could not set '%s' invalid key: %s", key, err)
+		log.Errorf("could not insert value: %s", err)
+		return
+	} else if newTree != nil {
+		// a new node was allocated, merge it into root
+		c.root, _ = c.root.Merge(newTree.(InnerNode))
 	}
 
 	receivers := slices.Clone(c.notificationReceivers)
 
 	// if no value has changed we don't notify
-	if !updated || reflect.DeepEqual(previousValue, newValue) {
+	if reflect.DeepEqual(previousValue, newValue) {
 		return
 	}
 
@@ -244,7 +237,18 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 	for _, receiver := range receivers {
 		receiver(key, source, previousValue, newValue, c.sequenceID)
 	}
+}
 
+func (c *ntmConfig) insertValueIntoTree(key string, value interface{}, source model.Source) (Node, error) {
+	tree, err := c.getTreeBySource(source)
+	if err != nil {
+		log.Errorf("Set invalid source: %s", source)
+		return nil, fmt.Errorf("invalid source: %s", source)
+	}
+
+	parts := splitKey(key)
+	err = tree.SetAt(parts, value, source)
+	return tree, err
 }
 
 // SetWithoutSource assigns the value to the given key using source Unknown, may only be called from tests
@@ -282,7 +286,7 @@ func (c *ntmConfig) SetDefault(key string, value interface{}) {
 	parts := splitKey(key)
 	// TODO: Ensure that for default tree, setting nil to a node will not override
 	// an existing value
-	_, _ = c.defaults.SetAt(parts, value, model.SourceDefault)
+	_ = c.defaults.SetAt(parts, value, model.SourceDefault)
 }
 
 func (c *ntmConfig) findPreviousSourceNode(key string, source model.Source) (Node, error) {
@@ -468,15 +472,16 @@ func (c *ntmConfig) mergeAllLayers() error {
 		c.cli,
 	}
 
-	root := newInnerNode(nil)
+	var merged InnerNode = newInnerNode(nil)
 	for _, tree := range treeList {
-		err := root.Merge(tree)
+		next, err := merged.Merge(tree)
 		if err != nil {
 			return err
 		}
+		merged = next
 	}
 
-	c.root = root
+	c.root = merged
 	// recompile allSettings now that we have the full config
 	c.allSettings = c.computeAllSettings("")
 	return nil
@@ -573,14 +578,13 @@ func (c *ntmConfig) buildEnvVars() {
 
 func (c *ntmConfig) insertNodeFromString(curr InnerNode, key string, envval string) error {
 	var actualValue interface{} = envval
-	// TODO: When the nodetreemodel config is further along, we should get the default[key] node
-	// and use its type to convert the envval into something appropriate.
+	// TODO: When nodetreemodel has a schema with type information, we should
+	// use this type to convert the value, instead of requiring a transformer
 	if transformer, found := c.envTransform[key]; found {
 		actualValue = transformer(envval)
 	}
 	parts := splitKeyFunc(key)
-	_, err := curr.SetAt(parts, actualValue, model.SourceEnvVar)
-	return err
+	return curr.SetAt(parts, actualValue, model.SourceEnvVar)
 }
 
 // ParseEnvAsStringSlice registers a transform function to parse an environment variable as a []string.
@@ -625,10 +629,10 @@ func (c *ntmConfig) ParseEnvAsSlice(key string, fn func(string) []interface{}) {
 
 // IsSet checks if a key is set in the config
 func (c *ntmConfig) IsSet(key string) bool {
-	c.maybeRebuild()
-
 	c.RLock()
 	defer c.RUnlock()
+
+	c.maybeRebuild()
 
 	if !c.isReady() && !c.allowDynamicSchema.Load() {
 		log.Errorf("attempt to read key before config is constructed: %s", key)
@@ -814,7 +818,12 @@ func (c *ntmConfig) MergeConfig(in io.Reader) error {
 		return err
 	}
 
-	return c.root.Merge(other)
+	merged, err := c.root.Merge(other)
+	if err != nil {
+		return err
+	}
+	c.root = merged
+	return nil
 }
 
 // MergeFleetPolicy merges the configuration from the reader given with an existing config
@@ -849,7 +858,12 @@ func (c *ntmConfig) MergeFleetPolicy(configPath string) error {
 		return err
 	}
 
-	return c.root.Merge(other)
+	merged, err := c.root.Merge(other)
+	if err != nil {
+		return err
+	}
+	c.root = merged
+	return nil
 }
 
 // AllSettings returns all settings from the config

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -1603,9 +1603,12 @@ fruit:
     12
 `
 	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
-	cfg.BindEnvAndSetDefault("fruit.apple.core.seeds", 2) // file wins over default
-	cfg.BindEnv("fruit.banana.peel.color")                // file only (missing default)
-	cfg.BindEnv("fruit.cherry.seed.num")                  // env wins over file
+	// default wins over invalid file
+	cfg.BindEnvAndSetDefault("fruit.apple.core.seeds", 2)
+	// file only (missing default)
+	cfg.BindEnv("fruit.banana.peel.color") //nolint:forbidigo // legit usage, testing compatibility with viper
+	// env wins over file
+	cfg.BindEnv("fruit.cherry.seed.num") //nolint:forbidigo // legit usage, testing compatibility with viper
 	t.Setenv("TEST_FRUIT_CHERRY_SEED_NUM", "1")
 	cfg.BuildSchema()
 

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -45,8 +45,8 @@ func TestBuildDefaultFileAndEnv(t *testing.T) {
     workers: 6
 secret_backend_command: ./my_secret_fetcher.sh
 `
-	os.Setenv("TEST_SECRET_BACKEND_TIMEOUT", "60")
-	os.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
+	t.Setenv("TEST_SECRET_BACKEND_TIMEOUT", "60")
+	t.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
 
 	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
 	cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 100000)
@@ -241,6 +241,23 @@ func TestSetLowerSource(t *testing.T) {
 
 	assert.Equal(t, 1, cfg.Get("setting"))
 	assert.Equal(t, model.SourceAgentRuntime, cfg.GetSource("setting"))
+
+	// Validate that the file layer was modified by Set, but it gets
+	// shadowed by the higher priority value from agent-runtime in the root
+	txt := cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> setting
+    leaf(#ptr<000001>), val:1, source:agent-runtime
+tree(#ptr<000002>) source=default
+> setting
+    leaf(#ptr<000003>), val:0, source:default
+tree(#ptr<000004>) source=file
+> setting
+    leaf(#ptr<000005>), val:2, source:file
+tree(#ptr<000006>) source=agent-runtime
+> setting
+    leaf(#ptr<000001>), val:1, source:agent-runtime`
+	assert.Equal(t, expect, txt)
 }
 
 func TestSetUnkownKey(t *testing.T) {
@@ -422,8 +439,8 @@ func TestStringifyLayers(t *testing.T) {
     workers: 6
 secret_backend_command: ./my_secret_fetcher.sh
 `
-	os.Setenv("TEST_SECRET_BACKEND_TIMEOUT", "60")
-	os.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
+	t.Setenv("TEST_SECRET_BACKEND_TIMEOUT", "60")
+	t.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
 
 	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
 	cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 100000)
@@ -492,17 +509,17 @@ secret_backend_command: ./my_secret_fetcher.sh
   > collector
     inner(#ptr<000021>)
     > input_chan_size
-        leaf(#ptr<000022>), val:"23456", source:environment-variable
+        leaf(#ptr<000017>), val:"23456", source:environment-variable
     > processing_chan_size
-        leaf(#ptr<000023>), val:100000, source:default
+        leaf(#ptr<000004>), val:100000, source:default
     > workers
-        leaf(#ptr<000024>), val:6, source:file
+        leaf(#ptr<000012>), val:6, source:file
 > secret_backend_command
-    leaf(#ptr<000025>), val:"./my_secret_fetcher.sh", source:file
+    leaf(#ptr<000013>), val:"./my_secret_fetcher.sh", source:file
 > secret_backend_timeout
-    leaf(#ptr<000026>), val:"60", source:environment-variable
+    leaf(#ptr<000018>), val:"60", source:environment-variable
 > server_timeout
-    leaf(#ptr<000027>), val:30, source:default`
+    leaf(#ptr<000008>), val:30, source:default`
 	assert.Equal(t, expect, txt)
 }
 
@@ -511,7 +528,7 @@ func TestStringifyAll(t *testing.T) {
   collector:
     workers: 6
 `
-	os.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
+	t.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
 
 	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
 	cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 100000)
@@ -544,21 +561,21 @@ tree(#ptr<000006>) source=default
     > workers
         leaf(#ptr<000010>), val:4, source:default
 > secret_backend_command
-    leaf(#ptr<000011>), val:"", source:default
-tree(#ptr<000012>) source=environment-variable
+    leaf(#ptr<000005>), val:"", source:default
+tree(#ptr<000011>) source=file
 > network_path
-  inner(#ptr<000013>)
+  inner(#ptr<000012>)
   > collector
-    inner(#ptr<000014>)
-    > input_chan_size
-        leaf(#ptr<000015>), val:"23456", source:environment-variable
-tree(#ptr<000016>) source=file
-> network_path
-  inner(#ptr<000017>)
-  > collector
-    inner(#ptr<000018>)
+    inner(#ptr<000013>)
     > workers
-        leaf(#ptr<000019>), val:6, source:file`
+        leaf(#ptr<000004>), val:6, source:file
+tree(#ptr<000014>) source=environment-variable
+> network_path
+  inner(#ptr<000015>)
+  > collector
+    inner(#ptr<000016>)
+    > input_chan_size
+        leaf(#ptr<000003>), val:"23456", source:environment-variable`
 	assert.Equal(t, expect, txt)
 }
 
@@ -636,11 +653,312 @@ process_config:
 	assert.Equal(t, expect, txt)
 }
 
+func TestMergeReusesNodes(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
+	cfg.BindEnvAndSetDefault("a.apple.one", 1)
+	cfg.BindEnvAndSetDefault("a.apple.two", 2)
+	cfg.BindEnvAndSetDefault("b.banana.color", "yellow")
+	cfg.BindEnvAndSetDefault("c.cherry.third", 3)
+	cfg.BindEnvAndSetDefault("c.cherry.fourth", 4)
+
+	configData := `b:
+  banana:
+    color: green
+c:
+  cherry:
+    third: 567
+`
+	cfg.BuildSchema()
+	err := cfg.ReadConfig(strings.NewReader(configData))
+	require.NoError(t, err)
+
+	// Validate that merged config contains nodes from default and file layer
+	// that have the same address as the corresponding nodes in the merged root
+	txt := cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> a
+  inner(#ptr<000001>)
+  > apple
+    inner(#ptr<000002>)
+    > one
+        leaf(#ptr<000003>), val:1, source:default
+    > two
+        leaf(#ptr<000004>), val:2, source:default
+> b
+  inner(#ptr<000005>)
+  > banana
+    inner(#ptr<000006>)
+    > color
+        leaf(#ptr<000007>), val:"green", source:file
+> c
+  inner(#ptr<000008>)
+  > cherry
+    inner(#ptr<000009>)
+    > fourth
+        leaf(#ptr<000010>), val:4, source:default
+    > third
+        leaf(#ptr<000011>), val:567, source:file
+tree(#ptr<000012>) source=default
+> a
+  inner(#ptr<000001>)
+  > apple
+    inner(#ptr<000002>)
+    > one
+        leaf(#ptr<000003>), val:1, source:default
+    > two
+        leaf(#ptr<000004>), val:2, source:default
+> b
+  inner(#ptr<000013>)
+  > banana
+    inner(#ptr<000014>)
+    > color
+        leaf(#ptr<000015>), val:"yellow", source:default
+> c
+  inner(#ptr<000016>)
+  > cherry
+    inner(#ptr<000017>)
+    > fourth
+        leaf(#ptr<000010>), val:4, source:default
+    > third
+        leaf(#ptr<000018>), val:3, source:default
+tree(#ptr<000019>) source=file
+> b
+  inner(#ptr<000020>)
+  > banana
+    inner(#ptr<000021>)
+    > color
+        leaf(#ptr<000007>), val:"green", source:file
+> c
+  inner(#ptr<000022>)
+  > cherry
+    inner(#ptr<000023>)
+    > third
+        leaf(#ptr<000011>), val:567, source:file`
+	assert.Equal(t, expect, txt)
+
+	// Validate that assigning to a node affects the merged root and also
+	// allocates nodes in the source layer, which was previously not present
+	cfg.Set("a.apple.one", 1000, model.SourceAgentRuntime)
+	txt = cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect = `tree(#ptr<000024>) source=root
+> a
+  inner(#ptr<000025>)
+  > apple
+    inner(#ptr<000026>)
+    > one
+        leaf(#ptr<000027>), val:1000, source:agent-runtime
+    > two
+        leaf(#ptr<000004>), val:2, source:default
+> b
+  inner(#ptr<000005>)
+  > banana
+    inner(#ptr<000006>)
+    > color
+        leaf(#ptr<000007>), val:"green", source:file
+> c
+  inner(#ptr<000008>)
+  > cherry
+    inner(#ptr<000009>)
+    > fourth
+        leaf(#ptr<000010>), val:4, source:default
+    > third
+        leaf(#ptr<000011>), val:567, source:file
+tree(#ptr<000012>) source=default
+> a
+  inner(#ptr<000001>)
+  > apple
+    inner(#ptr<000002>)
+    > one
+        leaf(#ptr<000003>), val:1, source:default
+    > two
+        leaf(#ptr<000004>), val:2, source:default
+> b
+  inner(#ptr<000013>)
+  > banana
+    inner(#ptr<000014>)
+    > color
+        leaf(#ptr<000015>), val:"yellow", source:default
+> c
+  inner(#ptr<000016>)
+  > cherry
+    inner(#ptr<000017>)
+    > fourth
+        leaf(#ptr<000010>), val:4, source:default
+    > third
+        leaf(#ptr<000018>), val:3, source:default
+tree(#ptr<000019>) source=file
+> b
+  inner(#ptr<000020>)
+  > banana
+    inner(#ptr<000021>)
+    > color
+        leaf(#ptr<000007>), val:"green", source:file
+> c
+  inner(#ptr<000022>)
+  > cherry
+    inner(#ptr<000023>)
+    > third
+        leaf(#ptr<000011>), val:567, source:file
+tree(#ptr<000028>) source=agent-runtime
+> a
+  inner(#ptr<000029>)
+  > apple
+    inner(#ptr<000030>)
+    > one
+        leaf(#ptr<000027>), val:1000, source:agent-runtime`
+	assert.Equal(t, expect, txt)
+}
+
+func TestSetWhenMerged(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
+	cfg.BindEnvAndSetDefault("a.apple.one", 1)
+	cfg.BindEnvAndSetDefault("a.apple.two", 2)
+	cfg.BindEnvAndSetDefault("b.banana.color", "yellow")
+
+	cfg.BuildSchema()
+
+	cfg.Set("a.apple.one", 1000, model.SourceAgentRuntime)
+
+	txt := cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> a
+  inner(#ptr<000001>)
+  > apple
+    inner(#ptr<000002>)
+    > one
+        leaf(#ptr<000003>), val:1000, source:agent-runtime
+    > two
+        leaf(#ptr<000004>), val:2, source:default
+> b
+  inner(#ptr<000005>)
+  > banana
+    inner(#ptr<000006>)
+    > color
+        leaf(#ptr<000007>), val:"yellow", source:default
+tree(#ptr<000008>) source=default
+> a
+  inner(#ptr<000009>)
+  > apple
+    inner(#ptr<000010>)
+    > one
+        leaf(#ptr<000011>), val:1, source:default
+    > two
+        leaf(#ptr<000004>), val:2, source:default
+> b
+  inner(#ptr<000005>)
+  > banana
+    inner(#ptr<000006>)
+    > color
+        leaf(#ptr<000007>), val:"yellow", source:default
+tree(#ptr<000012>) source=agent-runtime
+> a
+  inner(#ptr<000013>)
+  > apple
+    inner(#ptr<000014>)
+    > one
+        leaf(#ptr<000003>), val:1000, source:agent-runtime`
+	assert.Equal(t, expect, txt)
+
+	cfg.Set("a.apple.two", 2000, model.SourceAgentRuntime)
+
+	txt = cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect = `tree(#ptr<000015>) source=root
+> a
+  inner(#ptr<000016>)
+  > apple
+    inner(#ptr<000017>)
+    > one
+        leaf(#ptr<000003>), val:1000, source:agent-runtime
+    > two
+        leaf(#ptr<000018>), val:2000, source:agent-runtime
+> b
+  inner(#ptr<000005>)
+  > banana
+    inner(#ptr<000006>)
+    > color
+        leaf(#ptr<000007>), val:"yellow", source:default
+tree(#ptr<000008>) source=default
+> a
+  inner(#ptr<000009>)
+  > apple
+    inner(#ptr<000010>)
+    > one
+        leaf(#ptr<000011>), val:1, source:default
+    > two
+        leaf(#ptr<000004>), val:2, source:default
+> b
+  inner(#ptr<000005>)
+  > banana
+    inner(#ptr<000006>)
+    > color
+        leaf(#ptr<000007>), val:"yellow", source:default
+tree(#ptr<000012>) source=agent-runtime
+> a
+  inner(#ptr<000019>)
+  > apple
+    inner(#ptr<000020>)
+    > one
+        leaf(#ptr<000003>), val:1000, source:agent-runtime
+    > two
+        leaf(#ptr<000018>), val:2000, source:agent-runtime`
+	assert.Equal(t, expect, txt)
+
+	cfg.Set("b.banana.color", "green", model.SourceAgentRuntime)
+
+	txt = cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect = `tree(#ptr<000021>) source=root
+> a
+  inner(#ptr<000022>)
+  > apple
+    inner(#ptr<000023>)
+    > one
+        leaf(#ptr<000003>), val:1000, source:agent-runtime
+    > two
+        leaf(#ptr<000018>), val:2000, source:agent-runtime
+> b
+  inner(#ptr<000024>)
+  > banana
+    inner(#ptr<000025>)
+    > color
+        leaf(#ptr<000026>), val:"green", source:agent-runtime
+tree(#ptr<000008>) source=default
+> a
+  inner(#ptr<000009>)
+  > apple
+    inner(#ptr<000010>)
+    > one
+        leaf(#ptr<000011>), val:1, source:default
+    > two
+        leaf(#ptr<000004>), val:2, source:default
+> b
+  inner(#ptr<000005>)
+  > banana
+    inner(#ptr<000006>)
+    > color
+        leaf(#ptr<000007>), val:"yellow", source:default
+tree(#ptr<000012>) source=agent-runtime
+> a
+  inner(#ptr<000019>)
+  > apple
+    inner(#ptr<000020>)
+    > one
+        leaf(#ptr<000003>), val:1000, source:agent-runtime
+    > two
+        leaf(#ptr<000018>), val:2000, source:agent-runtime
+> b
+  inner(#ptr<000027>)
+  > banana
+    inner(#ptr<000028>)
+    > color
+        leaf(#ptr<000026>), val:"green", source:agent-runtime`
+	assert.Equal(t, expect, txt)
+}
+
 func TestUnsetForSource(t *testing.T) {
 	// env source, highest priority
-	os.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
-	os.Setenv("TEST_NETWORK_PATH_COLLECTOR_PATHTEST_CONTEXTS_LIMIT", "654321")
-	os.Setenv("TEST_NETWORK_PATH_COLLECTOR_PROCESSING_CHAN_SIZE", "78900")
+	t.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
+	t.Setenv("TEST_NETWORK_PATH_COLLECTOR_PATHTEST_CONTEXTS_LIMIT", "654321")
+	t.Setenv("TEST_NETWORK_PATH_COLLECTOR_PROCESSING_CHAN_SIZE", "78900")
 	// file source, medium priority
 	configData := `network_path:
   collector:
@@ -799,6 +1117,107 @@ func TestUnsetForSource(t *testing.T) {
         leaf(#ptr<000010>), val:100000, source:default
     > workers
         leaf(#ptr<000008>), val:4, source:default`
+	assert.Equal(t, expect, txt)
+}
+
+func TestUnsetForSourceAllLayers(t *testing.T) {
+	// env source, highest priority
+	t.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
+	// file source, medium priority
+	configData := `network_path:
+  collector:
+    processing_chan_size: 45678`
+	// default source, lowest priority
+	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
+	cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 100000)
+	cfg.BindEnvAndSetDefault("network_path.collector.pathtest_contexts_limit", 100000)
+	cfg.BindEnvAndSetDefault("network_path.collector.processing_chan_size", 100000)
+
+	cfg.BuildSchema()
+	err := cfg.ReadConfig(strings.NewReader(configData))
+	require.NoError(t, err)
+
+	// The merged config
+	txt := cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000003>), val:"23456", source:environment-variable
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:100000, source:default
+    > processing_chan_size
+        leaf(#ptr<000005>), val:45678, source:file
+tree(#ptr<000006>) source=default
+> network_path
+  inner(#ptr<000007>)
+  > collector
+    inner(#ptr<000008>)
+    > input_chan_size
+        leaf(#ptr<000009>), val:100000, source:default
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:100000, source:default
+    > processing_chan_size
+        leaf(#ptr<000010>), val:100000, source:default
+tree(#ptr<000011>) source=file
+> network_path
+  inner(#ptr<000012>)
+  > collector
+    inner(#ptr<000013>)
+    > processing_chan_size
+        leaf(#ptr<000005>), val:45678, source:file
+tree(#ptr<000014>) source=environment-variable
+> network_path
+  inner(#ptr<000015>)
+  > collector
+    inner(#ptr<000016>)
+    > input_chan_size
+        leaf(#ptr<000003>), val:"23456", source:environment-variable`
+	assert.Equal(t, expect, txt)
+
+	// Remove a setting from the env source, nothing in the file source, it goes to default
+	cfg.UnsetForSource("network_path.collector.input_chan_size", model.SourceEnvVar)
+
+	// NOTE: The replacement node in the root tree has a different address than the
+	// corresponding node in the original layer. Also the env tree still has inner nodes
+	// but no leaf nodes.
+	txt = cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000017>), val:100000, source:default
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:100000, source:default
+    > processing_chan_size
+        leaf(#ptr<000005>), val:45678, source:file
+tree(#ptr<000006>) source=default
+> network_path
+  inner(#ptr<000007>)
+  > collector
+    inner(#ptr<000008>)
+    > input_chan_size
+        leaf(#ptr<000009>), val:100000, source:default
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:100000, source:default
+    > processing_chan_size
+        leaf(#ptr<000010>), val:100000, source:default
+tree(#ptr<000011>) source=file
+> network_path
+  inner(#ptr<000012>)
+  > collector
+    inner(#ptr<000013>)
+    > processing_chan_size
+        leaf(#ptr<000005>), val:45678, source:file
+tree(#ptr<000014>) source=environment-variable
+> network_path
+  inner(#ptr<000015>)
+  > collector
+    inner(#ptr<000016>)`
 	assert.Equal(t, expect, txt)
 }
 
@@ -1001,10 +1420,10 @@ func TestEnvVarTransformers(t *testing.T) {
 	cfg.BindEnvAndSetDefault("tag_set", []map[string]string{}, "TEST_TAG_SET")
 	cfg.BindEnvAndSetDefault("list_keypairs", map[string]interface{}{}, "TEST_LIST_KEYPAIRS")
 
-	os.Setenv("TEST_LIST_OF_NUMS", "34,67.5,901.125")
-	os.Setenv("TEST_LIST_OF_FRUIT", "apple,banana,cherry")
-	os.Setenv("TEST_TAG_SET", `[{"cat":"meow"},{"dog":"bark"}]`)
-	os.Setenv("TEST_LIST_KEYPAIRS", `a=1,b=2,c=3`)
+	t.Setenv("TEST_LIST_OF_NUMS", "34,67.5,901.125")
+	t.Setenv("TEST_LIST_OF_FRUIT", "apple,banana,cherry")
+	t.Setenv("TEST_TAG_SET", `[{"cat":"meow"},{"dog":"bark"}]`)
+	t.Setenv("TEST_LIST_KEYPAIRS", `a=1,b=2,c=3`)
 
 	cfg.ParseEnvAsSlice("list_of_nums", func(in string) []interface{} {
 		vals := []interface{}{}
@@ -1172,4 +1591,75 @@ func TestMultipleTransformersRaisesError(t *testing.T) {
 			return strings.Split(in, ",")
 		})
 	})
+}
+
+func TestMergeInvalidFileData(t *testing.T) {
+	configData := `
+fruit:
+  apple:
+  banana:
+  cherry:
+  donut:
+    12
+`
+	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
+	cfg.BindEnvAndSetDefault("fruit.apple.core.seeds", 2) // file wins over default
+	cfg.BindEnv("fruit.banana.peel.color")                // file only (missing default)
+	cfg.BindEnv("fruit.cherry.seed.num")                  // env wins over file
+	t.Setenv("TEST_FRUIT_CHERRY_SEED_NUM", "1")
+	cfg.BuildSchema()
+
+	err := cfg.ReadConfig(strings.NewReader(configData))
+	require.NoError(t, err)
+
+	// In the merged tree, the following appears:
+	// fruit.apple.core.seeds from default
+	// fruit.banana           from file (invalid data)
+	// fruit.cherry.seed.num  from env
+	txt := cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> fruit
+  inner(#ptr<000001>)
+  > apple
+    inner(#ptr<000002>)
+    > core
+      inner(#ptr<000003>)
+      > seeds
+          leaf(#ptr<000004>), val:2, source:default
+  > banana
+      leaf(#ptr<000005>), val:<nil>, source:file
+  > cherry
+    inner(#ptr<000006>)
+    > seed
+      inner(#ptr<000007>)
+      > num
+          leaf(#ptr<000008>), val:"1", source:environment-variable
+tree(#ptr<000009>) source=default
+> fruit
+  inner(#ptr<000010>)
+  > apple
+    inner(#ptr<000002>)
+    > core
+      inner(#ptr<000003>)
+      > seeds
+          leaf(#ptr<000004>), val:2, source:default
+tree(#ptr<000011>) source=file
+> fruit
+  inner(#ptr<000012>)
+  > apple
+      leaf(#ptr<000013>), val:<nil>, source:file
+  > banana
+      leaf(#ptr<000005>), val:<nil>, source:file
+  > cherry
+      leaf(#ptr<000014>), val:<nil>, source:file
+tree(#ptr<000015>) source=environment-variable
+> fruit
+  inner(#ptr<000016>)
+  > cherry
+    inner(#ptr<000006>)
+    > seed
+      inner(#ptr<000007>)
+      > num
+          leaf(#ptr<000008>), val:"1", source:environment-variable`
+	assert.Equal(t, expect, txt)
 }

--- a/pkg/config/nodetreemodel/debug_string_testonly.go
+++ b/pkg/config/nodetreemodel/debug_string_testonly.go
@@ -45,8 +45,10 @@ func (c *ntmConfig) toDebugString(source model.Source, opts ...model.StringifyOp
 
 	if source == "all" {
 		lines := []string{}
-		for _, src := range []model.Source{"root", model.SourceDefault, model.SourceEnvVar, model.SourceFile} {
-			single, err := c.td.stringifySourceTree(c.selectTree(src), src)
+		allSources := append([]model.Source{model.Source("root")}, model.Sources...)
+		for _, src := range allSources {
+			tree, _ := c.getTreeBySource(src)
+			single, err := c.td.stringifySourceTree(tree, src)
 			if err != nil {
 				return "", err
 			}
@@ -56,27 +58,16 @@ func (c *ntmConfig) toDebugString(source model.Source, opts ...model.StringifyOp
 		return strings.Join(lines, "\n"), nil
 	}
 
-	lines, err := c.td.stringifySourceTree(c.selectTree(source), source)
+	tree, err := c.getTreeBySource(source)
+	if err != nil {
+		return "", err
+	}
+	lines, err := c.td.stringifySourceTree(tree, source)
 	if err != nil {
 		return "", err
 	}
 	lines = c.td.appendExtraDetails(lines)
 	return strings.Join(lines, "\n"), nil
-}
-
-func (c *ntmConfig) selectTree(src model.Source) Node {
-	switch src {
-	case "root":
-		return c.root
-	case model.SourceEnvVar:
-		return c.envs
-	case model.SourceDefault:
-		return c.defaults
-	case model.SourceFile:
-		return c.file
-	default:
-		return nil
-	}
 }
 
 type ptrCount struct {
@@ -108,6 +99,11 @@ func (d *treeDebugger) appendExtraDetails(lines []string) []string {
 func (d *treeDebugger) stringifySourceTree(tree Node, src model.Source) ([]string, error) {
 	if tree == nil {
 		return nil, fmt.Errorf("invalid source: %s", src)
+	}
+	if len(tree.(InnerNode).ChildrenKeys()) == 0 {
+		// If a tree is empty, don't process its root nodes. This allows
+		// OmitPointerAddr to correctly count unique nodes that actually appear.
+		return nil, nil
 	}
 	res, err := d.nodeToString(tree, 0, "")
 	if err != nil {

--- a/pkg/config/nodetreemodel/inner_node.go
+++ b/pkg/config/nodetreemodel/inner_node.go
@@ -159,8 +159,7 @@ func setNodeAtPath(n *innerNode, fields []string, value interface{}, source mode
 			} else if leafNode, ok := child.(LeafNode); ok {
 				// If we find a leaf, simply replace its value, and return nil for
 				// the first return value because no node was created
-				leafNode.ReplaceValue(value)
-				return nil, nil
+				return nil, leafNode.ReplaceValue(value)
 			}
 		}
 	}

--- a/pkg/config/nodetreemodel/inner_node.go
+++ b/pkg/config/nodetreemodel/inner_node.go
@@ -6,11 +6,12 @@
 package nodetreemodel
 
 import (
-	"fmt"
+	"errors"
 	"slices"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"golang.org/x/exp/maps"
 )
 
@@ -55,41 +56,63 @@ func (n *innerNode) HasChild(key string) bool {
 	return ok
 }
 
-// Merge mergs src node within current tree
-func (n *innerNode) Merge(src InnerNode) error {
-	for _, name := range src.ChildrenKeys() {
-		srcChild, _ := src.GetChild(name)
+// Merge merges this node with that and returns the merged result
+func (n *innerNode) Merge(that InnerNode) (InnerNode, error) {
+	newChildren := map[string]Node{}
 
-		if !n.HasChild(name) {
-			n.children[name] = srcChild.Clone()
-		} else {
-			// We alredy have child with the same name
+	// iterate our keys
+	for _, name := range n.ChildrenKeys() {
+		ourChild, _ := n.GetChild(name)
 
-			dstChild, _ := n.GetChild(name)
+		if !that.HasChild(name) {
+			// if their tree doesn't have the node, use our node
+			newChildren[name] = ourChild
+			continue
+		}
+		theirChild, _ := that.GetChild(name)
+		ourLeaf, ourIsLeaf := ourChild.(LeafNode)
+		theirLeaf, theirIsLeaf := theirChild.(LeafNode)
 
-			dstLeaf, dstIsLeaf := dstChild.(LeafNode)
-			srcLeaf, srcIsLeaf := srcChild.(LeafNode)
-			if srcIsLeaf != dstIsLeaf {
-				// Ignore the source (incoming) node and keep the destination (current) node
-				// TODO: Improve error handling in a follow-up PR. We should collect errors
-				// and log.Error them, but not break functionality in doing so
-				continue
-			}
+		// If subtree shapes differ, take the longer branch
+		// TODO: Improve error handling in a follow-up PR. We should collect errors
+		// and log.Error them, but also display these errors in more places
+		if ourIsLeaf && !theirIsLeaf {
+			newChildren[name] = theirChild
+			continue
+		} else if !ourIsLeaf && theirIsLeaf {
+			newChildren[name] = ourChild
+			continue
+		}
 
-			if srcIsLeaf {
-				if srcLeaf.Source() == dstLeaf.Source() || srcLeaf.SourceGreaterThan(dstLeaf.Source()) {
-					n.children[name] = srcLeaf.Clone()
-				}
+		if ourIsLeaf && theirIsLeaf {
+			// both are leafs, check the priority by source
+			if ourLeaf.Source() == theirLeaf.Source() || theirLeaf.SourceGreaterThan(ourLeaf.Source()) {
+				newChildren[name] = theirChild
 			} else {
-				dstInner, _ := dstChild.(InnerNode)
-				childInner, _ := srcChild.(InnerNode)
-				if err := dstInner.Merge(childInner); err != nil {
-					return err
-				}
+				newChildren[name] = ourChild
 			}
+			continue
+		}
+
+		// both are inner nodes, recursively merge
+		ourInner := ourChild.(InnerNode)
+		theirInner := theirChild.(InnerNode)
+		result, err := ourInner.Merge(theirInner)
+		if err != nil {
+			log.Errorf("merging config tree: %v\n", err)
+			continue
+		}
+		newChildren[name] = result
+	}
+
+	// iterate their keys
+	for _, name := range that.ChildrenKeys() {
+		if !n.HasChild(name) {
+			newChildren[name], _ = that.GetChild(name)
 		}
 	}
-	return nil
+
+	return newInnerNode(newChildren), nil
 }
 
 // ChildrenKeys returns the list of keys of the children of the given node, if it is a map
@@ -104,44 +127,59 @@ func (n *innerNode) ChildrenKeys() []string {
 // the existing one. The function returns true if an update was done or false if nothing was changed.
 //
 // The key parts should already be lowercased.
-func (n *innerNode) SetAt(key []string, value interface{}, source model.Source) (bool, error) {
-	keyLen := len(key)
-	if keyLen == 0 {
-		return false, fmt.Errorf("empty key given to Set")
+//
+// This method should only be called on the root of a tree, not on an inner node with parents.
+// TODO: Consider adding a RootNode type, move this method to that.
+func (n *innerNode) SetAt(key []string, value interface{}, source model.Source) error {
+	if len(key) == 0 {
+		return errors.New("empty key given to Set")
 	}
+	newNode, err := setNodeAtPath(n, key, value, source)
+	if inner, ok := newNode.(*innerNode); ok {
+		n.children = inner.children
+	}
+	return err
+}
 
-	part := key[0]
-	if keyLen == 1 {
-		node, ok := n.children[part]
-		if !ok {
-			n.children[part] = newLeafNode(value, source)
-			return true, nil
-		}
+// setNodeAtPath allocates a new branch, ending in a leaf at the given path of fields, with the
+// given value, and returns the root of that branch. If a leaf already exists at that path,
+// instead it is modified and no branch is allocated and this returns nil
+func setNodeAtPath(n *innerNode, fields []string, value interface{}, source model.Source) (Node, error) {
+	if len(fields) == 0 {
+		return newLeafNode(value, source), nil
+	}
+	f := fields[0]
 
-		if leaf, ok := node.(LeafNode); ok {
-			if source == leaf.Source() || source.IsGreaterThan(leaf.Source()) {
-				n.children[part] = newLeafNode(value, source)
-				return true, nil
+	// Locate the next node down in the tree (or nil if it doesn't exist)
+	var next *innerNode
+	if n != nil {
+		if child, _ := n.GetChild(f); child != nil {
+			if innerNode, ok := child.(*innerNode); ok {
+				next = innerNode
+			} else if leafNode, ok := child.(LeafNode); ok {
+				// If we find a leaf, simply replace its value, and return nil for
+				// the first return value because no node was created
+				leafNode.ReplaceValue(value)
+				return nil, nil
 			}
-			return false, nil
 		}
-		return false, fmt.Errorf("can't overrides inner node with a leaf node")
 	}
 
-	// new node case
-	if _, ok := n.children[part]; !ok {
-		newNode := newInnerNode(nil)
-		n.children[part] = newNode
-		return newNode.SetAt(key[1:keyLen], value, source)
+	// Recursively set the node at the remaining part of the path
+	createdNode, err := setNodeAtPath(next, fields[1:], value, source)
+	if err != nil || createdNode == nil {
+		return nil, err
 	}
 
-	// update node case
-	child, err := n.GetChild(part)
-	node, ok := child.(InnerNode)
-	if err != nil || !ok {
-		return false, fmt.Errorf("can't update a leaf node into a inner node")
+	// Create a new inner node using the modified list of child nodes
+	var copyChildren map[string]Node
+	if n != nil {
+		copyChildren = maps.Clone(n.children)
+	} else {
+		copyChildren = make(map[string]Node)
 	}
-	return node.SetAt(key[1:keyLen], value, source)
+	copyChildren[f] = createdNode
+	return newInnerNode(copyChildren), nil
 }
 
 // InsertChildNode sets a node in the current node

--- a/pkg/config/nodetreemodel/inner_node_test.go
+++ b/pkg/config/nodetreemodel/inner_node_test.go
@@ -32,7 +32,7 @@ func TestMergeToEmpty(t *testing.T) {
 
 	dst := newInnerNode(nil)
 
-	err = dst.Merge(src)
+	merged, err := dst.Merge(src)
 	require.NoError(t, err)
 
 	expected := &innerNode{
@@ -51,7 +51,7 @@ func TestMergeToEmpty(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, dst)
+	assert.Equal(t, expected, merged)
 }
 
 func TestMergeTwoTree(t *testing.T) {
@@ -88,7 +88,7 @@ func TestMergeTwoTree(t *testing.T) {
 	overwrite, ok := node.(InnerNode)
 	require.True(t, ok)
 
-	err = base.Merge(overwrite)
+	merged, err := base.Merge(overwrite)
 	require.NoError(t, err)
 
 	expected := &innerNode{
@@ -109,7 +109,7 @@ func TestMergeTwoTree(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, base)
+	assert.Equal(t, expected, merged)
 }
 
 func TestMergeErrorLeafToNode(t *testing.T) {
@@ -132,10 +132,10 @@ func TestMergeErrorLeafToNode(t *testing.T) {
 	require.True(t, ok)
 
 	// checking leaf to node
-	err = base.Merge(overwrite)
+	_, err = base.Merge(overwrite)
 	require.NoError(t, err)
 
 	// checking node to leaf
-	err = overwrite.Merge(base)
+	_, err = overwrite.Merge(base)
 	require.NoError(t, err)
 }

--- a/pkg/config/nodetreemodel/leaf_node.go
+++ b/pkg/config/nodetreemodel/leaf_node.go
@@ -65,6 +65,12 @@ func (n *leafNodeImpl) Get() interface{} {
 	return n.val
 }
 
+// ReplaceValue replaces the value in the leaf node
+func (n *leafNodeImpl) ReplaceValue(v interface{}) error {
+	n.val = v
+	return nil
+}
+
 // Source returns the source for this leaf
 func (n *leafNodeImpl) Source() model.Source {
 	return n.source

--- a/pkg/config/nodetreemodel/missing_node.go
+++ b/pkg/config/nodetreemodel/missing_node.go
@@ -26,6 +26,10 @@ func (m *missingLeafImpl) Get() interface{} {
 	return nil
 }
 
+func (m *missingLeafImpl) ReplaceValue(interface{}) error {
+	return fmt.Errorf("Replacevalue(): missing")
+}
+
 func (m *missingLeafImpl) SetWithSource(interface{}, model.Source) error {
 	return fmt.Errorf("SetWithSource(): missing")
 }

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -122,8 +122,8 @@ type InnerNode interface {
 	Node
 	HasChild(string) bool
 	ChildrenKeys() []string
-	Merge(InnerNode) error
-	SetAt([]string, interface{}, model.Source) (bool, error)
+	Merge(InnerNode) (InnerNode, error)
+	SetAt([]string, interface{}, model.Source) error
 	InsertChildNode(string, Node)
 	RemoveChild(string)
 	DumpSettings(func(model.Source) bool) map[string]interface{}
@@ -133,6 +133,7 @@ type InnerNode interface {
 type LeafNode interface {
 	Node
 	Get() interface{}
+	ReplaceValue(v interface{}) error
 	Source() model.Source
 	SourceGreaterThan(model.Source) bool
 }

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -255,15 +255,14 @@ tree(#ptr<000004>) source=default
 > a
     leaf(#ptr<000005>), val:"apple", source:default
 > c
-  inner(#ptr<000006>)
+  inner(#ptr<000002>)
   > d
-      leaf(#ptr<000007>), val:true, source:default
-tree(#ptr<000008>) source=environment-variable
-tree(#ptr<000009>) source=file
+      leaf(#ptr<000003>), val:true, source:default
+tree(#ptr<000006>) source=file
 > a
-    leaf(#ptr<000010>), val:"orange", source:file
+    leaf(#ptr<000001>), val:"orange", source:file
 > c
-    leaf(#ptr<000011>), val:1234, source:file`
+    leaf(#ptr<000007>), val:1234, source:file`
 	assert.Equal(t, expected, c.Stringify("all", model.OmitPointerAddr))
 }
 

--- a/pkg/config/nodetreemodel/struct_node.go
+++ b/pkg/config/nodetreemodel/struct_node.go
@@ -42,8 +42,8 @@ func (n *structNodeImpl) HasChild(name string) bool {
 	return slices.Contains(names, name)
 }
 
-func (n *structNodeImpl) Merge(InnerNode) error {
-	return fmt.Errorf("not implemented")
+func (n *structNodeImpl) Merge(InnerNode) (InnerNode, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 // ChildrenKeys returns the list of keys of the children of the given node, if it is a map
@@ -62,18 +62,18 @@ func (n *structNodeImpl) ChildrenKeys() []string {
 	return keys
 }
 
-// SetAt is not implemented for a leaf node
-func (n *structNodeImpl) SetAt([]string, interface{}, model.Source) (bool, error) {
-	return false, fmt.Errorf("not implemented")
+// SetAt is not implemented for a struct node
+func (n *structNodeImpl) SetAt([]string, interface{}, model.Source) error {
+	return fmt.Errorf("not implemented")
 }
 
-// InsertChildNode is not implemented for a leaf node
+// InsertChildNode is not implemented for a struct node
 func (n *structNodeImpl) InsertChildNode(string, Node) {}
 
 // RemoveChild is not implemented for struct node
 func (n *structNodeImpl) RemoveChild(string) {}
 
-// Clone clones a LeafNode
+// Clone clones a StructNode
 func (n *structNodeImpl) Clone() Node {
 	return &structNodeImpl{val: n.val}
 }


### PR DESCRIPTION
### What does this PR do?

When merging node trees, don't just insert into the current node. Instead, merge the child nodes and then construct a new parent. This means we don't need to clone nodes. By observing the tests that Stringify the tree, you can see that nodes are now shared across trees, meaning less memory is used overall.

In addition, when merging subtrees with different shapes, keep the non-leaf subtree. This matches how viper works for compatibility reasons, when the config file has invalid data.

While we're here, fix some incorrect locks.

When run with `DD_CONF_NODETREEMODEL=enable`, this fixes the test `TestOTLPGrpcMaxRecvMsgSizeMibFromEnv` in `comp/trace/config`.

### Motivation

Memory efficiency and correctness of nodetreemodel, so we can move off of viper.

### Describe how you validated your changes

Unit tests, especially some that show how nodes are shared between trees.

### Additional Notes
