### PR TITLE
Re-enable OCB build test

### DIFF
--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -60,7 +60,7 @@ datadog_otel_components_ocb_build:
     - echo "see artifacts for job logs"
   rules:
     - !reference [.except_mergequeue]
-    - when: always
+    - when: on_success
   timeout: 15 minutes
 
 # Test that the BYOC packages can be built with the existing Dockerfile

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -60,7 +60,7 @@ datadog_otel_components_ocb_build:
     - echo "see artifacts for job logs"
   rules:
     - !reference [.except_mergequeue]
-    - when: never
+    - when: always
   timeout: 15 minutes
 
 # Test that the BYOC packages can be built with the existing Dockerfile

--- a/test/otel/testdata/builder-config.yaml
+++ b/test/otel/testdata/builder-config.yaml
@@ -91,6 +91,3 @@ receivers:
     v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
     v0.135.0
-replaces:
-# to be removed in v0.137.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.136.1-0.20250924124118-d5b415b0878f

--- a/test/otel/testdata/builder-config.yaml
+++ b/test/otel/testdata/builder-config.yaml
@@ -91,3 +91,6 @@ receivers:
     v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
     v0.135.0
+replaces:
+# to be removed in v0.137.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.136.1-0.20250924124118-d5b415b0878f

--- a/test/otel/testdata/ocb_build_script.sh
+++ b/test/otel/testdata/ocb_build_script.sh
@@ -65,6 +65,8 @@ dd_mods=$(find . -type f -name "go.mod" -exec dirname {} \; | sort | sed 's/.//'
 	for mod in $dd_mods; do
 		echo "- github.com/DataDog/datadog-agent$mod => $current_dir$mod"
 	done
+	# to be removed in v0.137.0
+    echo "- github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.136.1-0.20250924124118-d5b415b0878f"
 } >>"$WORK_DIR/builder-config.yaml"
 
 # Install and configure OCB

--- a/test/otel/testdata/ocb_build_script.sh
+++ b/test/otel/testdata/ocb_build_script.sh
@@ -67,6 +67,7 @@ dd_mods=$(find . -type f -name "go.mod" -exec dirname {} \; | sort | sed 's/.//'
 	done
 	# to be removed in v0.137.0
     echo "- github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.136.1-0.20250924124118-d5b415b0878f"
+	echo "- github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog => github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog v0.136.1-0.20250924124118-d5b415b0878f"
 } >>"$WORK_DIR/builder-config.yaml"
 
 # Install and configure OCB


### PR DESCRIPTION
### What does this PR do?
OCB Build test was failing because of #41225:
```
/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter@v0.135.0/traces_exporter.go:243:8: acfg.HTTPClientFunc undefined (type *"github.com/DataDog/datadog-agent/pkg/trace/config".AgentConfig has no field or method HTTPClientFunc)
```
Temporary fix by replacing datadogexporter by pseudoversion of: https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/d5b415b0878fc024e77b2995cb072e2dcda9bd5d.

### Motivation

### Describe how you validated your changes

### Additional Notes
