### PR TITLE
fix(fleet): Use embedded installer for SSI scripts

### DIFF
--- a/pkg/fleet/installer/packages/embedded/scripts/dd-container-install
+++ b/pkg/fleet/installer/packages/embedded/scripts/dd-container-install
@@ -47,7 +47,7 @@ done
 if [ -x /opt/datadog-packages/run/datadog-installer-ssi ]; then
     installerPath="/opt/datadog-packages/run/datadog-installer-ssi"
 else
-    installerPath="/opt/datadog-packages/datadog-installer/stable/bin/installer/installer"
+    installerPath="/opt/datadog-packages/datadog-agent/embedded/bin/installer"
 fi
 
 if [ -z "$uninstall_flag" ]; then

--- a/pkg/fleet/installer/packages/embedded/scripts/dd-host-install
+++ b/pkg/fleet/installer/packages/embedded/scripts/dd-host-install
@@ -47,7 +47,7 @@ done
 if [ -x /opt/datadog-packages/run/datadog-installer-ssi ]; then
     installerPath="/opt/datadog-packages/run/datadog-installer-ssi"
 else
-    installerPath="/opt/datadog-packages/datadog-installer/stable/bin/installer/installer"
+    installerPath="/opt/datadog-packages/datadog-agent/embedded/bin/installer"
 fi
 
 if [ -z "$uninstall_flag" ]; then


### PR DESCRIPTION
### What does this PR do?
Uses the embedded installer for SSI scripts as we are deprecating the installer deb / rpm packages

### Motivation

### Describe how you validated your changes

### Additional Notes
