### PR TITLE
[ACIX-1058] Set shallow clone to most start jobs

### DIFF
--- a/.gitlab/.pre/cancel-prev-pipelines.yml
+++ b/.gitlab/.pre/cancel-prev-pipelines.yml
@@ -2,6 +2,9 @@ cancel-prev-pipelines:
   stage: .pre
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
   rules:
     - if: $CI_COMMIT_MESSAGE =~ /.*\[skip cancel\].*/
       when: never

--- a/.gitlab/.pre/ci_configuration.yml
+++ b/.gitlab/.pre/ci_configuration.yml
@@ -60,3 +60,6 @@ lint_github_actions_shellcheck:
   allow_failure: true
   script:
     - dda inv -- -e linter.github-actions-shellcheck
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"

--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -22,6 +22,8 @@
     BAZEL_OUTPUT_USER_ROOT: "$XDG_CACHE_HOME/bazel"
     BAZEL_REPO_CONTENTS_CACHE: "$BAZEL_OUTPUT_USER_ROOT/repo-contents"
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "2"
 
 .bazel:ext:windows:
   extends: .windows_docker_default

--- a/.gitlab/binary_build/fakeintake.yml
+++ b/.gitlab/binary_build/fakeintake.yml
@@ -9,3 +9,6 @@ build_fakeintake:
   tags: ["arch:amd64", "specific:true"]
   script:
     - dda inv -- fakeintake.build
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"

--- a/.gitlab/binary_build/windows.yml
+++ b/.gitlab/binary_build/windows.yml
@@ -9,6 +9,8 @@ build_windows_container_entrypoint:
   extends: .windows_docker_default
   variables:
     ARCH: "x64"
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
   script:
     - $ErrorActionPreference = "Stop"
     - if (Test-Path build-out) { remove-item -recurse -force build-out }

--- a/.gitlab/check_merge/do_not_merge.yml
+++ b/.gitlab/check_merge/do_not_merge.yml
@@ -27,3 +27,6 @@ do-not-merge:
       fi
     - dda inv -- -e release.check-omnibus-branches --no-worktree || exit 1
     - exit 0
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"

--- a/.gitlab/common/skip_ci_check.yml
+++ b/.gitlab/common/skip_ci_check.yml
@@ -16,3 +16,6 @@ skip-ci-check:
             exit 1
       fi
     - "echo 'success: No check skip found'"
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -231,6 +231,8 @@ docker_build_fips_agent7_arm64_jmx:
     BUILD_CONTEXT: Dockerfiles/base-image
     TARGET_ARG: --target release
     CACHE_TARGET: release
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
 
 docker_build_base_image_amd64:
   extends: [.docker_build_base_image, .docker_build_amd64]

--- a/.gitlab/container_build/fakeintake.yml
+++ b/.gitlab/container_build/fakeintake.yml
@@ -13,6 +13,8 @@ docker_build_fakeintake:
     DOCKERFILE: test/fakeintake/Dockerfile
     PLATFORMS: linux/amd64,linux/arm64
     BUILD_CONTEXT: .
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
   script:
     - !reference [.login_to_docker_readonly]
     - docker buildx build --push --pull --platform ${PLATFORMS} --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -118,6 +118,8 @@ fetch_openjdk:
     JDK_FILENAME: OpenJDK11U-jre_x64_windows_hotspot_11.0.25_9.zip
     JDK_URL: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.25%2B9
     JDK_SHA256: 052f09448d5b8d9afb7a8e5049d40d7fafa8f5884afe6043bb2359787fd41e84
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
   script:
     - wget "$JDK_URL/$JDK_FILENAME" -O "$JDK_FILENAME"
     - echo "$JDK_SHA256  $JDK_FILENAME" | sha256sum -c

--- a/.gitlab/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/e2e_testing_deploy/e2e_deploy.yml
@@ -264,6 +264,9 @@ export_testing_public_key:
     paths:
       - gpg-testing-public-key.asc
     expire_in: 1 day
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
 
 .deploy_dmg_testing-a7:
   rules:
@@ -281,7 +284,7 @@ export_testing_public_key:
     - |
       echo "Listing all datadog-agent-7.*.dmg files in $OMNIBUS_PACKAGE_DIR:"
       ls -la "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg 2>/dev/null || echo "No datadog-agent-7.*.dmg files found"
-      
+
       count=$(ls -1 "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg 2>/dev/null | wc -l || true)
       if [ "$count" -eq 0 ]; then
         echo "No DMG found in $OMNIBUS_PACKAGE_DIR matching datadog-agent-7.*.dmg" >&2

--- a/.gitlab/fuzz/infra.yaml
+++ b/.gitlab/fuzz/infra.yaml
@@ -10,3 +10,6 @@ test_fuzz:
   script:
     - dda self dep sync -f legacy-tasks
     - dda inv -- build-and-upload-fuzz
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"

--- a/.gitlab/lint/technical_linters.yml
+++ b/.gitlab/lint/technical_linters.yml
@@ -4,6 +4,9 @@
   tags: ["arch:amd64", "specific:true"]
   needs: []
   retry: !reference [.retry_only_infra_failure, retry]
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
 
 lint_licenses:
   extends: .lint

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -125,6 +125,8 @@ powershell_script_signing:
   needs: []
   variables:
     ARCH: "x64"
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -27,6 +27,9 @@ github_rate_limit_info:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
   script:
     - dda self dep sync -f legacy-tasks
     # Send stats for app 1

--- a/.gitlab/source_test/protobuf.yml
+++ b/.gitlab/source_test/protobuf.yml
@@ -3,6 +3,9 @@ protobuf_test:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   needs: []
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"
   script:
     - dda inv -- install-tools
     # Run protobuf generation in pre-commit mode to ensure that it fails if the files are not up to date

--- a/.gitlab/source_test/slack.yml
+++ b/.gitlab/source_test/slack.yml
@@ -10,3 +10,6 @@ slack_teams_channels_check:
     - when: on_success
   script:
     - dda inv -- -e notify.check-teams
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"

--- a/.gitlab/source_test/tooling_unit_tests.yml
+++ b/.gitlab/source_test/tooling_unit_tests.yml
@@ -10,3 +10,6 @@ invoke_unit_tests:
   script:
     - dda self dep sync -f legacy-tasks -f legacy-kernel-matrix-testing
     - dda inv -- -e invoke-unit-tests.run
+  variables:
+    GIT_STRATEGY: "clone"
+    GIT_DEPTH: "1"


### PR DESCRIPTION
### What does this PR do?

Many jobs starting at the beginning of the pipeline do not use any specific git strategy since they cannot use the s3 cache. Added shallow clone to speed up these jobs.

This is not done in some jobs that possibly rely on git.

### Motivation

### Describe how you validated your changes

### Additional Notes
