### PR TITLE
Bump timeout too short when pulling a fresh Windows image

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -25,7 +25,7 @@
 
 .bazel:ext:windows:
   extends: .windows_docker_default
-  timeout: 15m
+  timeout: 20m
   allow_failure: true
   retry: 0
   variables:


### PR DESCRIPTION
### Motivation
The timeout introduced by #41023 happens to be too short when pulling a fresh Windows image, leaving almost no time to the `bazel` payload.

### Additional Notes
Example: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1143038916

Monitor:
https://app.datadoghq.com/monitors/154228955?q=%40ci.job.name%3A%22bazel%3Abuild-deps%3Awindows-amd64%22&link_source=monitor_notif&from_ts=1757585932264&to_ts=1758795532264&live=false