### PR TITLE
dyninst: default SymDB uploads to true when DI is enabled

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -181,7 +181,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(diNS, "probes_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_PROBES_FILE_PATH")
 	cfg.BindEnvAndSetDefault(join(diNS, "snapshot_output_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_SNAPSHOT_FILE_PATH")
 	cfg.BindEnvAndSetDefault(join(diNS, "diagnostics_output_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_FILE_PATH")
-	cfg.BindEnvAndSetDefault(join(diNS, "symdb_upload_enabled"), false, "DD_SYMBOL_DATABASE_UPLOAD_ENABLED")
+	cfg.BindEnvAndSetDefault(join(diNS, "symdb_upload_enabled"), true, "DD_SYMBOL_DATABASE_UPLOAD_ENABLED")
 	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "enabled"), true)
 	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "dir"), defaultDynamicInstrumentationDebugInfoDir)
 	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "max_total_bytes"), int64(2<<30 /* 2GiB */))

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -26,11 +26,10 @@ import (
 // Config is the configuration for the dynamic instrumentation module.
 type Config struct {
 	ebpf.Config
-	DynamicInstrumentationEnabled bool
-	LogUploaderURL                string
-	DiagsUploaderURL              string
-	SymDBUploadEnabled            bool
-	SymDBUploaderURL              string
+	LogUploaderURL     string
+	DiagsUploaderURL   string
+	SymDBUploadEnabled bool
+	SymDBUploaderURL   string
 
 	// DiskCacheEnabled enables the disk cache for debug info.  If this is
 	// false, no disk cache will be used and the debug info will be stored in
@@ -58,10 +57,6 @@ func (e *erasedActuator[A, AT]) Shutdown() error {
 
 // NewConfig creates a new Config object.
 func NewConfig(spConfig *sysconfigtypes.Config) (*Config, error) {
-	var diEnabled bool
-	if spConfig != nil {
-		_, diEnabled = spConfig.EnabledModules[sysconfig.DynamicInstrumentationModule]
-	}
 	traceAgentURL := getTraceAgentURL(os.Getenv)
 	cacheConfig, cacheEnabled, err := getDebugInfoDiskCacheConfig()
 	if err != nil {
@@ -69,14 +64,13 @@ func NewConfig(spConfig *sysconfigtypes.Config) (*Config, error) {
 	}
 
 	c := &Config{
-		Config:                        *ebpf.NewConfig(),
-		DynamicInstrumentationEnabled: diEnabled,
-		LogUploaderURL:                withPath(traceAgentURL, logUploaderPath),
-		DiagsUploaderURL:              withPath(traceAgentURL, diagsUploaderPath),
-		SymDBUploadEnabled:            pkgconfigsetup.SystemProbe().GetBool("dynamic_instrumentation.symdb_upload_enabled"),
-		SymDBUploaderURL:              withPath(traceAgentURL, symdbUploaderPath),
-		DiskCacheEnabled:              cacheEnabled,
-		DiskCacheConfig:               cacheConfig,
+		Config:             *ebpf.NewConfig(),
+		LogUploaderURL:     withPath(traceAgentURL, logUploaderPath),
+		DiagsUploaderURL:   withPath(traceAgentURL, diagsUploaderPath),
+		SymDBUploadEnabled: pkgconfigsetup.SystemProbe().GetBool("dynamic_instrumentation.symdb_upload_enabled"),
+		SymDBUploaderURL:   withPath(traceAgentURL, symdbUploaderPath),
+		DiskCacheEnabled:   cacheEnabled,
+		DiskCacheConfig:    cacheConfig,
 	}
 	return c, nil
 }

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -56,7 +56,7 @@ func (e *erasedActuator[A, AT]) Shutdown() error {
 }
 
 // NewConfig creates a new Config object.
-func NewConfig(spConfig *sysconfigtypes.Config) (*Config, error) {
+func NewConfig(_ *sysconfigtypes.Config) (*Config, error) {
 	traceAgentURL := getTraceAgentURL(os.Getenv)
 	cacheConfig, cacheEnabled, err := getDebugInfoDiskCacheConfig()
 	if err != nil {


### PR DESCRIPTION
Before this patch, the system-probe needed both
DD_DYNAMIC_INSTRUMENTATION_ENABLED and also
DD_SYMBOL_DATABASE_UPLOAD_ENABLED to be set in order to perform uploads
of symbols of Go processes that themselves also have
DD_DYNAMIC_INSTRUMENTATION_ENABLED. After this patch,
DD_SYMBOL_DATABASE_ENABLED defaults to true.

We've been testing SymDB uploads in staging and it's looking good so
far.  Also, we have control over the uploads on the backend so that we
can roll them out gradually to production.

DD_SYMBOL_DATABASE_ENABLED remains in order to let users manually
disable these uploads in exceptional cases on a per-agent basis (if they
run into memory limits, for example).