### PR TITLE
[INCIDENT-43183] Unskip suse tests

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -103,9 +103,6 @@ func TestPackages(t *testing.T) {
 			if flavor.Flavor == e2eos.Suse && method == InstallMethodAnsible {
 				continue
 			}
-			if flavor.Flavor == e2eos.Suse {
-				continue
-			}
 
 			suite := test.t(flavor, flavor.Architecture, method)
 			t.Run(suite.Name(), func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

We updated the suse arm64 image on test-infra-definitions, the installer tests on suse arm64 are now fully functional and we can re-enable them like before the incident.
The test infra bump has been done in a previous [PR](https://github.com/DataDog/datadog-agent/pull/41218).

### Motivation

### Describe how you validated your changes

### Additional Notes
