### PR TITLE
Make psycopg files to be patchelf-ed explicit and fail early

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -279,8 +279,8 @@ build do
         # in the binary that references it using patchelf
         cryptography_folder = "#{site_packages_path}/cryptography"
         so_to_patch = "#{cryptography_folder}/hazmat/bindings/_rust.abi3.so"
-        libssl_match = Dir.glob("#{cryptography_folder}.libs/libssl-*.so.3")[0]
-        libcrypto_match = Dir.glob("#{cryptography_folder}.libs/libcrypto-*.so.3")[0]
+        libssl_match = Dir.glob("#{cryptography_folder}.libs/libssl-*.so.3").fetch(0)
+        libcrypto_match = Dir.glob("#{cryptography_folder}.libs/libcrypto-*.so.3").fetch(0)
         shellout! "patchelf --replace-needed #{File.basename(libssl_match)} libssl.so.3 #{so_to_patch}"
         shellout! "patchelf --replace-needed #{File.basename(libcrypto_match)} libcrypto.so.3 #{so_to_patch}"
         shellout! "patchelf --add-rpath #{install_dir}/embedded/lib #{so_to_patch}"
@@ -290,9 +290,15 @@ build do
       block "Patch psycopg's openssl linking" do
         # Same for psycopg
         psycopg_folder = "#{site_packages_path}/psycopg_c"
-        libssl_match = Dir.glob("#{psycopg_folder}.libs/libssl-*.so.3")[0]
-        libcrypto_match = Dir.glob("#{psycopg_folder}.libs/libcrypto-*.so.3")[0]
-        sos_to_patch = Dir.glob("#{psycopg_folder}/*.so*") + Dir.glob("#{psycopg_folder}.libs/*.so*")
+        libssl_match = Dir.glob("#{psycopg_folder}.libs/libssl-*.so.3").fetch(0)
+        libcrypto_match = Dir.glob("#{psycopg_folder}.libs/libcrypto-*.so.3").fetch(0)
+        # Files that might refer to the OpenSSL libraries and that need patching.
+        # Note that if we miss any file that would need patching, the Omnibus health check will have our back
+        sos_to_patch = [
+          Dir.glob("#{psycopg_folder}/_psycopg.cpython-*-linux-gnu.so").fetch(0),
+          Dir.glob("#{psycopg_folder}/pq.cpython-*-linux-gnu.so").fetch(0),
+          Dir.glob("#{psycopg_folder}.libs/libpq-*.so*").fetch(0),
+        ]
         sos_to_patch.each do |so_to_patch|
           shellout! "patchelf --replace-needed #{File.basename(libssl_match)} libssl.so.3 #{so_to_patch}"
           shellout! "patchelf --replace-needed #{File.basename(libcrypto_match)} libcrypto.so.3 #{so_to_patch}"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -279,8 +279,12 @@ build do
         # in the binary that references it using patchelf
         cryptography_folder = "#{site_packages_path}/cryptography"
         so_to_patch = "#{cryptography_folder}/hazmat/bindings/_rust.abi3.so"
-        libssl_match = Dir.glob("#{cryptography_folder}.libs/libssl-*.so.3").fetch(0)
-        libcrypto_match = Dir.glob("#{cryptography_folder}.libs/libcrypto-*.so.3").fetch(0)
+        libssl_matches = Dir.glob("#{cryptography_folder}.libs/libssl-*.so.3")
+        libcrypto_matches = Dir.glob("#{cryptography_folder}.libs/libcrypto-*.so.3")
+        raise "expected exactly one match for 'libssl-*.so.3' but got: #{libssl_matches}" if libssl_matches.size != 1
+        raise "expected exactly one match for 'libcrypto-*.so.3' but got: #{libcrypto_matches}" if libcrypto_matches.size != 1
+        libssl_match = libssl_matches.fetch(0)
+        libcrypto_match = libcrypto_matches.fetch(0)
         shellout! "patchelf --replace-needed #{File.basename(libssl_match)} libssl.so.3 #{so_to_patch}"
         shellout! "patchelf --replace-needed #{File.basename(libcrypto_match)} libcrypto.so.3 #{so_to_patch}"
         shellout! "patchelf --add-rpath #{install_dir}/embedded/lib #{so_to_patch}"
@@ -290,8 +294,13 @@ build do
       block "Patch psycopg's openssl linking" do
         # Same for psycopg
         psycopg_folder = "#{site_packages_path}/psycopg_c"
-        libssl_match = Dir.glob("#{psycopg_folder}.libs/libssl-*.so.3").fetch(0)
-        libcrypto_match = Dir.glob("#{psycopg_folder}.libs/libcrypto-*.so.3").fetch(0)
+        libssl_matches = Dir.glob("#{psycopg_folder}.libs/libssl-*.so.3")
+        libcrypto_matches = Dir.glob("#{psycopg_folder}.libs/libcrypto-*.so.3")
+        raise "expected exactly one match for 'libssl-*.so.3' but got: #{libssl_matches}" if libssl_matches.size != 1
+        raise "expected exactly one match for 'libcrypto-*.so.3' but got: #{libcrypto_matches}" if libcrypto_matches.size != 1
+        libssl_match = libssl_matches.fetch(0)
+        libcrypto_match = libcrypto_matches.fetch(0)
+
         # Files that might refer to the OpenSSL libraries and that need patching.
         # Note that if we miss any file that would need patching, the Omnibus health check will have our back
         sos_to_patch = [


### PR DESCRIPTION
### What does this PR do?

It adds some defensive measures to avoid accidental errors creeping in while patching libraries to link to the embedded openssl (done for cryptography and psycopg on the FIPS Agent).

This also prevents redundant application of `patchelf` to some files that we delete right after.

### Motivation

Clean up after https://github.com/DataDog/datadog-agent/pull/41003, particularly addressing https://github.com/DataDog/datadog-agent/pull/41003#discussion_r2375131341.

### Describe how you validated your changes

A passing build should be enough.

### Additional Notes


