### PR TITLE
[CNM-4739] Add multi-traceroute and e2e probe config to datadog-agent network path integration

### DIFF
--- a/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
@@ -66,6 +66,16 @@ instances:
     #
     # tcp_method: <METHOD>
 
+    ## @param traceroute_queries - integer - optional - default: 3
+    ## Number of traceroutes to send for each check run.
+    #
+    # traceroute_queries: 3
+
+    ## @param e2e_queries - integer - optional - default: 50
+    ## Number of end-to-end probes to send for each check run.
+    #
+    # e2e_queries: 50
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -131,6 +131,14 @@ func parseParams(req *http.Request) (tracerouteutil.Config, error) {
 	tcpMethod := query.Get("tcp_method")
 	tcpSynParisTracerouteMode := query.Get("tcp_syn_paris_traceroute_mode")
 	reverseDNS := query.Get("reverse_dns")
+	tracerouteQueries, err := parseUint(query, "traceroute_queries", 32)
+	if err != nil {
+		return tracerouteutil.Config{}, fmt.Errorf("invalid traceroute_queries: %s", err)
+	}
+	e2eQueries, err := parseUint(query, "e2e_queries", 32)
+	if err != nil {
+		return tracerouteutil.Config{}, fmt.Errorf("invalid e2e_queries: %s", err)
+	}
 
 	return tracerouteutil.Config{
 		DestHostname:              host,
@@ -141,6 +149,8 @@ func parseParams(req *http.Request) (tracerouteutil.Config, error) {
 		TCPMethod:                 payload.TCPMethod(tcpMethod),
 		TCPSynParisTracerouteMode: tcpSynParisTracerouteMode == "true",
 		ReverseDNS:                reverseDNS == "true",
+		TracerouteQueries:         int(tracerouteQueries),
+		E2eQueries:                int(e2eQueries),
 	}, nil
 }
 

--- a/cmd/system-probe/modules/traceroute_test.go
+++ b/cmd/system-probe/modules/traceroute_test.go
@@ -39,16 +39,38 @@ func TestParseParams(t *testing.T) {
 			name: "all config",
 			host: "1.2.3.4",
 			params: map[string]string{
-				"port":    "42",
-				"max_ttl": "35",
-				"timeout": "1000",
+				"port":               "42",
+				"max_ttl":            "35",
+				"timeout":            "1000",
+				"traceroute_queries": "3",
+				"e2e_queries":        "50",
 			},
 			expectedConfig: tracerouteutil.Config{
-				DestHostname: "1.2.3.4",
-				DestPort:     42,
-				MaxTTL:       35,
-				Timeout:      1000,
+				DestHostname:      "1.2.3.4",
+				DestPort:          42,
+				MaxTTL:            35,
+				Timeout:           1000,
+				TracerouteQueries: 3,
+				E2eQueries:        50,
 			},
+		},
+		{
+			name: "invalid traceroute_queries",
+			host: "1.2.3.4",
+			params: map[string]string{
+				"traceroute_queries": "invalid",
+			},
+			expectedConfig: tracerouteutil.Config{},
+			expectedError:  "invalid traceroute_queries: strconv.ParseUint: parsing \"invalid\": invalid syntax",
+		},
+		{
+			name: "invalid e2e_queries",
+			host: "1.2.3.4",
+			params: map[string]string{
+				"e2e_queries": "invalid",
+			},
+			expectedConfig: tracerouteutil.Config{},
+			expectedError:  "invalid e2e_queries: strconv.ParseUint: parsing \"invalid\": invalid syntax",
 		},
 	}
 	for _, tt := range tests {

--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -13,6 +13,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 )
 
+const (
+	// defaultNetworkPathDynamicPathTracerouteQueries defines the default number of traceroute queries for dynamic path
+	defaultNetworkPathDynamicPathTracerouteQueries = 1
+
+	// defaultNetworkPathDynamicPathE2eQueries defines the default number of end-to-end queries for dynamic path
+	defaultNetworkPathDynamicPathE2eQueries = 10
+)
+
 type collectorConfigs struct {
 	connectionsMonitoringEnabled bool
 	workers                      int
@@ -31,6 +39,8 @@ type collectorConfigs struct {
 	tcpMethod                    payload.TCPMethod
 	icmpMode                     payload.ICMPMode
 	tcpSynParisTracerouteMode    bool
+	tracerouteQueries            int
+	e2eQueries                   int
 }
 
 func newConfig(agentConfig config.Component) *collectorConfigs {
@@ -57,6 +67,8 @@ func newConfig(agentConfig config.Component) *collectorConfigs {
 		tcpMethod:                 payload.MakeTCPMethod(agentConfig.GetString("network_path.collector.tcp_method")),
 		icmpMode:                  payload.MakeICMPMode(agentConfig.GetString("network_path.collector.icmp_mode")),
 		tcpSynParisTracerouteMode: agentConfig.GetBool("network_path.collector.tcp_syn_paris_traceroute_mode"),
+		tracerouteQueries:         defaultNetworkPathDynamicPathTracerouteQueries,
+		e2eQueries:                defaultNetworkPathDynamicPathE2eQueries,
 		networkDevicesNamespace:   agentConfig.GetString("network_devices.namespace"),
 	}
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -354,6 +354,8 @@ func (s *npCollectorImpl) runTracerouteForPath(ptest *pathteststore.PathtestCont
 		TCPMethod:                 s.collectorConfigs.tcpMethod,
 		TCPSynParisTracerouteMode: s.collectorConfigs.tcpSynParisTracerouteMode,
 		ReverseDNS:                false, // Do not run reverse DNS in datadog-traceroute, it's handled in npcollector
+		TracerouteQueries:         s.collectorConfigs.tracerouteQueries,
+		E2eQueries:                s.collectorConfigs.e2eQueries,
 	}
 
 	path, err := s.runTraceroute(cfg, s.telemetrycomp)

--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	// TODO: pin to an operator released version once there is a release that includes the api module
 	github.com/DataDog/datadog-operator/api v0.0.0-20250909133746-a88261a5540c
-	github.com/DataDog/datadog-traceroute v0.1.21
+	github.com/DataDog/datadog-traceroute v0.1.25
 	github.com/DataDog/dd-trace-go/v2 v2.0.0
 	github.com/DataDog/ebpf-manager v0.7.14
 	github.com/DataDog/go-libddwaf/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20250909133746-a88261a5540c h1:UdSg3w7eOx2gZJemeb0aj6vepiFn1bxnaye8BZW+kNI=
 github.com/DataDog/datadog-operator/api v0.0.0-20250909133746-a88261a5540c/go.mod h1:E+dFku5SVIXDUj6apiBdDAzrUOR3xLz1bMgUOGjRAVQ=
-github.com/DataDog/datadog-traceroute v0.1.21 h1:Ic0Vy642X7PSNPYW2PTuBvae7gfsibAOU+7/mIskR60=
-github.com/DataDog/datadog-traceroute v0.1.21/go.mod h1:axG/S4dflSNuxcDt9xbjzs5JBvAHHSYzRyuEm/yTiRk=
+github.com/DataDog/datadog-traceroute v0.1.25 h1:2dsZrWJ0Il3TP3cBvwG0NUm3EpvsBxTghpDmkz7QmyA=
+github.com/DataDog/datadog-traceroute v0.1.25/go.mod h1:w5sW46QA2+i5VfzRM0Mx3JKPkcMiFpeVGAdXglIS5zE=
 github.com/DataDog/dd-trace-go/v2 v2.0.0 h1:cHMEzD0Wcgtu+Rec9d1GuVgpIN5f+4vCaNzuFHJ0v+Y=
 github.com/DataDog/dd-trace-go/v2 v2.0.0/go.mod h1:WBtf7TA9bWr5uA8DjOyw1qlSKe3bw9gN5nc0Ta9dHFE=
 github.com/DataDog/ebpf-manager v0.7.14 h1:k08TW46xdUEHggumRmbs9y+ymcZIJ1LKrRcXEq7EgIM=

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -32,6 +32,8 @@ type InitConfig struct {
 	MinCollectionInterval int64 `yaml:"min_collection_interval"`
 	TimeoutMs             int64 `yaml:"timeout"`
 	MaxTTL                uint8 `yaml:"max_ttl"`
+	TracerouteQueries     int   `yaml:"traceroute_queries"`
+	E2eQueries            int   `yaml:"e2e_queries"`
 }
 
 // InstanceConfig is used to deserialize integration instance config
@@ -54,6 +56,9 @@ type InstanceConfig struct {
 
 	MinCollectionInterval int `yaml:"min_collection_interval"`
 
+	TracerouteQueries int `yaml:"traceroute_queries"`
+	E2eQueries        int `yaml:"e2e_queries"`
+
 	Tags []string `yaml:"tags"`
 }
 
@@ -71,6 +76,8 @@ type CheckConfig struct {
 	TCPSynParisTracerouteMode bool
 	Timeout                   time.Duration
 	MinCollectionInterval     time.Duration
+	TracerouteQueries         int
+	E2eQueries                int
 	Tags                      []string
 	Namespace                 string
 }
@@ -122,6 +129,18 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		instance.MaxTTL,
 		initConfig.MaxTTL,
 		setup.DefaultNetworkPathMaxTTL,
+	)
+
+	c.TracerouteQueries = firstNonZero(
+		instance.TracerouteQueries,
+		initConfig.TracerouteQueries,
+		setup.DefaultNetworkPathStaticPathTracerouteQueries,
+	)
+
+	c.E2eQueries = firstNonZero(
+		instance.E2eQueries,
+		initConfig.E2eQueries,
+		setup.DefaultNetworkPathStaticPathE2eQueries,
 	)
 
 	c.Tags = instance.Tags

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -39,6 +39,8 @@ hostname: 1.2.3.4
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -75,6 +77,8 @@ min_collection_interval: 10
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -91,6 +95,8 @@ min_collection_interval: 10
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -104,6 +110,8 @@ hostname: 1.2.3.4
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -122,6 +130,8 @@ destination_service: service-b
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -138,6 +148,8 @@ protocol: udp
 				Protocol:              payload.ProtocolUDP,
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -154,6 +166,8 @@ protocol: UDP
 				Protocol:              payload.ProtocolUDP,
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -170,6 +184,8 @@ protocol: TCP
 				Protocol:              payload.ProtocolTCP,
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -188,6 +204,8 @@ min_collection_interval: 10
 				Namespace:             "my-namespace",
 				Timeout:               50000 * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -207,6 +225,8 @@ timeout: 70000
 				Namespace:             "my-namespace",
 				Timeout:               50000 * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -225,6 +245,8 @@ timeout: 70000
 				Namespace:             "my-namespace",
 				Timeout:               70000 * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -242,6 +264,8 @@ min_collection_interval: 10
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -272,6 +296,8 @@ min_collection_interval: 10
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                50,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -291,6 +317,8 @@ max_ttl: 64
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                50,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -309,6 +337,8 @@ max_ttl: 64
 				Namespace:             "my-namespace",
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                64,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -327,6 +357,8 @@ tcp_method: sack
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 				TCPMethod:             payload.TCPConfigSACK,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -345,6 +377,8 @@ tcp_method: prefer_SACK
 				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
 				TCPMethod:             payload.TCPConfigPreferSACK,
+				TracerouteQueries:     setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:            setup.DefaultNetworkPathStaticPathE2eQueries,
 			},
 		},
 		{
@@ -363,6 +397,73 @@ tcp_syn_paris_traceroute_mode: true
 				Timeout:                   setup.DefaultNetworkPathTimeout * time.Millisecond,
 				MaxTTL:                    setup.DefaultNetworkPathMaxTTL,
 				TCPSynParisTracerouteMode: true,
+				TracerouteQueries:         setup.DefaultNetworkPathStaticPathTracerouteQueries,
+				E2eQueries:                setup.DefaultNetworkPathStaticPathE2eQueries,
+			},
+		},
+		{
+			name: "tracerouteQueries and e2eQueries from instance config",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+traceroute_queries: 5
+e2e_queries: 100
+min_collection_interval: 42
+`),
+			rawInitConfig: []byte(`
+min_collection_interval: 10
+`),
+			expectedConfig: &CheckConfig{
+				DestHostname:          "1.2.3.4",
+				MinCollectionInterval: time.Duration(42) * time.Second,
+				Namespace:             "my-namespace",
+				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     5,
+				E2eQueries:            100,
+			},
+		},
+		{
+			name: "tracerouteQueries and e2eQueries from instance config preferred over init config",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+traceroute_queries: 5
+e2e_queries: 100
+min_collection_interval: 42
+`),
+			rawInitConfig: []byte(`
+min_collection_interval: 10
+traceroute_queries: 2
+e2e_queries: 2
+`),
+			expectedConfig: &CheckConfig{
+				DestHostname:          "1.2.3.4",
+				MinCollectionInterval: time.Duration(42) * time.Second,
+				Namespace:             "my-namespace",
+				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     5,
+				E2eQueries:            100,
+			},
+		},
+		{
+			name: "tracerouteQueries and e2eQueries from init config",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+min_collection_interval: 42
+`),
+			rawInitConfig: []byte(`
+min_collection_interval: 10
+traceroute_queries: 4
+e2e_queries: 20
+`),
+			expectedConfig: &CheckConfig{
+				DestHostname:          "1.2.3.4",
+				MinCollectionInterval: time.Duration(42) * time.Second,
+				Namespace:             "my-namespace",
+				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TracerouteQueries:     4,
+				E2eQueries:            20,
 			},
 		},
 	}

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -59,6 +59,8 @@ func (c *Check) Run() error {
 		TCPMethod:                 c.config.TCPMethod,
 		TCPSynParisTracerouteMode: c.config.TCPSynParisTracerouteMode,
 		ReverseDNS:                true,
+		TracerouteQueries:         c.config.TracerouteQueries,
+		E2eQueries:                c.config.E2eQueries,
 	}
 
 	tr, err := traceroute.New(cfg, c.telemetryComp)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -138,6 +138,12 @@ const (
 
 	// DefaultNetworkPathMaxTTL defines the default maximum TTL for traceroute tests
 	DefaultNetworkPathMaxTTL = 30
+
+	// DefaultNetworkPathStaticPathTracerouteQueries defines the default number of traceroute queries for static path
+	DefaultNetworkPathStaticPathTracerouteQueries = 3
+
+	// DefaultNetworkPathStaticPathE2eQueries defines the default number of end-to-end queries for static path
+	DefaultNetworkPathStaticPathE2eQueries = 50
 )
 
 var (
@@ -517,6 +523,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_path.collector.tcp_method", "")
 	config.BindEnvAndSetDefault("network_path.collector.icmp_mode", "")
 	config.BindEnvAndSetDefault("network_path.collector.tcp_syn_paris_traceroute_mode", false)
+	config.BindEnvAndSetDefault("network_path.collector.traceroute_queries", DefaultNetworkPathStaticPathTracerouteQueries)
+	config.BindEnvAndSetDefault("network_path.collector.e2e_queries", DefaultNetworkPathStaticPathE2eQueries)
 	bindEnvAndSetLogsConfigKeys(config, "network_path.forwarder.")
 
 	// HA Agent

--- a/pkg/networkpath/traceroute/config/config.go
+++ b/pkg/networkpath/traceroute/config/config.go
@@ -39,4 +39,8 @@ type Config struct {
 	TCPSynParisTracerouteMode bool
 	// ReverseDNS enrich IPs with reverse DNS
 	ReverseDNS bool
+	// TracerouteQueries is the number of traceroute queries to perform
+	TracerouteQueries int
+	// E2eQueries is the number of end-to-end queries to perform
+	E2eQueries int
 }

--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -15,6 +15,12 @@ import (
 	"strings"
 	"time"
 
+	trcommon "github.com/DataDog/datadog-traceroute/common"
+	tracerlog "github.com/DataDog/datadog-traceroute/log"
+	"github.com/DataDog/datadog-traceroute/result"
+	"github.com/DataDog/datadog-traceroute/runner"
+	"github.com/DataDog/datadog-traceroute/traceroute"
+
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	telemetryComponent "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -26,11 +32,6 @@ import (
 	cloudprovidersnetwork "github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	trcommon "github.com/DataDog/datadog-traceroute/common"
-	tracerlog "github.com/DataDog/datadog-traceroute/log"
-	"github.com/DataDog/datadog-traceroute/result"
-	"github.com/DataDog/datadog-traceroute/runner"
-	"github.com/DataDog/datadog-traceroute/traceroute"
 )
 
 const (
@@ -126,20 +127,18 @@ func (r *Runner) RunTraceroute(ctx context.Context, cfg config.Config) (payload.
 	}
 
 	params := runner.TracerouteParams{
-		Hostname:   cfg.DestHostname,
-		Port:       int(cfg.DestPort),
-		Protocol:   strings.ToLower(string(cfg.Protocol)),
-		MinTTL:     trcommon.DefaultMinTTL,
-		MaxTTL:     int(cfg.MaxTTL),
-		Delay:      DefaultDelay,
-		Timeout:    timeout,
-		TCPMethod:  traceroute.TCPMethod(cfg.TCPMethod),
-		WantV6:     false,
-		ReverseDns: cfg.ReverseDNS,
-
-		// TODO: Using TracerouteQueries = 1 for now since this PR is only about migrating the data model.
-		//       A separate PR will 1/ make traceroute_queries configurable, 2/ use 3x as default.
-		TracerouteQueries: 1,
+		Hostname:          cfg.DestHostname,
+		Port:              int(cfg.DestPort),
+		Protocol:          strings.ToLower(string(cfg.Protocol)),
+		MinTTL:            trcommon.DefaultMinTTL,
+		MaxTTL:            int(cfg.MaxTTL),
+		Delay:             DefaultDelay,
+		Timeout:           timeout,
+		TCPMethod:         traceroute.TCPMethod(cfg.TCPMethod),
+		WantV6:            false,
+		ReverseDns:        cfg.ReverseDNS,
+		TracerouteQueries: cfg.TracerouteQueries,
+		E2eQueries:        cfg.E2eQueries,
 	}
 
 	results, err := runner.RunTraceroute(ctx, params)

--- a/pkg/networkpath/traceroute/sysprobe.go
+++ b/pkg/networkpath/traceroute/sysprobe.go
@@ -19,13 +19,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, tcpSynParisTracerouteMode bool, reverseDNS bool, maxTTL uint8, timeout time.Duration) ([]byte, error) {
+func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, tcpSynParisTracerouteMode bool, reverseDNS bool, maxTTL uint8, timeout time.Duration, tracerouteQueries int, e2eQueries int) ([]byte, error) {
 	httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second // allow extra time for the system probe communication overhead, calculate full timeout for TCP traceroute
 	log.Tracef("Network Path traceroute HTTP request timeout: %s", httpTimeout)
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
-	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s&tcp_method=%s&tcp_syn_paris_traceroute_mode=%t&reverse_dns=%t", host, clientID, port, maxTTL, timeout, protocol, tcpMethod, tcpSynParisTracerouteMode, reverseDNS))
+	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s&tcp_method=%s&tcp_syn_paris_traceroute_mode=%t&reverse_dns=%t&traceroute_queries=%d&e2e_queries=%d", host, clientID, port, maxTTL, timeout, protocol, tcpMethod, tcpSynParisTracerouteMode, reverseDNS, tracerouteQueries, e2eQueries))
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/networkpath/traceroute/sysprobe_test.go
+++ b/pkg/networkpath/traceroute/sysprobe_test.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package traceroute
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
+)
+
+type mockRoundTripper struct {
+	statusCode      int
+	capturedRequest *http.Request
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.capturedRequest = req
+
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestGetTracerouteURL(t *testing.T) {
+	tests := []struct {
+		name                      string
+		host                      string
+		clientID                  string
+		port                      uint16
+		protocol                  payload.Protocol
+		tcpMethod                 payload.TCPMethod
+		tcpSynParisTracerouteMode bool
+		reverseDNS                bool
+		maxTTL                    uint8
+		timeout                   time.Duration
+		tracerouteQueries         int
+		e2eQueries                int
+		expectedParams            map[string]string
+	}{
+		{
+			name:                      "validate URL",
+			host:                      "google.com",
+			clientID:                  "test-client",
+			port:                      80,
+			protocol:                  payload.ProtocolTCP,
+			tcpMethod:                 payload.TCPConfigPreferSACK,
+			tcpSynParisTracerouteMode: true,
+			reverseDNS:                true,
+			maxTTL:                    30,
+			timeout:                   5 * time.Second,
+			tracerouteQueries:         3,
+			e2eQueries:                50,
+			expectedParams: map[string]string{
+				"client_id":                     "test-client",
+				"port":                          "80",
+				"max_ttl":                       "30",
+				"timeout":                       "5000000000",
+				"protocol":                      "TCP",
+				"tcp_method":                    "prefer_sack",
+				"tcp_syn_paris_traceroute_mode": "true",
+				"reverse_dns":                   "true",
+				"traceroute_queries":            "3",
+				"e2e_queries":                   "50",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock HTTP client that captures the request
+			mockTransport := &mockRoundTripper{
+				statusCode: http.StatusOK,
+			}
+			mockClient := &http.Client{
+				Transport: mockTransport,
+			}
+
+			_, err := getTraceroute(
+				mockClient,
+				tt.clientID,
+				tt.host,
+				tt.port,
+				tt.protocol,
+				tt.tcpMethod,
+				tt.tcpSynParisTracerouteMode,
+				tt.reverseDNS,
+				tt.maxTTL,
+				tt.timeout,
+				tt.tracerouteQueries,
+				tt.e2eQueries,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, mockTransport.capturedRequest, "HTTP request should have been captured")
+
+			capturedURL := mockTransport.capturedRequest.URL
+			require.NotNil(t, capturedURL, "Captured request should have a URL")
+
+			expectedPathPrefix := "/traceroute/" + tt.host
+			assert.Contains(t, capturedURL.Path, expectedPathPrefix, "URL path should contain the host")
+			assert.Equal(t, "GET", mockTransport.capturedRequest.Method, "Should use GET method")
+			assert.Equal(t, "application/json", mockTransport.capturedRequest.Header.Get("Accept"), "Should set Accept header")
+
+			query := capturedURL.Query()
+
+			expectedParamCount := len(tt.expectedParams)
+			actualParamCount := len(query)
+			assert.Equal(t, expectedParamCount, actualParamCount, "Should have exactly %d query parameters", expectedParamCount)
+
+			for key, expectedValue := range tt.expectedParams {
+				actualValue := query.Get(key)
+				assert.Equal(t, expectedValue, actualValue, "Query parameter %s should match expected value", key)
+			}
+		})
+	}
+}

--- a/pkg/networkpath/traceroute/traceroute_unix.go
+++ b/pkg/networkpath/traceroute/traceroute_unix.go
@@ -42,7 +42,7 @@ func New(cfg config.Config, _ telemetry.Component) (*UnixTraceroute, error) {
 
 // Run executes a traceroute
 func (l *UnixTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.TCPSynParisTracerouteMode, l.cfg.ReverseDNS, l.cfg.MaxTTL, l.cfg.Timeout)
+	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.TCPSynParisTracerouteMode, l.cfg.ReverseDNS, l.cfg.MaxTTL, l.cfg.Timeout, l.cfg.TracerouteQueries, l.cfg.E2eQueries)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}

--- a/pkg/networkpath/traceroute/traceroute_windows.go
+++ b/pkg/networkpath/traceroute/traceroute_windows.go
@@ -44,7 +44,7 @@ func New(cfg config.Config, _ telemetry.Component) (*WindowsTraceroute, error) {
 
 // Run executes a traceroute
 func (w *WindowsTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.TCPSynParisTracerouteMode, w.cfg.ReverseDNS, w.cfg.MaxTTL, w.cfg.Timeout)
+	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.TCPSynParisTracerouteMode, w.cfg.ReverseDNS, w.cfg.MaxTTL, w.cfg.Timeout, w.cfg.TracerouteQueries, w.cfg.E2eQueries)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}

--- a/releasenotes/notes/network-path-multi-traceroute-and-e2e-probes-68572f86975e0acf.yaml
+++ b/releasenotes/notes/network-path-multi-traceroute-and-e2e-probes-68572f86975e0acf.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Network Path will now run multiple traceroutes and end-to-end probes for each endpoint.

--- a/test/new-e2e/tests/netpath/network-path-integration/fake-traceroute/router_setup.sh
+++ b/test/new-e2e/tests/netpath/network-path-integration/fake-traceroute/router_setup.sh
@@ -45,3 +45,23 @@ ip netns exec endpoint ip link set lo up
 ip netns exec router sysctl -w net.ipv4.ip_forward=1
 ip netns exec endpoint ip route add default via 198.51.100.1
 ip route add 198.51.100.0/24 via 192.0.2.2 dev veth0
+
+# disable ICMP rate limiting
+sysctl -q -w net.ipv4.icmp_ratelimit=0
+sysctl -q -w net.ipv4.icmp_ratemask=0
+ip netns exec router sysctl -q -w net.ipv4.icmp_ratelimit=0
+ip netns exec router sysctl -q -w net.ipv4.icmp_ratemask=0
+ip netns exec endpoint sysctl -q -w net.ipv4.icmp_ratelimit=0
+ip netns exec endpoint sysctl -q -w net.ipv4.icmp_ratemask=0
+
+# disable reverse-path filtering to avoid dropping valid ICMP responses
+sysctl -q -w net.ipv4.conf.all.rp_filter=0
+sysctl -q -w net.ipv4.conf.default.rp_filter=0
+sysctl -q -w net.ipv4.conf.veth0.rp_filter=0
+ip netns exec router sysctl -q -w net.ipv4.conf.all.rp_filter=0
+ip netns exec router sysctl -q -w net.ipv4.conf.default.rp_filter=0
+ip netns exec router sysctl -q -w net.ipv4.conf.veth1.rp_filter=0
+ip netns exec router sysctl -q -w net.ipv4.conf.veth2.rp_filter=0
+ip netns exec endpoint sysctl -q -w net.ipv4.conf.all.rp_filter=0
+ip netns exec endpoint sysctl -q -w net.ipv4.conf.default.rp_filter=0
+ip netns exec endpoint sysctl -q -w net.ipv4.conf.veth3.rp_filter=0

--- a/test/new-e2e/tests/netpath/network-path-integration/fake_traceroute_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/fake_traceroute_test.go
@@ -81,7 +81,6 @@ func (s *fakeTracerouteTestSuite) TestFakeTraceroute() {
 		assert.Equal(c, targetIP.String(), np.Destination.Hostname)
 
 		require.Len(c, np.Traceroute.Runs, 3) // runs 3 traceroute by default
-		require.Len(c, np.E2eProbe.RTTs, 50)  // runs 50 e2e probes by default
 
 		// Validate all 3 traceroute runs
 		for i, run := range np.Traceroute.Runs {
@@ -103,6 +102,12 @@ func (s *fakeTracerouteTestSuite) TestFakeTraceroute() {
 			assert.Equal(c, targetIP, run.Hops[1].IPAddress, "Run %d hop 2 should be target IP", i+1)
 			assert.True(c, run.Hops[1].Reachable, "Run %d hop 2 should be reachable", i+1)
 		}
+
+		// Validate e2e probe statistics
+		require.Len(c, np.E2eProbe.RTTs, 50) // runs 50 e2e probes by default
+		assert.Equal(c, 50, np.E2eProbe.PacketsSent, "Should send exactly 50 packets")
+		assert.Equal(c, 50, np.E2eProbe.PacketsReceived, "Should receive exactly 50 packets")
+		assert.Equal(c, float32(0), np.E2eProbe.PacketLossPercentage, "Should have 0% packet loss")
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/test/new-e2e/tests/netpath/network-path-integration/fake_traceroute_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/fake_traceroute_test.go
@@ -80,25 +80,29 @@ func (s *fakeTracerouteTestSuite) TestFakeTraceroute() {
 		assert.Equal(c, hostname, np.Source.Hostname)
 		assert.Equal(c, targetIP.String(), np.Destination.Hostname)
 
-		require.Len(c, np.Traceroute.Runs, 1) // runs 1 traceroute by default
+		require.Len(c, np.Traceroute.Runs, 3) // runs 3 traceroute by default
+		require.Len(c, np.E2eProbe.RTTs, 50)  // runs 50 e2e probes by default
 
-		run1 := np.Traceroute.Runs[0]
+		// Validate all 3 traceroute runs
+		for i, run := range np.Traceroute.Runs {
+			assert.NotEmpty(c, run.RunID, "Run %d should have a RunID", i+1)
+			assert.NotEmpty(c, run.Source.IPAddress, "Run %d should have source IP", i+1)
+			assert.NotZero(c, run.Source.Port, "Run %d should have source port", i+1)
+			assert.NotEmpty(c, run.Destination.IPAddress, "Run %d should have destination IP", i+1)
+			assert.NotZero(c, run.Destination.Port, "Run %d should have destination port", i+1)
 
-		assert.NotEmpty(c, run1.RunID)
-		assert.NotEmpty(c, run1.Source.IPAddress)
-		assert.NotZero(c, run1.Source.Port)
-		assert.NotEmpty(c, run1.Destination.IPAddress)
-		assert.NotZero(c, run1.Destination.Port)
+			require.Len(c, run.Hops, 2, "Run %d should have exactly 2 hops", i+1)
 
-		require.Len(c, run1.Hops, 2)
+			// Validate first hop (router)
+			assert.Equal(c, 1, run.Hops[0].TTL, "Run %d hop 1 should have TTL=1", i+1)
+			assert.Equal(c, routerIP, run.Hops[0].IPAddress, "Run %d hop 1 should be router IP", i+1)
+			assert.True(c, run.Hops[0].Reachable, "Run %d hop 1 should be reachable", i+1)
 
-		assert.Equal(c, 1, run1.Hops[0].TTL)
-		assert.Equal(c, routerIP, run1.Hops[0].IPAddress)
-		assert.True(c, run1.Hops[0].Reachable)
-
-		assert.Equal(c, 2, run1.Hops[1].TTL)
-		assert.Equal(c, targetIP, run1.Hops[1].IPAddress)
-		assert.True(c, run1.Hops[1].Reachable)
+			// Validate second hop (target)
+			assert.Equal(c, 2, run.Hops[1].TTL, "Run %d hop 2 should have TTL=2", i+1)
+			assert.Equal(c, targetIP, run.Hops[1].IPAddress, "Run %d hop 2 should be target IP", i+1)
+			assert.True(c, run.Hops[1].Reachable, "Run %d hop 2 should be reachable", i+1)
+		}
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
### What does this PR do?
Add multi-traceroute and e2e probe config to datadog-agent network path integration.  For the network path integration (static path), traceroute_queries defaults to 3 and e2e_queries defaults to 50 and both are configurable.  For the npcollector (dynamic path), traceroute_queries defaults to 1 and e2e_queries defaults to 10 and neither are configurable currently because we're still determining dynamic path details.

### Motivation
To add configurable support for new multi-traceroute and e2e probe functionality of network path.

### Describe how you validated your changes
Built and ran agent, process agent and system-probe in a vagrant VM.  Validated defaults, init config, and instance config for static path and defaults for dynamic path.

### Additional Notes
