### PR TITLE
[tracer] Use 48-bit millisecond timestamps to save 4 bytes

### DIFF
--- a/pkg/network/ebpf/c/timestamp_ms.h
+++ b/pkg/network/ebpf/c/timestamp_ms.h
@@ -1,0 +1,40 @@
+#ifndef __TIMESTAMP_MS__
+#define __TIMESTAMP_MS__
+
+#include "ktypes.h"
+#include "bpf_helpers.h"
+
+#include "defs.h"
+#include "tracer/tracer.h"
+
+// 48-bit limit for an integer
+#define TIME_MS_LIMIT (((__u64) 1 << 48) - 1)
+
+// convert_ns_to_ms converts a 64-bit nanosecond timestamp into a 48-bit millisecond timestamp
+static __always_inline time_ms_t convert_ns_to_ms(__u64 timestamp) {
+    __u64 ms = timestamp / 1000;
+    if (ms > TIME_MS_LIMIT) {
+        ms = 0;
+    }
+
+    time_ms_t t = {0};
+    for (int i = 2; i >= 0; i--) {
+        t.timestamp[i] = ms & 0xffff;
+        ms >>= 16;
+    }
+
+    return t;
+}
+
+// convert_ns_to_ms converts a 48-bit millisecond timestamp into a 64-bit nanosecond timestamp
+static __always_inline __u64 convert_ms_to_ns(time_ms_t t) {
+    __u64 ms = 0;
+    for (int i = 0; i < 3; i++) {
+        ms <<= 16;
+        ms += t.timestamp[i];
+    }
+
+    return ms * 1000;
+}
+
+#endif // __TIMESTAMP_MS__

--- a/pkg/network/ebpf/c/tracer/events.h
+++ b/pkg/network/ebpf/c/tracer/events.h
@@ -120,7 +120,9 @@ static __always_inline int cleanup_conn(void *ctx, conn_tuple_t *tup, struct soc
     // the conn_stats_ts_t object up to now. we re-use this field
     // for the duration since we would overrun stack size limits
     // if we added another field
-    conn.conn_stats.duration = bpf_ktime_get_ns() - conn.conn_stats.duration;
+    __u64 start_ns = convert_ms_to_ns(conn.conn_stats.duration_ms);
+    __u64 delta_ns = bpf_ktime_get_ns() - start_ns;
+    conn.conn_stats.duration_ms = convert_ns_to_ms(delta_ns);
 
     if (is_batching_enabled()) {
         // Batch TCP closed connections before generating a perf event

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -17,6 +17,7 @@
 #include "ip.h"
 #include "skb.h"
 #include "pid_tgid.h"
+#include "timestamp_ms.h"
 
 #ifdef COMPILE_PREBUILT
 static __always_inline __u64 offset_rtt();
@@ -81,7 +82,7 @@ static __always_inline conn_stats_ts_t *get_conn_stats(conn_tuple_t *t, struct s
     // initialize-if-no-exist the connection stat, and load it
     conn_stats_ts_t empty = {};
     bpf_memset(&empty, 0, sizeof(conn_stats_ts_t));
-    empty.duration = bpf_ktime_get_ns();
+    empty.duration_ms = convert_ns_to_ms(bpf_ktime_get_ns());
     empty.cookie = get_sk_cookie(sk);
 
     // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
@@ -233,7 +234,7 @@ static __always_inline void update_conn_stats(conn_tuple_t *t, size_t sent_bytes
             val->sent_packets = packets_out;
         }
     }
-    val->timestamp = ts;
+    val->timestamp_ms = convert_ns_to_ms(ts);
 
     if (dir != CONN_DIRECTION_UNKNOWN) {
         val->direction = dir;

--- a/pkg/network/ebpf/c/tracer/tracer.h
+++ b/pkg/network/ebpf/c/tracer/tracer.h
@@ -44,19 +44,24 @@ typedef struct {
     tls_info_t info;
 } tls_info_wrapper_t;
 
+// 48-bit milliseconds timestamp
+typedef struct {
+    __u16 timestamp[3];
+} time_ms_t;
+
 typedef struct {
     __u64 sent_bytes;
     __u64 recv_bytes;
     __u32 sent_packets;
     __u32 recv_packets;
-    __u64 timestamp;
+    time_ms_t timestamp_ms;
     // duration of the connection.
     // this is initialized to the current unix
     // timestamp when a conn_stats_ts_t is created.
     // the field remains unchanged until this object
     // is removed from the conn_stats map when it
     // is updated with (CURRENT_TIME - duration)
-    __u64 duration;
+    time_ms_t duration_ms;
     // "cookie" that uniquely identifies
     // a conn_stas_ts_t. This is used
     // in user space to distinguish between
@@ -70,6 +75,7 @@ typedef struct {
     __u8 flags;
     __u8 direction;
     tls_info_t tls_tags;
+    __u32 cert_id;
 } conn_stats_ts_t;
 
 // Connection flags

--- a/pkg/network/ebpf/kprobe_types.go
+++ b/pkg/network/ebpf/kprobe_types.go
@@ -32,6 +32,7 @@ type ProtocolStack C.protocol_stack_t
 type ProtocolStackWrapper C.protocol_stack_wrapper_t
 type TLSTags C.tls_info_t
 type TLSTagsWrapper C.tls_info_wrapper_t
+type NetTimeMs C.time_ms_t
 
 // udp_recv_sock_t have *sock and *msghdr struct members, we make them opaque here
 type _Ctype_struct_sock uint64

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -26,13 +26,14 @@ type ConnStats struct {
 	Recv_bytes     uint64
 	Sent_packets   uint32
 	Recv_packets   uint32
-	Timestamp      uint64
-	Duration       uint64
+	Timestamp_ms   NetTimeMs
+	Duration_ms    NetTimeMs
 	Cookie         uint32
 	Protocol_stack ProtocolStack
 	Flags          uint8
 	Direction      uint8
 	Tls_tags       TLSTags
+	Cert_id        uint32
 }
 type Conn struct {
 	Tup        ConnTuple
@@ -111,6 +112,9 @@ type TLSTagsWrapper struct {
 	Updated   uint64
 	Info      TLSTags
 	Pad_cgo_0 [2]byte
+}
+type NetTimeMs struct {
+	Timestamp [3]uint16
 }
 
 type _Ctype_struct_sock uint64

--- a/pkg/network/ebpf/kprobe_types_linux_test.go
+++ b/pkg/network/ebpf/kprobe_types_linux_test.go
@@ -71,3 +71,7 @@ func TestCgoAlignment_TLSTags(t *testing.T) {
 func TestCgoAlignment_TLSTagsWrapper(t *testing.T) {
 	ebpftest.TestCgoAlignment[TLSTagsWrapper](t)
 }
+
+func TestCgoAlignment_NetTimeMs(t *testing.T) {
+	ebpftest.TestCgoAlignment[NetTimeMs](t)
+}


### PR DESCRIPTION
### What does this PR do?
This PR changes our connection timestamps to use a 48-bit millisecond timestamp instead of 64-bit nanoseconds. It allows us to save 4 bytes total on the connection, allowing us space to add in the `cert_id` field.

### Motivation
We can't increase the size of `conn_stats_ts_t` at the moment due to ebpf stack restrictions.

### Describe how you validated your changes
`TestConnectionDuration` still passes

### Additional Notes
2^48 milliseconds is 8920 years, so sizing issues are not a concern.