### PR TITLE
[Serverless] Add exit_code tag to Cloud Run Jobs shutdown metric

### DIFF
--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -75,7 +75,7 @@ func (a *AppService) Init() error {
 }
 
 // Shutdown emits the shutdown metric for AppService
-func (a *AppService) Shutdown(agent serverlessMetrics.ServerlessMetricAgent) {
+func (a *AppService) Shutdown(agent serverlessMetrics.ServerlessMetricAgent, _ error) {
 	metric.Add(fmt.Sprintf("%s.enhanced.shutdown", appServicePrefix), 1.0, a.GetSource(), agent)
 }
 

--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -8,11 +8,12 @@ package cloudservice
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
-	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"maps"
 	"os"
 
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
@@ -73,17 +74,14 @@ func (a *AppService) Init() error {
 	return nil
 }
 
-// Shutdown is empty for AppService
-func (a *AppService) Shutdown(serverlessMetrics.ServerlessMetricAgent) {}
+// Shutdown emits the shutdown metric for AppService
+func (a *AppService) Shutdown(agent serverlessMetrics.ServerlessMetricAgent) {
+	metric.Add(fmt.Sprintf("%s.enhanced.shutdown", appServicePrefix), 1.0, a.GetSource(), agent)
+}
 
 // GetStartMetricName returns the metric name for container start (coldstart) events
 func (a *AppService) GetStartMetricName() string {
 	return fmt.Sprintf("%s.enhanced.cold_start", appServicePrefix)
-}
-
-// GetShutdownMetricName returns the metric name for container shutdown events
-func (a *AppService) GetShutdownMetricName() string {
-	return fmt.Sprintf("%s.enhanced.shutdown", appServicePrefix)
 }
 
 // ShouldForceFlushAllOnForceFlushToSerializer is false usually.

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -7,14 +7,15 @@ package cloudservice
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
-	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -152,17 +153,14 @@ func (c *CloudRun) Init() error {
 	return nil
 }
 
-// Shutdown is empty for CloudRun
-func (c *CloudRun) Shutdown(serverlessMetrics.ServerlessMetricAgent) {}
+// Shutdown emits the shutdown metric for CloudRun
+func (c *CloudRun) Shutdown(agent serverlessMetrics.ServerlessMetricAgent) {
+	metric.Add(fmt.Sprintf("%s.enhanced.shutdown", cloudRunPrefix), 1.0, c.GetSource(), agent)
+}
 
 // GetStartMetricName returns the metric name for container start (coldstart) events
 func (c *CloudRun) GetStartMetricName() string {
 	return fmt.Sprintf("%s.enhanced.cold_start", cloudRunPrefix)
-}
-
-// GetShutdownMetricName returns the metric name for container shutdown events
-func (c *CloudRun) GetShutdownMetricName() string {
-	return fmt.Sprintf("%s.enhanced.shutdown", cloudRunPrefix)
 }
 
 // ShouldForceFlushAllOnForceFlushToSerializer is false usually.

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -154,7 +154,7 @@ func (c *CloudRun) Init() error {
 }
 
 // Shutdown emits the shutdown metric for CloudRun
-func (c *CloudRun) Shutdown(agent serverlessMetrics.ServerlessMetricAgent) {
+func (c *CloudRun) Shutdown(agent serverlessMetrics.ServerlessMetricAgent, _ error) {
 	metric.Add(fmt.Sprintf("%s.enhanced.shutdown", cloudRunPrefix), 1.0, c.GetSource(), agent)
 }
 

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/exitcode"
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
@@ -102,12 +103,14 @@ func (c *CloudRunJobs) Init() error {
 }
 
 // Shutdown submits the task duration and shutdown metrics for CloudRunJobs
-func (c *CloudRunJobs) Shutdown(metricAgent serverlessMetrics.ServerlessMetricAgent) {
+func (c *CloudRunJobs) Shutdown(metricAgent serverlessMetrics.ServerlessMetricAgent, runErr error) {
 	durationMetricName := fmt.Sprintf("%s.enhanced.task.duration", cloudRunJobsPrefix)
 	duration := float64(time.Since(c.startTime).Milliseconds())
 	metric.Add(durationMetricName, duration, c.GetSource(), metricAgent)
 
 	shutdownMetricName := fmt.Sprintf("%s.enhanced.task.ended", cloudRunJobsPrefix)
+	exitCode := exitcode.From(runErr)
+	// TODO pass exit code as tag on metric
 	metric.Add(shutdownMetricName, 1.0, c.GetSource(), metricAgent)
 }
 

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -110,8 +110,7 @@ func (c *CloudRunJobs) Shutdown(metricAgent serverlessMetrics.ServerlessMetricAg
 
 	shutdownMetricName := fmt.Sprintf("%s.enhanced.task.ended", cloudRunJobsPrefix)
 	exitCode := exitcode.From(runErr)
-	// TODO pass exit code as tag on metric
-	metric.Add(shutdownMetricName, 1.0, c.GetSource(), metricAgent)
+	metric.Add(shutdownMetricName, 1.0, c.GetSource(), metricAgent, fmt.Sprintf("exit_code:%d", exitCode))
 }
 
 // GetStartMetricName returns the metric name for container start events

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -101,21 +101,19 @@ func (c *CloudRunJobs) Init() error {
 	return nil
 }
 
-// Shutdown submits the task duration metric for CloudRunJobs
+// Shutdown submits the task duration and shutdown metrics for CloudRunJobs
 func (c *CloudRunJobs) Shutdown(metricAgent serverlessMetrics.ServerlessMetricAgent) {
-	metricName := fmt.Sprintf("%s.enhanced.task.duration", cloudRunJobsPrefix)
+	durationMetricName := fmt.Sprintf("%s.enhanced.task.duration", cloudRunJobsPrefix)
 	duration := float64(time.Since(c.startTime).Milliseconds())
-	metric.Add(metricName, duration, c.GetSource(), metricAgent)
+	metric.Add(durationMetricName, duration, c.GetSource(), metricAgent)
+
+	shutdownMetricName := fmt.Sprintf("%s.enhanced.task.ended", cloudRunJobsPrefix)
+	metric.Add(shutdownMetricName, 1.0, c.GetSource(), metricAgent)
 }
 
 // GetStartMetricName returns the metric name for container start events
 func (c *CloudRunJobs) GetStartMetricName() string {
 	return fmt.Sprintf("%s.enhanced.task.started", cloudRunJobsPrefix)
-}
-
-// GetShutdownMetricName returns the metric name for container shutdown events
-func (c *CloudRunJobs) GetShutdownMetricName() string {
-	return fmt.Sprintf("%s.enhanced.task.ended", cloudRunJobsPrefix)
 }
 
 // ShouldForceFlushAllOnForceFlushToSerializer is true for cloud run jobs.

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs_test.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs_test.go
@@ -6,9 +6,24 @@
 package cloudservice
 
 import (
+	"fmt"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx-mock"
+	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestGetCloudRunJobsTagsWithEnvironmentVariables(t *testing.T) {
@@ -65,4 +80,61 @@ func TestIsCloudRunJob(t *testing.T) {
 func TestIsCloudRunJobWhenNotSet(t *testing.T) {
 	// This test runs in a clean environment where CLOUD_RUN_JOB is not set
 	assert.False(t, isCloudRunJob())
+}
+
+func TestCloudRunJobsShutdownAddsExitCodeTag(t *testing.T) {
+	demux := createDemultiplexer(t)
+	agent := serverlessMetrics.ServerlessMetricAgent{Demux: demux}
+
+	jobs := &CloudRunJobs{startTime: time.Now().Add(-time.Second)}
+	shutdownMetricName := fmt.Sprintf("%s.enhanced.task.ended", cloudRunJobsPrefix)
+
+	cmd := exec.Command("bash", "-c", "exit 1")
+	err := cmd.Run()
+	require.Error(t, err)
+	jobs.Shutdown(agent, err)
+
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Empty(t, timedMetrics)
+	assert.Len(t, generatedMetrics, 2)
+
+	foundShutdown := false
+	for _, sample := range generatedMetrics {
+		if sample.Name == shutdownMetricName {
+			require.Contains(t, sample.Tags, "exit_code:1")
+			foundShutdown = true
+		}
+	}
+	assert.True(t, foundShutdown, "shutdown metric not emitted")
+}
+
+func TestCloudRunJobsShutdownExitCodeZeroOnSuccess(t *testing.T) {
+	demux := createDemultiplexer(t)
+	agent := serverlessMetrics.ServerlessMetricAgent{Demux: demux}
+
+	jobs := &CloudRunJobs{startTime: time.Now().Add(-time.Second)}
+	shutdownMetricName := fmt.Sprintf("%s.enhanced.task.ended", cloudRunJobsPrefix)
+
+	jobs.Shutdown(agent, nil)
+
+	generatedMetrics, _ := demux.WaitForSamples(100 * time.Millisecond)
+
+	foundShutdown := false
+	for _, sample := range generatedMetrics {
+		if sample.Name == shutdownMetricName {
+			require.Contains(t, sample.Tags, "exit_code:0")
+			foundShutdown = true
+		}
+	}
+	assert.True(t, foundShutdown, "shutdown metric not emitted")
+}
+
+func createDemultiplexer(t *testing.T) demultiplexer.FakeSamplerMock {
+	return fxutil.Test[demultiplexer.FakeSamplerMock](t,
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		demultiplexerimpl.FakeSamplerMockModule(),
+		hostnameimpl.MockModule(),
+	)
 }

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -7,11 +7,13 @@ package cloudservice
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
-	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 )
 
 // ContainerApp has helper functions for getting specific Azure Container App data
@@ -147,17 +149,14 @@ func (c *ContainerApp) Init() error {
 	return nil
 }
 
-// Shutdown is empty for ContainerApp
-func (c *ContainerApp) Shutdown(serverlessMetrics.ServerlessMetricAgent) {}
+// Shutdown emits the shutdown metric for ContainerApp
+func (c *ContainerApp) Shutdown(agent serverlessMetrics.ServerlessMetricAgent) {
+	metric.Add(fmt.Sprintf("%s.enhanced.shutdown", containerAppPrefix), 1.0, c.GetSource(), agent)
+}
 
 // GetStartMetricName returns the metric name for container start (coldstart) events
 func (c *ContainerApp) GetStartMetricName() string {
 	return fmt.Sprintf("%s.enhanced.cold_start", containerAppPrefix)
-}
-
-// GetShutdownMetricName returns the metric name for container shutdown events
-func (c *ContainerApp) GetShutdownMetricName() string {
-	return fmt.Sprintf("%s.enhanced.shutdown", containerAppPrefix)
 }
 
 // ShouldForceFlushAllOnForceFlushToSerializer is false usually.

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -150,7 +150,7 @@ func (c *ContainerApp) Init() error {
 }
 
 // Shutdown emits the shutdown metric for ContainerApp
-func (c *ContainerApp) Shutdown(agent serverlessMetrics.ServerlessMetricAgent) {
+func (c *ContainerApp) Shutdown(agent serverlessMetrics.ServerlessMetricAgent, _ error) {
 	metric.Add(fmt.Sprintf("%s.enhanced.shutdown", containerAppPrefix), 1.0, c.GetSource(), agent)
 }
 

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -34,7 +34,7 @@ type CloudService interface {
 	Init() error
 
 	// Shutdown cleans up the CloudService and allows emitting shutdown metrics
-	Shutdown(agent serverlessMetrics.ServerlessMetricAgent)
+	Shutdown(agent serverlessMetrics.ServerlessMetricAgent, runErr error)
 
 	// GetStartMetricName returns the metric name for start events
 	GetStartMetricName() string
@@ -79,7 +79,7 @@ func (l *LocalService) Init() error {
 }
 
 // Shutdown emits the shutdown metric for LocalService
-func (l *LocalService) Shutdown(agent serverlessMetrics.ServerlessMetricAgent) {
+func (l *LocalService) Shutdown(agent serverlessMetrics.ServerlessMetricAgent, _ error) {
 	metric.Add(fmt.Sprintf("%s.enhanced.shutdown", defaultPrefix), 1.0, l.GetSource(), agent)
 }
 

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -7,6 +7,8 @@ package cloudservice
 
 import (
 	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 )
@@ -31,14 +33,11 @@ type CloudService interface {
 	// Init bootstraps the CloudService.
 	Init() error
 
-	// Shutdown cleans up the CloudService
+	// Shutdown cleans up the CloudService and allows emitting shutdown metrics
 	Shutdown(agent serverlessMetrics.ServerlessMetricAgent)
 
 	// GetStartMetricName returns the metric name for start events
 	GetStartMetricName() string
-
-	// GetShutdownMetricName returns the metric name for shutdown events
-	GetShutdownMetricName() string
 
 	// ShouldForceFlushAllOnForceFlushToSerializer is used for the
 	// forceFlushAll parameter on the call to forceFlushToSerializer in the
@@ -79,17 +78,14 @@ func (l *LocalService) Init() error {
 	return nil
 }
 
-// Shutdown is not necessary for LocalService
-func (l *LocalService) Shutdown(serverlessMetrics.ServerlessMetricAgent) {}
+// Shutdown emits the shutdown metric for LocalService
+func (l *LocalService) Shutdown(agent serverlessMetrics.ServerlessMetricAgent) {
+	metric.Add(fmt.Sprintf("%s.enhanced.shutdown", defaultPrefix), 1.0, l.GetSource(), agent)
+}
 
 // GetStartMetricName returns the metric name for container start (coldstart) events
 func (l *LocalService) GetStartMetricName() string {
 	return fmt.Sprintf("%s.enhanced.cold_start", defaultPrefix)
-}
-
-// GetShutdownMetricName returns the metric name for container shutdown events
-func (l *LocalService) GetShutdownMetricName() string {
-	return fmt.Sprintf("%s.enhanced.shutdown", defaultPrefix)
 }
 
 // ShouldForceFlushAllOnForceFlushToSerializer is false usually.

--- a/cmd/serverless-init/exitcode/exitcode.go
+++ b/cmd/serverless-init/exitcode/exitcode.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package exitcode
+
+import (
+	"errors"
+	"os/exec"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// From returns the process exit code embedded in err.
+// If err is nil, 0 is returned. If no exit code is found, it falls back to 1.
+func From(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+
+	log.Debug("using default exit code 1")
+	return 1
+}

--- a/cmd/serverless-init/exitcode/exitcode.go
+++ b/cmd/serverless-init/exitcode/exitcode.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//nolint:revive // TODO(SERV) Fix revive linter
 package exitcode
 
 import (

--- a/cmd/serverless-init/exitcode/exitcode.go
+++ b/cmd/serverless-init/exitcode/exitcode.go
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
 
 package exitcode
 

--- a/cmd/serverless-init/exitcode/exitcode_test.go
+++ b/cmd/serverless-init/exitcode/exitcode_test.go
@@ -30,3 +30,12 @@ func TestFromExitError(t *testing.T) {
 		t.Fatalf("expected 5, got %d", got)
 	}
 }
+
+func TestFromJoinedExitError(t *testing.T) {
+	cmd := exec.Command("bash", "-c", "exit 3")
+	exitErr := cmd.Run()
+	joined := errors.Join(errors.New("wrapper"), exitErr)
+	if got := From(joined); got != 3 {
+		t.Fatalf("expected 3, got %d", got)
+	}
+}

--- a/cmd/serverless-init/exitcode/exitcode_test.go
+++ b/cmd/serverless-init/exitcode/exitcode_test.go
@@ -1,0 +1,27 @@
+package exitcode
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestFromNil(t *testing.T) {
+	if got := From(nil); got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+}
+
+func TestFromGenericError(t *testing.T) {
+	if got := From(errors.New("boom")); got != 1 {
+		t.Fatalf("expected fallback 1, got %d", got)
+	}
+}
+
+func TestFromExitError(t *testing.T) {
+	cmd := exec.Command("bash", "-c", "exit 5")
+	err := cmd.Run()
+	if got := From(err); got != 5 {
+		t.Fatalf("expected 5, got %d", got)
+	}
+}

--- a/cmd/serverless-init/exitcode/exitcode_test.go
+++ b/cmd/serverless-init/exitcode/exitcode_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package exitcode
 
 import (

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -110,8 +110,6 @@ func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Compon
 
 	err := modeConf.Runner(logConfig)
 
-	metric.Add(cloudService.GetShutdownMetricName(), 1.0, cloudService.GetSource(), *metricAgent)
-
 	// Defers are LIFO
 	defer lastFlush(logConfig.FlushTimeout, metricAgent, traceAgent, logsAgent)
 	defer cloudService.Shutdown(*metricAgent)

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -112,7 +112,7 @@ func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Compon
 
 	// Defers are LIFO
 	defer lastFlush(logConfig.FlushTimeout, metricAgent, traceAgent, logsAgent)
-	defer cloudService.Shutdown(*metricAgent)
+	defer cloudService.Shutdown(*metricAgent, err)
 
 	return err
 }

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -9,14 +9,13 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/exitcode"
 	serverlessInitLog "github.com/DataDog/datadog-agent/cmd/serverless-init/log"
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
@@ -98,7 +97,8 @@ func main() {
 
 	if err != nil {
 		log.Error(err)
-		exitCode := errorExitCode(err)
+		exitCode := exitcode.From(err)
+		log.Debugf("propagating exit code %v", exitCode)
 		log.Flush()
 		os.Exit(exitCode)
 	}
@@ -284,18 +284,4 @@ func setEnvWithoutOverride(envToSet map[string]string) {
 			log.Debugf("%s already set with %s, skipping setting it", envName, val)
 		}
 	}
-}
-
-func errorExitCode(err error) int {
-	// if error is of type exec.ExitError then propagate the exit code
-	var exitError *exec.ExitError
-	if errors.As(err, &exitError) {
-		exitCode := exitError.ExitCode()
-		log.Debugf("propagating exit code %v", exitCode)
-		return exitCode
-	}
-
-	// use exit code 1 if there is no exit code in the error to propagate
-	log.Debug("using default exit code 1")
-	return 1
 }

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -8,8 +8,6 @@
 package main
 
 import (
-	"errors"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -92,30 +90,4 @@ func TestFlushTimeout(t *testing.T) {
 	lastFlush(100*time.Millisecond, metricAgent, traceAgent, mockLogsAgent)
 	assert.Equal(t, false, metricAgent.hasBeenCalled)
 	assert.Equal(t, false, mockLogsAgent.DidFlush())
-}
-func TestExitCodePropagationGenericError(t *testing.T) {
-	err := errors.New("test error")
-
-	exitCode := errorExitCode(err)
-	assert.Equal(t, 1, exitCode)
-}
-
-func TestExitCodePropagationExitError(t *testing.T) {
-	cmd := exec.Command("bash", "-c", "exit 2")
-	err := cmd.Run()
-
-	exitCode := errorExitCode(err)
-	assert.Equal(t, 2, exitCode)
-}
-
-func TestExitCodePropagationJoinedExitError(t *testing.T) {
-	genericError := errors.New("test error")
-
-	cmd := exec.Command("bash", "-c", "exit 3")
-	exitCodeError := cmd.Run()
-
-	errs := errors.Join(genericError, exitCodeError)
-
-	exitCode := errorExitCode(errs)
-	assert.Equal(t, 3, exitCode)
 }

--- a/cmd/serverless-init/metric/metric.go
+++ b/cmd/serverless-init/metric/metric.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// Add records a distribution metric sample using the agent's extra tags plus any
+// optional tags supplied as `key:value` strings through extraTags.
 func Add(name string, value float64, source metrics.MetricSource, agent serverlessMetrics.ServerlessMetricAgent, extraTags ...string) {
 	if agent.Demux == nil {
 		log.Debugf("Cannot add metric %s, the metric agent is not running", name)

--- a/cmd/serverless-init/metric/metric.go
+++ b/cmd/serverless-init/metric/metric.go
@@ -14,17 +14,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func Add(name string, value float64, source metrics.MetricSource, agent serverlessMetrics.ServerlessMetricAgent) {
+func Add(name string, value float64, source metrics.MetricSource, agent serverlessMetrics.ServerlessMetricAgent, extraTags ...string) {
 	if agent.Demux == nil {
 		log.Debugf("Cannot add metric %s, the metric agent is not running", name)
 		return
 	}
 	metricTimestamp := float64(time.Now().UnixNano()) / float64(time.Second)
+	tags := agent.GetExtraTags()
+	if len(extraTags) > 0 {
+		tags = append(append([]string{}, tags...), extraTags...)
+	}
 	agent.Demux.AggregateSample(metrics.MetricSample{
 		Name:       name,
 		Value:      value,
 		Mtype:      metrics.DistributionType,
-		Tags:       agent.GetExtraTags(),
+		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  metricTimestamp,
 		Source:     source,

--- a/cmd/serverless-init/metric/metric_test.go
+++ b/cmd/serverless-init/metric/metric_test.go
@@ -71,6 +71,20 @@ func TestAddShutdownMetric(t *testing.T) {
 	assert.Equal(t, metric.Source, metrics.MetricSourceServerless)
 }
 
+func TestAddExtraTags(t *testing.T) {
+	demux := createDemultiplexer(t)
+	mockAgent := serverlessMetrics.ServerlessMetricAgent{
+		Demux: demux,
+	}
+	Add("tagged.metric", 1.0, mockMetricSource, mockAgent, "exit_code:1")
+	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	assert.Equal(t, 0, len(timedMetrics))
+	assert.Equal(t, 1, len(generatedMetrics))
+	metric := generatedMetrics[0]
+	assert.Contains(t, metric.Tags, "exit_code:1")
+	assert.NotContains(t, mockAgent.GetExtraTags(), "exit_code:1")
+}
+
 func TestNilDemuxDoesNotPanic(t *testing.T) {
 	demux := createDemultiplexer(t)
 	mockAgent := serverlessMetrics.ServerlessMetricAgent{

--- a/releasenotes/notes/cloud-run-jobs-exit-code-tag-7ad4cb346978b9ed.yaml
+++ b/releasenotes/notes/cloud-run-jobs-exit-code-tag-7ad4cb346978b9ed.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Set exit code as a tag in the task ended enhanced shutdown metric for Cloud Run Jobs.
+    The `task.ended` enhanced shutdown metric for Cloud Run Jobs now includes the exit code as a tag.

--- a/releasenotes/notes/cloud-run-jobs-exit-code-tag-7ad4cb346978b9ed.yaml
+++ b/releasenotes/notes/cloud-run-jobs-exit-code-tag-7ad4cb346978b9ed.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    The `task.ended` enhanced shutdown metric for Cloud Run Jobs now includes the exit code as a tag.
+    The `gcp.run.job.enhanced.task.ended` enhanced shutdown metric for Cloud Run Jobs now includes the exit code as a tag.

--- a/releasenotes/notes/cloud-run-jobs-exit-code-tag-7ad4cb346978b9ed.yaml
+++ b/releasenotes/notes/cloud-run-jobs-exit-code-tag-7ad4cb346978b9ed.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Set exit code as a tag in the task ended enhanced shutdown metric for Cloud Run Jobs.


### PR DESCRIPTION
### What does this PR do?

Add an `exit_code` tag on the `gcp.run.job.enhanced.task.ended` metric.

<img width="600" height="413" alt="Screenshot 2025-09-24 at 4 21 00 PM" src="https://github.com/user-attachments/assets/b31934e6-115e-4c91-98f1-586273c2bdc8" />


### Motivation

Will be used on the UI to display the exit code of each task, as well as to determine if the task succeeded (`exit_code=0`) or failed (`exit_code!=0`)

https://datadoghq.atlassian.net/browse/SVLS-7553

### Describe how you validated your changes

Unit tests and manually deploying a container to Cloud Run Jobs with a custom build of the agent. 

### Additional Notes

This is easiest reviewed commit-by-commit
