### PR TITLE
[dyninst/irgen] Collect line information for probed subprograms

### DIFF
--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -88,7 +88,7 @@ type Subprogram struct {
 	// Name is the name of the subprogram.
 	Name string
 	// OutOfLinePCRanges are the ranges of PC values that will be probed for the
-	// out-of-line-instances of the subprogram. These are sorted by start PC.
+	// out-of-line instance of the subprogram. These are sorted by start PC.
 	// Some functions may be inlined only in certain callers, in which case
 	// both OutOfLinePCRanges and InlinedPCRanges will be non-empty.
 	OutOfLinePCRanges []PCRange
@@ -97,17 +97,6 @@ type Subprogram struct {
 	InlinePCRanges []InlinePCRanges
 	// Variables are the variables that are used in the subprogram.
 	Variables []*Variable
-}
-
-// SubprogramLine represents a line in the subprogram.
-type SubprogramLine struct {
-	PC              uint64
-	File            string
-	Line            uint32
-	Column          uint32
-	IsStatement     bool
-	IsPrologueEnd   bool
-	IsEpilogueStart bool
 }
 
 // Variable represents a variable or parameter in the subprogram.

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -178,26 +178,29 @@ func generateIR(
 	if err != nil {
 		return nil, err
 	}
-	// Find prologues need to determine injection points. We make an assumption
-	// that prologue, if function has a frame, should be contained within the
-	// first pc range of a subprogram. This simplifies the logic slightly.
-	prologueSearch := make([]prologueSeachParams, 0, len(processed.pendingSubprograms))
+
+	// Collect line information about subprograms. It's important for performance
+	// to batch analysis of each compilation unit, and do it in incremental
+	// pc order for each compilation unit.
+	lineSearchRanges := make([]lineSearchRange, 0, len(processed.pendingSubprograms))
 	for _, sp := range processed.pendingSubprograms {
-		if len(sp.outOfLinePCRanges) > 0 {
-			prologueSearch = append(prologueSearch, prologueSeachParams{
+		for _, pcRange := range sp.outOfLinePCRanges {
+			lineSearchRanges = append(lineSearchRanges, lineSearchRange{
 				unit:    sp.unit,
-				pcRange: sp.outOfLinePCRanges[0],
+				pcRange: pcRange,
 			})
 		}
 		for _, inlined := range sp.inlinePCRanges {
-			prologueSearch = append(prologueSearch, prologueSeachParams{
-				unit:    sp.unit,
-				pcRange: inlined.RootRanges[0],
-			})
+			for _, pcRange := range inlined.RootRanges {
+				lineSearchRanges = append(lineSearchRanges, lineSearchRange{
+					unit:    sp.unit,
+					pcRange: pcRange,
+				})
+			}
 		}
 	}
 
-	prologueLocs, err := findProloguesEnds(objFile, prologueSearch)
+	lineData, err := collectLineData(objFile, lineSearchRanges)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +308,7 @@ func generateIR(
 	}
 	// Instantiate probes and gather any probe-related issues.
 	probes, subprograms, probeIssues, err := createProbes(
-		arch, processed.pendingSubprograms, prologueLocs, idToSub,
+		arch, processed.pendingSubprograms, lineData, idToSub,
 	)
 	if err != nil {
 		return nil, err
@@ -739,46 +742,56 @@ func materializePending(
 	return subprograms, nil
 }
 
-type prologueSeachParams struct {
+type lineSearchRange struct {
 	unit    *dwarf.Entry
 	pcRange ir.PCRange
 }
 
-type prologueEndLocation struct {
-	err       error
-	frameless bool
-	// If not frameless, the pc of the prologue end, otherwise the first pc
-	// of the subprogram.
-	pc uint64
+type line struct {
+	pc          uint64
+	line        uint32
+	isStatement bool
 }
 
-// findPrologues searches for prologue for each given search param. Results
-// are indexed by the start of the pc range. Provided ranges must be non-overlapping
-// but may contain duplicates.
-func findProloguesEnds(
+type lineData struct {
+	err error
+	// PC of prologue end or 0 if no prologue end statement is found.
+	prologueEnd uint64
+	lines       []line
+}
+
+// collectLineData evaluates DWARF line programs to aggregate line data for given ranges.
+func collectLineData(
 	objFile object.Dwarf,
-	searchParams []prologueSeachParams,
-) (map[uint64]prologueEndLocation, error) {
-	if len(searchParams) == 0 {
-		return make(map[uint64]prologueEndLocation), nil
+	searchRanges []lineSearchRange,
+) (map[ir.PCRange]lineData, error) {
+	if len(searchRanges) == 0 {
+		return make(map[ir.PCRange]lineData), nil
 	}
-	slices.SortFunc(searchParams, func(a, b prologueSeachParams) int {
+	slices.SortFunc(searchRanges, func(a, b lineSearchRange) int {
 		return cmp.Compare(a.pcRange[0], b.pcRange[0])
 	})
 	// Remove duplicates.
 	i := 1
-	for j := 1; j < len(searchParams); j++ {
-		if searchParams[i-1].pcRange != searchParams[j].pcRange {
-			searchParams[i] = searchParams[j]
+	for j := 1; j < len(searchRanges); j++ {
+		if searchRanges[i-1].pcRange != searchRanges[j].pcRange {
+			if searchRanges[i-1].unit == searchRanges[j].unit &&
+				searchRanges[i-1].pcRange[1] > searchRanges[j].pcRange[0] {
+				return nil, fmt.Errorf("overlapping line search ranges in unit %#x: %#x and %#x",
+					searchRanges[i-1].unit.Offset,
+					searchRanges[i-1].pcRange,
+					searchRanges[j].pcRange)
+			}
+			searchRanges[i] = searchRanges[j]
 			i++
 		}
 	}
-	searchParams = searchParams[:i]
+	searchRanges = searchRanges[:i]
 
-	res := make(map[uint64]prologueEndLocation, len(searchParams))
+	res := make(map[ir.PCRange]lineData, len(searchRanges))
 	var prevUnit *dwarf.Entry
 	var lineReader *dwarf.LineReader
-	for _, sp := range searchParams {
+	for _, sp := range searchRanges {
 		if prevUnit != sp.unit {
 			prevUnit = sp.unit
 			lr, err := objFile.DwarfData().LineReader(prevUnit)
@@ -787,22 +800,7 @@ func findProloguesEnds(
 			}
 			lineReader = lr
 		}
-
-		pc, ok, err := findPrologueEnd(lineReader, sp.pcRange)
-		switch {
-		case err != nil:
-			res[sp.pcRange[0]] = prologueEndLocation{err: err}
-		case ok:
-			res[sp.pcRange[0]] = prologueEndLocation{
-				frameless: false,
-				pc:        pc,
-			}
-		default:
-			res[sp.pcRange[0]] = prologueEndLocation{
-				frameless: true,
-				pc:        sp.pcRange[0],
-			}
-		}
+		res[sp.pcRange] = collectLineDataForRange(lineReader, sp.pcRange)
 	}
 	return res, nil
 }
@@ -812,7 +810,7 @@ func findProloguesEnds(
 func createProbes(
 	arch object.Architecture,
 	pending []*pendingSubprogram,
-	prologueLocs map[uint64]prologueEndLocation,
+	lineData map[ir.PCRange]lineData,
 	idToSubprogram map[ir.SubprogramID]*ir.Subprogram,
 ) ([]*ir.Probe, []*ir.Subprogram, []ir.ProbeIssue, error) {
 	var (
@@ -833,7 +831,7 @@ func createProbes(
 		sp := idToSubprogram[p.id]
 		var haveProbe bool
 		for _, cfg := range p.probesCfgs {
-			probe, iss, err := newProbe(arch, cfg, sp, &eventIDAlloc, prologueLocs)
+			probe, iss, err := newProbe(arch, cfg, sp, &eventIDAlloc, lineData)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -1762,7 +1760,7 @@ func newProbe(
 	probeCfg ir.ProbeDefinition,
 	subprogram *ir.Subprogram,
 	eventIDAlloc *idAllocator[ir.EventID],
-	prologueLocs map[uint64]prologueEndLocation,
+	lineData map[ir.PCRange]lineData,
 ) (*ir.Probe, ir.Issue, error) {
 	kind := probeCfg.GetKind()
 	if !kind.IsValid() {
@@ -1780,10 +1778,10 @@ func newProbe(
 		}, nil
 	}
 	if subprogram.OutOfLinePCRanges != nil {
-		pc := subprogram.OutOfLinePCRanges[0][0]
-		loc, ok := prologueLocs[pc]
+		loc, ok := lineData[subprogram.OutOfLinePCRanges[0]]
 		if !ok {
-			return nil, ir.Issue{}, fmt.Errorf("missing prologue loc for: %d", pc)
+			return nil, ir.Issue{}, fmt.Errorf("missing line data for range: [0x%x, 0x%x]",
+				subprogram.OutOfLinePCRanges[0][0], subprogram.OutOfLinePCRanges[0][1])
 		}
 		if loc.err != nil {
 			return nil, ir.Issue{
@@ -1791,29 +1789,34 @@ func newProbe(
 				Message: loc.err.Error(),
 			}, nil
 		}
+		frameless := loc.prologueEnd == 0
+		injectionPC := loc.prologueEnd
+		if injectionPC == 0 {
+			injectionPC = subprogram.OutOfLinePCRanges[0][0]
+		}
 		switch arch {
 		case "amd64":
 			// Do nothing
 		case "arm64":
 			// On arm, the prologue end is marked before the stack allocation.
-			loc.frameless = true
+			frameless = true
 		default:
 			return nil, ir.Issue{}, fmt.Errorf("unsupported architecture: %s", arch)
 		}
 		injectionPoints = append(injectionPoints, ir.InjectionPoint{
-			PC:        loc.pc,
-			Frameless: loc.frameless,
+			PC:        injectionPC,
+			Frameless: frameless,
 		})
 	}
 	for _, inlined := range subprogram.InlinePCRanges {
-		pc := inlined.RootRanges[0][0]
-		loc, ok := prologueLocs[pc]
+		loc, ok := lineData[inlined.RootRanges[0]]
 		if !ok {
-			return nil, ir.Issue{}, fmt.Errorf("missing prologue loc for: %d", pc)
+			return nil, ir.Issue{}, fmt.Errorf("missing line data for range: [0x%x, 0x%x]",
+				inlined.RootRanges[0][0], inlined.RootRanges[0][1])
 		}
 		injectionPoints = append(injectionPoints, ir.InjectionPoint{
 			PC:        inlined.Ranges[0][0],
-			Frameless: loc.frameless,
+			Frameless: loc.prologueEnd == 0,
 		})
 	}
 
@@ -1836,9 +1839,9 @@ func newProbe(
 	return probe, ir.Issue{}, nil
 }
 
-func findPrologueEnd(
+func collectLineDataForRange(
 	lineReader *dwarf.LineReader, r ir.PCRange,
-) (injectionPC uint64, ok bool, err error) {
+) lineData {
 	var lineEntry dwarf.LineEntry
 	prevPos := lineReader.Tell()
 	// In general, SeekPC is not the function we're looking for.  We
@@ -1848,7 +1851,7 @@ func findPrologueEnd(
 	//
 	// TODO: Find a way to seek to the first entry in a range rather
 	// than just
-	err = lineReader.SeekPC(r[0], &lineEntry)
+	err := lineReader.SeekPC(r[0], &lineEntry)
 	// If we find that we have a hole, then we'll have our hands on
 	// a reader that's positioned after our PC. We can then seek to
 	// the instruction prior to that which should be in range of a
@@ -1870,30 +1873,27 @@ func findPrologueEnd(
 		// than starting from 0 for the next seek given the caller is exploring
 		// in PC order.
 		lineReader.Seek(prevPos)
-		return 0, false, err
+		return lineData{err: err}
 	}
-	// For whatever reason the entrypoint of a function is marked as a
-	// statement and then should come the prologue end. If we see two
-	// statements in a row then we're not going to find the prologue end.
-	stmtsSeen := 0
-	for lineEntry.Address < r[1] && stmtsSeen < 2 {
+	prologueEnd := uint64(0)
+	lines := []line{}
+	for lineEntry.Address < r[1] {
 		if lineEntry.PrologueEnd {
-			return lineEntry.Address, true, nil
+			prologueEnd = lineEntry.Address
 		}
-		if lineEntry.IsStmt {
-			stmtsSeen++
-		}
+		lines = append(lines, line{
+			pc:          lineEntry.Address,
+			line:        uint32(lineEntry.Line),
+			isStatement: lineEntry.IsStmt,
+		})
 		if err := lineReader.Next(&lineEntry); err != nil {
-			// Should this return an error?
-			//
-			// In general, if we don't have the proper prologue end
-			// and it's not a frameless subprogram, then we're going
-			// to have a problem on x86 because we won't know the
-			// real cfa. On ARM things may be better.
-			break
+			return lineData{err: err}
 		}
 	}
-	return 0, false, nil
+	return lineData{
+		prologueEnd: prologueEnd,
+		lines:       lines,
+	}
 }
 
 type subprogramChildVisitor struct {


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/DEBUG-4042

Data is not used yet, but will be for line probe injection.

Also add some sanity checks, running irgen on crdb doesn't trip them. It does take twice as long now, since that evaluates lines on all the functions. But the main snapshot test shows no notable slowdown.
