### PR TITLE
Fix raw data len calculation for JSON aggregation 

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_aggregator.go
@@ -37,7 +37,7 @@ func NewJSONAggregator(tagCompleteJSON bool, maxContentSize int) *JSONAggregator
 // If the message is not a JSON message, it will be returned as is, and any buffered messages will be flushed (unmodified).
 func (r *JSONAggregator) Process(msg *message.Message) []*message.Message {
 	r.messageBuf = append(r.messageBuf, msg)
-	r.currentSize += len(msg.GetContent())
+	r.currentSize += msg.RawDataLen
 
 	// Flush if we've exceeded the max size
 	if r.currentSize > r.maxContentSize {

--- a/releasenotes/notes/fix-json-aggregator-byte-offset-dc6e9bdef4674140.yaml
+++ b/releasenotes/notes/fix-json-aggregator-byte-offset-dc6e9bdef4674140.yaml
@@ -10,4 +10,4 @@ fixes:
   - |
     Fixes a bug in the JSON aggregator where the byte offset was not correctly calculated.
     This ensures no logs are re-collected when auto multiline detection is enabled when
-    the agent is restarted.
+    the Agent is restarted.

--- a/releasenotes/notes/fix-json-aggregator-byte-offset-dc6e9bdef4674140.yaml
+++ b/releasenotes/notes/fix-json-aggregator-byte-offset-dc6e9bdef4674140.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug in the JSON aggregator where the byte offset was not correctly calculated.
+    This ensures no logs are re-collected when auto multiline detection is enabled when
+    the agent is restarted.


### PR DESCRIPTION


### What does this PR do?

This PR fixes a bug when auto multiline detection is enabled, the JSON aggregator would record the logs byte size as `1` byte smaller than the actual offset in the file. This can cause the agent to re-collect a small number of bytes from previously tailed files when the agent restarts and resumes from the offset stored in the registry. 

### Motivation

Bug Fix

### Describe how you validated your changes

Unit test reproduces the issue, and validate the fix. 
Also tested manually by emitting a log file that is exactly 300 bytes, and observing the offset in the `registry.json` 

### Additional Notes
