### PR TITLE
Adding valid origin values

### DIFF
--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -62,9 +62,9 @@ func buildSketchPayload() *gogen.SketchPayload {
 		Tags: []string{"tag1:value1", "tag2:value2"},
 		Metadata: &gogen.Metadata{
 			Origin: &gogen.Origin{
-				OriginProduct:  1234,
-				OriginCategory: 5678,
-				OriginService:  9012,
+				OriginProduct:  10,
+				OriginCategory: 10,
+				OriginService:  10,
 			},
 		},
 	}

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -63,8 +63,8 @@ func buildSketchPayload() *gogen.SketchPayload {
 		Metadata: &gogen.Metadata{
 			Origin: &gogen.Origin{
 				OriginProduct:  10,
-				OriginCategory: 10,
-				OriginService:  10,
+				OriginCategory: 0,
+				OriginService:  0,
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Metrics hosts need valid origin values for when we send info for the connectivity check. Following the [metrics origins doc](https://datadoghq.atlassian.net/wiki/spaces/METRICSIN/pages/2702413776/Origins), valid values are being set.

### Motivation

### Describe how you validated your changes

### Additional Notes
